### PR TITLE
Extract shared dotnet env vars into module constant

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -7,6 +7,11 @@ import sys
 import tempfile
 from pathlib import Path
 
+_DOTNET_ENV = {
+    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
+    "DOTNET_NOLOGO": "1",
+}
+
 
 def _target_framework(dotnet_path: str) -> str:
     """Return the target framework moniker for the installed
@@ -16,13 +21,7 @@ def _target_framework(dotnet_path: str) -> str:
         dotnet_tmp = Path(tmpdir) / "tmp"
         dotnet_tmp.mkdir()
         env = os.environ.copy()
-        env.update(
-            {
-                "TMPDIR": dotnet_tmp.as_posix(),
-                "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
-                "DOTNET_NOLOGO": "1",
-            }
-        )
+        env.update({"TMPDIR": dotnet_tmp.as_posix(), **_DOTNET_ENV})
         result = subprocess.run(
             args=[dotnet_path, "--version"],
             capture_output=True,
@@ -61,13 +60,7 @@ def main() -> None:
             dotnet_tmp = Path(tmpdir) / "tmp"
             dotnet_tmp.mkdir()
             env = os.environ.copy()
-            env["TMPDIR"] = dotnet_tmp.as_posix()
-            env.update(
-                {
-                    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
-                    "DOTNET_NOLOGO": "1",
-                }
-            )
+            env.update({"TMPDIR": dotnet_tmp.as_posix(), **_DOTNET_ENV})
             result = subprocess.run(
                 args=[dotnet_path, "build", csproj_path.as_posix()],
                 capture_output=True,


### PR DESCRIPTION
Consolidate the duplicate DOTNET_SKIP_FIRST_TIME_EXPERIENCE and DOTNET_NOLOGO environment variables into a module-level _DOTNET_ENV constant. Both _target_framework() and main() now reference this constant via unpacking, reducing duplication and making the shared configuration easier to maintain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes repeated `dotnet` environment variables; behavior should remain the same aside from how the env dict is constructed.
> 
> **Overview**
> Refactors `check_csharp_golden_syntax.py` to extract the shared `dotnet` environment flags (`DOTNET_SKIP_FIRST_TIME_EXPERIENCE`, `DOTNET_NOLOGO`) into a module-level `_DOTNET_ENV` constant.
> 
> Both `_target_framework()` and the `dotnet build` invocation now merge `TMPDIR` with `**_DOTNET_ENV`, removing duplicated env setup logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da19a4a9b72df6673cfdd9e9db7a1ebd21e44871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->