### PR TITLE
Fix YAML set comments misaligned when insertion order differs from sorted order

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -130,7 +130,10 @@ def extract_yaml_comments(
     else:
         keys = list(ruamel_data.keys())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 
-    elements: list[_ElementComments] = []
+    # Iterate in insertion order so that pending_before propagation is
+    # correct (a "before element N" comment is stored in the after-token
+    # of element N-1 in insertion order).
+    element_map: dict[object, _ElementComments] = {}
     for key in keys:
         before = list(pending_before)
         inline = ""
@@ -143,15 +146,23 @@ def extract_yaml_comments(
                 inline = parsed.inline
                 pending_before = parsed.before_next
 
-        elements.append(
-            _ElementComments(
-                before=tuple(before),
-                inline=inline,
-            ),
+        element_map[key] = _ElementComments(
+            before=tuple(before),
+            inline=inline,
         )
 
+    # CommentedSet elements are emitted in sorted order by _literalize,
+    # so reorder to match that sort key to keep comments aligned.
+    if isinstance(ruamel_data, CommentedSet):
+        output_keys: list[object] = sorted(
+            keys,
+            key=lambda v: (type(v).__name__, repr(v)),
+        )
+    else:
+        output_keys = keys
+
     return _CollectionComments(
-        elements=tuple(elements),
+        elements=tuple(element_map[k] for k in output_keys),
         trailing=tuple(pending_before),
     )
 

--- a/tests/integration/cases/set_comments_unsorted_order/ada.adb
+++ b/tests/integration/cases/set_comments_unsorted_order/ada.adb
@@ -1,0 +1,10 @@
+procedure Check is
+   X : A_Val := ASet'(
+       -- before apple
+       AStr ("apple"),
+       AStr ("banana")  -- banana inline
+       -- trailing
+   );
+begin
+   null;
+end Check;

--- a/tests/integration/cases/set_comments_unsorted_order/ada_combined.adb
+++ b/tests/integration/cases/set_comments_unsorted_order/ada_combined.adb
@@ -1,0 +1,24 @@
+procedure Check is
+   procedure Check_Declaration is
+      my_data : A_Val := ASet'(
+          -- before apple
+          AStr ("apple"),
+          AStr ("banana")  -- banana inline
+          -- trailing
+      );
+   begin
+      null;
+   end Check_Declaration;
+   procedure Check_Assignment is
+   begin
+      my_data := ASet'(
+          -- before apple
+          AStr ("apple"),
+          AStr ("banana")  -- banana inline
+          -- trailing
+      );
+   end Check_Assignment;
+begin
+   Check_Declaration;
+   Check_Assignment;
+end Check;

--- a/tests/integration/cases/set_comments_unsorted_order/ada_varname.adb
+++ b/tests/integration/cases/set_comments_unsorted_order/ada_varname.adb
@@ -1,0 +1,10 @@
+procedure Check is
+   my_data : A_Val := ASet'(
+       -- before apple
+       AStr ("apple"),
+       AStr ("banana")  -- banana inline
+       -- trailing
+   );
+begin
+   null;
+end Check;

--- a/tests/integration/cases/set_comments_unsorted_order/bash.sh
+++ b/tests/integration/cases/set_comments_unsorted_order/bash.sh
@@ -1,0 +1,6 @@
+declare _v=(
+    # before apple
+    "apple"
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/bash_combined.sh
+++ b/tests/integration/cases/set_comments_unsorted_order/bash_combined.sh
@@ -1,0 +1,12 @@
+declare my_data=(
+    # before apple
+    "apple"
+    "banana"  # banana inline
+    # trailing
+)
+my_data=(
+    # before apple
+    "apple"
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/bash_varname.sh
+++ b/tests/integration/cases/set_comments_unsorted_order/bash_varname.sh
@@ -1,0 +1,6 @@
+declare my_data=(
+    # before apple
+    "apple"
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/c.c
+++ b/tests/integration/cases/set_comments_unsorted_order/c.c
@@ -1,0 +1,24 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct _CVal _CVal;
+typedef struct _CKV _CKV;
+struct _CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const _CVal *a;
+        const _CKV *m;
+    };
+};
+struct _CKV { const char *k; _CVal v; };
+void _check(void) {
+    _CVal _v = ((_CVal){.a = (_CVal[]){
+    // before apple
+    ((_CVal){.s = "apple"}),
+    ((_CVal){.s = "banana"}),  // banana inline
+    // trailing
+}});
+    (void)_v;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/c_combined.c
+++ b/tests/integration/cases/set_comments_unsorted_order/c_combined.c
@@ -1,0 +1,30 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct _CVal _CVal;
+typedef struct _CKV _CKV;
+struct _CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const _CVal *a;
+        const _CKV *m;
+    };
+};
+struct _CKV { const char *k; _CVal v; };
+void _check(void) {
+_CVal my_data = ((_CVal){.a = (_CVal[]){
+    // before apple
+    ((_CVal){.s = "apple"}),
+    ((_CVal){.s = "banana"}),  // banana inline
+    // trailing
+}});
+my_data = ((_CVal){.a = (_CVal[]){
+    // before apple
+    ((_CVal){.s = "apple"}),
+    ((_CVal){.s = "banana"}),  // banana inline
+    // trailing
+}});
+    (void)my_data;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/c_varname.c
+++ b/tests/integration/cases/set_comments_unsorted_order/c_varname.c
@@ -1,0 +1,24 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct _CVal _CVal;
+typedef struct _CKV _CKV;
+struct _CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const _CVal *a;
+        const _CKV *m;
+    };
+};
+struct _CKV { const char *k; _CVal v; };
+void _check(void) {
+_CVal my_data = ((_CVal){.a = (_CVal[]){
+    // before apple
+    ((_CVal){.s = "apple"}),
+    ((_CVal){.s = "banana"}),  // banana inline
+    // trailing
+}});
+    (void)my_data;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/clojure.clj
+++ b/tests/integration/cases/set_comments_unsorted_order/clojure.clj
@@ -1,0 +1,6 @@
+#{
+    ; before apple
+    "apple"
+    "banana"  ; banana inline
+    ; trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/clojure_combined.clj
+++ b/tests/integration/cases/set_comments_unsorted_order/clojure_combined.clj
@@ -1,0 +1,12 @@
+(def my_data #{
+    ; before apple
+    "apple"
+    "banana"  ; banana inline
+    ; trailing
+})
+(def my_data #{
+    ; before apple
+    "apple"
+    "banana"  ; banana inline
+    ; trailing
+})

--- a/tests/integration/cases/set_comments_unsorted_order/clojure_varname.clj
+++ b/tests/integration/cases/set_comments_unsorted_order/clojure_varname.clj
@@ -1,0 +1,6 @@
+(def my_data #{
+    ; before apple
+    "apple"
+    "banana"  ; banana inline
+    ; trailing
+})

--- a/tests/integration/cases/set_comments_unsorted_order/cpp.cpp
+++ b/tests/integration/cases/set_comments_unsorted_order/cpp.cpp
@@ -1,0 +1,14 @@
+#include <initializer_list>
+#include <cstddef>
+struct _Any {
+    template<class T> _Any(T&&) noexcept {}
+    _Any(std::initializer_list<_Any>) noexcept {}
+};
+void _check() {
+    [[maybe_unused]] _Any _v = {
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+};
+}

--- a/tests/integration/cases/set_comments_unsorted_order/cpp_combined.cpp
+++ b/tests/integration/cases/set_comments_unsorted_order/cpp_combined.cpp
@@ -1,0 +1,20 @@
+#include <initializer_list>
+#include <cstddef>
+struct _Any {
+    template<class T> _Any(T&&) noexcept {}
+    _Any(std::initializer_list<_Any>) noexcept {}
+};
+void _check() {
+_Any my_data = {
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+};
+my_data = {
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+};
+}

--- a/tests/integration/cases/set_comments_unsorted_order/cpp_varname.cpp
+++ b/tests/integration/cases/set_comments_unsorted_order/cpp_varname.cpp
@@ -1,0 +1,14 @@
+#include <initializer_list>
+#include <cstddef>
+struct _Any {
+    template<class T> _Any(T&&) noexcept {}
+    _Any(std::initializer_list<_Any>) noexcept {}
+};
+void _check() {
+_Any my_data = {
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+};
+}

--- a/tests/integration/cases/set_comments_unsorted_order/crystal.cr
+++ b/tests/integration/cases/set_comments_unsorted_order/crystal.cr
@@ -1,0 +1,7 @@
+require "set"
+_ = Set{
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/crystal_combined.cr
+++ b/tests/integration/cases/set_comments_unsorted_order/crystal_combined.cr
@@ -1,0 +1,13 @@
+require "set"
+my_data = Set{
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}
+my_data = Set{
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/crystal_varname.cr
+++ b/tests/integration/cases/set_comments_unsorted_order/crystal_varname.cr
@@ -1,0 +1,7 @@
+require "set"
+my_data = Set{
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/csharp.cs
+++ b/tests/integration/cases/set_comments_unsorted_order/csharp.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+var x = new HashSet<object> {
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/csharp_combined.cs
+++ b/tests/integration/cases/set_comments_unsorted_order/csharp_combined.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+var my_data = new HashSet<object> {
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+};
+my_data = new HashSet<object> {
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/csharp_varname.cs
+++ b/tests/integration/cases/set_comments_unsorted_order/csharp_varname.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+var my_data = new HashSet<object> {
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/d.d
+++ b/tests/integration/cases/set_comments_unsorted_order/d.d
@@ -1,0 +1,10 @@
+import std.json;
+
+void _check() {
+    auto _v = JSONValue([
+    // before apple
+    JSONValue("apple"),
+    JSONValue("banana"),  // banana inline
+    // trailing
+]);
+}

--- a/tests/integration/cases/set_comments_unsorted_order/d_combined.d
+++ b/tests/integration/cases/set_comments_unsorted_order/d_combined.d
@@ -1,0 +1,16 @@
+import std.json;
+
+void _check() {
+auto my_data = JSONValue([
+    // before apple
+    JSONValue("apple"),
+    JSONValue("banana"),  // banana inline
+    // trailing
+]);
+my_data = JSONValue([
+    // before apple
+    JSONValue("apple"),
+    JSONValue("banana"),  // banana inline
+    // trailing
+]);
+}

--- a/tests/integration/cases/set_comments_unsorted_order/d_varname.d
+++ b/tests/integration/cases/set_comments_unsorted_order/d_varname.d
@@ -1,0 +1,10 @@
+import std.json;
+
+void _check() {
+auto my_data = JSONValue([
+    // before apple
+    JSONValue("apple"),
+    JSONValue("banana"),  // banana inline
+    // trailing
+]);
+}

--- a/tests/integration/cases/set_comments_unsorted_order/dart.dart
+++ b/tests/integration/cases/set_comments_unsorted_order/dart.dart
@@ -1,0 +1,6 @@
+final x = {
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/dart_combined.dart
+++ b/tests/integration/cases/set_comments_unsorted_order/dart_combined.dart
@@ -1,0 +1,23 @@
+void _declaration() {
+  final my_data = {
+      // before apple
+      "apple",
+      "banana",  // banana inline
+      // trailing
+  };
+  my_data.hashCode;
+}
+void _assignment() {
+  dynamic my_data;
+  my_data = {
+      // before apple
+      "apple",
+      "banana",  // banana inline
+      // trailing
+  };
+  my_data.hashCode;
+}
+void main() {
+  _declaration();
+  _assignment();
+}

--- a/tests/integration/cases/set_comments_unsorted_order/dart_varname.dart
+++ b/tests/integration/cases/set_comments_unsorted_order/dart_varname.dart
@@ -1,0 +1,6 @@
+final my_data = {
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/elixir.ex
+++ b/tests/integration/cases/set_comments_unsorted_order/elixir.ex
@@ -1,0 +1,10 @@
+defmodule Check do
+  def x do
+    MapSet.new([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])
+  end
+end

--- a/tests/integration/cases/set_comments_unsorted_order/elixir_combined.ex
+++ b/tests/integration/cases/set_comments_unsorted_order/elixir_combined.ex
@@ -1,0 +1,11 @@
+defmodule Check do
+  def x do
+    my_data = MapSet.new([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])
+    _ = my_data
+  end
+end

--- a/tests/integration/cases/set_comments_unsorted_order/elixir_varname.ex
+++ b/tests/integration/cases/set_comments_unsorted_order/elixir_varname.ex
@@ -1,0 +1,11 @@
+defmodule Check do
+  def x do
+    my_data = MapSet.new([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])
+    _ = my_data
+  end
+end

--- a/tests/integration/cases/set_comments_unsorted_order/erlang.erl
+++ b/tests/integration/cases/set_comments_unsorted_order/erlang.erl
@@ -1,0 +1,9 @@
+-module(check).
+-export([x/0]).
+x() ->
+    sets:from_list([
+    % before apple
+    "apple",
+    "banana"  % banana inline
+    % trailing
+]).

--- a/tests/integration/cases/set_comments_unsorted_order/erlang_combined.erl
+++ b/tests/integration/cases/set_comments_unsorted_order/erlang_combined.erl
@@ -1,0 +1,10 @@
+-module(check).
+-export([x/0]).
+x() ->
+    My_data = sets:from_list([
+    % before apple
+    "apple",
+    "banana"  % banana inline
+    % trailing
+]),
+    My_data.

--- a/tests/integration/cases/set_comments_unsorted_order/erlang_varname.erl
+++ b/tests/integration/cases/set_comments_unsorted_order/erlang_varname.erl
@@ -1,0 +1,10 @@
+-module(check).
+-export([x/0]).
+x() ->
+    My_data = sets:from_list([
+    % before apple
+    "apple",
+    "banana"  % banana inline
+    % trailing
+]),
+    My_data.

--- a/tests/integration/cases/set_comments_unsorted_order/fsharp.fs
+++ b/tests/integration/cases/set_comments_unsorted_order/fsharp.fs
@@ -1,0 +1,18 @@
+module Check
+
+type Val =
+    | FNull
+    | FBool of bool
+    | FInt of int64
+    | FFloat of float
+    | FStr of string
+    | FList of Val list
+    | FMap of (string * Val) list
+    | FSet of Val list
+
+let x: Val = FSet [
+    // before apple
+    FStr "apple";
+    FStr "banana"  // banana inline
+    // trailing
+]

--- a/tests/integration/cases/set_comments_unsorted_order/fsharp_combined.fs
+++ b/tests/integration/cases/set_comments_unsorted_order/fsharp_combined.fs
@@ -1,0 +1,18 @@
+module Check
+
+type Val =
+    | FNull
+    | FBool of bool
+    | FInt of int64
+    | FFloat of float
+    | FStr of string
+    | FList of Val list
+    | FMap of (string * Val) list
+    | FSet of Val list
+
+let my_data: Val = FSet [
+    // before apple
+    FStr "apple";
+    FStr "banana"  // banana inline
+    // trailing
+]

--- a/tests/integration/cases/set_comments_unsorted_order/fsharp_varname.fs
+++ b/tests/integration/cases/set_comments_unsorted_order/fsharp_varname.fs
@@ -1,0 +1,18 @@
+module Check
+
+type Val =
+    | FNull
+    | FBool of bool
+    | FInt of int64
+    | FFloat of float
+    | FStr of string
+    | FList of Val list
+    | FMap of (string * Val) list
+    | FSet of Val list
+
+let my_data: Val = FSet [
+    // before apple
+    FStr "apple";
+    FStr "banana"  // banana inline
+    // trailing
+]

--- a/tests/integration/cases/set_comments_unsorted_order/go.go
+++ b/tests/integration/cases/set_comments_unsorted_order/go.go
@@ -1,0 +1,8 @@
+package main
+
+var _ = map[any]struct{}{
+    // before apple
+    "apple": struct{}{},
+    "banana": struct{}{},  // banana inline
+    // trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/go_combined.go
+++ b/tests/integration/cases/set_comments_unsorted_order/go_combined.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+my_data := map[any]struct{}{
+    // before apple
+    "apple": struct{}{},
+    "banana": struct{}{},  // banana inline
+    // trailing
+}
+my_data = map[any]struct{}{
+    // before apple
+    "apple": struct{}{},
+    "banana": struct{}{},  // banana inline
+    // trailing
+}
+_ = my_data
+}

--- a/tests/integration/cases/set_comments_unsorted_order/go_varname.go
+++ b/tests/integration/cases/set_comments_unsorted_order/go_varname.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+my_data := map[any]struct{}{
+    // before apple
+    "apple": struct{}{},
+    "banana": struct{}{},  // banana inline
+    // trailing
+}
+_ = my_data
+}

--- a/tests/integration/cases/set_comments_unsorted_order/groovy.groovy
+++ b/tests/integration/cases/set_comments_unsorted_order/groovy.groovy
@@ -1,0 +1,6 @@
+def x = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+] as Set<Object>

--- a/tests/integration/cases/set_comments_unsorted_order/groovy_combined.groovy
+++ b/tests/integration/cases/set_comments_unsorted_order/groovy_combined.groovy
@@ -1,0 +1,12 @@
+def my_data = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+] as Set<Object>
+my_data = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+] as Set<Object>

--- a/tests/integration/cases/set_comments_unsorted_order/groovy_varname.groovy
+++ b/tests/integration/cases/set_comments_unsorted_order/groovy_varname.groovy
@@ -1,0 +1,6 @@
+def my_data = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+] as Set<Object>

--- a/tests/integration/cases/set_comments_unsorted_order/haskell.hs
+++ b/tests/integration/cases/set_comments_unsorted_order/haskell.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Check where
+import Data.String (IsString(fromString))
+data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)] | HSet [Val]
+instance IsString Val where
+    fromString = HStr
+instance Num Val where
+    fromInteger = HInt
+    a + b = error "not implemented"
+    a * b = error "not implemented"
+    abs a = error "not implemented"
+    signum a = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional Val where
+    fromRational r = HFloat (realToFrac r)
+    a / b = error "not implemented"
+x :: Val
+x = HSet [
+    -- before apple
+    "apple",
+    "banana"  -- banana inline
+    -- trailing
+    ]

--- a/tests/integration/cases/set_comments_unsorted_order/haskell_combined.hs
+++ b/tests/integration/cases/set_comments_unsorted_order/haskell_combined.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Check where
+import Data.String (IsString(fromString))
+data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)] | HSet [Val]
+instance IsString Val where
+    fromString = HStr
+instance Num Val where
+    fromInteger = HInt
+    a + b = error "not implemented"
+    a * b = error "not implemented"
+    abs a = error "not implemented"
+    signum a = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional Val where
+    fromRational r = HFloat (realToFrac r)
+    a / b = error "not implemented"
+my_data :: Val
+my_data = HSet [
+    -- before apple
+    "apple",
+    "banana"  -- banana inline
+    -- trailing
+    ]

--- a/tests/integration/cases/set_comments_unsorted_order/haskell_varname.hs
+++ b/tests/integration/cases/set_comments_unsorted_order/haskell_varname.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Check where
+import Data.String (IsString(fromString))
+data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)] | HSet [Val]
+instance IsString Val where
+    fromString = HStr
+instance Num Val where
+    fromInteger = HInt
+    a + b = error "not implemented"
+    a * b = error "not implemented"
+    abs a = error "not implemented"
+    signum a = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional Val where
+    fromRational r = HFloat (realToFrac r)
+    a / b = error "not implemented"
+my_data :: Val
+my_data = HSet [
+    -- before apple
+    "apple",
+    "banana"  -- banana inline
+    -- trailing
+    ]

--- a/tests/integration/cases/set_comments_unsorted_order/input.yaml
+++ b/tests/integration/cases/set_comments_unsorted_order/input.yaml
@@ -1,0 +1,5 @@
+--- !!set
+? banana  # banana inline
+# before apple
+? apple
+# trailing

--- a/tests/integration/cases/set_comments_unsorted_order/java.java
+++ b/tests/integration/cases/set_comments_unsorted_order/java.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+import java.util.Set;
+class Check {
+    Object x = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+}

--- a/tests/integration/cases/set_comments_unsorted_order/java_combined.java
+++ b/tests/integration/cases/set_comments_unsorted_order/java_combined.java
@@ -1,0 +1,18 @@
+import java.util.Map;
+import java.util.Set;
+class Check {
+    public static void check() {
+var my_data = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+my_data = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_comments_unsorted_order/java_varname.java
+++ b/tests/integration/cases/set_comments_unsorted_order/java_varname.java
@@ -1,0 +1,12 @@
+import java.util.Map;
+import java.util.Set;
+class Check {
+    public static void check() {
+var my_data = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_comments_unsorted_order/javascript.js
+++ b/tests/integration/cases/set_comments_unsorted_order/javascript.js
@@ -1,0 +1,8 @@
+void (
+new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+])
+)

--- a/tests/integration/cases/set_comments_unsorted_order/javascript_combined.js
+++ b/tests/integration/cases/set_comments_unsorted_order/javascript_combined.js
@@ -1,0 +1,15 @@
+void (function() {
+const my_data = new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+]);
+})();
+var my_data;
+my_data = new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+]);

--- a/tests/integration/cases/set_comments_unsorted_order/javascript_varname.js
+++ b/tests/integration/cases/set_comments_unsorted_order/javascript_varname.js
@@ -1,0 +1,6 @@
+const my_data = new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+]);

--- a/tests/integration/cases/set_comments_unsorted_order/julia.jl
+++ b/tests/integration/cases/set_comments_unsorted_order/julia.jl
@@ -1,0 +1,6 @@
+Set([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/julia_combined.jl
+++ b/tests/integration/cases/set_comments_unsorted_order/julia_combined.jl
@@ -1,0 +1,12 @@
+my_data = Set([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])
+my_data = Set([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/julia_varname.jl
+++ b/tests/integration/cases/set_comments_unsorted_order/julia_varname.jl
@@ -1,0 +1,6 @@
+my_data = Set([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/kotlin.kts
+++ b/tests/integration/cases/set_comments_unsorted_order/kotlin.kts
@@ -1,0 +1,6 @@
+val x: Any? = setOf<Any?>(
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/kotlin_combined.kts
+++ b/tests/integration/cases/set_comments_unsorted_order/kotlin_combined.kts
@@ -1,0 +1,17 @@
+fun _declaration() {
+    val my_data = setOf<Any?>(
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    )
+}
+fun _assignment() {
+    var my_data: Any? = null
+    my_data = setOf<Any?>(
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    )
+}

--- a/tests/integration/cases/set_comments_unsorted_order/kotlin_varname.kts
+++ b/tests/integration/cases/set_comments_unsorted_order/kotlin_varname.kts
@@ -1,0 +1,6 @@
+val my_data = setOf<Any?>(
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/lua.lua
+++ b/tests/integration/cases/set_comments_unsorted_order/lua.lua
@@ -1,0 +1,6 @@
+local _ = {
+    -- before apple
+    ["apple"] = true,
+    ["banana"] = true,  -- banana inline
+    -- trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/lua_combined.lua
+++ b/tests/integration/cases/set_comments_unsorted_order/lua_combined.lua
@@ -1,0 +1,12 @@
+local my_data = {
+    -- before apple
+    ["apple"] = true,
+    ["banana"] = true,  -- banana inline
+    -- trailing
+}
+my_data = {
+    -- before apple
+    ["apple"] = true,
+    ["banana"] = true,  -- banana inline
+    -- trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/lua_varname.lua
+++ b/tests/integration/cases/set_comments_unsorted_order/lua_varname.lua
@@ -1,0 +1,6 @@
+local my_data = {
+    -- before apple
+    ["apple"] = true,
+    ["banana"] = true,  -- banana inline
+    -- trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/matlab.m
+++ b/tests/integration/cases/set_comments_unsorted_order/matlab.m
@@ -1,0 +1,6 @@
+x = {
+    % before apple
+    "apple",
+    "banana"  % banana inline
+    % trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/matlab_combined.m
+++ b/tests/integration/cases/set_comments_unsorted_order/matlab_combined.m
@@ -1,0 +1,12 @@
+my_data = {
+    % before apple
+    "apple",
+    "banana"  % banana inline
+    % trailing
+};
+my_data = {
+    % before apple
+    "apple",
+    "banana"  % banana inline
+    % trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/matlab_varname.m
+++ b/tests/integration/cases/set_comments_unsorted_order/matlab_varname.m
@@ -1,0 +1,6 @@
+my_data = {
+    % before apple
+    "apple",
+    "banana"  % banana inline
+    % trailing
+};

--- a/tests/integration/cases/set_comments_unsorted_order/nim.nim
+++ b/tests/integration/cases/set_comments_unsorted_order/nim.nim
@@ -1,0 +1,7 @@
+import json
+let _ = %*[
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+]

--- a/tests/integration/cases/set_comments_unsorted_order/nim_combined.nim
+++ b/tests/integration/cases/set_comments_unsorted_order/nim_combined.nim
@@ -1,0 +1,13 @@
+import json
+var my_data = %*[
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+]
+my_data = %*[
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+]

--- a/tests/integration/cases/set_comments_unsorted_order/nim_varname.nim
+++ b/tests/integration/cases/set_comments_unsorted_order/nim_varname.nim
@@ -1,0 +1,7 @@
+import json
+var my_data = %*[
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+]

--- a/tests/integration/cases/set_comments_unsorted_order/ocaml.ml
+++ b/tests/integration/cases/set_comments_unsorted_order/ocaml.ml
@@ -1,0 +1,20 @@
+module Check = struct
+
+type val_t =
+  | ONull
+  | OBool of bool
+  | OInt of int
+  | OFloat of float
+  | OStr of string
+  | OList of val_t list
+  | OMap of (string * val_t) list
+  | OSet of val_t list
+
+let x : val_t = OSet [
+    (* before apple *)
+    OStr "apple";
+    OStr "banana"  (* banana inline *)
+    (* trailing *)
+]
+
+end

--- a/tests/integration/cases/set_comments_unsorted_order/ocaml_combined.ml
+++ b/tests/integration/cases/set_comments_unsorted_order/ocaml_combined.ml
@@ -1,0 +1,20 @@
+module Check = struct
+
+type val_t =
+  | ONull
+  | OBool of bool
+  | OInt of int
+  | OFloat of float
+  | OStr of string
+  | OList of val_t list
+  | OMap of (string * val_t) list
+  | OSet of val_t list
+
+let my_data : val_t = OSet [
+    (* before apple *)
+    OStr "apple";
+    OStr "banana"  (* banana inline *)
+    (* trailing *)
+]
+
+end

--- a/tests/integration/cases/set_comments_unsorted_order/ocaml_varname.ml
+++ b/tests/integration/cases/set_comments_unsorted_order/ocaml_varname.ml
@@ -1,0 +1,20 @@
+module Check = struct
+
+type val_t =
+  | ONull
+  | OBool of bool
+  | OInt of int
+  | OFloat of float
+  | OStr of string
+  | OList of val_t list
+  | OMap of (string * val_t) list
+  | OSet of val_t list
+
+let my_data : val_t = OSet [
+    (* before apple *)
+    OStr "apple";
+    OStr "banana"  (* banana inline *)
+    (* trailing *)
+]
+
+end

--- a/tests/integration/cases/set_comments_unsorted_order/occam.occ
+++ b/tests/integration/cases/set_comments_unsorted_order/occam.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC check ()
+  VAL MOBILE LIT x IS MOBILE LIT(lit.set; MOBILE []MOBILE LIT [
+    -- before apple
+    MOBILE LIT(lit.str; MOBILE []BYTE "apple"),
+    MOBILE LIT(lit.str; MOBILE []BYTE "banana")  -- banana inline
+    -- trailing
+]):
+  SEQ
+    SKIP
+:

--- a/tests/integration/cases/set_comments_unsorted_order/occam_combined.occ
+++ b/tests/integration/cases/set_comments_unsorted_order/occam_combined.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC check ()
+  VAL MOBILE LIT my_data IS MOBILE LIT(lit.set; MOBILE []MOBILE LIT [
+      -- before apple
+      MOBILE LIT(lit.str; MOBILE []BYTE "apple"),
+      MOBILE LIT(lit.str; MOBILE []BYTE "banana")  -- banana inline
+      -- trailing
+  ]):
+  SEQ
+    SKIP
+:

--- a/tests/integration/cases/set_comments_unsorted_order/occam_varname.occ
+++ b/tests/integration/cases/set_comments_unsorted_order/occam_varname.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC check ()
+  VAL MOBILE LIT my_data IS MOBILE LIT(lit.set; MOBILE []MOBILE LIT [
+      -- before apple
+      MOBILE LIT(lit.str; MOBILE []BYTE "apple"),
+      MOBILE LIT(lit.str; MOBILE []BYTE "banana")  -- banana inline
+      -- trailing
+  ]):
+  SEQ
+    SKIP
+:

--- a/tests/integration/cases/set_comments_unsorted_order/perl.pl
+++ b/tests/integration/cases/set_comments_unsorted_order/perl.pl
@@ -1,0 +1,6 @@
+my $x = [
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+];

--- a/tests/integration/cases/set_comments_unsorted_order/perl_combined.pl
+++ b/tests/integration/cases/set_comments_unsorted_order/perl_combined.pl
@@ -1,0 +1,12 @@
+my $my_data = [
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+];
+$my_data = [
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+];

--- a/tests/integration/cases/set_comments_unsorted_order/perl_varname.pl
+++ b/tests/integration/cases/set_comments_unsorted_order/perl_varname.pl
@@ -1,0 +1,6 @@
+my $my_data = [
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+];

--- a/tests/integration/cases/set_comments_unsorted_order/php.php
+++ b/tests/integration/cases/set_comments_unsorted_order/php.php
@@ -1,0 +1,7 @@
+<?php
+$x = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+];

--- a/tests/integration/cases/set_comments_unsorted_order/php_combined.php
+++ b/tests/integration/cases/set_comments_unsorted_order/php_combined.php
@@ -1,0 +1,13 @@
+<?php
+$my_data = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+];
+$my_data = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+];

--- a/tests/integration/cases/set_comments_unsorted_order/php_varname.php
+++ b/tests/integration/cases/set_comments_unsorted_order/php_varname.php
@@ -1,0 +1,7 @@
+<?php
+$my_data = [
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+];

--- a/tests/integration/cases/set_comments_unsorted_order/powershell.ps1
+++ b/tests/integration/cases/set_comments_unsorted_order/powershell.ps1
@@ -1,0 +1,6 @@
+$x = @(
+    # before apple
+    "apple";
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/powershell_combined.ps1
+++ b/tests/integration/cases/set_comments_unsorted_order/powershell_combined.ps1
@@ -1,0 +1,12 @@
+$my_data = @(
+    # before apple
+    "apple";
+    "banana"  # banana inline
+    # trailing
+)
+$my_data = @(
+    # before apple
+    "apple";
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/powershell_varname.ps1
+++ b/tests/integration/cases/set_comments_unsorted_order/powershell_varname.ps1
@@ -1,0 +1,6 @@
+$my_data = @(
+    # before apple
+    "apple";
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/python.py
+++ b/tests/integration/cases/set_comments_unsorted_order/python.py
@@ -1,0 +1,6 @@
+{
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/python_combined.py
+++ b/tests/integration/cases/set_comments_unsorted_order/python_combined.py
@@ -1,0 +1,12 @@
+my_data = {
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}
+my_data = {
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/python_varname.py
+++ b/tests/integration/cases/set_comments_unsorted_order/python_varname.py
@@ -1,0 +1,6 @@
+my_data = {
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+}

--- a/tests/integration/cases/set_comments_unsorted_order/r.R
+++ b/tests/integration/cases/set_comments_unsorted_order/r.R
@@ -1,0 +1,6 @@
+x <- list(
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/r_combined.R
+++ b/tests/integration/cases/set_comments_unsorted_order/r_combined.R
@@ -1,0 +1,12 @@
+my_data <- list(
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+)
+my_data <- list(
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/r_varname.R
+++ b/tests/integration/cases/set_comments_unsorted_order/r_varname.R
@@ -1,0 +1,6 @@
+my_data <- list(
+    # before apple
+    "apple",
+    "banana"  # banana inline
+    # trailing
+)

--- a/tests/integration/cases/set_comments_unsorted_order/ruby.rb
+++ b/tests/integration/cases/set_comments_unsorted_order/ruby.rb
@@ -1,0 +1,6 @@
+Set.new([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/ruby_combined.rb
+++ b/tests/integration/cases/set_comments_unsorted_order/ruby_combined.rb
@@ -1,0 +1,12 @@
+my_data = Set.new([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])
+my_data = Set.new([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/ruby_varname.rb
+++ b/tests/integration/cases/set_comments_unsorted_order/ruby_varname.rb
@@ -1,0 +1,6 @@
+my_data = Set.new([
+    # before apple
+    "apple",
+    "banana",  # banana inline
+    # trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/rust.rs
+++ b/tests/integration/cases/set_comments_unsorted_order/rust.rs
@@ -1,0 +1,10 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+fn main() {
+    let _ = HashSet::from([
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    ]);
+}

--- a/tests/integration/cases/set_comments_unsorted_order/rust_combined.rs
+++ b/tests/integration/cases/set_comments_unsorted_order/rust_combined.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+fn main() {
+    {
+        let my_data = HashSet::from([
+            // before apple
+            "apple",
+            "banana",  // banana inline
+            // trailing
+        ]);
+        let _ = my_data;
+    }
+    let my_data;
+    my_data = HashSet::from([
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/rust_varname.rs
+++ b/tests/integration/cases/set_comments_unsorted_order/rust_varname.rs
@@ -1,0 +1,11 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+fn main() {
+    let my_data = HashSet::from([
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/scala.scala
+++ b/tests/integration/cases/set_comments_unsorted_order/scala.scala
@@ -1,0 +1,8 @@
+object Check {
+val x: Any = Set(
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+)
+}

--- a/tests/integration/cases/set_comments_unsorted_order/scala_combined.scala
+++ b/tests/integration/cases/set_comments_unsorted_order/scala_combined.scala
@@ -1,0 +1,17 @@
+object Declaration {
+  val my_data = Set(
+      // before apple
+      "apple",
+      "banana",  // banana inline
+      // trailing
+  )
+}
+object Assignment {
+  var my_data: Any = null
+  my_data = Set(
+      // before apple
+      "apple",
+      "banana",  // banana inline
+      // trailing
+  )
+}

--- a/tests/integration/cases/set_comments_unsorted_order/scala_varname.scala
+++ b/tests/integration/cases/set_comments_unsorted_order/scala_varname.scala
@@ -1,0 +1,8 @@
+object Check {
+val my_data = Set(
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+)
+}

--- a/tests/integration/cases/set_comments_unsorted_order/swift.swift
+++ b/tests/integration/cases/set_comments_unsorted_order/swift.swift
@@ -1,0 +1,6 @@
+let x: Any? = Set<AnyHashable>([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/swift_combined.swift
+++ b/tests/integration/cases/set_comments_unsorted_order/swift_combined.swift
@@ -1,0 +1,15 @@
+do {
+    let my_data: Any = Set<AnyHashable>([
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    ])
+}
+var my_data: Any
+my_data = Set<AnyHashable>([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/swift_varname.swift
+++ b/tests/integration/cases/set_comments_unsorted_order/swift_varname.swift
@@ -1,0 +1,6 @@
+let my_data: Any = Set<AnyHashable>([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+])

--- a/tests/integration/cases/set_comments_unsorted_order/typescript.ts
+++ b/tests/integration/cases/set_comments_unsorted_order/typescript.ts
@@ -1,0 +1,8 @@
+void (
+new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+])
+)

--- a/tests/integration/cases/set_comments_unsorted_order/typescript_combined.ts
+++ b/tests/integration/cases/set_comments_unsorted_order/typescript_combined.ts
@@ -1,0 +1,16 @@
+void (function() {
+const my_data = new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+]);
+})();
+var my_data;
+my_data = new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+]);
+export {};

--- a/tests/integration/cases/set_comments_unsorted_order/typescript_varname.ts
+++ b/tests/integration/cases/set_comments_unsorted_order/typescript_varname.ts
@@ -1,0 +1,7 @@
+const my_data = new Set([
+    // before apple
+    "apple",
+    "banana",  // banana inline
+    // trailing
+]);
+export {};

--- a/tests/integration/cases/set_comments_unsorted_order/zig.zig
+++ b/tests/integration/cases/set_comments_unsorted_order/zig.zig
@@ -1,0 +1,20 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+pub fn main() void {
+    const v: ZVal = .{ .set = &.{
+        // before apple
+        .{ .str = "apple" },
+        .{ .str = "banana" },  // banana inline
+        // trailing
+    }};
+    _ = v;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/zig_combined.zig
+++ b/tests/integration/cases/set_comments_unsorted_order/zig_combined.zig
@@ -1,0 +1,31 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+pub fn main() void {
+    {
+        const my_data: ZVal = .{ .set = &.{
+            // before apple
+            .{ .str = "apple" },
+            .{ .str = "banana" },  // banana inline
+            // trailing
+        }};
+        _ = my_data;
+    }
+    var my_data: ZVal = undefined;
+    my_data = .{ .set = &.{
+        // before apple
+        .{ .str = "apple" },
+        .{ .str = "banana" },  // banana inline
+        // trailing
+    }};
+    const _my_data_read = my_data;
+    _ = _my_data_read;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/zig_varname.zig
+++ b/tests/integration/cases/set_comments_unsorted_order/zig_varname.zig
@@ -1,0 +1,20 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+pub fn main() void {
+    const my_data: ZVal = .{ .set = &.{
+        // before apple
+        .{ .str = "apple" },
+        .{ .str = "banana" },  // banana inline
+        // trailing
+    }};
+    _ = my_data;
+}


### PR DESCRIPTION
## Summary

- Fixes the bug identified in #267 review: `extract_yaml_comments` iterated `CommentedSet` elements in YAML insertion order, but `_literalize` emits set elements in sorted order, causing comments to be applied to the wrong elements when YAML insertion order differed from sorted order.
- Fix collects element comments into a dict during insertion-order iteration (preserving correct `pending_before` propagation), then re-orders by the same sort key as `_literalize` before returning.
- Adds a regression test case (`set_comments_unsorted_order`) where `banana` precedes `apple` in YAML but `apple` sorts first alphabetically, verifying comments are aligned to the correct elements.

## Test plan

- [ ] All existing tests pass (`uv run --all-extras pytest tests/`)
- [ ] New `set_comments_unsorted_order` golden files confirm comments are attached to the correct sorted elements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how YAML set comments are associated/reordered, which could affect comment placement for `CommentedSet` outputs; the change is localized and covered by a new regression integration case.
> 
> **Overview**
> Fixes misaligned comment placement when literalizing YAML `!!set` values by collecting per-element comments in insertion order (to preserve `pending_before` propagation) and then reordering them to match the same sorted emission order used by `_literalize`.
> 
> Adds a new integration regression case (`set_comments_unsorted_order`) with golden outputs across supported languages to ensure comments stay attached to the correct set elements when YAML insertion order differs from the sorted output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1b11f70f3ee70a58e02ab70de496cd792c8c79f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->