### PR TITLE
Document all 35 supported languages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,18 @@
 literalizer
 ===========
 
-``literalizer`` converts JSON data structures to native language literal syntax (Python, JavaScript, TypeScript, Go, Ruby, C#, C++, Java, Kotlin, Rust, Haskell, Swift, PHP).
+``literalizer`` converts JSON data structures to native language literal syntax.
 
 .. contents::
    :local:
+
+Supported languages
+-------------------
+
+Ada, Bash, C, C#, C++, Clojure, Crystal, D, Dart, Elixir, Erlang, F#, Go,
+Groovy, Haskell, Java, JavaScript, Julia, Kotlin, Lua, MATLAB, Nim, OCaml,
+Occam-pi, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, Swift,
+TypeScript, Zig.
 
 Installation
 ------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,15 @@
 |project|
 =========
 
-|project| converts JSON data structures to native language literal syntax
-(Python, JavaScript, TypeScript, Go, Ruby, C#, C++, Java, Kotlin, Rust, Haskell, Swift, PHP).
+|project| converts JSON data structures to native language literal syntax.
+
+Supported languages
+-------------------
+
+Ada, Bash, C, C#, C++, Clojure, Crystal, D, Dart, Elixir, Erlang, F#, Go,
+Groovy, Haskell, Java, JavaScript, Julia, Kotlin, Lua, MATLAB, Nim, OCaml,
+Occam-pi, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, Swift,
+TypeScript, Zig.
 
 Installation
 ------------


### PR DESCRIPTION
Updates README.rst and docs/source/index.rst to list the complete set of 35 supported programming languages instead of the outdated list of 13 languages. Adds a dedicated 'Supported languages' section in both files for better visibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that expand and reorganize the supported-language list; no runtime or API behavior changes.
> 
> **Overview**
> Updates `README.rst` and `docs/source/index.rst` to replace the outdated inline language list with a dedicated **Supported languages** section enumerating the full set of supported targets.
> 
> Also tweaks the intro sentence to be language-agnostic (removing the parenthetical list) so the docs stay accurate as language support evolves.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55febcbdb0863d8171dcc91deddf380fd78138ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->