### PR TITLE
Remove 3 pyright ignore comments via type annotation

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -84,17 +84,17 @@ def _format_value(*, value: Value, spec: Language) -> str:
     Handles scalars, lists (recursively), dicts, and sets.
     """
     if isinstance(value, ordereddict):
-        omap_items = [  # pyright: ignore[reportUnknownVariableType]
+        omap_items: list[tuple[str, Value]] = [
             (k, v)
             for k, v in value.items()  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
             if not (spec.skip_null_dict_values and v is None)
         ]
         pairs = [
             spec.format_omap_entry(
-                _format_value(value=k, spec=spec),  # pyright: ignore[reportUnknownArgumentType]
-                _format_value(value=v, spec=spec),  # pyright: ignore[reportUnknownArgumentType]
+                _format_value(value=k, spec=spec),
+                _format_value(value=v, spec=spec),
             )
-            for k, v in omap_items  # pyright: ignore[reportUnknownVariableType]
+            for k, v in omap_items
         ]
         return spec.omap_open + ", ".join(pairs) + spec.omap_close
 


### PR DESCRIPTION
Added explicit type annotation to the `omap_items` list comprehension result (`list[tuple[str, Value]]`). This provides pyright with sufficient type information for downstream usage, eliminating the need for 3 separate ignore directives.

The remaining pyright ignore on `value.items()` is necessary due to `ordereddict` lacking generic type parameters in ruamel.yaml's type stubs.

All 442 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: type-only changes that remove `pyright: ignore` directives without altering runtime formatting logic. Remaining risk is limited to potential static-type regressions for `ordereddict`-based YAML maps.
> 
> **Overview**
> Adds an explicit `list[tuple[str, Value]]` annotation for `omap_items` in `_format_value` when handling `ruamel.yaml` `ordereddict` values.
> 
> This lets the ordered-map formatting path call `_format_value` and iterate `omap_items` without the prior `pyright: ignore` suppressions (leaving only the ignore needed on `value.items()` due to stub limitations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb4107d9c1a0f59625cda8b7f26452b433d7ec85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->