### PR TITLE
Fix NuGet mutex EEXIST by using unique TMPDIR per dotnet build

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -1,5 +1,6 @@
 """Check syntax of C# golden files using ``dotnet build``."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -45,11 +46,16 @@ def main() -> None:
             csproj_path = Path(tmpdir) / "check.csproj"
             cs_path.write_text(data=content, encoding="utf-8")
             csproj_path.write_text(data=csproj, encoding="utf-8")
+            dotnet_tmp = Path(tmpdir) / "tmp"
+            dotnet_tmp.mkdir()
+            env = os.environ.copy()
+            env["TMPDIR"] = dotnet_tmp.as_posix()
             result = subprocess.run(
                 args=[dotnet_path, "build", str(csproj_path)],  # type: ignore[call-overload]
                 capture_output=True,
                 text=True,
                 check=False,
+                env=env,
             )
         if result.returncode != 0:
             msg = (


### PR DESCRIPTION
## Summary

- Set a unique `TMPDIR` for each `dotnet build` invocation inside the existing `TemporaryDirectory` context
- Prevents `/tmp/.dotnet/shm/session*` path collisions when processing multiple C# files sequentially

Closes #113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the C# syntax-check script and only adjusts the environment for `dotnet build` to use a unique temp directory.
> 
> **Overview**
> Prevents intermittent `dotnet build` failures when validating C# golden files by creating a per-invocation temp directory and exporting it via `TMPDIR`.
> 
> This updates `check_csharp_golden_syntax.py` to clone the current environment and pass it to `subprocess.run`, isolating .NET’s temp/shm paths and avoiding cross-run collisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76f3bd1a0acfc9b4ec3d585d7858d664e5ee111e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->