### PR TITLE
Add format_string to MATLAB language specification

### DIFF
--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -10,6 +10,7 @@ from literalizer._formatters import (
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
+    format_string_backslash,
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
@@ -77,6 +78,7 @@ MATLAB = Language(
     multiline_close_indent="",
     element_separator=", ",
     skip_null_dict_values=False,
+    format_string=format_string_backslash,
     format_variable_declaration=_format_variable_declaration,
     format_variable_assignment=_format_variable_assignment,
 )


### PR DESCRIPTION
The format_string field was added as a required parameter to the Language class. MATLAB uses double-quoted strings with backslash escaping, so format_string_backslash is the appropriate formatter.

This fixes the mypy error that was preventing the build from passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small configuration change to the MATLAB `Language` definition to satisfy a new required field, with no behavioral impact outside string literal escaping/quoting for MATLAB output.
> 
> **Overview**
> Adds the required `format_string` formatter to the MATLAB `Language` specification, using `format_string_backslash` to emit double-quoted, backslash-escaped string literals.
> 
> This resolves the type-check/build failure introduced by `Language` now requiring `format_string`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48b63d011113d6ebb9b028175399970ddf2f6ee7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->