### PR TITLE
Replace loose assertions with exact equality checks

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -191,8 +191,8 @@ def test_java_dict_skips_null_values_no_wrap() -> None:
         prefix="",
         wrap=False,
     )
-    assert "null" not in result
-    assert 'Map.entry("b", 1)' in result
+    expected = 'Map.entry("b", 1)'
+    assert result == expected
 
 
 def test_java_dict_all_null_values_wrap() -> None:
@@ -217,8 +217,14 @@ def test_java_yaml_dict_null_values_with_comments() -> None:
         prefix="",
         wrap=True,
     )
-    assert 'Map.entry("name", "Alice")' in result
-    assert "null" not in result
+    expected = textwrap.dedent(
+        text="""\
+        Map.ofEntries(
+            // comment
+            Map.entry("name", "Alice")
+        )"""
+    )
+    assert result == expected
 
 
 def test_java_yaml_all_null_dict_with_trailing_comments() -> None:
@@ -232,7 +238,8 @@ def test_java_yaml_all_null_dict_with_trailing_comments() -> None:
         prefix="",
         wrap=True,
     )
-    assert result.count("Map.ofEntries()") == 1
+    expected = "Map.ofEntries()\n    // trailing"
+    assert result == expected
 
 
 def test_java_yaml_omap_skips_null_values() -> None:
@@ -252,9 +259,13 @@ def test_java_yaml_omap_skips_null_values() -> None:
         prefix="",
         wrap=True,
     )
-    assert "null" not in result
-    assert 'Map.entry("name", "Alice")' in result
-    assert 'Map.entry("age", 30)' in result
+    expected = textwrap.dedent(
+        text="""\
+        new Object[]{
+            Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30))
+        }"""
+    )
+    assert result == expected
 
 
 def test_java_list_wrap_uses_braces() -> None:


### PR DESCRIPTION
Replace loose assertions in four Java-related tests with exact equality checks using `== expected`. This makes test assertions more precise and easier to debug when they fail, improving clarity of what the expected output should be.

Tests updated:
- `test_java_dict_skips_null_values_no_wrap`
- `test_java_yaml_dict_null_values_with_comments`
- `test_java_yaml_all_null_dict_with_trailing_comments`
- `test_java_yaml_omap_skips_null_values`

All tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tightening assertions in Java-related unit tests, with no production code modifications. Risk is mainly increased brittleness if formatting output changes legitimately.
> 
> **Overview**
> Updates four Java-focused converter tests to assert **exact rendered output** (`result == expected`) instead of checking for substrings/absence of `null`. This makes expectations explicit for Java JSON/YAML dict handling with null filtering and comment/trailing-comment formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8821b1a530925751680c54990169baa9bf28eecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->