### PR TITLE
Fix kotlin-syntax-check hook to handle multiple files and .kts extension

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -453,10 +453,9 @@ repos:
 
       - id: kotlin-syntax-check
         name: Kotlin golden file syntax check
-        entry: kotlinc -script
+        entry: bash -c 'for f; do kotlinc -script "$f" || exit 1; done' --
         language: system
-        types: [kotlin]
-        files: ^tests/integration/cases/
+        files: ^tests/integration/cases/.*\.kts$
         stages: [pre-commit]
 
       - id: csharp-golden-syntax-check


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Addresses issues raised in the Bugbot review on #100:

- Replace `kotlinc -script` entry with a bash loop (`bash -c 'for f; do kotlinc -script "$f" || exit 1; done' --`) so all staged `.kts` files are syntax-checked, not just the first one
- Replace `types: [kotlin]` with an explicit `files: ^tests/integration/cases/.*\.kts$` pattern to reliably match Kotlin Script files without relying on type detection

## Test plan

- [ ] Run the pre-commit hook against a valid `.kts` file — should pass
- [ ] Stage multiple `.kts` files and confirm all are checked (not just the first)
- [ ] Introduce a syntax error in a `.kts` file and confirm the hook catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change to a local pre-commit hook; main risk is slightly different file matching/execution behavior for Kotlin script checks.
> 
> **Overview**
> Updates the local `kotlin-syntax-check` pre-commit hook to iterate over *all* provided filenames (instead of only checking the first file) by wrapping `kotlinc -script` in a bash loop.
> 
> Tightens hook targeting to Kotlin script files by replacing `types: [kotlin]` with an explicit `files: ^tests/integration/cases/.*\.kts$` pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7b8eee85f53b54a4dd61245c490624efdf6d23c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->