### PR TITLE
Fix C# nullable annotation in syntax check hook

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -32,14 +32,14 @@ def main() -> None:
     for filename in sys.argv[1:]:
         content = Path(filename).read_text(encoding="utf-8").strip()
 
-        # Replace the null literal with (object?)null so the C# compiler
+        # Replace the null literal with (object)null so the C# compiler
         # can infer tuple element types; bare null has no type in C# tuple
         # literals and causes CS0815.
         null_literal: str = CSHARP.null_literal
         null_pattern = rf"\b{null_literal}\b"
         content = re.sub(
             pattern=null_pattern,
-            repl="(object?)null",
+            repl="(object)null",
             string=content,
         )
 


### PR DESCRIPTION
The csproj disables nullable context, so (object?)null generates CS8632 warnings. Use (object)null instead, which works identically for type inference without warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to a C# syntax-check helper that only affects how `null` literals are rewritten before compiling, reducing warnings without changing build behavior.
> 
> **Overview**
> Updates `check_csharp_golden_syntax.py` to rewrite `null` tuple elements as `(object)null` instead of `(object?)null` when compiling golden C# snippets, avoiding CS8632 warnings in projects with nullable context disabled while preserving tuple type inference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2c60f80d925e1cad80e3db32f714d2d29e7149f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->