### PR TITLE
Replace invalid cache input with cache-snapshot for Swift setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Swift
         uses: SwiftyLab/setup-swift@v1
         with:
-          cache: true
+          cache-snapshot: true
       - name: Install R
         uses: r-lib/actions/setup-r@v2
       - name: Install Dart


### PR DESCRIPTION
Replaces the unsupported 'cache' input with 'cache-snapshot' in the SwiftyLab/setup-swift action. The 'cache' input is not valid for this action; 'cache-snapshot' is the correct input for caching Swift toolchain snapshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that corrects a GitHub Action input; it may only affect workflow caching behavior and execution time.
> 
> **Overview**
> Fixes the Lint GitHub Actions workflow by replacing the invalid `cache` input on `SwiftyLab/setup-swift@v1` with the supported `cache-snapshot` option, enabling Swift toolchain snapshot caching to work as intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c41f04175eeda2b2224fc09ce39db9743ae9c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->