### PR TITLE
Add format_variable_assignment for existing variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ lint.ignore = [
     "D212",
     # Ruff warns that this conflicts with the formatter.
     "ISC001",
+    # literalize_json and literalize_yaml have 6 keyword-only arguments,
+    # which is justified by the public API design.
+    "PLR0913",
 ]
 lint.per-file-ignores."doccmd_*.py" = [
     # Allow our chosen docstring line-style - pydocstringformatter handles

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -266,6 +266,7 @@ def literalize_json(
     prefix: str,
     wrap: bool,
     variable_name: str | None = None,
+    new_variable: bool = True,
 ) -> str:
     r"""Convert a JSON string to native language literal text.
 
@@ -283,7 +284,13 @@ def literalize_json(
             (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
         variable_name: If given, wrap the output in a variable
             declaration using the language's
-            ``format_variable_declaration`` callable.
+            ``format_variable_declaration`` or
+            ``format_variable_assignment`` callable.
+        new_variable: If ``True`` (the default), use
+            ``format_variable_declaration`` (e.g. ``const x =`` in
+            JavaScript).  If ``False``, use
+            ``format_variable_assignment`` (e.g. ``x =``).  Only
+            relevant when *variable_name* is given.
 
     Raises:
         JSONParseError: If *json_string* is not valid JSON.
@@ -302,7 +309,12 @@ def literalize_json(
         wrap=wrap,
     )
     if variable_name is not None:
-        return language.format_variable_declaration(variable_name, result)
+        formatter = (
+            language.format_variable_declaration
+            if new_variable
+            else language.format_variable_assignment
+        )
+        return formatter(variable_name, result)
     return result
 
 
@@ -314,6 +326,7 @@ def literalize_yaml(
     prefix: str,
     wrap: bool,
     variable_name: str | None = None,
+    new_variable: bool = True,
 ) -> str:
     r"""Convert a YAML string to native language literal text.
 
@@ -334,7 +347,13 @@ def literalize_yaml(
             (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
         variable_name: If given, wrap the output in a variable
             declaration using the language's
-            ``format_variable_declaration`` callable.
+            ``format_variable_declaration`` or
+            ``format_variable_assignment`` callable.
+        new_variable: If ``True`` (the default), use
+            ``format_variable_declaration`` (e.g. ``const x =`` in
+            JavaScript).  If ``False``, use
+            ``format_variable_assignment`` (e.g. ``x =``).  Only
+            relevant when *variable_name* is given.
 
     Raises:
         YAMLParseError: If *yaml_string* is not valid YAML.
@@ -420,5 +439,10 @@ def literalize_yaml(
             result = literalize_yaml_collection(ctx=ctx)
 
     if variable_name is not None:
-        return language.format_variable_declaration(variable_name, result)
+        formatter = (
+            language.format_variable_declaration
+            if new_variable
+            else language.format_variable_assignment
+        )
+        return formatter(variable_name, result)
     return result

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -171,8 +171,15 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
 
     @property
     def format_variable_declaration(self) -> Callable[[str, str], str]:
-        """Callable that formats a variable declaration from a name and
-        value string.
+        """Callable that formats a new variable declaration from a name
+        and value string.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def format_variable_assignment(self) -> Callable[[str, str], str]:
+        """Callable that formats an assignment to an existing variable
+        from a name and value string.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
@@ -217,3 +224,4 @@ class LanguageSpec:
     multiline_close_indent: str
     skip_null_dict_values: bool
     format_variable_declaration: Callable[[str, str], str]
+    format_variable_assignment: Callable[[str, str], str]

--- a/src/literalizer/formatters.py
+++ b/src/literalizer/formatters.py
@@ -38,6 +38,18 @@ __all__ = [
     "format_datetime_python",
     "format_datetime_ruby",
     "format_datetime_rust",
+    "format_variable_assignment_cpp",
+    "format_variable_assignment_csharp",
+    "format_variable_assignment_go",
+    "format_variable_assignment_haskell",
+    "format_variable_assignment_java",
+    "format_variable_assignment_js",
+    "format_variable_assignment_kotlin",
+    "format_variable_assignment_php",
+    "format_variable_assignment_python",
+    "format_variable_assignment_ruby",
+    "format_variable_assignment_rust",
+    "format_variable_assignment_swift",
     "format_variable_declaration_cpp",
     "format_variable_declaration_csharp",
     "format_variable_declaration_go",
@@ -487,6 +499,117 @@ def format_variable_declaration_php(name: str, value: str) -> str:
 @beartype
 def format_variable_declaration_haskell(name: str, value: str) -> str:
     """Format a Haskell variable binding.
+
+    Example: ``"x"`` and ``"HList [1, 2]"`` → ``"x = HList [1, 2]"``
+    """
+    return f"{name} = {value}"
+
+
+@beartype
+def format_variable_assignment_python(name: str, value: str) -> str:
+    """Format a Python variable assignment to an existing variable.
+
+    Example: ``"x"`` and ``"[1, 2]"`` → ``"x = [1, 2]"``.
+    """
+    return f"{name} = {value}"
+
+
+@beartype
+def format_variable_assignment_js(name: str, value: str) -> str:
+    """Format a JavaScript/TypeScript assignment to an existing variable.
+
+    Example: ``"x"`` and ``"[1, 2]"`` → ``"x = [1, 2];"``
+    """
+    return f"{name} = {value};"
+
+
+@beartype
+def format_variable_assignment_go(name: str, value: str) -> str:
+    """Format a Go assignment to an existing variable.
+
+    Example: ``"x"`` and ``"[]any{1, 2}"`` → ``"x = []any{1, 2}"``.
+    """
+    return f"{name} = {value}"
+
+
+@beartype
+def format_variable_assignment_ruby(name: str, value: str) -> str:
+    """Format a Ruby assignment to an existing variable.
+
+    Example: ``"x"`` and ``"[1, 2]"`` → ``"x = [1, 2]"``.
+    """
+    return f"{name} = {value}"
+
+
+@beartype
+def format_variable_assignment_csharp(name: str, value: str) -> str:
+    """Format a C# assignment to an existing variable.
+
+    Example: ``"x"`` and ``"new object[]{1}"`` → ``"x = new object[]{1};"``
+    """
+    return f"{name} = {value};"
+
+
+@beartype
+def format_variable_assignment_cpp(name: str, value: str) -> str:
+    """Format a C++ assignment to an existing variable.
+
+    Example: ``"x"`` and ``"{1, 2}"`` → ``"x = {1, 2};"``
+    """
+    return f"{name} = {value};"
+
+
+@beartype
+def format_variable_assignment_java(name: str, value: str) -> str:
+    """Format a Java assignment to an existing variable.
+
+    Example: ``"x"`` and ``"new Object[]{1}"`` → ``"x = new Object[]{1};"``
+    """
+    return f"{name} = {value};"
+
+
+@beartype
+def format_variable_assignment_kotlin(name: str, value: str) -> str:
+    """Format a Kotlin assignment to an existing variable.
+
+    Example: ``"x"`` and ``"listOf(1, 2)"`` → ``"x = listOf(1, 2)"``
+    """
+    return f"{name} = {value}"
+
+
+@beartype
+def format_variable_assignment_swift(name: str, value: str) -> str:
+    """Format a Swift assignment to an existing variable.
+
+    Example: ``"x"`` and ``"[1, 2]"`` → ``"x = [1, 2]"``
+    """
+    return f"{name} = {value}"
+
+
+@beartype
+def format_variable_assignment_rust(name: str, value: str) -> str:
+    """Format a Rust assignment to an existing variable.
+
+    Example: ``"x"`` and ``"vec![1, 2]"`` → ``"x = vec![1, 2];"``
+    """
+    return f"{name} = {value};"
+
+
+@beartype
+def format_variable_assignment_php(name: str, value: str) -> str:
+    """Format a PHP assignment to an existing variable.
+
+    The ``$`` sigil is prepended automatically.
+
+    Example: ``"x"`` and ``"[1, 2]"`` → ``"$x = [1, 2];"``
+    """
+    return f"${name} = {value};"
+
+
+@beartype
+def format_variable_assignment_haskell(name: str, value: str) -> str:
+    """Format a Haskell variable binding (same syntax for new and
+    existing).
 
     Example: ``"x"`` and ``"HList [1, 2]"`` → ``"x = HList [1, 2]"``
     """

--- a/src/literalizer/languages.py
+++ b/src/literalizer/languages.py
@@ -28,6 +28,18 @@ from literalizer.formatters import (
     format_date_php,
     format_datetime_iso,
     format_datetime_php,
+    format_variable_assignment_cpp,
+    format_variable_assignment_csharp,
+    format_variable_assignment_go,
+    format_variable_assignment_haskell,
+    format_variable_assignment_java,
+    format_variable_assignment_js,
+    format_variable_assignment_kotlin,
+    format_variable_assignment_php,
+    format_variable_assignment_python,
+    format_variable_assignment_ruby,
+    format_variable_assignment_rust,
+    format_variable_assignment_swift,
     format_variable_declaration_cpp,
     format_variable_declaration_csharp,
     format_variable_declaration_go,
@@ -76,6 +88,7 @@ PYTHON = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_python,
+    format_variable_assignment=format_variable_assignment_python,
 )
 
 
@@ -112,6 +125,7 @@ CSHARP = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_csharp,
+    format_variable_assignment=format_variable_assignment_csharp,
 )
 
 
@@ -147,6 +161,7 @@ JAVASCRIPT = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_js,
+    format_variable_assignment=format_variable_assignment_js,
 )
 
 TYPESCRIPT = LanguageSpec(
@@ -176,6 +191,7 @@ TYPESCRIPT = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_js,
+    format_variable_assignment=format_variable_assignment_js,
 )
 
 
@@ -211,6 +227,7 @@ RUBY = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_ruby,
+    format_variable_assignment=format_variable_assignment_ruby,
 )
 
 
@@ -255,6 +272,7 @@ GO = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_go,
+    format_variable_assignment=format_variable_assignment_go,
 )
 
 
@@ -291,6 +309,7 @@ CPP = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_cpp,
+    format_variable_assignment=format_variable_assignment_cpp,
 )
 
 
@@ -326,6 +345,7 @@ JAVA = LanguageSpec(
     format_omap_entry=_format_java_dict_entry,
     multiline_close_indent="",
     format_variable_declaration=format_variable_declaration_java,
+    format_variable_assignment=format_variable_assignment_java,
     skip_null_dict_values=True,
 )
 
@@ -362,6 +382,7 @@ SWIFT = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_swift,
+    format_variable_assignment=format_variable_assignment_swift,
 )
 
 
@@ -403,6 +424,7 @@ RUST = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_rust,
+    format_variable_assignment=format_variable_assignment_rust,
 )
 
 
@@ -438,6 +460,7 @@ KOTLIN = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_kotlin,
+    format_variable_assignment=format_variable_assignment_kotlin,
 )
 
 
@@ -473,6 +496,7 @@ PHP = LanguageSpec(
     multiline_close_indent="",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_php,
+    format_variable_assignment=format_variable_assignment_php,
 )
 
 
@@ -514,4 +538,5 @@ HASKELL = LanguageSpec(
     multiline_close_indent="    ",
     skip_null_dict_values=False,
     format_variable_declaration=format_variable_declaration_haskell,
+    format_variable_assignment=format_variable_assignment_haskell,
 )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -49,6 +49,7 @@ from literalizer.formatters import (
     format_datetime_python,
     format_datetime_ruby,
     format_datetime_rust,
+    format_variable_assignment_python,
     format_variable_declaration_python,
     passthrough_set_entry,
 )
@@ -533,6 +534,7 @@ def test_custom_language() -> None:
         multiline_close_indent="",
         skip_null_dict_values=False,
         format_variable_declaration=format_variable_declaration_python,
+        format_variable_assignment=format_variable_assignment_python,
     )
     result = literalize_json(
         json_string=json.dumps(obj=[True, None, "hi"]),
@@ -1092,6 +1094,7 @@ def test_custom_format_date() -> None:
         multiline_close_indent="",
         skip_null_dict_values=False,
         format_variable_declaration=format_variable_declaration_python,
+        format_variable_assignment=format_variable_assignment_python,
     )
     result = literalize_yaml(
         yaml_string="- 2024-01-15\n",
@@ -1131,6 +1134,7 @@ def test_custom_format_datetime() -> None:
         multiline_close_indent="",
         skip_null_dict_values=False,
         format_variable_declaration=format_variable_declaration_python,
+        format_variable_assignment=format_variable_assignment_python,
     )
     result = literalize_yaml(
         yaml_string="- 2024-01-15T12:30:00\n",
@@ -1170,6 +1174,7 @@ def test_java_native_dates() -> None:
         multiline_close_indent="",
         skip_null_dict_values=False,
         format_variable_declaration=format_variable_declaration_python,
+        format_variable_assignment=format_variable_assignment_python,
     )
     result = literalize_yaml(
         yaml_string="- 2024-01-15\n- 2024-01-15T12:30:00\n",
@@ -1211,6 +1216,7 @@ def test_ruby_native_dates() -> None:
         multiline_close_indent="",
         skip_null_dict_values=False,
         format_variable_declaration=format_variable_declaration_python,
+        format_variable_assignment=format_variable_assignment_python,
     )
     result = literalize_yaml(
         yaml_string="- 2024-01-15T12:30:00\n",
@@ -1347,6 +1353,7 @@ def test_custom_format_bytes() -> None:
         multiline_close_indent="",
         skip_null_dict_values=False,
         format_variable_declaration=format_variable_declaration_python,
+        format_variable_assignment=format_variable_assignment_python,
     )
     result = literalize_yaml(
         yaml_string="- !!binary |\n    SGVsbG8=\n",
@@ -1746,6 +1753,7 @@ def test_omap_custom_language_spec() -> None:
         multiline_close_indent="",
         skip_null_dict_values=False,
         format_variable_declaration=format_variable_declaration_python,
+        format_variable_assignment=format_variable_assignment_python,
     )
     result = literalize_yaml(
         yaml_string=yaml_string,
@@ -1856,3 +1864,73 @@ def test_variable_declaration_none_no_wrap() -> None:
         variable_name=None,
     )
     assert result == "(\n    1,\n    2,\n)"
+
+
+@pytest.mark.parametrize(
+    argnames=("language", "expected"),
+    argvalues=[
+        (PYTHON, "my_var = 42"),
+        (JAVASCRIPT, "my_var = 42;"),
+        (TYPESCRIPT, "my_var = 42;"),
+        (GO, "my_var = 42"),
+        (RUBY, "my_var = 42"),
+        (CSHARP, "my_var = 42;"),
+        (CPP, "my_var = 42;"),
+        (JAVA, "my_var = 42;"),
+        (KOTLIN, "my_var = 42"),
+        (SWIFT, "my_var = 42"),
+        (RUST, "my_var = 42;"),
+        (PHP, "$my_var = 42;"),
+        (HASKELL, "my_var = 42"),
+    ],
+)
+def test_existing_variable_assignment_json(
+    *, language: Language, expected: str
+) -> None:
+    """Each language produces correct existing-variable assignment
+    syntax.
+    """
+    result = literalize_json(
+        json_string="42",
+        language=language,
+        prefix="",
+        wrap=False,
+        variable_name="my_var",
+        new_variable=False,
+    )
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    argnames=("language", "expected"),
+    argvalues=[
+        (PYTHON, "my_var = 42"),
+        (JAVASCRIPT, "my_var = 42;"),
+        (TYPESCRIPT, "my_var = 42;"),
+        (GO, "my_var = 42"),
+        (RUBY, "my_var = 42"),
+        (CSHARP, "my_var = 42;"),
+        (CPP, "my_var = 42;"),
+        (JAVA, "my_var = 42;"),
+        (KOTLIN, "my_var = 42"),
+        (SWIFT, "my_var = 42"),
+        (RUST, "my_var = 42;"),
+        (PHP, "$my_var = 42;"),
+        (HASKELL, "my_var = 42"),
+    ],
+)
+def test_existing_variable_assignment_yaml(
+    *, language: Language, expected: str
+) -> None:
+    """Each language produces correct existing-variable assignment syntax
+    for YAML.
+    """
+    result = literalize_yaml(
+        yaml_string="42\n",
+        language=language,
+        prefix="",
+        wrap=False,
+        variable_name="my_var",
+        new_variable=False,
+    )
+    assert result == expected


### PR DESCRIPTION
Support both new variable declarations and assignments to existing variables via new `new_variable` parameter in `literalize_json()` and `literalize_yaml()`.

Added `format_variable_assignment` to Language protocol and LanguageSpec for all 13 languages, generating appropriate syntax without keyword prefixes (e.g., `x = value;` instead of `const x = value;` in JavaScript).

All 199 unit tests pass, including 26 new tests covering the existing-variable assignment forms across all supported languages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `new_variable` parameter and a required `format_variable_assignment` hook on `Language`, which can break custom `Language` implementations or callers relying on the old protocol shape.
> 
> **Overview**
> **Adds existing-variable assignment output.** `literalize_json()` and `literalize_yaml()` gain a `new_variable` flag that chooses between `format_variable_declaration` (default) and a new `format_variable_assignment` formatter when `variable_name` is provided.
> 
> **Extends the language contract.** The `Language` protocol and `LanguageSpec` now include `format_variable_assignment`, with new assignment formatter functions wired up for all 13 built-in languages.
> 
> **Tests and linting updated.** Adds parameterized tests covering assignment syntax for both JSON and YAML across all languages, and adjusts Ruff config to ignore `PLR0913` for the expanded public API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 708f8a9f17d265b35b49ff3d410c67dcb62b0e67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->