### PR TITLE
Simplify test_integration.py with date variants in config

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -20,6 +20,7 @@ from pytest_regressions.file_regression import FileRegressionFixture
 import literalizer
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable
 
 _CASES_DIR = Path(__file__).parent / "cases"
@@ -148,12 +149,23 @@ def _wrap_ruby_date(content: str) -> str:
 
 
 @dataclasses.dataclass
+class _DateVariant:
+    """A date/datetime formatting variant for a language."""
+
+    name: str
+    format_date: Callable[[datetime.date], str] | None
+    format_datetime: Callable[[datetime.datetime], str]
+    wrap: Callable[[str], str]
+
+
+@dataclasses.dataclass
 class _LanguageConfig:
     """Language configuration with spec, file extension, and wrapper."""
 
     spec: literalizer.LanguageSpec
     extension: str
     wrap: Callable[[str], str]
+    date_variants: tuple[_DateVariant, ...] = ()
 
 
 _LANGUAGES: dict[str, _LanguageConfig] = {
@@ -161,46 +173,130 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.PYTHON,
         extension=".py",
         wrap=_wrap_identity,
+        date_variants=(
+            _DateVariant(
+                name="python_native",
+                format_date=literalizer.format_date_python,
+                format_datetime=literalizer.format_datetime_python,
+                wrap=_wrap_python_datetime,
+            ),
+            _DateVariant(
+                name="python_epoch",
+                format_date=None,
+                format_datetime=literalizer.format_datetime_epoch,
+                wrap=_wrap_identity,
+            ),
+        ),
     ),
     "javascript": _LanguageConfig(
         spec=literalizer.JAVASCRIPT,
         extension=".js",
         wrap=_wrap_js,
+        date_variants=(
+            _DateVariant(
+                name="js_native",
+                format_date=literalizer.format_date_js,
+                format_datetime=literalizer.format_datetime_js,
+                wrap=_wrap_js,
+            ),
+        ),
     ),
     "typescript": _LanguageConfig(
         spec=literalizer.TYPESCRIPT,
         extension=".ts",
         wrap=_wrap_js,
+        date_variants=(
+            _DateVariant(
+                name="ts_native",
+                format_date=literalizer.format_date_js,
+                format_datetime=literalizer.format_datetime_js,
+                wrap=_wrap_js,
+            ),
+        ),
     ),
     "kotlin": _LanguageConfig(
         spec=literalizer.KOTLIN,
         extension=".kts",
         wrap=_wrap_kotlin,
+        date_variants=(
+            _DateVariant(
+                name="kotlin_native",
+                format_date=literalizer.format_date_kotlin,
+                format_datetime=literalizer.format_datetime_kotlin,
+                wrap=_wrap_kotlin_time,
+            ),
+        ),
     ),
     "ruby": _LanguageConfig(
         spec=literalizer.RUBY,
         extension=".rb",
         wrap=_wrap_identity,
+        date_variants=(
+            _DateVariant(
+                name="ruby_native",
+                format_date=literalizer.format_date_ruby,
+                format_datetime=literalizer.format_datetime_ruby,
+                wrap=_wrap_ruby_date,
+            ),
+        ),
     ),
     "go": _LanguageConfig(
         spec=literalizer.GO,
         extension=".go",
         wrap=_wrap_go,
+        date_variants=(
+            _DateVariant(
+                name="go_native",
+                format_date=literalizer.format_date_go,
+                format_datetime=literalizer.format_datetime_go,
+                wrap=_wrap_go_time,
+            ),
+        ),
     ),
     "java": _LanguageConfig(
         spec=literalizer.JAVA,
         extension=".java",
         wrap=_wrap_java,
+        date_variants=(
+            _DateVariant(
+                name="java_instant",
+                format_date=literalizer.format_date_java,
+                format_datetime=literalizer.format_datetime_java_instant,
+                wrap=_wrap_java_time,
+            ),
+            _DateVariant(
+                name="java_zoned",
+                format_date=literalizer.format_date_java,
+                format_datetime=literalizer.format_datetime_java_zoned,
+                wrap=_wrap_java_time,
+            ),
+        ),
     ),
     "csharp": _LanguageConfig(
         spec=literalizer.CSHARP,
         extension=".cs",
         wrap=_wrap_csharp,
+        date_variants=(
+            _DateVariant(
+                name="csharp_native",
+                format_date=literalizer.format_date_csharp,
+                format_datetime=literalizer.format_datetime_csharp,
+                wrap=_wrap_csharp_date,
+            ),
+        ),
     ),
     "cpp": _LanguageConfig(
         spec=literalizer.CPP,
         extension=".cpp",
         wrap=_wrap_cpp,
+        date_variants=(
+            _DateVariant(
+                name="cpp_native",
+                format_date=literalizer.format_date_cpp,
+                format_datetime=literalizer.format_datetime_cpp,
+                wrap=_wrap_cpp_chrono,
+            ),
+        ),
     ),
     "php": _LanguageConfig(
         spec=literalizer.PHP,
@@ -252,132 +348,48 @@ def test_golden_file(
     )
 
 
-_DATE_FORMAT_LANGUAGES: dict[str, _LanguageConfig] = {
-    "python_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.PYTHON,
-            format_date=literalizer.format_date_python,
-            format_datetime=literalizer.format_datetime_python,
-        ),
-        extension=".py",
-        wrap=_wrap_python_datetime,
-    ),
-    "python_epoch": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.PYTHON,
-            format_datetime=literalizer.format_datetime_epoch,
-        ),
-        extension=".py",
-        wrap=_wrap_identity,
-    ),
-    "java_instant": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.JAVA,
-            format_date=literalizer.format_date_java,
-            format_datetime=literalizer.format_datetime_java_instant,
-        ),
-        extension=".java",
-        wrap=_wrap_java_time,
-    ),
-    "java_zoned": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.JAVA,
-            format_date=literalizer.format_date_java,
-            format_datetime=literalizer.format_datetime_java_zoned,
-        ),
-        extension=".java",
-        wrap=_wrap_java_time,
-    ),
-    "kotlin_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.KOTLIN,
-            format_date=literalizer.format_date_kotlin,
-            format_datetime=literalizer.format_datetime_kotlin,
-        ),
-        extension=".kts",
-        wrap=_wrap_kotlin_time,
-    ),
-    "ruby_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.RUBY,
-            format_date=literalizer.format_date_ruby,
-            format_datetime=literalizer.format_datetime_ruby,
-        ),
-        extension=".rb",
-        wrap=_wrap_ruby_date,
-    ),
-    "js_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.JAVASCRIPT,
-            format_date=literalizer.format_date_js,
-            format_datetime=literalizer.format_datetime_js,
-        ),
-        extension=".js",
-        wrap=_wrap_js,
-    ),
-    "ts_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.TYPESCRIPT,
-            format_date=literalizer.format_date_js,
-            format_datetime=literalizer.format_datetime_js,
-        ),
-        extension=".ts",
-        wrap=_wrap_js,
-    ),
-    "csharp_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.CSHARP,
-            format_date=literalizer.format_date_csharp,
-            format_datetime=literalizer.format_datetime_csharp,
-        ),
-        extension=".cs",
-        wrap=_wrap_csharp_date,
-    ),
-    "go_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.GO,
-            format_date=literalizer.format_date_go,
-            format_datetime=literalizer.format_datetime_go,
-        ),
-        extension=".go",
-        wrap=_wrap_go_time,
-    ),
-    "cpp_native": _LanguageConfig(
-        spec=dataclasses.replace(
-            literalizer.CPP,
-            format_date=literalizer.format_date_cpp,
-            format_datetime=literalizer.format_datetime_cpp,
-        ),
-        extension=".cpp",
-        wrap=_wrap_cpp_chrono,
-    ),
-}
-
-_DATE_FORMAT_CASES = list(_DATE_FORMAT_LANGUAGES.keys())
 _DATES_CASE_DIR = _CASES_DIR / "dates"
+
+_DATE_VARIANT_CASES: list[tuple[str, _LanguageConfig, _DateVariant]] = [
+    (variant.name, lang_config, variant)
+    for lang_config in _LANGUAGES.values()
+    for variant in lang_config.date_variants
+]
 
 
 @pytest.mark.parametrize(
-    argnames="language",
-    argvalues=_DATE_FORMAT_CASES,
-    ids=_DATE_FORMAT_CASES,
+    argnames=("variant_name", "lang_config", "variant"),
+    argvalues=_DATE_VARIANT_CASES,
+    ids=[c[0] for c in _DATE_VARIANT_CASES],
 )
 def test_date_format_golden_file(
-    language: str,
+    variant_name: str,
+    lang_config: _LanguageConfig,
+    variant: _DateVariant,
     file_regression: FileRegressionFixture,
 ) -> None:
     """Test native date format variants against golden files."""
-    lang_config = _DATE_FORMAT_LANGUAGES[language]
+    if variant.format_date is not None:
+        spec = dataclasses.replace(
+            lang_config.spec,
+            format_date=variant.format_date,
+            format_datetime=variant.format_datetime,
+        )
+    else:
+        spec = dataclasses.replace(
+            lang_config.spec,
+            format_datetime=variant.format_datetime,
+        )
     yaml_string = (_DATES_CASE_DIR / "input.yaml").read_text()
     result = literalizer.literalize_yaml(
         yaml_string=yaml_string,
-        language=lang_config.spec,
+        language=spec,
         prefix="",
         wrap=True,
     )
-    wrapped = lang_config.wrap(result)
+    wrapped = variant.wrap(result)
     file_regression.check(
         contents=wrapped + "\n",
         extension=lang_config.extension,
-        fullpath=_DATES_CASE_DIR / (language + lang_config.extension),
+        fullpath=_DATES_CASE_DIR / (variant_name + lang_config.extension),
     )


### PR DESCRIPTION
Refactored _LanguageConfig to include date/datetime formatting variants as a tuple field. Moved date variant info from the separate _DATE_FORMAT_LANGUAGES dict into each language entry, eliminating duplicate code. Simplified test_date_format_golden_file to build specs dynamically from variants. All 91 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to integration test configuration/parameterization; main risk is accidentally changing golden file naming or wrapper selection for date variants.
> 
> **Overview**
> Refactors `tests/integration/test_integration.py` to model date/datetime golden-file variants as per-language `date_variants` on `_LanguageConfig` (via a new `_DateVariant` dataclass), removing the separate `_DATE_FORMAT_LANGUAGES` mapping and its duplicated `LanguageSpec` construction.
> 
> Updates `test_date_format_golden_file` to parametrize over `(variant_name, lang_config, variant)`, dynamically `dataclasses.replace(...)` the spec for each variant (including handling variants without `format_date`), and to wrap/output using the variant’s wrapper and golden file name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f8258ff5a4d5a8539cbb88532609ee099cc00c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->