### PR TITLE
Relax ruamel-yaml requirement to >=0.18.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dynamic = [
 ]
 dependencies = [
     "beartype==0.22.9",
-    "ruamel-yaml>=0.19.1",
+    # We require >=0.18.16 as a minimum because some users use sphinx-toolbox,
+    # which has a maximum ruamel.yaml version of 0.18.16.
+    "ruamel-yaml>=0.18.16",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.11.24",


### PR DESCRIPTION
Some users depend on sphinx-toolbox, which has a maximum ruamel.yaml version of 0.18.16. This change relaxes our minimum requirement from >=0.19.1 to >=0.18.16 to improve compatibility with those users' environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a dependency version constraint and adds a clarifying comment, with no code or runtime logic changes.
> 
> **Overview**
> Relaxes the `ruamel-yaml` dependency requirement from `>=0.19.1` to **`>=0.18.16`** to avoid conflicts with tools (e.g., `sphinx-toolbox`) that cap the maximum supported version.
> 
> Adds an inline comment in `pyproject.toml` documenting the compatibility rationale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6278dbb60bdd75a460fc360b133f88252c964c09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->