### PR TITLE
Fail if OCaml and occam-pi tools are missing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -546,8 +546,8 @@ repos:
 
       - id: ocaml-golden-syntax-check
         name: OCaml golden file syntax check
-        entry: bash -c 'command -v ocamlopt > /dev/null || exit 0; tmpdir=$(mktemp
-          -d); for f; do ocamlopt -c -o "$tmpdir/check.o" "$f" || exit 1; done' --
+        entry: bash -c 'tmpdir=$(mktemp -d); for f; do ocamlopt -c -o "$tmpdir/check.o"
+          "$f" || exit 1; done' --
         language: system
         types: [ocaml]
         files: ^tests/integration/cases/
@@ -555,8 +555,8 @@ repos:
 
       - id: occam-golden-syntax-check
         name: occam-pi golden file syntax check
-        entry: bash -c 'command -v kroc > /dev/null || exit 0; for f; do tmpdir=$(mktemp
-          -d); kroc -o "$tmpdir/check" "$f" || exit 1; done' --
+        entry: bash -c 'for f; do tmpdir=$(mktemp -d); kroc -o "$tmpdir/check" "$f"
+          || exit 1; done' --
         language: system
         files: ^tests/integration/cases/.*\.occ$
         stages: [pre-commit]


### PR DESCRIPTION
Remove silent exit 0 guards from ocamlopt and kroc hooks so they fail when the tools are not available, instead of silently succeeding.

The ocaml-golden-syntax-check and occam-golden-syntax-check hooks now require their respective tools to be present and will fail if they're missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tightens local `pre-commit` hooks to fail when `ocamlopt`/`kroc` are missing, which may newly block contributors without these tools installed.
> 
> **Overview**
> Updates the `ocaml-golden-syntax-check` and `occam-golden-syntax-check` `pre-commit` hooks to **no longer silently succeed** when `ocamlopt` or `kroc` is not installed.
> 
> Both hooks now always attempt compilation/typechecking and will fail fast if the required tool is missing, making missing dependencies visible during local checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec85d90843695041a2ededf8f87b50cd9ab6acd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->