### PR TITLE
Pre-initialize .NET runtime on Ubuntu CI to fix flaky C# syntax check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,10 @@ jobs:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
+      - name: Initialize .NET runtime
+        if: runner.os == 'Linux'
+        run: dotnet --info
+
       - name: Lint
         shell: bash
         run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}


### PR DESCRIPTION
## Summary

- Adds a `dotnet --info` step in `lint.yml` before the lint job on Linux runners
- This completes .NET first-time initialization (including NuGet migrations) before `dotnet build` is invoked by the C# golden syntax check hook
- Prevents the flaky `NuGet-Migrations` mutex `EEXIST` error that caused false C# syntax failures on Ubuntu CI

Fixes #126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a Linux-only `dotnet --info` warm-up step; primary risk is minor increase in lint job runtime or unexpected failure if .NET is unavailable.
> 
> **Overview**
> Adds a Linux-only "Initialize .NET runtime" step (`dotnet --info`) to the `lint.yml` workflow before running pre-commit linting.
> 
> This pre-warms .NET/NuGet first-time initialization on Ubuntu runners to reduce flakiness in C# syntax checks triggered during the lint job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d92d6937085b360b37842478d6a3ba5eeaaa4a5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->