### PR TITLE
Make _DateVariant.format_date required

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -153,7 +153,7 @@ class _DateVariant:
     """A date/datetime formatting variant for a language."""
 
     name: str
-    format_date: Callable[[datetime.date], str] | None
+    format_date: Callable[[datetime.date], str]
     format_datetime: Callable[[datetime.datetime], str]
     wrap: Callable[[str], str]
 
@@ -182,7 +182,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
             ),
             _DateVariant(
                 name="python_epoch",
-                format_date=None,
+                format_date=literalizer.format_date_iso,
                 format_datetime=literalizer.format_datetime_epoch,
                 wrap=_wrap_identity,
             ),
@@ -369,17 +369,11 @@ def test_date_format_golden_file(
     file_regression: FileRegressionFixture,
 ) -> None:
     """Test native date format variants against golden files."""
-    if variant.format_date is not None:
-        spec = dataclasses.replace(
-            lang_config.spec,
-            format_date=variant.format_date,
-            format_datetime=variant.format_datetime,
-        )
-    else:
-        spec = dataclasses.replace(
-            lang_config.spec,
-            format_datetime=variant.format_datetime,
-        )
+    spec = dataclasses.replace(
+        lang_config.spec,
+        format_date=variant.format_date,
+        format_datetime=variant.format_datetime,
+    )
     yaml_string = (_DATES_CASE_DIR / "input.yaml").read_text()
     result = literalizer.literalize_yaml(
         yaml_string=yaml_string,


### PR DESCRIPTION
Removed None union from format_date to require an explicit formatter for all variants. Changed python_epoch to use format_date_iso (the PYTHON spec default) instead of None, preserving behavior while making the type required. Simplified test_date_format_golden_file by removing the if/else branch that handled None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to integration test scaffolding and should not affect production code paths, aside from potentially changing golden outputs if any variant relied on the previous implicit default.
> 
> **Overview**
> Makes `_DateVariant.format_date` non-optional and updates the `python_epoch` test variant to explicitly use `literalizer.format_date_iso` instead of `None`.
> 
> Simplifies `test_date_format_golden_file` by always overriding both `format_date` and `format_datetime` via `dataclasses.replace`, removing the conditional branch that handled a missing date formatter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4864896b31b8c3bcf5cd935633c5e6d314ae7b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->