### PR TITLE
Document all public functions in README and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Usage examples
 
    """Examples of using literalizer."""
 
-   from literalizer import JAVASCRIPT, PYTHON, LanguageSpec, literalize
+   from literalizer import JAVASCRIPT, PYTHON, LanguageSpec, literalize, literalize_json, literalize_yaml
 
    # Convert a Python list to Python literal items
    data = [True, None, "hi", [1, 2]]
@@ -54,6 +54,36 @@ Usage examples
    #     null,
    #     "hi",
    #     [1, 2],
+   # ]
+
+   # Convert from a JSON string directly
+   result = literalize_json(
+       json_string='[true, null, "hi", [1, 2]]',
+       language=PYTHON,
+       prefix="",
+       wrap=True,
+   )
+   # result:
+   # [
+   #     True,
+   #     None,
+   #     "hi",
+   #     (1, 2),
+   # ]
+
+   # Convert from a YAML string directly
+   result = literalize_yaml(
+       yaml_string="- true\n- null\n- hi\n- [1, 2]",
+       language=PYTHON,
+       prefix="",
+       wrap=True,
+   )
+   # result:
+   # [
+   #     True,
+   #     None,
+   #     "hi",
+   #     (1, 2),
    # ]
 
    # Built-in languages: PYTHON, JAVASCRIPT, TYPESCRIPT, GO, RUBY,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,27 +21,86 @@ Usage examples
 
    """Examples of using literalizer."""
 
-   from literalizer import literalize
+   from literalizer import (
+       JAVASCRIPT,
+       PYTHON,
+       LanguageSpec,
+       literalize,
+       literalize_json,
+       literalize_yaml,
+   )
 
-   # Convert a JSON array to Python tuple literal
+   # Convert a Python list to Python literal items
    data = [True, None, "hi", [1, 2]]
    result = literalize(
        data=data,
-       language="py",
+       language=PYTHON,
        prefix="",
        wrap=False,
    )
-   # result: '(True, None, "hi", (1, 2)),'
+   # result:
+   # True,
+   # None,
+   # "hi",
+   # (1, 2),
 
-   # Convert to JavaScript/TypeScript with wrapping
+   # Convert to JavaScript/TypeScript array
    result = literalize(
        data=data,
-       language="js",
+       language=JAVASCRIPT,
        prefix="    ",
        wrap=True,
    )
+   # result:
+   # [
+   #     true,
+   #     null,
+   #     "hi",
+   #     [1, 2],
+   # ]
 
-   # Supported languages: py, js, ts, go, rb, cs, cpp, java, kt
+   # Convert from a JSON string directly
+   result = literalize_json(
+       json_string='[true, null, "hi", [1, 2]]',
+       language=PYTHON,
+       prefix="",
+       wrap=True,
+   )
+   # result:
+   # [
+   #     True,
+   #     None,
+   #     "hi",
+   #     (1, 2),
+   # ]
+
+   # Convert from a YAML string directly
+   result = literalize_yaml(
+       yaml_string="- true\n- null\n- hi\n- [1, 2]",
+       language=PYTHON,
+       prefix="",
+       wrap=True,
+   )
+   # result:
+   # [
+   #     True,
+   #     None,
+   #     "hi",
+   #     (1, 2),
+   # ]
+
+   # Built-in languages: PYTHON, JAVASCRIPT, TYPESCRIPT, GO, RUBY,
+   #                      CSHARP, CPP, JAVA, KOTLIN
+
+   # Create a custom language:
+   custom = LanguageSpec(
+       null_literal="nil",
+       true_literal="TRUE",
+       false_literal="FALSE",
+       collection_open="[",
+       collection_close="]",
+       dict_separator=": ",
+   )
 
 Use cases
 ---------


### PR DESCRIPTION
## Summary

Add documentation examples for `literalize_json` and `literalize_yaml` convenience wrapper functions in both README and docs. Fix incorrect documentation examples that were using invalid string shortcuts (language="py", language="js") and replace them with actual language constants (PYTHON, JAVASCRIPT). Add LanguageSpec example and expand all usage examples with consistent, working code samples across both documentation sources.

## What changed

- README.rst: Added literalize_json and literalize_yaml examples with their imports
- docs/source/index.rst: Fixed broken language string examples, added all public function examples, and included LanguageSpec custom language example for completeness

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; main risk is confusing users if examples are still incorrect, but no runtime behavior is modified.
> 
> **Overview**
> Updates the README and Sphinx landing page to **document the `literalize_json` and `literalize_yaml` convenience helpers**, including direct string-to-literals examples.
> 
> Refreshes the existing `literalize` examples to use the exported language constants (`PYTHON`, `JAVASCRIPT`) instead of string shorthands, and expands the docs with a `LanguageSpec` custom-language snippet for consistency across both docs entry points.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bddb232805f4f3ca5892bb5f89b38b6792c1cb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->