### PR TITLE
Fix incorrect comments in README examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Usage examples
 
    from literalizer import JAVASCRIPT, PYTHON, LanguageSpec, literalize
 
-   # Convert a JSON array to Python tuple literal
+   # Convert a Python list to Python literal items
    data = [True, None, "hi", [1, 2]]
    result = literalize(
        data=data,
@@ -35,7 +35,11 @@ Usage examples
        prefix="",
        wrap=False,
    )
-   # result: '(True, None, "hi", (1, 2)),'
+   # result:
+   # True,
+   # None,
+   # "hi",
+   # (1, 2),
 
    # Convert to JavaScript/TypeScript array
    result = literalize(


### PR DESCRIPTION
## Summary
Fixed incorrect comments in the first README example that misrepresented both the input type and output format. The input was incorrectly described as "JSON array" when it's already-parsed Python data, and the output was incorrectly described as a "Python tuple literal" when it actually produces individual literal-formatted items.

Also corrected the result comment to show the actual multiline output instead of a fabricated single-line representation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that correct example comments/output formatting; no runtime behavior is affected.
> 
> **Overview**
> Updates `README.rst` to correct the first usage example description and expected output. The example now accurately states it literalizes a Python list into individual Python literal items and shows the correct multiline result format instead of an incorrect single-line tuple representation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dac615caa1f9de35be6858c71fdffeb8cd300632. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->