### PR TITLE
Extract _wrap_combined_newline helper

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -366,6 +366,11 @@ def _wrap_rust_combined(declaration: str, assignment: str) -> str:
     )
 
 
+def _wrap_combined_newline(declaration: str, assignment: str) -> str:
+    """Join declaration and assignment with a newline."""
+    return declaration + "\n" + assignment
+
+
 def _wrap_python_datetime(content: str) -> str:
     """Wrap with a datetime import for native Python date literals."""
     return f"import datetime\n{content}"
@@ -460,7 +465,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         extension=".py",
         wrap=_wrap_identity,
         varname_wrap=_wrap_identity,
-        combined_wrap=lambda d, a: d + "\n" + a,
+        combined_wrap=_wrap_combined_newline,
         date_variants=(
             _DateVariant(
                 name="python_native",
@@ -526,7 +531,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         extension=".rb",
         wrap=_wrap_identity,
         varname_wrap=_wrap_identity,
-        combined_wrap=lambda d, a: d + "\n" + a,
+        combined_wrap=_wrap_combined_newline,
         date_variants=(
             _DateVariant(
                 name="ruby_native",
@@ -653,7 +658,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         extension=".jl",
         wrap=_wrap_identity,
         varname_wrap=_wrap_identity,
-        combined_wrap=lambda d, a: d + "\n" + a,
+        combined_wrap=_wrap_combined_newline,
         date_variants=(
             _DateVariant(
                 name="julia_native",


### PR DESCRIPTION
Replace inline lambdas in Python, Ruby, and Julia language configs with a named helper function for better code clarity. The three languages use identical logic (concatenating declaration and assignment with a newline), which is now extracted into `_wrap_combined_newline`.

This reduces lambda usage while improving readability and maintainability of the test configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to integration test configuration; behavior should remain unchanged aside from potential formatting differences if the helper is misused.
> 
> **Overview**
> Extracts a named `_wrap_combined_newline` helper in `tests/integration/test_integration.py` and switches the Python, Ruby, and Julia `combined_wrap` configs from inline lambdas to this shared function.
> 
> No functional test expectations are intended to change; this is a readability/maintainability refactor of how declaration/assignment outputs are concatenated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaf1249b2b1b58494f8b38b4bf729517d5a8c371. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->