### PR TITLE
Remove # type: ignore[misc] comments, use keyword arguments

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2011,7 +2011,7 @@ def test_to_fsharp_val_unknown_value() -> None:
     """``to_fsharp_val`` returns the value unchanged when it cannot be
     classified as a string literal, int, or float.
     """
-    result = to_fsharp_val("SomeUnknownValue")  # type: ignore[misc]
+    result = to_fsharp_val(value="SomeUnknownValue")
     assert result == "SomeUnknownValue"
 
 
@@ -2027,5 +2027,5 @@ def test_to_ocaml_val_unknown_value() -> None:
     """``to_ocaml_val`` returns the value unchanged when it cannot be
     classified as a string literal, int, or float.
     """
-    result = to_ocaml_val("SomeUnknownValue")  # type: ignore[misc]
+    result = to_ocaml_val(value="SomeUnknownValue")
     assert result == "SomeUnknownValue"


### PR DESCRIPTION
Replace suppressed type-ignore comments with proper keyword argument calls to beartype-decorated functions in test cases.

This removes `# type: ignore[misc]` comments from calls to `to_fsharp_val()` and `to_ocaml_val()`, using keyword arguments instead, which is the correct way to satisfy mypy-strict-kwargs validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change replacing positional calls with keyword arguments to satisfy strict-kwargs/type-checking; no production logic is modified.
> 
> **Overview**
> Updates two converter tests to call `to_fsharp_val` and `to_ocaml_val` using the `value=` keyword argument, allowing removal of `# type: ignore[misc]` suppressions under `mypy` strict keyword-arg rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd4317182555647507eda08029bb978d4fb64cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->