### PR TITLE
Add test for Java YAML omap null value filtering

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -235,6 +235,28 @@ def test_java_yaml_all_null_dict_with_trailing_comments() -> None:
     assert result.count("Map.ofEntries()") == 1
 
 
+def test_java_yaml_omap_skips_null_values() -> None:
+    """Java YAML omap nested in a list filters null values."""
+    yaml_string = textwrap.dedent(
+        text="""\
+        ---
+        - !!omap
+          - name: Alice
+          - score: null
+          - age: 30
+        """,
+    )
+    result = literalize_yaml(
+        yaml_string=yaml_string,
+        language=JAVA,
+        prefix="",
+        wrap=True,
+    )
+    assert "null" not in result
+    assert 'Map.entry("name", "Alice")' in result
+    assert 'Map.entry("age", 30)' in result
+
+
 def test_java_list_wrap_uses_braces() -> None:
     """Java wrapped lists use ``new Object[]{…}``."""
     result = literalize_json(


### PR DESCRIPTION
## Summary

- Adds `test_java_yaml_omap_skips_null_values` to cover the unaddressed bugbot comment from #116 (bug ID `b257a464`): null filtering missing from the inline `ordereddict` path in `_format_value`
- The fix for that path was already present in the merged code (L1200–1204), but had no test; this PR adds the missing regression test

## Test plan

- [ ] `test_java_yaml_omap_skips_null_values` passes: a YAML omap nested in a list with a null entry is rendered by Java without the null entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is test-only and tightens coverage around Java YAML `!!omap` null filtering without altering production logic.
> 
> **Overview**
> Adds `test_java_yaml_omap_skips_null_values` to verify that when converting YAML containing a `!!omap` inside a list to Java literals, entries with `null` values are omitted (no `null` in output, expected `Map.entry(...)` pairs remain).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f2c59cac8afdad87785d2e0ebb6f79c259f4b91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->