### PR TITLE
Fix flaky C# syntax check caused by dotnet NuGet mutex race

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -23,6 +23,14 @@ _DOTNET_ENV: dict[str, str] = {
     "NUGET_XMLDOC_MODE": "skip",
 }
 
+# String present in dotnet stderr when the NuGet mutex race occurs.
+# Used to distinguish infrastructure noise from real compilation errors.
+_NUGET_MUTEX_MARKER = "NuGet-Migrations"
+
+# Number of times to retry a dotnet invocation that failed only because of
+# the shared-memory mutex race condition (not a real C# error).
+_MUTEX_RETRY_LIMIT = 3
+
 
 def _target_framework(dotnet_path: str) -> str:
     """Return the target framework moniker for the installed
@@ -38,6 +46,38 @@ def _target_framework(dotnet_path: str) -> str:
     version = result.stdout.strip()
     major_minor = ".".join(version.split(sep=".")[:2])
     return f"net{major_minor}"
+
+
+def _build(
+    dotnet_path: str,
+    csproj_path: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``dotnet build``, retrying on transient NuGet mutex failures.
+
+    Returns the last result, which callers should inspect for success or
+    failure.
+    """
+    remaining = _MUTEX_RETRY_LIMIT
+    while True:
+        result = subprocess.run(
+            args=[dotnet_path, "build", str(csproj_path)],  # type: ignore[call-overload]
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_DOTNET_ENV,
+        )
+        remaining -= 1
+        if result.returncode == 0:
+            # Successful build — no need to retry.
+            return result
+        if _NUGET_MUTEX_MARKER not in result.stderr:
+            # Genuine C# compilation error, not a transient mutex race.
+            return result
+        if remaining == 0:
+            # All retries exhausted; propagate the last (mutex) failure.
+            return result
+        # The failure is the NuGet shared-memory mutex race (errno==EEXIST).
+        # Retry in case the next attempt avoids the contention.
 
 
 def main() -> None:
@@ -63,12 +103,9 @@ def main() -> None:
             csproj_path = Path(tmpdir) / "check.csproj"
             cs_path.write_text(data=content, encoding="utf-8")
             csproj_path.write_text(data=csproj, encoding="utf-8")
-            result = subprocess.run(
-                args=[dotnet_path, "build", str(csproj_path)],  # type: ignore[call-overload]
-                capture_output=True,
-                text=True,
-                check=False,
-                env=_DOTNET_ENV,
+            result = _build(
+                dotnet_path=dotnet_path,
+                csproj_path=csproj_path,
             )
         if result.returncode != 0:
             msg = (


### PR DESCRIPTION
## Summary

The `csharp-golden-syntax-check` pre-commit hook was failing intermittently on Ubuntu CI with a .NET runtime error unrelated to the C# source being checked:

```
System.IO.IOException: The system cannot open the device or file specified. : 'NuGet-Migrations'.
One or more system calls failed: mkdir("/tmp/.dotnet/shm/session2088", AllUsers_ReadWriteExecute) == -1; errno == EEXIST
```

When multiple CI jobs run in parallel, dotnet's first-time NuGet initialization races to create a shared-memory mutex directory. The losing process gets `EEXIST` and throws an `IOException`, causing `dotnet build` to exit non-zero and the hook to report a false "C# syntax error".

## Fix

Pass three environment variables to every `dotnet` subprocess call in `check_csharp_golden_syntax.py` that suppress the first-time initialization entirely:

- `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1` — skips NuGet migration and telemetry
- `DOTNET_NOLOGO=1` — suppresses the dotnet welcome banner
- `NUGET_XMLDOC_MODE=skip` — skips downloading NuGet XML documentation

## Test plan

- [ ] Confirm the pre-commit C# syntax check passes on Ubuntu CI without the mutex error
- [ ] Confirm valid C# files still pass and invalid ones still fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a developer/CI validation script and mainly add environment flags plus a small retry loop around `dotnet build`. The main risk is masking a real build failure if stderr matching is too broad, but non-mutex errors still fail immediately.
> 
> **Overview**
> Reduces flakiness in `check_csharp_golden_syntax.py` by running all `dotnet` subprocesses with a consistent `_DOTNET_ENV` that disables first-time experience/telemetry and NuGet XML doc downloads.
> 
> Wraps `dotnet build` in a new `_build()` helper that retries up to 3 times when failures appear to be the transient `NuGet-Migrations` mutex race, while preserving immediate failure behavior for genuine compilation errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9430ee58a51d70c4a589e0373408312f7113217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->