### PR TITLE
Remove type-ignore comment from check_csharp_golden_syntax.py

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -37,7 +37,7 @@ def _target_framework(dotnet_path: str) -> str:
 
 def main() -> None:
     """Check syntax of each given C# golden file."""
-    dotnet_path = shutil.which(cmd="dotnet") or "dotnet"
+    dotnet_path: str = shutil.which(cmd="dotnet") or "dotnet"
     target_framework = _target_framework(dotnet_path=dotnet_path)
     for filename in sys.argv[1:]:
         content = Path(filename).read_text(encoding="utf-8")
@@ -69,7 +69,7 @@ def main() -> None:
                 }
             )
             result = subprocess.run(
-                args=[dotnet_path, "build", str(csproj_path)],  # type: ignore[call-overload]
+                args=[dotnet_path, "build", csproj_path.as_posix()],
                 capture_output=True,
                 text=True,
                 check=False,


### PR DESCRIPTION
Remove # type: ignore[call-overload] comment by adding explicit str type annotation to dotnet_path and using Path.as_posix() for better type inference.

Changes:
- Add explicit type annotation to dotnet_path variable
- Replace str(csproj_path) with csproj_path.as_posix() for idiomatic Path handling
- Remove # type: ignore[call-overload] comment that's no longer needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only type-hinting/Path conversion changes in a local `dotnet build` invocation, with no behavioral changes expected aside from improved typing.
> 
> **Overview**
> Improves type inference in `check_csharp_golden_syntax.py` by explicitly annotating `dotnet_path` as `str` and switching the `dotnet build` argument from `str(csproj_path)` to `csproj_path.as_posix()`.
> 
> This removes the need for the `# type: ignore[call-overload]` comment while keeping the script’s runtime behavior effectively the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ec5bbf6ed18be6cf03ada6db18487e4d09e2c74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->