### PR TITLE
Simplify README and docs to single impressive example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,118 +18,38 @@ Requires Python |minimum-python-version|\+.
    pip install literalizer
 
 
-Usage examples
---------------
+Usage
+-----
 
 .. code-block:: python
 
-   """Examples of using literalizer."""
+   """Example of using literalizer."""
 
-   from literalizer import LanguageSpec, literalize_json, literalize_yaml
-   from literalizer.formatters import (
-       format_bytes_hex,
-       format_date_iso,
-       format_datetime_iso,
-   )
-   from literalizer.languages import JAVA, JAVASCRIPT, PYTHON
+   from literalizer import literalize_yaml
+   from literalizer.languages import GO
 
-   # Convert a JSON array to Java literal items
-   result = literalize_json(
-       json_string='[true, null, "hi", [1, 2]]',
-       language=JAVA,
-       prefix="",
-       wrap=False,
-   )
-   # result:
-   # true,
-   # null,
-   # "hi",
-   # {1, 2},
-
-   # Convert to JavaScript/TypeScript array
-   result = literalize_json(
-       json_string='[true, null, "hi", [1, 2]]',
-       language=JAVASCRIPT,
+   # YAML comments are preserved using the target language's comment syntax
+   yaml_config = """\
+   # Server configuration
+   host: localhost  # default host
+   port: 8080
+   # Enable debug mode for development
+   debug: true
+   """
+   result = literalize_yaml(
+       yaml_string=yaml_config,
+       language=GO,
        prefix="    ",
        wrap=True,
    )
    # result:
-   # [
-   #     true,
-   #     null,
-   #     "hi",
-   #     [1, 2],
-   # ]
-
-   # Convert a JSON string to Python
-   result = literalize_json(
-       json_string='[true, null, "hi", [1, 2]]',
-       language=PYTHON,
-       prefix="",
-       wrap=True,
-   )
-   # result:
-   # (
-   #     True,
-   #     None,
-   #     "hi",
-   #     (1, 2),
-   # )
-
-   # Convert from a YAML string directly
-   result = literalize_yaml(
-       yaml_string="- true\n- null\n- hi\n- [1, 2]",
-       language=PYTHON,
-       prefix="",
-       wrap=True,
-   )
-   # result:
-   # (
-   #     True,
-   #     None,
-   #     "hi",
-   #     (1, 2),
-   # )
-
-   # Built-in languages: PYTHON, JAVASCRIPT, TYPESCRIPT, GO, RUBY,
-   #                      CSHARP, CPP, JAVA, KOTLIN, RUST, HASKELL, SWIFT, PHP
-
-
-   # Create a custom language:
-   def _omap_entry(key: str, value: str) -> str:
-       """Format an ordered-map entry."""
-       return f"{key}: {value}"
-
-
-   custom = LanguageSpec(
-       null_literal="nil",
-       true_literal="TRUE",
-       false_literal="FALSE",
-       collection_open="[",
-       collection_close="]",
-       dict_separator=": ",
-       dict_open="{",
-       dict_close="}",
-       format_dict_entry=None,
-       trailing_comma=True,
-       single_element_trailing_comma=False,
-       format_bytes=format_bytes_hex,
-       format_date=format_date_iso,
-       format_datetime=format_datetime_iso,
-       empty_collection=None,
-       empty_dict=None,
-       set_open="[",
-       set_close="]",
-       empty_set=None,
-       format_set_entry=None,
-       comment_prefix="//",
-       omap_open="{",
-       omap_close="}",
-       format_omap_entry=_omap_entry,
-       multiline_close_indent="",
-       skip_null_dict_values=False,
-       format_variable_declaration=None,
-   )
+   # map[string]any{
+   #     // Server configuration
+   #     "host": "localhost",  // default host
+   #     "port": 8080,
+   #     // Enable debug mode for development
+   #     "debug": true,
+   # }
 
 Use cases
 ---------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,86 +14,18 @@ Requires Python |minimum-python-version|\+.
    pip install literalizer
 
 
-Usage examples
---------------
+Usage
+-----
 
 .. code-block:: python
 
-   """Examples of using literalizer."""
+   """Example of using literalizer."""
 
-   from literalizer import LanguageSpec, literalize_json, literalize_yaml
-   from literalizer.formatters import (
-       format_bytes_hex,
-       format_date_iso,
-       format_date_java,
-       format_date_python,
-       format_datetime_iso,
-       format_datetime_java_instant,
-       format_datetime_python,
-       format_datetime_ruby,
-   )
-   from literalizer.languages import JAVA, JAVASCRIPT, PYTHON
-
-   # Convert a JSON array to Java literal items
-   result = literalize_json(
-       json_string='[true, null, "hi", [1, 2]]',
-       language=JAVA,
-       prefix="",
-       wrap=False,
-   )
-   # result:
-   # true,
-   # null,
-   # "hi",
-   # {1, 2},
-
-   # Convert to JavaScript/TypeScript array
-   result = literalize_json(
-       json_string='[true, null, "hi", [1, 2]]',
-       language=JAVASCRIPT,
-       prefix="    ",
-       wrap=True,
-   )
-   # result:
-   # [
-   #     true,
-   #     null,
-   #     "hi",
-   #     [1, 2],
-   # ]
-
-   # Convert a JSON string to Python
-   result = literalize_json(
-       json_string='[true, null, "hi", [1, 2]]',
-       language=PYTHON,
-       prefix="",
-       wrap=True,
-   )
-   # result:
-   # (
-   #     True,
-   #     None,
-   #     "hi",
-   #     (1, 2),
-   # )
-
-   # Convert from a YAML string directly
-   result = literalize_yaml(
-       yaml_string="- true\n- null\n- hi\n- [1, 2]",
-       language=PYTHON,
-       prefix="",
-       wrap=True,
-   )
-   # result:
-   # (
-   #     True,
-   #     None,
-   #     "hi",
-   #     (1, 2),
-   # )
+   from literalizer import literalize_yaml
+   from literalizer.languages import GO
 
    # YAML comments are preserved using the target language's comment syntax
-   yaml_with_comments = """\
+   yaml_config = """\
    # Server configuration
    host: localhost  # default host
    port: 8080
@@ -101,189 +33,19 @@ Usage examples
    debug: true
    """
    result = literalize_yaml(
-       yaml_string=yaml_with_comments,
-       language=PYTHON,
+       yaml_string=yaml_config,
+       language=GO,
        prefix="    ",
        wrap=True,
    )
    # result:
-   # {
-   #     # Server configuration
-   #     "host": "localhost",  # default host
+   # map[string]any{
+   #     // Server configuration
+   #     "host": "localhost",  // default host
    #     "port": 8080,
-   #     # Enable debug mode for development
-   #     "debug": True,
+   #     // Enable debug mode for development
+   #     "debug": true,
    # }
-
-   # Built-in languages: PYTHON, JAVASCRIPT, TYPESCRIPT, GO, RUBY,
-   #                      CSHARP, CPP, JAVA, KOTLIN, RUST, HASKELL, SWIFT, PHP
-
-
-   # Helper used in custom LanguageSpec examples below.
-   def _omap_entry(key: str, value: str) -> str:
-       """Format an ordered-map entry."""
-       return f"{key}: {value}"
-
-
-   # Create a custom language:
-   custom = LanguageSpec(
-       null_literal="nil",
-       true_literal="TRUE",
-       false_literal="FALSE",
-       collection_open="[",
-       collection_close="]",
-       dict_separator=": ",
-       dict_open="{",
-       dict_close="}",
-       format_dict_entry=None,
-       trailing_comma=True,
-       single_element_trailing_comma=False,
-       format_bytes=format_bytes_hex,
-       format_date=format_date_iso,
-       format_datetime=format_datetime_iso,
-       empty_collection=None,
-       empty_dict=None,
-       set_open="[",
-       set_close="]",
-       empty_set=None,
-       format_set_entry=None,
-       comment_prefix="//",
-       omap_open="{",
-       omap_close="}",
-       format_omap_entry=_omap_entry,
-       multiline_close_indent="",
-       skip_null_dict_values=False,
-       format_variable_declaration=None,
-   )
-
-   # Customize date/datetime formatting with built-in formatters:
-   # Use Python-native date objects instead of ISO strings (via YAML)
-   python_with_dates = LanguageSpec(
-       null_literal="None",
-       true_literal="True",
-       false_literal="False",
-       collection_open="(",
-       collection_close=")",
-       dict_separator=": ",
-       dict_open="{",
-       dict_close="}",
-       format_dict_entry=None,
-       trailing_comma=True,
-       single_element_trailing_comma=False,
-       format_bytes=format_bytes_hex,
-       format_date=format_date_python,
-       format_datetime=format_datetime_python,
-       empty_collection=None,
-       empty_dict=None,
-       set_open="{",
-       set_close="}",
-       empty_set="set()",
-       format_set_entry=None,
-       comment_prefix="#",
-       omap_open="{",
-       omap_close="}",
-       format_omap_entry=_omap_entry,
-       multiline_close_indent="",
-       skip_null_dict_values=False,
-       format_variable_declaration=None,
-   )
-   result = literalize_yaml(
-       yaml_string="- 2024-01-15\n",
-       language=python_with_dates,
-       prefix="",
-       wrap=False,
-   )
-   # result: datetime.date(2024, 1, 15),
-
-   # Use Java Instant and LocalDate
-   java_with_dates = LanguageSpec(
-       null_literal="null",
-       true_literal="true",
-       false_literal="false",
-       collection_open="{",
-       collection_close="}",
-       dict_separator=": ",
-       dict_open="{",
-       dict_close="}",
-       format_dict_entry=None,
-       trailing_comma=True,
-       single_element_trailing_comma=False,
-       format_bytes=format_bytes_hex,
-       format_date=format_date_java,
-       format_datetime=format_datetime_java_instant,
-       empty_collection=None,
-       empty_dict=None,
-       set_open="Set.of(",
-       set_close=")",
-       empty_set=None,
-       format_set_entry=None,
-       comment_prefix="//",
-       omap_open="{",
-       omap_close="}",
-       format_omap_entry=_omap_entry,
-       multiline_close_indent="",
-       skip_null_dict_values=False,
-       format_variable_declaration=None,
-   )
-   result = literalize_yaml(
-       yaml_string="- 2024-01-15\n",
-       language=java_with_dates,
-       prefix="",
-       wrap=False,
-   )
-   # result: LocalDate.of(2024, 1, 15),
-
-   # Use Ruby Time objects
-   ruby_with_dates = LanguageSpec(
-       null_literal="nil",
-       true_literal="true",
-       false_literal="false",
-       collection_open="[",
-       collection_close="]",
-       dict_separator=" => ",
-       dict_open="{",
-       dict_close="}",
-       format_dict_entry=None,
-       trailing_comma=True,
-       single_element_trailing_comma=False,
-       format_bytes=format_bytes_hex,
-       format_date=format_date_iso,
-       format_datetime=format_datetime_ruby,
-       empty_collection=None,
-       empty_dict=None,
-       set_open="Set.new([",
-       set_close="])",
-       empty_set="Set.new",
-       format_set_entry=None,
-       comment_prefix="#",
-       omap_open="{",
-       omap_close="}",
-       format_omap_entry=_omap_entry,
-       multiline_close_indent="",
-       skip_null_dict_values=False,
-       format_variable_declaration=None,
-   )
-   result = literalize_yaml(
-       yaml_string="- 2024-01-15T12:30:00\n",
-       language=ruby_with_dates,
-       prefix="",
-       wrap=False,
-   )
-   # result: Time.new(2024, 1, 15, 12, 30, 0),
-
-   # Available formatters:
-   # format_date_iso / format_datetime_iso (default — ISO 8601 strings)
-   # format_date_python / format_datetime_python
-   # format_date_java / format_datetime_java_instant / format_datetime_java_zoned
-   # format_date_ruby / format_datetime_ruby
-   # format_date_js / format_datetime_js
-   # format_date_csharp / format_datetime_csharp
-   # format_date_go / format_datetime_go
-   # format_date_kotlin / format_datetime_kotlin
-   # format_date_cpp / format_datetime_cpp
-   # format_date_rust / format_datetime_rust
-   # format_date_php / format_datetime_php
-   # format_datetime_epoch (Unix timestamp)
 
 Use cases
 ---------


### PR DESCRIPTION
## Summary

Replaced multiple basic examples in README.rst and docs/source/index.rst with one unified example that showcases the project's most distinctive feature: YAML comment preservation across language conversion. 

Uses Go as the target language to highlight the # → // comment transformation and the distinctive `map[string]any{` syntax, making the conversion immediately striking and memorable.

Removes ~355 lines of documentation examples while maintaining exemplary content that better demonstrates core functionality.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that remove/replace usage examples without affecting runtime code.
> 
> **Overview**
> Simplifies `README.rst` and `docs/source/index.rst` by replacing the previous multi-language/advanced `literalize_json` and `LanguageSpec` examples with one focused `literalize_yaml` example targeting Go.
> 
> The new example highlights YAML comment preservation and the resulting Go literal output (including `#` to `//` comment conversion), significantly reducing the amount of inline documentation example code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66233de7febec1cb9d8950901bd9addc126aba76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->