### PR TITLE
Use GitHub Actions for linting tool setup

### DIFF
--- a/.github/workflows/lint-ocaml.yml
+++ b/.github/workflows/lint-ocaml.yml
@@ -13,9 +13,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: ocaml-base-compiler
+      - name: Install OCaml
+        run: sudo apt-get install -y ocaml
       - name: Check OCaml syntax
         run: |-
           tmpdir=$(mktemp -d)


### PR DESCRIPTION
Replace apt-get installations with official GitHub Actions marketplace actions for better maintainability and cross-platform support.

- **Haskell**: Use `haskell-actions/setup@v2` instead of apt-get for GHC setup
- **OCaml**: Use `ocaml/setup-ocaml@v3` instead of apt-get for OCaml compiler

These official, actively maintained actions provide better versioning control and consistency across CI environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that swaps the GHC installation method; main potential impact is workflow failures if the setup action or `latest` GHC version behaves differently than the Ubuntu package.
> 
> **Overview**
> The Haskell lint GitHub Action now installs GHC via `haskell-actions/setup@v2` (using `ghc-version: latest`) instead of `apt-get`, while keeping the existing syntax-check loop unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb6c0b6dc09bfe67ea49076ecc0bd01082605b77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->