### PR TITLE
Remove pyright ignores

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -6,7 +6,7 @@ import ast
 import datetime
 import json
 import textwrap
-from typing import Any, cast
+from typing import Any
 
 import pytest
 import yaml
@@ -357,18 +357,19 @@ def test_part2_sample_go() -> None:
     assert lines[1] == '        {"user_9", 10, 1003.0},'
 
 
-def _lists_to_tuples(*, value: Any) -> Any:  # noqa: ANN401
+type _JSONValue = (
+    str | int | float | bool | None | list[_JSONValue] | dict[str, _JSONValue]
+)
+
+
+def _lists_to_tuples(*, value: _JSONValue) -> object:
     """Recursively convert lists to tuples to match Python converter
     output.
     """
     if isinstance(value, list):
-        list_value = cast("list[Any]", value)
-        return tuple(_lists_to_tuples(value=v) for v in list_value)
+        return tuple(_lists_to_tuples(value=v) for v in value)
     if isinstance(value, dict):
-        return {
-            k: _lists_to_tuples(value=v)
-            for k, v in cast("dict[Any, Any]", value).items()
-        }
+        return {k: _lists_to_tuples(value=v) for k, v in value.items()}
     return value
 
 


### PR DESCRIPTION
## Summary

- Introduces a recursive `_JSONValue` type alias (Python 3.12 `type` statement) covering all JSON-compatible values
- Replaces `Any` in `_lists_to_tuples` with `_JSONValue`, giving pyright concrete element types when iterating — eliminating the need for `# pyright: ignore[reportUnknownVariableType]` comments

Closes #32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes test typing/annotations and removes Pyright ignore comments without altering production code behavior.
> 
> **Overview**
> Improves `tests/test_converter.py` type-safety by introducing a recursive `_JSONValue` alias for JSON-compatible data and tightening `_lists_to_tuples` to accept it.
> 
> Removes `# pyright: ignore[reportUnknownVariableType]` suppressions in the list/dict recursion by giving the type checker concrete element types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f12d50c1429d26677ccb899346c7699a88e494d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->