### PR TITLE
Fix shfmt hook entry to use uv run prefix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,7 +129,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
## Summary
- Add missing `uv run --extra=dev` prefix to the `shfmt` pre-commit hook entry, matching the pattern used by all other hooks
- Fixes issue identified in #94 review: https://github.com/adamtheturtle/literalizer/pull/94#discussion_r2937455340

## Test plan
- [ ] Verify the `shfmt` hook runs successfully on shell files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to pre-commit configuration; it only affects how the `shfmt` hook is invoked and does not touch runtime code or data handling.
> 
> **Overview**
> Updates the local `shfmt` pre-commit hook in `.pre-commit-config.yaml` to run via `uv run --extra=dev`, aligning it with the other hooks’ invocation pattern and ensuring `shfmt` executes from the managed dev environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0c738485a2b6fb16d40cb3d81c49acfcc74e542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->