### PR TITLE
Fix C# syntax checker glob failure by disabling default compile items

### DIFF
--- a/check_csharp_golden_syntax.py
+++ b/check_csharp_golden_syntax.py
@@ -54,9 +54,14 @@ def main() -> None:
             f"    <TargetFramework>{target_framework}</TargetFramework>\n"
             "    <Nullable>disable</Nullable>\n"
             "    <ImplicitUsings>enable</ImplicitUsings>\n"
+            "    <EnableDefaultCompileItems>false"
+            "</EnableDefaultCompileItems>\n"
             "    <EnableDefaultEmbeddedResourceItems>false"
             "</EnableDefaultEmbeddedResourceItems>\n"
             "  </PropertyGroup>\n"
+            "  <ItemGroup>\n"
+            '    <Compile Include="Program.cs" />\n'
+            "  </ItemGroup>\n"
             "</Project>\n"
         )
 


### PR DESCRIPTION
## Summary

- Add `<EnableDefaultCompileItems>false</EnableDefaultCompileItems>` to the temp project's `<PropertyGroup>`
- Add an explicit `<ItemGroup><Compile Include="Program.cs" /></ItemGroup>`

This avoids environment-dependent wildcard resolution that caused `CSC : error CS2021: File name '**/*.cs'` failures in CI.

Fixes #256

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the temporary `.csproj` used for syntax-check builds to avoid environment-dependent globbing; no production logic or data/security paths are affected.
> 
> **Overview**
> Fixes flaky C# golden-file syntax checks by changing the generated temporary `.csproj` in `check_csharp_golden_syntax.py` to **disable default compile items** and **explicitly include `Program.cs`**.
> 
> This prevents `dotnet build` from picking up wildcard compile patterns (e.g., `**/*.cs`) that can fail in some CI environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f9ec4ac6d79657a4e348a937bc639c106ae4fd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->