### PR TITLE
Remove FBT001 noqa by using * for keyword-only args

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -184,7 +184,7 @@ def test_java_list_wrap_uses_braces() -> None:
 
 
 @pytest.mark.parametrize(argnames="wrap", argvalues=[False, True])
-def test_dict_empty(wrap: bool) -> None:  # noqa: FBT001
+def test_dict_empty(*, wrap: bool) -> None:
     """An empty dict produces an empty string regardless of wrap."""
     result = literalize_json(
         json_string=json.dumps(obj={}), language=PYTHON, prefix="", wrap=wrap
@@ -341,7 +341,7 @@ def test_wrap_with_prefix() -> None:
 
 
 @pytest.mark.parametrize(argnames="wrap", argvalues=[False, True])
-def test_empty_data(wrap: bool) -> None:  # noqa: FBT001
+def test_empty_data(*, wrap: bool) -> None:
     """An empty list produces an empty string regardless of wrap."""
     result = literalize_json(
         json_string=json.dumps(obj=[]), language=PYTHON, prefix="", wrap=wrap


### PR DESCRIPTION
Removes FBT001 noqa comments from two test functions by making the boolean parameter keyword-only using the * syntax. This is a better solution than suppressing the linter, as it addresses the underlying issue by preventing the boolean from being passed positionally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that adjusts function signatures to comply with linting; no production code or behavior changes.
> 
> **Overview**
> Updates two parametrized tests in `tests/test_converter.py` to make the `wrap: bool` argument keyword-only (via `*`), allowing removal of prior `FBT001` suppression comments and preventing positional passing of the boolean parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e086872cbff39a2a5581687cdd5bac6af579d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->