### PR TITLE
Add hypothesis tests for JSON and YAML parsing

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -568,11 +568,8 @@ def _yaml_roundtrips_as_str(s: str) -> bool:
     """Return True if ``s`` survives a YAML dump/load cycle as a
     string.
     """
-    try:
-        loaded = yaml.safe_load(stream=yaml.dump(data=s))
-        return bool(loaded == s)
-    except yaml.YAMLError:
-        return False
+    loaded = yaml.safe_load(stream=yaml.dump(data=s))
+    return bool(loaded == s)
 
 
 yaml_safe_text = st.text(


### PR DESCRIPTION
Add property-based tests that verify `literalize_json` and `literalize_yaml` produce the same output as calling `literalize` directly. This ensures the string parsing paths are equivalent to the direct path.

For YAML, the strategy filters strings to avoid YAML's implicit type coercion and uses `sort_keys=False` to preserve dict ordering across the dump/load cycle.

All 109 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to tests and add broader Hypothesis coverage to validate `literalize_json`/`literalize_yaml` parity with `literalize`, with no production logic changes.
> 
> **Overview**
> Adds Hypothesis property-based tests to ensure the string-parsing helpers `literalize_json` and `literalize_yaml` produce the *same* Python-literal output as calling `literalize` directly for arrays, objects, and scalars.
> 
> Introduces YAML-specific strategies that filter generated strings to avoid YAML implicit type coercion (e.g., date/bool-like strings) and uses `sort_keys=False` during YAML dumps to keep ordering stable for comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0919fa80c690e5c4408b9797525750a723f077e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->