### PR TITLE
Remove __all__ from _formatters.py

### DIFF
--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -10,42 +10,6 @@ from beartype import beartype
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-__all__ = [
-    "dict_entry_with_separator",
-    "format_bytes_hex",
-    "format_bytes_python",
-    "format_date_cpp",
-    "format_date_csharp",
-    "format_date_dart",
-    "format_date_go",
-    "format_date_iso",
-    "format_date_java",
-    "format_date_js",
-    "format_date_julia",
-    "format_date_kotlin",
-    "format_date_python",
-    "format_date_r",
-    "format_date_ruby",
-    "format_date_rust",
-    "format_datetime_cpp",
-    "format_datetime_csharp",
-    "format_datetime_dart",
-    "format_datetime_epoch",
-    "format_datetime_go",
-    "format_datetime_iso",
-    "format_datetime_java_instant",
-    "format_datetime_java_zoned",
-    "format_datetime_js",
-    "format_datetime_julia",
-    "format_datetime_kotlin",
-    "format_datetime_python",
-    "format_datetime_r",
-    "format_datetime_ruby",
-    "format_datetime_rust",
-    "passthrough_sequence_entry",
-    "passthrough_set_entry",
-]
-
 
 @beartype
 def format_date_iso(value: datetime.date) -> str:


### PR DESCRIPTION
Remove the redundant __all__ list. Public/private distinction is already clear from naming conventions, and __all__ only matters for 'from module import *' behavior, which is unlikely for an internal module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only affects `from literalizer._formatters import *` behavior and does not change any formatting logic.
> 
> **Overview**
> Removes the explicit `__all__` list from `src/literalizer/_formatters.py`, relying on normal module exports/naming rather than maintaining a manual public symbol list.
> 
> No formatter implementations are changed; the only behavioral impact is on wildcard imports (`import *`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b459450fe2aa0253526592a94c418dbaa6896a04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->