### PR TITLE
Move wrapper functions into _LanguageConfig

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -83,61 +83,59 @@ var x = {content};"""
 
 @dataclasses.dataclass
 class _LanguageConfig:
-    """Language configuration with spec and file extension."""
+    """Language configuration with spec, file extension, and wrapper."""
 
     spec: literalizer.LanguageSpec
     extension: str
+    wrap: Callable[[str], str]
 
 
 _LANGUAGES: dict[str, _LanguageConfig] = {
     "python": _LanguageConfig(
         spec=literalizer.PYTHON,
         extension=".py",
+        wrap=_wrap_identity,
     ),
     "javascript": _LanguageConfig(
         spec=literalizer.JAVASCRIPT,
         extension=".js",
+        wrap=_wrap_js,
     ),
     "typescript": _LanguageConfig(
         spec=literalizer.TYPESCRIPT,
         extension=".ts",
+        wrap=_wrap_js,
     ),
     "kotlin": _LanguageConfig(
         spec=literalizer.KOTLIN,
         extension=".kt",
+        wrap=_wrap_kotlin,
     ),
     "ruby": _LanguageConfig(
         spec=literalizer.RUBY,
         extension=".rb",
+        wrap=_wrap_identity,
     ),
     "go": _LanguageConfig(
         spec=literalizer.GO,
         extension=".go",
+        wrap=_wrap_go,
     ),
     "java": _LanguageConfig(
         spec=literalizer.JAVA,
         extension=".java",
+        wrap=_wrap_java,
     ),
     "csharp": _LanguageConfig(
         spec=literalizer.CSHARP,
         extension=".cs",
+        wrap=_wrap_csharp,
     ),
     "cpp": _LanguageConfig(
         spec=literalizer.CPP,
         extension=".cpp",
+        wrap=_wrap_cpp,
     ),
-}
-
-_WRAPPERS: dict[str, Callable[[str], str]] = {
-    "python": _wrap_identity,
-    "ruby": _wrap_identity,
-    "javascript": _wrap_js,
-    "typescript": _wrap_js,
-    "go": _wrap_go,
-    "java": _wrap_java,
-    "kotlin": _wrap_kotlin,
-    "cpp": _wrap_cpp,
-    "csharp": _wrap_csharp,
 }
 
 
@@ -175,7 +173,7 @@ def test_golden_file(
         prefix="",
         wrap=True,
     )
-    wrapped = _WRAPPERS[language](result)
+    wrapped = lang_config.wrap(result)
     file_regression.check(
         contents=wrapped + "\n",
         extension=lang_config.extension,


### PR DESCRIPTION
Consolidate per-language configuration by moving wrapper functions into the _LanguageConfig dataclass. The _WRAPPERS dict was a parallel structure that duplicated keys from _LANGUAGES, creating implicit coupling that could diverge. This change ensures all language settings (spec, extension, wrapper) stay in sync.

## Changes
- Add `wrap` field to _LanguageConfig
- Move wrapper function references from _WRAPPERS dict into each language entry
- Remove the now-unused _WRAPPERS dict
- Update test to use `lang_config.wrap()` instead of `_WRAPPERS[language]()`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to integration test configuration wiring; behavior should be unchanged aside from how wrapper functions are selected.
> 
> **Overview**
> Consolidates per-language integration test configuration by adding a `wrap` callable to `_LanguageConfig` and storing each language’s wrapper alongside its `spec` and `extension` in `_LANGUAGES`.
> 
> Removes the separate `_WRAPPERS` mapping and updates the golden-file test to call `lang_config.wrap(result)` instead of indexing a parallel dict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2725d91b5924253fc43bb05375652075d00a51fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->