### PR TITLE
Fix F# top-level scalar wrapping in variable declarations

### DIFF
--- a/src/literalizer/formatters.py
+++ b/src/literalizer/formatters.py
@@ -559,7 +559,7 @@ def format_variable_declaration_fsharp(name: str, value: str) -> str:
 
     Example: ``"x"`` and ``"FList [...]"`` → ``"let x: Val = FList [...]"``
     """
-    return f"let {name}: Val = {value}"
+    return f"let {name}: Val = {to_fsharp_val(value=value)}"
 
 
 def to_fsharp_val(value: str) -> str:
@@ -866,7 +866,7 @@ def format_variable_assignment_fsharp(name: str, value: str) -> str:
 
     Example: ``"x"`` and ``"FList [1; 2]"`` → ``"let x: Val = FList [1; 2]"``
     """
-    return f"let {name}: Val = {value}"
+    return f"let {name}: Val = {to_fsharp_val(value=value)}"
 
 
 def dict_entry_with_separator(separator: str) -> Callable[[str, str], str]:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1880,7 +1880,8 @@ _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {
         declaration="my_var = 42", assignment="my_var = 42"
     ),
     FSHARP: _VariableSyntax(
-        declaration="let my_var: Val = 42", assignment="let my_var: Val = 42"
+        declaration="let my_var: Val = FInt 42L",
+        assignment="let my_var: Val = FInt 42L",
     ),
     CLOJURE: _VariableSyntax(
         declaration="(def my_var 42)", assignment="(def my_var 42)"


### PR DESCRIPTION
## Summary
Fixes invalid F# code generation when using top-level scalars with variable names. Integers, floats, and strings now wrap in Val constructors (`FInt 42L`, `FFloat 3.14`, `FStr "hello"`) instead of bare values that don't match the Val type.

## Changes
- `format_variable_declaration_fsharp` and `format_variable_assignment_fsharp` now call `to_fsharp_val` to ensure proper wrapping
- Updated test expectations from `let my_var: Val = 42` to `let my_var: Val = FInt 42L`

Resolves comment from PR #161 discussion.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to F# code generation plus updated golden test expectations; only affects formatting output for scalar `variable_name` cases.
> 
> **Overview**
> Fixes F# variable declarations/assignments to always emit values as `Val` expressions by routing the RHS through `to_fsharp_val`, preventing invalid `let x: Val = 42`-style output for top-level scalars.
> 
> Updates converter tests to expect wrapped scalars (e.g. `FInt 42L`) for F# variable syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 844f48b478279754c3990b899735da129e02e7eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->