### PR TITLE
Use Java as the first example in docs instead of Python-to-Python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ Usage examples
    """Examples of using literalizer."""
 
    from literalizer import (
+       JAVA,
        JAVASCRIPT,
        PYTHON,
        LanguageSpec,
@@ -34,19 +35,19 @@ Usage examples
        literalize_yaml,
    )
 
-   # Convert a Python list to Python literal items
+   # Convert a Python list to Java literal items
    data = [True, None, "hi", [1, 2]]
    result = literalize(
        data=data,
-       language=PYTHON,
+       language=JAVA,
        prefix="",
        wrap=False,
    )
    # result:
-   # True,
-   # None,
+   # true,
+   # null,
    # "hi",
-   # (1, 2),
+   # {1, 2},
 
    # Convert to JavaScript/TypeScript array
    result = literalize(

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Usage examples
    """Examples of using literalizer."""
 
    from literalizer import (
+       JAVA,
        JAVASCRIPT,
        PYTHON,
        LanguageSpec,
@@ -30,19 +31,19 @@ Usage examples
        literalize_yaml,
    )
 
-   # Convert a Python list to Python literal items
+   # Convert a Python list to Java literal items
    data = [True, None, "hi", [1, 2]]
    result = literalize(
        data=data,
-       language=PYTHON,
+       language=JAVA,
        prefix="",
        wrap=False,
    )
    # result:
-   # True,
-   # None,
+   # true,
+   # null,
    # "hi",
-   # (1, 2),
+   # {1, 2},
 
    # Convert to JavaScript/TypeScript array
    result = literalize(


### PR DESCRIPTION
## Summary

- The first example in the docs converted a Python list to Python literals, which doesn't demonstrate the tool's cross-language value
- Replace it with a Java example (`JAVA` language spec) to show actual literal conversion
- Update expected output accordingly (`true`, `null`, `{1, 2}`)

## Test plan

- [ ] Verify the rendered docs show the Java example correctly
- [ ] Confirm the import includes `JAVA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates examples and expected output; no runtime code paths are affected.
> 
> **Overview**
> Updates the first usage example in `README.rst` and `docs/source/index.rst` to demonstrate cross-language conversion by using the `JAVA` language spec instead of `PYTHON`.
> 
> Adjusts the shown expected output accordingly (e.g., `true`, `null`, `{1, 2}`) and adds `JAVA` to the example imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b377b7deb1afece5985497f015665ccfae67ae2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->