### PR TITLE
Remove unnecessary YAML round-trip filter

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -564,10 +564,8 @@ def test_roundtrip_json_scalar(data: Any) -> None:  # noqa: ANN401
     assert result_via_json == result_direct
 
 
-# yaml.dump properly quotes strings that YAML would otherwise interpret
-# as dates, booleans, or null, so arbitrary text round-trips through
-# yaml.dump -> yaml.safe_load unchanged.  Dates and datetimes are
-# tested as their own types in yaml_scalars below.
+# Dates and datetimes are tested as their own types below because
+# yaml.safe_load parses them into date/datetime objects.
 yaml_scalars = (
     st.none()
     | st.booleans()


### PR DESCRIPTION
## Summary
- `yaml.dump` properly quotes strings that `safe_load` would otherwise interpret as dates, booleans, or null, so the `_yaml_roundtrips_as_str` filter and character category restrictions in the hypothesis text strategy were unnecessary
- Replaced the filtered, restricted `yaml_safe_text` strategy with plain `st.text()` — all 109 tests pass
- Verified empirically that arbitrary unicode strings (including control chars, YAML keywords like `yes`/`null`/`true`, date-like strings) all survive a `yaml.dump` → `yaml.safe_load` cycle unchanged

Closes #39

## Test plan
- [x] All 109 existing tests pass, including all 17 YAML-specific tests
- [x] Hypothesis tests now cover a broader range of strings without the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test data generation, expanding coverage without affecting production code paths.
> 
> **Overview**
> Removes the custom `_yaml_roundtrips_as_str`/`yaml_safe_text` filtering used in YAML Hypothesis tests and replaces it with plain `st.text()` for both scalar strings and dictionary keys.
> 
> This broadens YAML round-trip property tests to include arbitrary text while keeping date/datetime behavior explicitly covered via `st.dates()`/`st.datetimes()` strategies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12c437fdfc1b7ba2b534c9eb9b6661e4003b0879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->