### PR TITLE
Add Ruby syntax check hook for golden files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -359,7 +359,7 @@ repos:
 
       - id: ruby-syntax-check
         name: Ruby syntax check
-        entry: bash -c 'for f; do ruby -c "$f" || exit 1; done' --
+        entry: ruby -c
         language: system
         types: [ruby]
         stages: [pre-commit]


### PR DESCRIPTION
Adds a pre-commit hook that validates Ruby golden files in `tests/integration/cases/` contain syntactically valid Ruby code using `ruby -c`. The hook runs at the pre-commit stage and is added to the CI skip list since CI may not have Ruby available.

This provides validation for one of the generated language outputs similar to Python which is already covered by ruff, mypy, and other tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk tooling-only change; it adds a local `ruby -c` pre-commit hook and may require Ruby to be installed for contributors editing Ruby files, but it is skipped in CI.
> 
> **Overview**
> Adds a new local pre-commit hook `ruby-syntax-check` that runs `ruby -c` on Ruby files to catch syntax errors before commit.
> 
> Updates the `ci.skip` list to exclude this hook so CI doesn’t require Ruby to be installed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f637d18a4db1efebf07702c35421b096998c7c54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->