### PR TITLE
Remove cast usage

### DIFF
--- a/src/literalizer/_converter.py
+++ b/src/literalizer/_converter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import json
-from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import yaml
 from beartype import BeartypeConf, beartype
@@ -520,7 +520,7 @@ def literalize(
     lines: list[str] = []
 
     if isinstance(data, dict):
-        for k, v in cast("dict[str, _Value]", data).items():
+        for k, v in data.items():
             formatted_key = _format_value(value=k, spec=spec)
             formatted_val = _format_value(value=v, spec=spec)
             lines.append(


### PR DESCRIPTION
Eliminated the cast() call on line 523 by relying on type narrowing from the isinstance() check. After the isinstance(data, dict) check, the data parameter is narrowed to dict[str, Any], so the explicit cast to dict[str, _Value] is no longer needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type-hint cleanup that removes an unnecessary `cast()` after an `isinstance(data, dict)` check, with no behavioral changes expected.
> 
> **Overview**
> Removes redundant typing cruft in `literalize()` by dropping the `typing.cast` import and relying on `isinstance(data, dict)` narrowing when iterating `data.items()`.
> 
> No functional logic is changed; this is purely a cleanup to simplify dict handling and imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcbbb54f5c25c3f11c923f4be55f116100705c63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->