### PR TITLE
Enable Swift toolchain caching in Windows CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,8 @@ jobs:
           apps: scalac
       - name: Install Swift
         uses: SwiftyLab/setup-swift@v1
+        with:
+          cache: true
       - name: Install R
         uses: r-lib/actions/setup-r@v2
       - name: Install Dart


### PR DESCRIPTION
Cache the Swift toolchain in the Windows lint job to avoid slow downloads and installations on repeated runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects how the Swift toolchain is installed/cached; main risk is potential cache-related flakiness or stale toolchains on runners.
> 
> **Overview**
> Enables caching for the Swift toolchain in the `Lint` GitHub Actions workflow by setting `cache: true` on the `SwiftyLab/setup-swift@v1` step, reducing repeated download/install time (notably on Windows runners).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce1fed86780ad1da4957cc1889c0df3d8a97b6df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->