### PR TITLE
Fix CI: enable Pages and remove conf.py shebang

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -25,3 +25,4 @@ jobs:
           python_version: '3.13'
           sphinx_build_options: -W
           publish: ${{ github.ref_name == 'main' }}
+          enablement: ${{ github.ref_name == 'main' }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Configuration for Sphinx."""
 
 import importlib.metadata


### PR DESCRIPTION
Fixes two CI failures:

1. **Lint failure**: Removed unnecessary shebang from docs/source/conf.py. Sphinx config files don't need to be executable.

2. **Deploy docs failure**: Added enablement parameter to sphinx-notes/pages action to auto-enable GitHub Pages on the repository.

Both changes are needed to make main branch CI pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CI/docs tweaks only, changing GitHub Pages deployment configuration and removing a stray shebang from `conf.py`.
> 
> **Overview**
> Fixes documentation CI by updating the `sphinx-notes/pages@v3` workflow to pass `enablement` (only on `main`) so GitHub Pages can be auto-enabled during deploy.
> 
> Also removes the unnecessary executable shebang from `docs/source/conf.py` to satisfy linting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96fde807f8f611cfd330ea0e437629be5b352faf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->