### PR TITLE
Skip NuGet first-time config to fix CI flakes

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -12,11 +12,19 @@ def _target_framework(dotnet_path: str) -> str:
     """Return the target framework moniker for the installed
     ``dotnet``.
     """
+    env = os.environ.copy()
+    env.update(
+        {
+            "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
+            "DOTNET_NOLOGO": "1",
+        }
+    )
     result = subprocess.run(
         args=[dotnet_path, "--version"],
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
     version = result.stdout.strip()
     major_minor = ".".join(version.split(sep=".")[:2])
@@ -50,6 +58,12 @@ def main() -> None:
             dotnet_tmp.mkdir()
             env = os.environ.copy()
             env["TMPDIR"] = dotnet_tmp.as_posix()
+            env.update(
+                {
+                    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
+                    "DOTNET_NOLOGO": "1",
+                }
+            )
             result = subprocess.run(
                 args=[dotnet_path, "build", str(csproj_path)],  # type: ignore[call-overload]
                 capture_output=True,


### PR DESCRIPTION
Set DOTNET_SKIP_FIRST_TIME_EXPERIENCE and DOTNET_NOLOGO environment variables
to prevent the NuGet migration runner from creating exclusive-access mutex files
that conflict when dotnet is invoked multiple times. The .NET runtime tries to
acquire the NuGet-Migrations mutex at /tmp/.dotnet/shm/*, and when multiple
processes start in quick succession, EEXIST errors occur. This environment
variable disables the first-time configuration that triggers the migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts environment variables for `dotnet` invocations to reduce CI flakiness without changing build inputs or validation logic.
> 
> **Overview**
> Reduces CI flakiness in `check_csharp_golden_syntax.py` by running `dotnet --version` and `dotnet build` with `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1` and `DOTNET_NOLOGO=1`, avoiding first-run NuGet migration/lock behavior and suppressing logo output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f37e6686167e4b0991c8c8134b710115f00966fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->