### PR TITLE
Remove redundant assert on format_omap_entry

### DIFF
--- a/src/literalizer/_converter.py
+++ b/src/literalizer/_converter.py
@@ -1336,7 +1336,6 @@ def _literalize(
                 ordereddict() if is_omap else {}
             )
             return _format_value(value=empty_value, spec=spec)
-        assert not is_omap or spec.format_omap_entry is not None  # noqa: S101
         last_idx = len(entries) - 1
         for i, (k, v) in enumerate(iterable=entries):
             formatted_key = _format_value(value=k, spec=spec)


### PR DESCRIPTION
Remove a redundant assert that checks if format_omap_entry is non-None. The format_omap_entry property is typed as Callable[[str, str], str] (non-optional) in both the Language protocol and LanguageSpec dataclass, making this assert always true and unnecessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant assertion without changing runtime behavior, since `format_omap_entry` is non-optional in the `Language`/`LanguageSpec` types.
> 
> **Overview**
> Removes a redundant `assert` in `_literalize` that checked `format_omap_entry` was non-`None` when formatting ordered maps, relying on the non-optional typing of `Language.format_omap_entry` instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dacdf13aa771aba2f116140b3ce939b9adfd35d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->