### PR TITLE
Use LanguageSpec values in golden syntax checks

### DIFF
--- a/check_go_golden_syntax.py
+++ b/check_go_golden_syntax.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from literalizer import GO
+
 
 def main() -> None:
     """Check syntax of each given Go golden file."""
@@ -14,7 +16,7 @@ def main() -> None:
         # Wrap in a package-level variable declaration to make valid Go.
         # gofmt accepts elided-type composite literals inside a typed
         # outer literal, so nested {…} elements parse without error.
-        if content.startswith("map[string]any{"):
+        if content.startswith(GO.dict_open):
             # Already a typed composite literal — use it directly.
             wrapped = f"package main\n\nvar _ = {content}\n"
         else:

--- a/check_java_golden_syntax.py
+++ b/check_java_golden_syntax.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from literalizer import JAVA
+
 
 def main() -> None:
     """Check syntax of each given Java golden file."""
@@ -13,10 +15,12 @@ def main() -> None:
     for filename in sys.argv[1:]:
         content = Path(filename).read_text(encoding="utf-8").strip()
 
-        # Every { in golden files is a collection open (array initializer).
+        # Every collection open in golden files is an array initializer.
         # Java requires "new Object[]" before bare array initializers used
         # as expressions.
-        content = content.replace("{", "new Object[]{")
+        content = content.replace(
+            JAVA.collection_open, f"new Object[]{JAVA.collection_open}"
+        )
 
         wrapped = (
             "import java.util.Map;\n"

--- a/check_kotlin_golden_syntax.py
+++ b/check_kotlin_golden_syntax.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from literalizer import KOTLIN
+
 
 def main() -> None:
     """Check syntax of each given Kotlin golden file."""
@@ -13,8 +15,10 @@ def main() -> None:
     for filename in sys.argv[1:]:
         content = Path(filename).read_text(encoding="utf-8")
         # Empty collections need explicit type parameters for ``kotlinc``.
-        content = content.replace("listOf()", "listOf<Any?>()")
-        content = content.replace("mapOf()", "mapOf<String, Any?>()")
+        empty_list = KOTLIN.collection_open + KOTLIN.collection_close
+        empty_dict = KOTLIN.dict_open + KOTLIN.dict_close
+        content = content.replace(empty_list, "listOf<Any?>()")
+        content = content.replace(empty_dict, "mapOf<String, Any?>()")
         wrapped = f"val x: Any? = {content}\n"
 
         with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
Move hardcoded language-specific values from check_*_golden_syntax.py scripts into direct references of the LanguageSpec constants from literalizer. This eliminates duplication where GO.dict_open, KOTLIN.collection_open, KOTLIN.dict_open, and JAVA.collection_open were hardcoded. The check scripts now import these values directly from the converter rather than maintaining separate copies.

Closes #64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to test/CI syntax-check scripts; main risk is subtle mismatch if `literalizer` constants change, potentially affecting golden validation.
> 
> **Overview**
> Golden syntax check scripts now import language delimiter constants from `literalizer` (`GO.dict_open`, `JAVA.collection_open`, `KOTLIN.collection_open`/`dict_open`/closes) instead of duplicating string literals.
> 
> This updates the Go wrapper detection, Java array-initializer rewriting, and Kotlin empty-collection replacements to key off the shared LanguageSpec values, reducing drift between converters and checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b6b0e0b7679732899e160cc4f16727bb7ecfd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->