### PR TITLE
Fix C# golden file syntax check CI failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Initialize .NET runtime
         if: runner.os == 'Linux'
-        run: dotnet --info
+        run: |
+          dotnet --info
+          mkdir -p /tmp/.dotnet/shm
 
       - name: Lint
         shell: bash


### PR DESCRIPTION
Create /tmp/.dotnet/shm directory during .NET runtime initialization to fix dotnet crashes in the C# syntax check hook.

The dotnet runtime requires this POSIX shared memory directory to exist for named mutexes used by NuGet migrations. Without it, the C# syntax check hook fails during first-time-use initialization with a System.IO.IOException.

Fixes: https://github.com/adamtheturtle/literalizer/actions/runs/23188940227/job/67379581561

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a directory creation step to prevent .NET runtime crashes during linting on Linux runners.
> 
> **Overview**
> Adjusts the `Lint` GitHub Actions workflow to initialize the .NET runtime more reliably on Linux by creating `/tmp/.dotnet/shm` after `dotnet --info`.
> 
> This is intended to prevent CI failures in C#-related lint hooks caused by missing POSIX shared memory directories on ephemeral runners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7bb5c7ac9fad14eb58afde7bc6c1d27c3bca51b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->