### PR TITLE
Use _YAMLScalar and _YAMLValue types to remove Any

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -365,6 +365,10 @@ type _JSONScalar = str | int | float | bool | None
 
 type _JSONValue = _JSONScalar | list[_JSONValue] | dict[str, _JSONValue]
 
+type _YAMLScalar = _JSONScalar | datetime.date | datetime.datetime
+
+type _YAMLValue = _YAMLScalar | list[_YAMLValue] | dict[str, _YAMLValue]
+
 
 def _lists_to_tuples(*, value: _JSONValue) -> object:
     """Recursively convert lists to tuples to match Python converter
@@ -591,7 +595,7 @@ yaml_scalars = (
     | st.datetimes()
 )
 
-yaml_values: st.SearchStrategy[Any] = st.recursive(
+yaml_values: st.SearchStrategy[_YAMLValue] = st.recursive(
     base=yaml_scalars,
     extend=lambda children: (
         st.lists(elements=children)
@@ -604,7 +608,7 @@ yaml_objects = st.dictionaries(keys=st.text(), values=yaml_values, max_size=10)
 
 
 @given(data=yaml_arrays)
-def test_roundtrip_yaml_array(data: list[Any]) -> None:
+def test_roundtrip_yaml_array(data: list[_YAMLValue]) -> None:
     """Yaml.dump -> literalize_yaml matches literalize for arrays."""
     yaml_string = yaml.dump(data=data, sort_keys=False)
     result_via_yaml = literalize_yaml(
@@ -623,7 +627,7 @@ def test_roundtrip_yaml_array(data: list[Any]) -> None:
 
 
 @given(data=yaml_objects)
-def test_roundtrip_yaml_object(data: dict[str, Any]) -> None:
+def test_roundtrip_yaml_object(data: dict[str, _YAMLValue]) -> None:
     """Yaml.dump -> literalize_yaml matches literalize for objects."""
     yaml_string = yaml.dump(data=data, sort_keys=False)
     result_via_yaml = literalize_yaml(
@@ -642,7 +646,7 @@ def test_roundtrip_yaml_object(data: dict[str, Any]) -> None:
 
 
 @given(data=yaml_scalars)
-def test_roundtrip_yaml_scalar(data: _JSONScalar) -> None:
+def test_roundtrip_yaml_scalar(data: _YAMLScalar) -> None:
     """Yaml.dump -> literalize_yaml matches literalize for scalars."""
     yaml_string = yaml.dump(data=data, sort_keys=False)
     result_via_yaml = literalize_yaml(


### PR DESCRIPTION
Adds type aliases for YAML-specific data structures that include dates and datetimes, then uses them to replace `Any` annotations in the yaml_values strategy and test function signatures. This improves type safety in YAML-related tests.

Also fixes a pre-existing annotation bug in `test_roundtrip_yaml_scalar` to use `_YAMLScalar` instead of `_JSONScalar`, which better matches the yaml_scalars strategy that includes date and datetime values.

Incorporates types introduced in PR #44.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only type annotation changes that don’t affect runtime behavior, aside from improving static type checking for YAML cases involving `date`/`datetime`.
> 
> **Overview**
> **Improves type safety in YAML-related tests.** Introduces `_YAMLScalar`/`_YAMLValue` aliases (including `datetime.date` and `datetime.datetime`) and uses them to type the Hypothesis `yaml_values` strategy and YAML roundtrip test inputs instead of `Any`.
> 
> Fixes a mismatched annotation in `test_roundtrip_yaml_scalar` so the parameter type matches the `yaml_scalars` strategy (which can generate dates/datetimes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f33ea64627bde6aa43a15be3a16630a87cf95062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->