### PR TITLE
Fix pylint spelling issues in comments and docstrings

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -8,9 +8,12 @@ CPP
 datetime
 datetimes
 dicts
+formatter
 formatters
 json
 JSONDecodeError
+subclasses
+literalize
 literalizer
 pre
 prepended

--- a/src/literalizer/_converter.py
+++ b/src/literalizer/_converter.py
@@ -502,7 +502,7 @@ def literalize(
     """
     spec = language
 
-    # Handle scalars (check str before Sequence since str is a
+    # Handle scalars (check ``str`` before Sequence since ``str`` is a
     # Sequence, and datetime before date since datetime subclasses
     # date).
     scalar_types = (


### PR DESCRIPTION
Resolves pylint spelling warnings by wrapping code terms in double backticks and adding legitimate words to the spelling dictionary. Wrapped `str` references in backticks in a comment, and added `formatter`, `subclasses`, and `literalize` to the private spelling dictionary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only comment/doc spelling and dictionary updates; no runtime logic changes.
> 
> **Overview**
> Reduces lint/spell-check noise by adding `formatter`, `subclasses`, and `literalize` to `spelling_private_dict.txt`.
> 
> Updates a comment in `src/literalizer/_converter.py` to wrap `str` in double backticks for correct doc-style code formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9feb6f9c67929da609a909840728f4ab314c06e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->