### PR TITLE
Fix Kotlin hook to match .kts files using files pattern

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -455,8 +455,7 @@ repos:
         name: Kotlin golden file syntax check
         entry: kotlinc -script
         language: system
-        types: [kotlin]
-        files: ^tests/integration/cases/
+        files: ^tests/integration/cases/.*\.kts$
         stages: [pre-commit]
 
       - id: csharp-golden-syntax-check


### PR DESCRIPTION
## Summary

- Replaces `types: [kotlin]` with an explicit `files` pattern (`^tests/integration/cases/.*\.kts$`) since the `identify` library may not recognize `.kts` (Kotlin Script) files as the `kotlin` type, which would silently prevent the hook from running

Addresses https://github.com/adamtheturtle/literalizer/pull/100#discussion_r2937550477

## Test plan

- [ ] Verify the Kotlin golden file syntax check hook runs on `.kts` files in `tests/integration/cases/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that narrows the hook’s file matching to `.kts` scripts; main risk is unintentionally excluding non-`.kts` Kotlin files in that directory.
> 
> **Overview**
> Ensures the `kotlin-syntax-check` pre-commit hook runs for Kotlin script golden files by replacing `types: [kotlin]` with an explicit `files: ^tests/integration/cases/.*\.kts$` matcher.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3311feddb50a2688c516d72de0671b51ac2ec8c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->