### PR TITLE
Remove pragma: no branch comment from conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,5 +7,5 @@ from beartype import beartype
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """Apply the beartype decorator to all collected test functions."""
     for item in items:
-        if isinstance(item, pytest.Function):  # pragma: no branch
+        if isinstance(item, pytest.Function):
             item.obj = beartype(obj=item.obj)


### PR DESCRIPTION
Remove unused pragma comment that excluded a branch from code coverage analysis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a `# pragma: no branch` comment only, with no functional or behavioral changes to test collection or runtime type checking.
> 
> **Overview**
> Removes the `# pragma: no branch` marker from the `pytest_collection_modifyitems` loop in `conftest.py`, so the `isinstance(item, pytest.Function)` check is no longer excluded from coverage reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01b71a1047e9eabdeb30f7984d8239d5b266268e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->