### PR TITLE
Make golden file output valid without wrappers

### DIFF
--- a/check_java_golden_syntax.py
+++ b/check_java_golden_syntax.py
@@ -6,21 +6,12 @@ import sys
 import tempfile
 from pathlib import Path
 
-from literalizer import JAVA
-
 
 def main() -> None:
     """Check syntax of each given Java golden file."""
     javac_path = shutil.which(cmd="javac") or "javac"
     for filename in sys.argv[1:]:
         content = Path(filename).read_text(encoding="utf-8").strip()
-
-        # Every collection open in golden files is an array initializer.
-        # Java requires "new Object[]" before bare array initializers used
-        # as expressions.
-        content = content.replace(
-            JAVA.collection_open, f"new Object[]{JAVA.collection_open}"
-        )
 
         wrapped = (
             "import java.util.Map;\n"

--- a/check_kotlin_golden_syntax.py
+++ b/check_kotlin_golden_syntax.py
@@ -6,19 +6,12 @@ import sys
 import tempfile
 from pathlib import Path
 
-from literalizer import KOTLIN
-
 
 def main() -> None:
     """Check syntax of each given Kotlin golden file."""
     kotlinc_path = shutil.which(cmd="kotlinc") or "kotlinc"
     for filename in sys.argv[1:]:
         content = Path(filename).read_text(encoding="utf-8")
-        # Empty collections need explicit type parameters for ``kotlinc``.
-        empty_list = KOTLIN.collection_open + KOTLIN.collection_close
-        empty_dict = KOTLIN.dict_open + KOTLIN.dict_close
-        content = content.replace(empty_list, "listOf<Any?>()")
-        content = content.replace(empty_dict, "mapOf<String, Any?>()")
         wrapped = f"val x: Any? = {content}\n"
 
         with tempfile.NamedTemporaryFile(

--- a/src/literalizer/_converter.py
+++ b/src/literalizer/_converter.py
@@ -458,7 +458,7 @@ JAVA = LanguageSpec(
     null_literal="null",
     true_literal="true",
     false_literal="false",
-    collection_open="{",
+    collection_open="new Object[]{",
     collection_close="}",
     dict_separator=": ",
     dict_open="Map.ofEntries(",
@@ -471,10 +471,10 @@ KOTLIN = LanguageSpec(
     null_literal="null",
     true_literal="true",
     false_literal="false",
-    collection_open="listOf(",
+    collection_open="listOf<Any?>(",
     collection_close=")",
     dict_separator=" to ",
-    dict_open="mapOf(",
+    dict_open="mapOf<String, Any?>(",
     dict_close=")",
 )
 

--- a/tests/integration/cases/comments/kotlin.kt
+++ b/tests/integration/cases/comments/kotlin.kt
@@ -1,4 +1,4 @@
-mapOf(
+mapOf<String, Any?>(
     // Server configuration
     "host" to "localhost",  // default host
     "port" to 8080,

--- a/tests/integration/cases/empty_list/java.java
+++ b/tests/integration/cases/empty_list/java.java
@@ -1,4 +1,4 @@
-{
-    {},
+new Object[]{
+    new Object[]{},
     Map.ofEntries()
 }

--- a/tests/integration/cases/empty_list/kotlin.kt
+++ b/tests/integration/cases/empty_list/kotlin.kt
@@ -1,4 +1,4 @@
-listOf(
-    listOf(),
-    mapOf(),
+listOf<Any?>(
+    listOf<Any?>(),
+    mapOf<String, Any?>(),
 )

--- a/tests/integration/cases/nested/java.java
+++ b/tests/integration/cases/nested/java.java
@@ -1,3 +1,3 @@
 Map.ofEntries(
-    Map.entry("users", {Map.ofEntries(Map.entry("name", "Bob"), Map.entry("tags", {"admin", "user"})), Map.ofEntries(Map.entry("name", "Carol"), Map.entry("tags", {"guest"}))})
+    Map.entry("users", new Object[]{Map.ofEntries(Map.entry("name", "Bob"), Map.entry("tags", new Object[]{"admin", "user"})), Map.ofEntries(Map.entry("name", "Carol"), Map.entry("tags", new Object[]{"guest"}))})
 )

--- a/tests/integration/cases/nested/kotlin.kt
+++ b/tests/integration/cases/nested/kotlin.kt
@@ -1,3 +1,3 @@
-mapOf(
-    "users" to listOf(mapOf("name" to "Bob", "tags" to listOf("admin", "user")), mapOf("name" to "Carol", "tags" to listOf("guest"))),
+mapOf<String, Any?>(
+    "users" to listOf<Any?>(mapOf<String, Any?>("name" to "Bob", "tags" to listOf<Any?>("admin", "user")), mapOf<String, Any?>("name" to "Carol", "tags" to listOf<Any?>("guest"))),
 )

--- a/tests/integration/cases/scalars/java.java
+++ b/tests/integration/cases/scalars/java.java
@@ -1,4 +1,4 @@
-{
+new Object[]{
     42,
     3.14,
     true,

--- a/tests/integration/cases/scalars/kotlin.kt
+++ b/tests/integration/cases/scalars/kotlin.kt
@@ -1,4 +1,4 @@
-listOf(
+listOf<Any?>(
     42,
     3.14,
     true,

--- a/tests/integration/cases/simple_dict/kotlin.kt
+++ b/tests/integration/cases/simple_dict/kotlin.kt
@@ -1,4 +1,4 @@
-mapOf(
+mapOf<String, Any?>(
     "name" to "Alice",
     "age" to 30,
     "active" to true,

--- a/tests/integration/cases/simple_list/java.java
+++ b/tests/integration/cases/simple_list/java.java
@@ -1,4 +1,4 @@
-{
+new Object[]{
     1,
     "hello",
     true,

--- a/tests/integration/cases/simple_list/kotlin.kt
+++ b/tests/integration/cases/simple_list/kotlin.kt
@@ -1,4 +1,4 @@
-listOf(
+listOf<Any?>(
     1,
     "hello",
     true,

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -62,10 +62,10 @@ from literalizer.exceptions import JSONParseError, ParseError, YAMLParseError
         (TYPESCRIPT, '[true, null, "hi", [1, 2]],'),
         (GO, '{true, nil, "hi", {1, 2}},'),
         (CPP, '{true, nullptr, "hi", {1, 2}},'),
-        (JAVA, '{true, null, "hi", {1, 2}}'),
+        (JAVA, 'new Object[]{true, null, "hi", new Object[]{1, 2}}'),
         (CSHARP, '(true, null, "hi", (1, 2)),'),
         (RUBY, '[true, nil, "hi", [1, 2]],'),
-        (KOTLIN, 'listOf(true, null, "hi", listOf(1, 2)),'),
+        (KOTLIN, 'listOf<Any?>(true, null, "hi", listOf<Any?>(1, 2)),'),
     ],
 )
 def test_language_list(*, language: Language, expected: str) -> None:
@@ -127,12 +127,12 @@ def test_java_dict_wrap_no_trailing_comma() -> None:
 
 
 def test_java_list_wrap_uses_braces() -> None:
-    """Java wrapped lists use curly braces, not square brackets."""
+    """Java wrapped lists use ``new Object[]{…}``."""
     data = [1, "hello", True]
     result = literalize(data=data, language=JAVA, prefix="", wrap=True)
     expected = textwrap.dedent(
         text="""\
-        {
+        new Object[]{
             1,
             "hello",
             true


### PR DESCRIPTION
## Summary

Change JAVA `collection_open` from `"{"` to `"new Object[]{"` and update KOTLIN to use generic type parameters: `listOf<Any?>` and `mapOf<String, Any?>`. This makes all golden files valid expressions without needing content transformations in the syntax checkers.

Simplify `check_java_golden_syntax.py` and `check_kotlin_golden_syntax.py` to pure wrappers (class/val assignment) with no content replacement logic. Both wrapper scripts now rely on the specs being correct rather than transforming the golden files at check time.

This paves the way for wrapping the code before golden file creation and removing the wrappers entirely in a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the emitted literal syntax for Java and Kotlin across the library, which may impact any downstream golden comparisons or consumers expecting the previous brace/listOf/mapOf forms.
> 
> **Overview**
> Updates the Java and Kotlin `LanguageSpec` output so generated collection literals are valid standalone expressions: Java lists now emit `new Object[]{...}` (including nested lists), and Kotlin `listOf`/`mapOf` now include explicit type parameters (`<Any?>`, `<String, Any?>`).
> 
> Simplifies `check_java_golden_syntax.py` and `check_kotlin_golden_syntax.py` by removing their content-rewrite workarounds and relying on the specs to produce compilable expressions; integration golden files and converter unit tests are updated to match the new syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a5f320de98b795a50e22563dc7fc78349526ec4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->