### PR TITLE
Fix C# system: create /tmp/.dotnet/shm before dotnet --info

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Initialize .NET runtime
         if: runner.os == 'Linux'
-        run: dotnet --info
+        run: |
+          mkdir -p /tmp/.dotnet/shm
+          dotnet --info
 
       - name: Lint
         shell: bash


### PR DESCRIPTION
Move `mkdir -p /tmp/.dotnet/shm` before `dotnet --info` so the directory exists when the .NET runtime first initializes, fixing the potential race condition flagged in #164.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just ensures a temporary directory exists before `dotnet --info` runs, reducing intermittent Linux runner failures.
> 
> **Overview**
> Updates the `Lint` GitHub Actions workflow to **pre-create** `/tmp/.dotnet/shm` on Linux before running `dotnet --info`, to avoid .NET initialization issues during CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dff3766fee43752f9b980a8780a2f83ad2455ce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->