### PR TITLE
Add empty_collection field to handle C# ValueTuple syntax

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -47,11 +47,6 @@ def main() -> None:
         # trailing comma that immediately precedes a closing parenthesis.
         content = re.sub(pattern=r",(\s*\))", repl=r"\1", string=content)
 
-        # Empty collections become (), which is not valid C# syntax,
-        # so replace with ValueTuple.Create().
-        empty_collection = CSHARP.collection_open + CSHARP.collection_close
-        content = content.replace(empty_collection, "ValueTuple.Create()")
-
         wrapped = f"using System.Collections.Generic;\nvar x = {content};\n"
 
         csproj = (

--- a/src/literalizer/_converter.py
+++ b/src/literalizer/_converter.py
@@ -342,6 +342,13 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def empty_collection(self) -> str | None:
+        """Override for empty list literals, or ``None`` to use
+        ``collection_open + collection_close``.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def comment_prefix(self) -> str:
         """The comment prefix for the language (e.g. ``"#"`` or
         ``"//"``).
@@ -371,6 +378,7 @@ class LanguageSpec:
     format_date: Callable[[datetime.date], str] = format_date_iso
     format_datetime: Callable[[datetime.datetime], str] = format_datetime_iso
     comment_prefix: str = "//"
+    empty_collection: str | None = None
 
 
 PYTHON = LanguageSpec(
@@ -399,6 +407,7 @@ CSHARP = LanguageSpec(
     dict_open="new Dictionary<string, object> {",
     dict_close="}",
     format_dict_entry=_format_csharp_dict_entry,
+    empty_collection="ValueTuple.Create()",
 )
 
 JAVASCRIPT = LanguageSpec(
@@ -537,6 +546,8 @@ def _format_value(*, value: _Value, spec: Language) -> str:
         return spec.dict_open + ", ".join(pairs) + spec.dict_close
 
     if isinstance(value, list):
+        if not value and spec.empty_collection is not None:
+            return spec.empty_collection
         items = [_format_value(value=v, spec=spec) for v in value]
         joined = ", ".join(items)
         # Single-element tuples need a trailing comma in Python/C#.

--- a/tests/integration/cases/empty_list/csharp.cs
+++ b/tests/integration/cases/empty_list/csharp.cs
@@ -1,4 +1,4 @@
 (
-    (),
+    ValueTuple.Create(),
     new Dictionary<string, object> {},
 )


### PR DESCRIPTION
Add empty_collection field to Language protocol and LanguageSpec to allow languages to specify custom syntax for empty lists. Set it to ValueTuple.Create() for C#, eliminating the need for the workaround in check_csharp_golden_syntax.py.

Fixes #80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to literal formatting with an integration fixture update; primary risk is output compatibility for consumers expecting previous empty-list syntax.
> 
> **Overview**
> Adds an `empty_collection` override to the `Language`/`LanguageSpec` API and teaches list formatting to emit this override when a list is empty.
> 
> Sets C#’s `empty_collection` to `ValueTuple.Create()`, deletes the C# golden syntax checker’s special-case rewrite for `()`, and updates the C# empty-list integration case accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18d0be1fed0132ef980a6bd61be1fb802b777a34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->