### PR TITLE
Split lint workflow into per-language files

### DIFF
--- a/.github/workflows/lint-ada.yml
+++ b/.github/workflows/lint-ada.yml
@@ -1,0 +1,26 @@
+---
+name: Lint Ada
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-ada:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install GNAT
+        run: sudo apt-get install -y gnat
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Check Ada syntax
+        run: >-
+          find tests/integration/cases -name "*.adb" -print0 |
+          xargs -0 uv run python check_ada_golden_syntax.py

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -1,0 +1,18 @@
+---
+name: Lint C
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-c:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check C syntax
+        run: find tests/integration/cases -name "*.c" -exec clang -fsyntax-only -std=c11
+          {} +

--- a/.github/workflows/lint-clojure.yml
+++ b/.github/workflows/lint-clojure.yml
@@ -1,0 +1,23 @@
+---
+name: Lint Clojure
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-clojure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install clj-kondo
+        uses: DeLaGuardo/setup-clojure@13
+        with:
+          clj-kondo: latest
+      - name: Check Clojure syntax
+        run: >-
+          find tests/integration/cases -name "*.clj" -print0 |
+          xargs -0 clj-kondo --lint

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -1,0 +1,18 @@
+---
+name: Lint C++
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-cpp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check C++ syntax
+        run: find tests/integration/cases -name "*.cpp" -exec clang++ -fsyntax-only
+          -std=c++20 {} +

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -1,0 +1,28 @@
+---
+name: Lint C#
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-csharp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Initialize .NET runtime
+        run: |
+          mkdir -p /tmp/.dotnet/shm
+          dotnet --info
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Check C# syntax
+        run: >-
+          find tests/integration/cases -name "*.cs" -print0 |
+          xargs -0 uv run python check_csharp_golden_syntax.py

--- a/.github/workflows/lint-d.yml
+++ b/.github/workflows/lint-d.yml
@@ -1,0 +1,26 @@
+---
+name: Lint D
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-d:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install DMD
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: dmd-latest
+      - name: Check D syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.d" -print0 | \
+            while IFS= read -r -d '' f; do
+              dmd -o- -c "$f" || exit 1
+            done

--- a/.github/workflows/lint-dart.yml
+++ b/.github/workflows/lint-dart.yml
@@ -1,0 +1,27 @@
+---
+name: Lint Dart
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-dart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+      - name: Check Dart syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.dart" -print0 | \
+            while IFS= read -r -d '' f; do
+              tmpdir=$(mktemp -d)
+              printf 'name: check\nenvironment:\n  sdk: ^3.0.0\n' > "$tmpdir/pubspec.yaml"
+              cp "$f" "$tmpdir/check.dart"
+              dart analyze --fatal-infos "$tmpdir/check.dart" || exit 1
+            done

--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -1,0 +1,29 @@
+---
+name: Lint Elixir
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-elixir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.18'
+          otp-version: '27'
+      - name: Check Elixir syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.ex" -print0 | \
+            while IFS= read -r -d '' f; do
+              tmpdir=$(mktemp -d)
+              cp "$f" "$tmpdir/check.ex"
+              (cd "$tmpdir" && elixirc check.ex) || exit 1
+            done

--- a/.github/workflows/lint-erlang.yml
+++ b/.github/workflows/lint-erlang.yml
@@ -1,0 +1,30 @@
+---
+name: Lint Erlang
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-erlang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27'
+          install-rebar: false
+          install-hex: false
+      - name: Check Erlang syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.erl" -print0 | \
+            while IFS= read -r -d '' f; do
+              tmpdir=$(mktemp -d)
+              cp "$f" "$tmpdir/check.erl"
+              (cd "$tmpdir" && erlc check.erl) || exit 1
+            done

--- a/.github/workflows/lint-fsharp.yml
+++ b/.github/workflows/lint-fsharp.yml
@@ -1,0 +1,29 @@
+---
+name: Lint F#
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-fsharp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Initialize .NET runtime
+        run: |
+          mkdir -p /tmp/.dotnet/shm
+          dotnet --info
+      - name: Check F# syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases \( -name "*.fs" -o -name "*.fsi" \) -print0 | \
+            while IFS= read -r -d '' f; do
+              tmpdir=$(mktemp -d)
+              DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 \
+                TMPDIR="$tmpdir" HOME="$tmpdir" \
+                dotnet fsi --nologo --exec "$f" || exit 1
+            done

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -1,0 +1,17 @@
+---
+name: Lint Go
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check Go syntax
+        run: find tests/integration/cases -name "*.go" -exec gofmt -e {} +

--- a/.github/workflows/lint-groovy.yml
+++ b/.github/workflows/lint-groovy.yml
@@ -1,0 +1,27 @@
+---
+name: Lint Groovy
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-groovy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Groovy
+        uses: wtfjoke/setup-groovy@v3
+        with:
+          groovy-version: 4.x
+      - name: Check Groovy syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.groovy" -print0 | \
+            while IFS= read -r -d '' f; do
+              tmpdir=$(mktemp -d)
+              groovyc -d "$tmpdir" "$(realpath "$f")" || exit 1
+            done

--- a/.github/workflows/lint-haskell.yml
+++ b/.github/workflows/lint-haskell.yml
@@ -1,0 +1,25 @@
+---
+name: Lint Haskell
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-haskell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install GHC
+        run: sudo apt-get install -y ghc
+      - name: Check Haskell syntax
+        run: |-
+          tmpdir=$(mktemp -d)
+          set -o pipefail
+          find tests/integration/cases -name "*.hs" -print0 | \
+            while IFS= read -r -d '' f; do
+              ghc -fno-code -outputdir "$tmpdir" "$f" || exit 1
+            done

--- a/.github/workflows/lint-java.yml
+++ b/.github/workflows/lint-java.yml
@@ -1,0 +1,23 @@
+---
+name: Lint Java
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-java:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check Java syntax
+        run: |-
+          tmpdir=$(mktemp -d)
+          set -o pipefail
+          find tests/integration/cases -name "*.java" -print0 | \
+            while IFS= read -r -d '' f; do
+              javac -d "$tmpdir" "$f" || exit 1
+            done

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -1,0 +1,22 @@
+---
+name: Lint JavaScript
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-javascript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check JavaScript syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.js" -print0 | \
+            while IFS= read -r -d '' f; do
+              node --check "$f" || exit 1
+            done

--- a/.github/workflows/lint-julia.yml
+++ b/.github/workflows/lint-julia.yml
@@ -1,0 +1,24 @@
+---
+name: Lint Julia
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-julia:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Julia
+        uses: julia-actions/setup-julia@v2
+      - name: Check Julia syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.jl" -print0 | \
+            while IFS= read -r -d '' f; do
+              julia --startup-file=no -e 'Meta.parseall(read(ARGS[1], String))' -- "$f" || exit 1
+            done

--- a/.github/workflows/lint-kotlin.yml
+++ b/.github/workflows/lint-kotlin.yml
@@ -1,0 +1,24 @@
+---
+name: Lint Kotlin
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-kotlin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Kotlin
+        uses: fwilhe2/setup-kotlin@v1
+      - name: Check Kotlin syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.kts" -print0 | \
+            while IFS= read -r -d '' f; do
+              kotlinc -script "$f" || exit 1
+            done

--- a/.github/workflows/lint-lua.yml
+++ b/.github/workflows/lint-lua.yml
@@ -1,0 +1,21 @@
+---
+name: Lint Lua
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-lua:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Lua
+        uses: leafo/gh-actions-lua@v12
+        with:
+          luaVersion: '5.4'
+      - name: Check Lua syntax
+        run: find tests/integration/cases -name "*.lua" -exec luac -p {} +

--- a/.github/workflows/lint-ocaml.yml
+++ b/.github/workflows/lint-ocaml.yml
@@ -1,0 +1,25 @@
+---
+name: Lint OCaml
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-ocaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install OCaml
+        run: sudo apt-get install -y ocaml
+      - name: Check OCaml syntax
+        run: |-
+          tmpdir=$(mktemp -d)
+          set -o pipefail
+          find tests/integration/cases -name "*.ml" -print0 | \
+            while IFS= read -r -d '' f; do
+              ocamlopt -c -o "$tmpdir/check.o" "$f" || exit 1
+            done

--- a/.github/workflows/lint-perl.yml
+++ b/.github/workflows/lint-perl.yml
@@ -1,0 +1,22 @@
+---
+name: Lint Perl
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-perl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check Perl syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.pl" -print0 | \
+            while IFS= read -r -d '' f; do
+              perl -c "$f" || exit 1
+            done

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,0 +1,17 @@
+---
+name: Lint PHP
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-php:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check PHP syntax
+        run: find tests/integration/cases -name "*.php" -exec php -l {} +

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -1,0 +1,23 @@
+---
+name: Lint R
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-r:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          windows-path-include-rtools: false
+      - name: Check R syntax
+        run: >-
+          find tests/integration/cases -name "*.R" -print0 |
+          xargs -0 Rscript -e 'for (f in commandArgs(trailingOnly=TRUE)) parse(file=f)'

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -1,0 +1,22 @@
+---
+name: Lint Ruby
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-ruby:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check Ruby syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.rb" -print0 | \
+            while IFS= read -r -d '' f; do
+              ruby -c "$f" || exit 1
+            done

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -1,0 +1,24 @@
+---
+name: Lint Rust
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+      - name: Check Rust syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.rs" -print0 | \
+            while IFS= read -r -d '' f; do
+              rustfmt --edition 2021 --emit stdout "$f" > /dev/null || exit 1
+            done

--- a/.github/workflows/lint-scala.yml
+++ b/.github/workflows/lint-scala.yml
@@ -1,0 +1,27 @@
+---
+name: Lint Scala
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-scala:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Scala
+        uses: coursier/setup-action@v2
+        with:
+          apps: scalac
+      - name: Check Scala syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.scala" -print0 | \
+            while IFS= read -r -d '' f; do
+              tmpdir=$(mktemp -d)
+              scalac -d "$tmpdir" "$f" || exit 1
+            done

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -1,0 +1,28 @@
+---
+name: Lint Swift
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-swift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Swift
+        uses: SwiftyLab/setup-swift@v1
+        with:
+          cache-snapshot: true
+      - name: Check Swift syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.swift" -print0 | \
+            while IFS= read -r -d '' f; do
+              tmpdir=$(mktemp -d)
+              cp "$f" "$tmpdir/check.swift"
+              swiftc -typecheck "$tmpdir/check.swift" || exit 1
+            done

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -1,0 +1,24 @@
+---
+name: Lint TypeScript
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  lint-typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install TypeScript
+        run: npm install -g typescript
+      - name: Check TypeScript syntax
+        run: |-
+          set -o pipefail
+          find tests/integration/cases -name "*.ts" -print0 | \
+            while IFS= read -r -d '' f; do
+              tsc --noEmit --noResolve --skipLibCheck --lib es2015 "$f" || exit 1
+            done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,437 +43,85 @@ jobs:
         if: always()
 
   lint-ruby:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check Ruby syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.rb" -print0 | \
-            while IFS= read -r -d '' f; do
-              ruby -c "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-ruby.yml
 
   lint-go:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check Go syntax
-        run: find tests/integration/cases -name "*.go" -exec gofmt -e {} +
+    uses: ./.github/workflows/lint-go.yml
 
   lint-groovy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Groovy
-        uses: wtfjoke/setup-groovy@v3
-        with:
-          groovy-version: 4.x
-      - name: Check Groovy syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.groovy" -print0 | \
-            while IFS= read -r -d '' f; do
-              tmpdir=$(mktemp -d)
-              groovyc -d "$tmpdir" "$(realpath "$f")" || exit 1
-            done
+    uses: ./.github/workflows/lint-groovy.yml
 
   lint-javascript:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check JavaScript syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.js" -print0 | \
-            while IFS= read -r -d '' f; do
-              node --check "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-javascript.yml
 
   lint-typescript:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install TypeScript
-        run: npm install -g typescript
-      - name: Check TypeScript syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.ts" -print0 | \
-            while IFS= read -r -d '' f; do
-              tsc --noEmit --noResolve --skipLibCheck --lib es2015 "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-typescript.yml
 
   lint-java:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check Java syntax
-        run: |
-          tmpdir=$(mktemp -d)
-          set -o pipefail
-          find tests/integration/cases -name "*.java" -print0 | \
-            while IFS= read -r -d '' f; do
-              javac -d "$tmpdir" "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-java.yml
 
   lint-c:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check C syntax
-        run: find tests/integration/cases -name "*.c" -exec clang -fsyntax-only -std=c11
-          {} +
+    uses: ./.github/workflows/lint-c.yml
 
   lint-cpp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check C++ syntax
-        run: find tests/integration/cases -name "*.cpp" -exec clang++ -fsyntax-only
-          -std=c++20 {} +
+    uses: ./.github/workflows/lint-cpp.yml
 
   lint-kotlin:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Kotlin
-        uses: fwilhe2/setup-kotlin@v1
-      - name: Check Kotlin syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.kts" -print0 | \
-            while IFS= read -r -d '' f; do
-              kotlinc -script "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-kotlin.yml
 
   lint-rust:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install rustfmt
-        run: rustup component add rustfmt
-      - name: Check Rust syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.rs" -print0 | \
-            while IFS= read -r -d '' f; do
-              rustfmt --edition 2021 --emit stdout "$f" > /dev/null || exit 1
-            done
+    uses: ./.github/workflows/lint-rust.yml
 
   lint-swift:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Swift
-        uses: SwiftyLab/setup-swift@v1
-        with:
-          cache-snapshot: true
-      - name: Check Swift syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.swift" -print0 | \
-            while IFS= read -r -d '' f; do
-              tmpdir=$(mktemp -d)
-              cp "$f" "$tmpdir/check.swift"
-              swiftc -typecheck "$tmpdir/check.swift" || exit 1
-            done
+    uses: ./.github/workflows/lint-swift.yml
 
   lint-csharp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Initialize .NET runtime
-        run: |
-          mkdir -p /tmp/.dotnet/shm
-          dotnet --info
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check C# syntax
-        run: >
-          find tests/integration/cases -name "*.cs" -print0 |
-          xargs -0 uv run python check_csharp_golden_syntax.py
+    uses: ./.github/workflows/lint-csharp.yml
 
   lint-elixir:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          elixir-version: '1.18'
-          otp-version: '27'
-      - name: Check Elixir syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.ex" -print0 | \
-            while IFS= read -r -d '' f; do
-              tmpdir=$(mktemp -d)
-              cp "$f" "$tmpdir/check.ex"
-              (cd "$tmpdir" && elixirc check.ex) || exit 1
-            done
+    uses: ./.github/workflows/lint-elixir.yml
 
   lint-erlang:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Erlang
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: '27'
-          install-rebar: false
-          install-hex: false
-      - name: Check Erlang syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.erl" -print0 | \
-            while IFS= read -r -d '' f; do
-              tmpdir=$(mktemp -d)
-              cp "$f" "$tmpdir/check.erl"
-              (cd "$tmpdir" && erlc check.erl) || exit 1
-            done
+    uses: ./.github/workflows/lint-erlang.yml
 
   lint-fsharp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Initialize .NET runtime
-        run: |
-          mkdir -p /tmp/.dotnet/shm
-          dotnet --info
-      - name: Check F# syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases \( -name "*.fs" -o -name "*.fsi" \) -print0 | \
-            while IFS= read -r -d '' f; do
-              tmpdir=$(mktemp -d)
-              DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 \
-                TMPDIR="$tmpdir" HOME="$tmpdir" \
-                dotnet fsi --nologo --exec "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-fsharp.yml
 
   lint-ocaml:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install OCaml
-        run: sudo apt-get install -y ocaml
-      - name: Check OCaml syntax
-        run: |
-          tmpdir=$(mktemp -d)
-          set -o pipefail
-          find tests/integration/cases -name "*.ml" -print0 | \
-            while IFS= read -r -d '' f; do
-              ocamlopt -c -o "$tmpdir/check.o" "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-ocaml.yml
 
   lint-haskell:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install GHC
-        run: sudo apt-get install -y ghc
-      - name: Check Haskell syntax
-        run: |
-          tmpdir=$(mktemp -d)
-          set -o pipefail
-          find tests/integration/cases -name "*.hs" -print0 | \
-            while IFS= read -r -d '' f; do
-              ghc -fno-code -outputdir "$tmpdir" "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-haskell.yml
 
   lint-clojure:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install clj-kondo
-        uses: DeLaGuardo/setup-clojure@13
-        with:
-          clj-kondo: latest
-      - name: Check Clojure syntax
-        run: >
-          find tests/integration/cases -name "*.clj" -print0 |
-          xargs -0 clj-kondo --lint
+    uses: ./.github/workflows/lint-clojure.yml
 
   lint-scala:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Scala
-        uses: coursier/setup-action@v2
-        with:
-          apps: scalac
-      - name: Check Scala syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.scala" -print0 | \
-            while IFS= read -r -d '' f; do
-              tmpdir=$(mktemp -d)
-              scalac -d "$tmpdir" "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-scala.yml
 
   lint-dart:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Dart
-        uses: dart-lang/setup-dart@v1
-      - name: Check Dart syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.dart" -print0 | \
-            while IFS= read -r -d '' f; do
-              tmpdir=$(mktemp -d)
-              printf 'name: check\nenvironment:\n  sdk: ^3.0.0\n' > "$tmpdir/pubspec.yaml"
-              cp "$f" "$tmpdir/check.dart"
-              dart analyze --fatal-infos "$tmpdir/check.dart" || exit 1
-            done
+    uses: ./.github/workflows/lint-dart.yml
 
   lint-julia:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Julia
-        uses: julia-actions/setup-julia@v2
-      - name: Check Julia syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.jl" -print0 | \
-            while IFS= read -r -d '' f; do
-              julia --startup-file=no -e 'Meta.parseall(read(ARGS[1], String))' -- "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-julia.yml
 
   lint-perl:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check Perl syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.pl" -print0 | \
-            while IFS= read -r -d '' f; do
-              perl -c "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-perl.yml
 
   lint-lua:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install Lua
-        uses: leafo/gh-actions-lua@v12
-        with:
-          luaVersion: '5.4'
-      - name: Check Lua syntax
-        run: find tests/integration/cases -name "*.lua" -exec luac -p {} +
+    uses: ./.github/workflows/lint-lua.yml
 
   lint-php:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Check PHP syntax
-        run: find tests/integration/cases -name "*.php" -exec php -l {} +
+    uses: ./.github/workflows/lint-php.yml
 
   lint-r:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          windows-path-include-rtools: false
-      - name: Check R syntax
-        run: >
-          find tests/integration/cases -name "*.R" -print0 |
-          xargs -0 Rscript -e 'for (f in commandArgs(trailingOnly=TRUE)) parse(file=f)'
+    uses: ./.github/workflows/lint-r.yml
 
   lint-d:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install DMD
-        uses: dlang-community/setup-dlang@v1
-        with:
-          compiler: dmd-latest
-      - name: Check D syntax
-        run: |
-          set -o pipefail
-          find tests/integration/cases -name "*.d" -print0 | \
-            while IFS= read -r -d '' f; do
-              dmd -o- -c "$f" || exit 1
-            done
+    uses: ./.github/workflows/lint-d.yml
 
   lint-ada:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install GNAT
-        run: sudo apt-get install -y gnat
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check Ada syntax
-        run: >
-          find tests/integration/cases -name "*.adb" -print0 |
-          xargs -0 uv run python check_ada_golden_syntax.py
+    uses: ./.github/workflows/lint-ada.yml
 
   completion-lint:
     needs:


### PR DESCRIPTION
Separated each language's linting job into its own reusable workflow file using GitHub Actions `workflow_call`. The main lint.yml now orchestrates all language checks and maintains the completion-lint job with proper dependency resolution. This improves maintainability by isolating language-specific configuration while keeping the workflow dependency graph intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only refactor but touches many GitHub Actions jobs; miswired `workflow_call` or missing tools could cause lint coverage gaps or failing checks.
> 
> **Overview**
> Refactors the monolithic `lint.yml` by extracting each language-specific syntax check into its own reusable GitHub Actions workflow (`.github/workflows/lint-*.yml`) triggered via `workflow_call`.
> 
> Updates `lint.yml` to orchestrate these workflows via `uses:` entries and keeps the `completion-lint` aggregator job with an expanded `needs:` list to preserve the overall dependency/required-check behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f310a78d6387f7d7c2e75731800a63ef6d0cdc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->