### PR TITLE
Remove unused fetch-metadata step

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
Remove the unused dependabot/fetch-metadata step from the Dependabot auto-merge workflow. The step's outputs were never referenced, so removing it simplifies the CI configuration without changing behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused GitHub Actions step without changing the auto-merge command or permissions, so behavior should remain the same.
> 
> **Overview**
> Simplifies the `Dependabot auto-merge` GitHub Actions workflow by removing the unused `dependabot/fetch-metadata@v2` step.
> 
> The job now only runs the `gh pr merge --auto --merge` command for PRs opened by `dependabot[bot]`, with no functional changes expected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4715809f6161bf365993a5d073e7c08d33c65bdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->