### PR TITLE
Consolidate variable syntax tests into single source

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1805,20 +1805,44 @@ class _VariableSyntax:
 # from this single source of truth so that adding a language to one
 # automatically adds it to the other.
 _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {
-    PYTHON: _VariableSyntax("my_var = 42", "my_var = 42"),
-    JAVASCRIPT: _VariableSyntax("const my_var = 42;", "my_var = 42;"),
-    TYPESCRIPT: _VariableSyntax("const my_var = 42;", "my_var = 42;"),
-    GO: _VariableSyntax("my_var := 42", "my_var = 42"),
-    RUBY: _VariableSyntax("my_var = 42", "my_var = 42"),
-    CSHARP: _VariableSyntax("var my_var = 42;", "my_var = 42;"),
-    CPP: _VariableSyntax("auto my_var = 42;", "my_var = 42;"),
-    JAVA: _VariableSyntax("var my_var = 42;", "my_var = 42;"),
-    KOTLIN: _VariableSyntax("val my_var = 42", "my_var = 42"),
-    SWIFT: _VariableSyntax("let my_var = 42", "my_var = 42"),
-    RUST: _VariableSyntax("let my_var = 42;", "my_var = 42;"),
-    PHP: _VariableSyntax("$my_var = 42;", "$my_var = 42;"),
-    HASKELL: _VariableSyntax("my_var = 42", "my_var = 42"),
-    DART: _VariableSyntax("final my_var = 42;", "my_var = 42;"),
+    PYTHON: _VariableSyntax(
+        declaration="my_var = 42", assignment="my_var = 42"
+    ),
+    JAVASCRIPT: _VariableSyntax(
+        declaration="const my_var = 42;", assignment="my_var = 42;"
+    ),
+    TYPESCRIPT: _VariableSyntax(
+        declaration="const my_var = 42;", assignment="my_var = 42;"
+    ),
+    GO: _VariableSyntax(declaration="my_var := 42", assignment="my_var = 42"),
+    RUBY: _VariableSyntax(declaration="my_var = 42", assignment="my_var = 42"),
+    CSHARP: _VariableSyntax(
+        declaration="var my_var = 42;", assignment="my_var = 42;"
+    ),
+    CPP: _VariableSyntax(
+        declaration="auto my_var = 42;", assignment="my_var = 42;"
+    ),
+    JAVA: _VariableSyntax(
+        declaration="var my_var = 42;", assignment="my_var = 42;"
+    ),
+    KOTLIN: _VariableSyntax(
+        declaration="val my_var = 42", assignment="my_var = 42"
+    ),
+    SWIFT: _VariableSyntax(
+        declaration="let my_var = 42", assignment="my_var = 42"
+    ),
+    RUST: _VariableSyntax(
+        declaration="let my_var = 42;", assignment="my_var = 42;"
+    ),
+    PHP: _VariableSyntax(
+        declaration="$my_var = 42;", assignment="$my_var = 42;"
+    ),
+    HASKELL: _VariableSyntax(
+        declaration="my_var = 42", assignment="my_var = 42"
+    ),
+    DART: _VariableSyntax(
+        declaration="final my_var = 42;", assignment="my_var = 42;"
+    ),
 }
 
 _DECLARATION_PARAMS = [


### PR DESCRIPTION
Refactor variable declaration and assignment test parametrization to prevent accidental omissions when adding new languages.

Created a single `_VARIABLE_SYNTAX` dict mapping each language to both its declaration and assignment expected output. Both `_DECLARATION_PARAMS` and `_ASSIGNMENT_PARAMS` are derived from this dict, ensuring both test groups always cover the same set of languages.

This prevents the issue where SCALA was added to assignment tests but forgotten in declaration tests (as reported in #155).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only refactor that centralizes expected strings; main risk is missing/incorrect expectations causing spurious test failures.
> 
> **Overview**
> Refactors the variable declaration/assignment parametrized tests to use a single `_VARIABLE_SYNTAX` mapping (via a frozen dataclass) as the source of truth for expected outputs across languages.
> 
> Both JSON/YAML declaration tests now share `_DECLARATION_PARAMS`, and both existing-variable assignment tests share `_ASSIGNMENT_PARAMS`, reducing the chance of adding a language to one matrix but not the other.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b21db14e05df80ec4f12800f4834574a94276c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->