### PR TITLE
Add mypy with strict-kwargs plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,13 @@ max_supported_python = "3.14"
 ini_options.xfail_strict = true
 ini_options.log_cli = true
 
+[tool.coverage]
+run.branch = true
+report.exclude_also = [
+    "if TYPE_CHECKING:",
+]
+report.show_missing = true
+
 [tool.mypy]
 strict = true
 files = [ "." ]
@@ -107,10 +114,3 @@ plugins = [
     "mypy_strict_kwargs",
 ]
 follow_untyped_imports = true
-
-[tool.coverage]
-run.branch = true
-report.exclude_also = [
-    "if TYPE_CHECKING:",
-]
-report.show_missing = true


### PR DESCRIPTION
Configures mypy with strict mode enabled and the mypy-strict-kwargs plugin to enforce keyword-only arguments. This matches the configuration in the requests-mock-flask project, improving type safety and consistency across projects. The plugin is added to dev dependencies alongside mypy[faster-cache].

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds development-time type-checking dependencies and `mypy` configuration, with no runtime behavior changes. It may cause new CI/lint failures if type checks are enforced in pipelines.
> 
> **Overview**
> Adds `mypy` as a dev dependency (with `faster-cache`) and includes `mypy-strict-kwargs`.
> 
> Configures `[tool.mypy]` in `pyproject.toml` to run in **strict** mode over the repo (excluding `build`), enable the `mypy_strict_kwargs` plugin, and follow untyped imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15d27cdc18207bf131231c3bffb52483866a1c70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->