### PR TITLE
Fix format_sequence_entry in _wrap_occam/_wrap_d and backslash-escape in occam checker

### DIFF
--- a/check_occam_golden_syntax.py
+++ b/check_occam_golden_syntax.py
@@ -12,6 +12,9 @@ def _strip_comment(line: str) -> str:
     i = 0
     while i < len(line):
         ch = line[i]
+        if ch == "\\" and in_string:
+            i += 2
+            continue
         if ch == '"':
             in_string = not in_string
         elif not in_string and line[i : i + 2] == "--":
@@ -67,7 +70,12 @@ def _check_brackets(lines: list[str]) -> str | None:
     for line_num, line in enumerate(iterable=lines, start=1):
         clean = _strip_comment(line=line)
         in_string = False
-        for ch in clean:
+        i = 0
+        while i < len(clean):
+            ch = clean[i]
+            if ch == "\\" and in_string:
+                i += 2
+                continue
             if ch == '"':
                 in_string = not in_string
             elif not in_string:
@@ -77,6 +85,7 @@ def _check_brackets(lines: list[str]) -> str | None:
                     depth -= 1
                     if depth < 0:
                         return f"Unmatched ']' at line {line_num}"
+            i += 1
 
     if depth != 0:
         return f"Unbalanced '[': {depth} unclosed bracket(s)"

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/d.d
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/d.d
@@ -1,5 +1,5 @@
 import std.json;
 
 void _check() {
-    auto _v = "hello \"world\" -- not a comment";
+    auto _v = JSONValue("hello \"world\" -- not a comment");
 }

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/occam.occ
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/occam.occ
@@ -12,7 +12,7 @@ MOBILE DATA TYPE LIT IS
 :
 
 PROC check ()
-  VAL MOBILE LIT x IS "hello \"world\" -- not a comment":
+  VAL MOBILE LIT x IS MOBILE LIT(lit.str; MOBILE []BYTE "hello \"world\" -- not a comment"):
   SEQ
     SKIP
 :

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -178,11 +178,12 @@ def _wrap_ocaml_varname(content: str) -> str:
 
 def _wrap_occam(content: str) -> str:
     """Wrap in an occam-pi PROC with a custom ``LIT`` mobile data type."""
+    typed = literalizer.languages.Occam().format_sequence_entry(content)
     return (
         _OCCAM_LIT_TYPE
         + "\n\n"
         + "PROC check ()\n"
-        + f"  VAL MOBILE LIT x IS {content}:\n"
+        + f"  VAL MOBILE LIT x IS {typed}:\n"
         + "  SEQ\n"
         + "    SKIP\n"
         + ":"
@@ -494,9 +495,8 @@ def _wrap_nim_combined(declaration: str, assignment: str) -> str:
 
 def _wrap_d(content: str) -> str:
     """Wrap in a D function with ``std.json`` imported."""
-    return (
-        f"import std.json;\n\nvoid _check() {{\n    auto _v = {content};\n}}"
-    )
+    typed = literalizer.languages.D().format_sequence_entry(content)
+    return f"import std.json;\n\nvoid _check() {{\n    auto _v = {typed};\n}}"
 
 
 def _wrap_d_varname(content: str) -> str:


### PR DESCRIPTION
## Summary

Addresses bugbot issues from #235 and #236.

- **`_wrap_occam`**: now calls `format_sequence_entry` on content so bare scalar strings are wrapped in `MOBILE LIT(lit.str; MOBILE []BYTE ...)` instead of being embedded raw (was producing type-incorrect `VAL MOBILE LIT x IS "hello \"world\"..."`)
- **`_wrap_d`**: now calls `format_sequence_entry` on content so bare scalar strings are wrapped in `JSONValue(...)` instead of being embedded raw
- **`check_occam_golden_syntax.py`**: `_strip_comment` and `_check_brackets` now skip backslash-escaped characters inside strings, so `\"` no longer incorrectly toggles the `in_string` flag — fixing false comment-strip and bracket-mismatch errors for strings containing `\"`
- Regenerated golden files for `string_escaped_quotes_and_dashes` case

## Test plan

- All 1905 integration tests pass
- Golden files updated: `occam.occ` now has `MOBILE LIT(lit.str; ...)` wrapper, `d.d` now has `JSONValue(...)` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test wrappers and a golden-file syntax checker, mainly improving handling of escaped quotes and typed string literals.
> 
> **Overview**
> Fixes Occam golden-file validation to correctly ignore backslash-escaped characters inside strings, preventing `\"` from toggling string state and causing false comment/bracket errors.
> 
> Updates integration-test wrappers for `occam` and `d` to run values through `format_sequence_entry`, so scalar strings are emitted as typed constructors (e.g., `MOBILE LIT(lit.str; ...)` / `JSONValue(...)`) instead of being embedded raw, and regenerates the affected `string_escaped_quotes_and_dashes` golden outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f970e98e10ef32abcf0c0da85cba3f8e59cb80c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->