### PR TITLE
Add list_of_dicts test case for trailing comma validation

### DIFF
--- a/tests/integration/cases/list_of_dicts/cpp.cpp
+++ b/tests/integration/cases/list_of_dicts/cpp.cpp
@@ -1,0 +1,12 @@
+#include <initializer_list>
+#include <cstddef>
+struct _Any {
+    template<class T> _Any(T&&) noexcept {}
+    _Any(std::initializer_list<_Any>) noexcept {}
+};
+void _check() {
+    [[maybe_unused]] _Any _v = {
+    {{"name", "Alice"}, {"age", 30}},
+    {{"name", "Bob"}, {"age", 25}},
+};
+}

--- a/tests/integration/cases/list_of_dicts/cpp_varname.cpp
+++ b/tests/integration/cases/list_of_dicts/cpp_varname.cpp
@@ -1,0 +1,12 @@
+#include <initializer_list>
+#include <cstddef>
+struct _Any {
+    template<class T> _Any(T&&) noexcept {}
+    _Any(std::initializer_list<_Any>) noexcept {}
+};
+void _check() {
+_Any my_data = {
+    {{"name", "Alice"}, {"age", 30}},
+    {{"name", "Bob"}, {"age", 25}},
+};
+}

--- a/tests/integration/cases/list_of_dicts/csharp.cs
+++ b/tests/integration/cases/list_of_dicts/csharp.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+var x = (
+    new Dictionary<string, object> {["name"] = "Alice", ["age"] = 30},
+    new Dictionary<string, object> {["name"] = "Bob", ["age"] = 25}
+);

--- a/tests/integration/cases/list_of_dicts/csharp_varname.cs
+++ b/tests/integration/cases/list_of_dicts/csharp_varname.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+var my_data = (
+    new Dictionary<string, object> {["name"] = "Alice", ["age"] = 30},
+    new Dictionary<string, object> {["name"] = "Bob", ["age"] = 25}
+);

--- a/tests/integration/cases/list_of_dicts/dart.dart
+++ b/tests/integration/cases/list_of_dicts/dart.dart
@@ -1,0 +1,4 @@
+final x = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+];

--- a/tests/integration/cases/list_of_dicts/dart_varname.dart
+++ b/tests/integration/cases/list_of_dicts/dart_varname.dart
@@ -1,0 +1,4 @@
+final my_data = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+];

--- a/tests/integration/cases/list_of_dicts/go.go
+++ b/tests/integration/cases/list_of_dicts/go.go
@@ -1,0 +1,6 @@
+package main
+
+var _ = []any{
+    map[string]any{"name": "Alice", "age": 30},
+    map[string]any{"name": "Bob", "age": 25},
+}

--- a/tests/integration/cases/list_of_dicts/go_varname.go
+++ b/tests/integration/cases/list_of_dicts/go_varname.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+my_data := []any{
+    map[string]any{"name": "Alice", "age": 30},
+    map[string]any{"name": "Bob", "age": 25},
+}
+_ = my_data
+}

--- a/tests/integration/cases/list_of_dicts/haskell.hs
+++ b/tests/integration/cases/list_of_dicts/haskell.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Check where
+import Data.String (IsString(fromString))
+data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)] | HSet [Val]
+instance IsString Val where
+    fromString = HStr
+instance Num Val where
+    fromInteger = HInt
+    a + b = error "not implemented"
+    a * b = error "not implemented"
+    abs a = error "not implemented"
+    signum a = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional Val where
+    fromRational r = HFloat (realToFrac r)
+    a / b = error "not implemented"
+x :: Val
+x = HList [
+    HMap [("name", "Alice"), ("age", 30)],
+    HMap [("name", "Bob"), ("age", 25)]
+    ]

--- a/tests/integration/cases/list_of_dicts/haskell_varname.hs
+++ b/tests/integration/cases/list_of_dicts/haskell_varname.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Check where
+import Data.String (IsString(fromString))
+data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)] | HSet [Val]
+instance IsString Val where
+    fromString = HStr
+instance Num Val where
+    fromInteger = HInt
+    a + b = error "not implemented"
+    a * b = error "not implemented"
+    abs a = error "not implemented"
+    signum a = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional Val where
+    fromRational r = HFloat (realToFrac r)
+    a / b = error "not implemented"
+my_data :: Val
+my_data = HList [
+    HMap [("name", "Alice"), ("age", 30)],
+    HMap [("name", "Bob"), ("age", 25)]
+    ]

--- a/tests/integration/cases/list_of_dicts/input.yaml
+++ b/tests/integration/cases/list_of_dicts/input.yaml
@@ -1,0 +1,5 @@
+---
+- name: Alice
+  age: 30
+- name: Bob
+  age: 25

--- a/tests/integration/cases/list_of_dicts/java.java
+++ b/tests/integration/cases/list_of_dicts/java.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+import java.util.Set;
+class Check {
+    Object x = new Object[]{
+    Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)),
+    Map.ofEntries(Map.entry("name", "Bob"), Map.entry("age", 25))
+};
+}

--- a/tests/integration/cases/list_of_dicts/java_varname.java
+++ b/tests/integration/cases/list_of_dicts/java_varname.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+import java.util.Set;
+class Check {
+    public static void check() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)),
+    Map.ofEntries(Map.entry("name", "Bob"), Map.entry("age", 25))
+};
+    }
+}

--- a/tests/integration/cases/list_of_dicts/javascript.js
+++ b/tests/integration/cases/list_of_dicts/javascript.js
@@ -1,0 +1,6 @@
+void (
+[
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+]
+)

--- a/tests/integration/cases/list_of_dicts/javascript_varname.js
+++ b/tests/integration/cases/list_of_dicts/javascript_varname.js
@@ -1,0 +1,4 @@
+const my_data = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+];

--- a/tests/integration/cases/list_of_dicts/julia.jl
+++ b/tests/integration/cases/list_of_dicts/julia.jl
@@ -1,0 +1,4 @@
+[
+    Dict("name" => "Alice", "age" => 30),
+    Dict("name" => "Bob", "age" => 25),
+]

--- a/tests/integration/cases/list_of_dicts/julia_varname.jl
+++ b/tests/integration/cases/list_of_dicts/julia_varname.jl
@@ -1,0 +1,4 @@
+my_data = [
+    Dict("name" => "Alice", "age" => 30),
+    Dict("name" => "Bob", "age" => 25),
+]

--- a/tests/integration/cases/list_of_dicts/kotlin.kts
+++ b/tests/integration/cases/list_of_dicts/kotlin.kts
@@ -1,0 +1,4 @@
+val x: Any? = listOf<Any?>(
+    mapOf<String, Any?>("name" to "Alice", "age" to 30),
+    mapOf<String, Any?>("name" to "Bob", "age" to 25),
+)

--- a/tests/integration/cases/list_of_dicts/kotlin_varname.kts
+++ b/tests/integration/cases/list_of_dicts/kotlin_varname.kts
@@ -1,0 +1,4 @@
+val my_data = listOf<Any?>(
+    mapOf<String, Any?>("name" to "Alice", "age" to 30),
+    mapOf<String, Any?>("name" to "Bob", "age" to 25),
+)

--- a/tests/integration/cases/list_of_dicts/php.php
+++ b/tests/integration/cases/list_of_dicts/php.php
@@ -1,0 +1,5 @@
+<?php
+$x = [
+    ["name" => "Alice", "age" => 30],
+    ["name" => "Bob", "age" => 25],
+];

--- a/tests/integration/cases/list_of_dicts/php_varname.php
+++ b/tests/integration/cases/list_of_dicts/php_varname.php
@@ -1,0 +1,5 @@
+<?php
+$my_data = [
+    ["name" => "Alice", "age" => 30],
+    ["name" => "Bob", "age" => 25],
+];

--- a/tests/integration/cases/list_of_dicts/python.py
+++ b/tests/integration/cases/list_of_dicts/python.py
@@ -1,0 +1,4 @@
+(
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+)

--- a/tests/integration/cases/list_of_dicts/python_varname.py
+++ b/tests/integration/cases/list_of_dicts/python_varname.py
@@ -1,0 +1,4 @@
+my_data = (
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+)

--- a/tests/integration/cases/list_of_dicts/ruby.rb
+++ b/tests/integration/cases/list_of_dicts/ruby.rb
@@ -1,0 +1,4 @@
+[
+    {"name" => "Alice", "age" => 30},
+    {"name" => "Bob", "age" => 25},
+]

--- a/tests/integration/cases/list_of_dicts/ruby_varname.rb
+++ b/tests/integration/cases/list_of_dicts/ruby_varname.rb
@@ -1,0 +1,4 @@
+my_data = [
+    {"name" => "Alice", "age" => 30},
+    {"name" => "Bob", "age" => 25},
+]

--- a/tests/integration/cases/list_of_dicts/rust.rs
+++ b/tests/integration/cases/list_of_dicts/rust.rs
@@ -1,0 +1,8 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+fn main() {
+    let _ = vec![
+        HashMap::from([("name", "Alice"), ("age", 30)]),
+        HashMap::from([("name", "Bob"), ("age", 25)]),
+    ];
+}

--- a/tests/integration/cases/list_of_dicts/rust_varname.rs
+++ b/tests/integration/cases/list_of_dicts/rust_varname.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+fn main() {
+    let my_data = vec![
+        HashMap::from([("name", "Alice"), ("age", 30)]),
+        HashMap::from([("name", "Bob"), ("age", 25)]),
+    ];
+    let _ = my_data;
+}

--- a/tests/integration/cases/list_of_dicts/swift.swift
+++ b/tests/integration/cases/list_of_dicts/swift.swift
@@ -1,0 +1,4 @@
+let x: Any? = [
+    ["name": "Alice", "age": 30],
+    ["name": "Bob", "age": 25],
+]

--- a/tests/integration/cases/list_of_dicts/swift_varname.swift
+++ b/tests/integration/cases/list_of_dicts/swift_varname.swift
@@ -1,0 +1,4 @@
+let my_data: Any = [
+    ["name": "Alice", "age": 30],
+    ["name": "Bob", "age": 25],
+]

--- a/tests/integration/cases/list_of_dicts/typescript.ts
+++ b/tests/integration/cases/list_of_dicts/typescript.ts
@@ -1,0 +1,6 @@
+void (
+[
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+]
+)

--- a/tests/integration/cases/list_of_dicts/typescript_varname.ts
+++ b/tests/integration/cases/list_of_dicts/typescript_varname.ts
@@ -1,0 +1,5 @@
+const my_data = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+];
+export {};


### PR DESCRIPTION
Adds a new test case with nested dictionaries to generate 30 additional golden files (15 languages × 2 variants) across all supported languages.

This expands pre-commit syntax hook coverage so that when new languages are added (e.g., R with multiline_trailing_comma=True), the hooks will catch invalid trailing comma syntax in the generated golden files.

Testing: all 404 integration tests pass (up from 374).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new integration golden fixtures only; no production logic changes, but may require updating generators if any language output formatting mismatches.
> 
> **Overview**
> Adds a new `tests/integration/cases/list_of_dicts` fixture with an `input.yaml` containing a list of maps, plus generated golden outputs across multiple languages (and `*_varname` variants).
> 
> The new goldens intentionally exercise *nested collection literals with trailing commas* to improve pre-commit/integration coverage for language-specific trailing-comma syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47968915ae30942e353253efe2031cd05eb20f3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->