### PR TITLE
Remove unused dependabot/fetch-metadata step

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
The fetch-metadata step outputs were never used. Removing the unnecessary step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only deletes an unused workflow step and does not change merge behavior or production code.
> 
> **Overview**
> Removes the unused `dependabot/fetch-metadata@v2` step from `.github/workflows/dependabot-merge.yml`, leaving the workflow to only run `gh pr merge --auto --merge` for Dependabot PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8df857bf014f0db061963640038b547fa426ddab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->