### PR TITLE
Add missing input.yaml to test case dirs and enforce presence

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -569,8 +569,8 @@ repos:
 
       - id: scala-golden-syntax-check
         name: Scala golden file syntax check
-        entry: bash -c 'for f; do tmpdir=$(mktemp -d) && (cd "$tmpdir" && scalac "$(realpath
-          "$f")") || exit 1; done' --
+        entry: bash -c 'for f; do tmpdir=$(mktemp -d) && scalac -d "$tmpdir" "$f"
+          || exit 1; done' --
         language: system
         files: ^tests/integration/cases/.*\.scala$
         stages: [pre-commit]


### PR DESCRIPTION
## Summary

- Add `input.yaml` to four test case directories that were missing it: `empty_list`, `simple_list`, `list_of_dicts`, `nested_list`
- Generate golden files for all languages in those directories
- Add a `check-case-input-yaml` pre-commit hook that fails if any test case directory lacks `input.yaml`, preventing recurrence

Fixes #201

## Test plan

- [ ] Integration tests pass (`uv run pytest tests/integration/`)
- [ ] Pre-commit hook `check-case-input-yaml` passes on the fixed directories
- [ ] Verify hook fails if `input.yaml` is removed from a case directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates pre-commit tooling only, adding a guard for missing `input.yaml` files and slightly adjusting the Scala syntax check invocation.
> 
> **Overview**
> Adds a new pre-commit hook (`check-case-input-yaml`) that fails if any `tests/integration/cases/*/` directory is missing an `input.yaml`, preventing incomplete integration test fixtures from being committed.
> 
> Also simplifies the `scala-golden-syntax-check` hook to compile each `.scala` file into a temp output directory via `scalac -d`, removing the prior `realpath`/subshell approach.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95dedbf4ad104559da335610e7f08738bdfa16e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->