### PR TITLE
Add beartype conftest.py config

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+"""Configuration for pytest."""
+
+import pytest
+from beartype import beartype
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Apply the beartype decorator to all collected test functions."""
+    for item in items:
+        if isinstance(item, pytest.Function):
+            item.obj = beartype(obj=item.obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dynamic = [
     "version",
 ]
 optional-dependencies.dev = [
+    "beartype==0.22.9",
     "furo==2025.12.19",
     "hypothesis>=6.0",
     "prek==0.3.5",


### PR DESCRIPTION
Closes #13

## Summary
- Add `conftest.py` with `pytest_collection_modifyitems` hook that applies `beartype` to all collected test functions for runtime type checking
- Add `beartype==0.22.9` to dev dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the test runner and dev dependencies, though it may surface new type-related test failures.
> 
> **Overview**
> This PR adds a new `conftest.py` that hooks `pytest_collection_modifyitems` to automatically decorate every collected `pytest.Function` with `beartype`, enabling runtime type checking across the test suite.
> 
> It also updates `pyproject.toml` to include `beartype==0.22.9` in the dev dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b5609da4b5e545c37e15d8b6cbfb64fbc3fe34c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->