### PR TITLE
Avoid hypothesis filter_too_much warnings and add comments

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -601,7 +601,7 @@ def _lists_to_tuples(*, value: _JSONValue) -> object:
 
 # Characters valid in JSON strings: Unicode letters (L), marks (M), numbers
 # (N), punctuation (P), symbols (S), and separators (Z). Control characters
-# (category C) are excluded because JSON forbids unescaped control characters,
+# (category C) are excluded because JSON forbids raw control characters,
 # and ``\x00`` is excluded explicitly because json.dumps refuses null bytes.
 json_text = st.text(
     alphabet=st.characters(
@@ -612,7 +612,7 @@ json_scalars = (
     st.none()
     | st.booleans()
     | st.integers()
-    # NaN and Infinity are excluded because JSON does not support them.
+    # ``nan`` and ``inf`` are excluded because JSON does not support them.
     | st.floats(allow_nan=False, allow_infinity=False)
     | json_text
 )
@@ -708,7 +708,7 @@ def test_roundtrip_scalar(data: _JSONScalar) -> None:
 
 # ``st.dictionaries`` internally filters draws to ensure unique keys, which
 # can accumulate enough filtered examples to trigger the ``filter_too_much``
-# health check on unlucky seeds.  The filtering is expected behaviour here,
+# health check on unlucky seeds.  The filtering is expected behavior here,
 # so we suppress the check rather than change the strategy.
 @given(data=json_objects)
 @settings(suppress_health_check=[HealthCheck.filter_too_much])


### PR DESCRIPTION
## Summary

Add explanatory comments to hypothesis strategy definitions and suppress the `filter_too_much` health check in `test_roundtrip_dict`. The `st.dictionaries` strategy internally filters draws to ensure unique keys, which can accumulate enough filtered examples to trigger the health check on unlucky seeds. Suppressing this check is appropriate since the filtering is internal to hypothesis, not user-defined.

## Changes

- Add `@settings(suppress_health_check=[HealthCheck.filter_too_much])` to `test_roundtrip_dict`
- Add comments explaining character category choices (L,M,N,P,S,Z covers printable Unicode)
- Add comments explaining why null bytes, NaN, and Infinity are excluded from strategies
- Add comments explaining `max_size` caps on recursive and collection strategies

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust Hypothesis settings and add strategy documentation; behavior of production code is unchanged.
> 
> **Overview**
> Improves reliability of the property-based JSON roundtrip tests by suppressing Hypothesis' `HealthCheck.filter_too_much` for the `st.dictionaries`-driven `test_roundtrip_dict`, avoiding flaky failures from internal key-uniqueness filtering.
> 
> Adds clarifying comments to the JSON Hypothesis strategies describing the chosen Unicode character categories, and why `\x00`, `nan/inf`, and various `max_size` limits are excluded/used to keep generated JSON valid and test runtime bounded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629d09f681fbca1a659985ea29ad2ea04a724f6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->