### PR TITLE
Fix Bash whitespace preservation in nested collections

### DIFF
--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from beartype import beartype
 
 from literalizer._formatters import (
@@ -22,7 +24,7 @@ def _to_bash_value(item: str) -> str:
     ``(``) is collapsed to a single line and double-quoted.
     """
     if item.startswith("("):
-        collapsed = " ".join(item.split())
+        collapsed = re.sub(pattern=r"[ \t]*\n[ \t]*", repl=" ", string=item)
         escaped = collapsed.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
     return item

--- a/tests/integration/cases/nested_collection_multi_space_string/bash.sh
+++ b/tests/integration/cases/nested_collection_multi_space_string/bash.sh
@@ -1,3 +1,3 @@
 declare _v=(
-    "([\"key\"]=\"hello world\" [\"value\"]=1)"
+    "([\"key\"]=\"hello   world\" [\"value\"]=1)"
 )

--- a/tests/integration/cases/nested_collection_multi_space_string/bash_combined.sh
+++ b/tests/integration/cases/nested_collection_multi_space_string/bash_combined.sh
@@ -1,6 +1,6 @@
 declare my_data=(
-    "([\"key\"]=\"hello world\" [\"value\"]=1)"
+    "([\"key\"]=\"hello   world\" [\"value\"]=1)"
 )
 my_data=(
-    "([\"key\"]=\"hello world\" [\"value\"]=1)"
+    "([\"key\"]=\"hello   world\" [\"value\"]=1)"
 )

--- a/tests/integration/cases/nested_collection_multi_space_string/bash_varname.sh
+++ b/tests/integration/cases/nested_collection_multi_space_string/bash_varname.sh
@@ -1,3 +1,3 @@
 declare my_data=(
-    "([\"key\"]=\"hello world\" [\"value\"]=1)"
+    "([\"key\"]=\"hello   world\" [\"value\"]=1)"
 )


### PR DESCRIPTION
The `_to_bash_value` function was collapsing all whitespace, including intentional spaces within string values. Changed from `split()/join()` to a regex that only collapses newlines while preserving spaces. Updated three golden files to reflect correct multi-space string handling.

Addresses Bugbot issue on #238.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to Bash literal formatting that only alters whitespace normalization for nested collection rendering, with updated golden integration outputs.
> 
> **Overview**
> Fixes Bash nested-collection quoting to **preserve intentional intra-string spacing** by replacing the `split()/join()` whitespace collapse with a regex that only removes newlines (and surrounding indentation).
> 
> Updates the `nested_collection_multi_space_string` integration golden outputs to expect `"hello   world"` (multiple spaces) in the rendered associative-array string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 845b53ad6ec3ff504e8e09bb7e9482ca92271dc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->