### PR TITLE
Remove from __future__ import annotations and TC noqa

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -1,14 +1,12 @@
 """YAML comment extraction and formatting."""
 
-from __future__ import annotations
-
 import dataclasses
-from collections.abc import Iterable  # noqa: TC003
+from collections.abc import Iterable
 from typing import Any
 
 from beartype import beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
-from ruamel.yaml.tokens import CommentToken  # noqa: TC002
+from ruamel.yaml.tokens import CommentToken
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1,16 +1,14 @@
 """Core conversion logic: formatting values and parsing JSON/YAML."""
 
-from __future__ import annotations
-
 import dataclasses
 import datetime
 import json
 from io import StringIO
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml import YAML
-from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 from ruamel.yaml.compat import ordereddict
 from ruamel.yaml.error import YAMLError
 
@@ -19,12 +17,9 @@ from literalizer._comments import (
     extract_yaml_comments,
     literalize_yaml_scalar,
 )
-from literalizer._language import Language  # noqa: TC001
-from literalizer._types import Scalar, Value  # noqa: TC001
+from literalizer._language import Language
+from literalizer._types import Scalar, Value
 from literalizer.exceptions import JSONParseError, YAMLParseError
-
-if TYPE_CHECKING:
-    from ruamel.yaml.comments import CommentedSeq, CommentedSet
 
 
 @beartype

--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -1,9 +1,7 @@
 """Functions for formatting scalars as language-specific literals."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from collections.abc import Callable  # noqa: TC003
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1,13 +1,9 @@
 """Language protocol and internal spec dataclass."""
 
-from __future__ import annotations
-
 import dataclasses
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+import datetime
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -1,9 +1,7 @@
 """Ada language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -13,9 +11,6 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_ada,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -1,9 +1,7 @@
 """Bash language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -14,9 +12,6 @@ from literalizer._formatters import (
     format_string_backslash,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -1,9 +1,7 @@
 """C language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -13,9 +11,6 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -1,9 +1,7 @@
 """Clojure language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1,9 +1,8 @@
 """C++ language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -17,9 +16,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -1,9 +1,7 @@
 """Crystal language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -1,9 +1,8 @@
 """C# language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -17,9 +16,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -1,9 +1,7 @@
 """D language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -13,9 +11,6 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -1,9 +1,8 @@
 """Dart language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -18,9 +17,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -1,9 +1,7 @@
 """Elixir language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -1,9 +1,7 @@
 """Erlang language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -15,9 +13,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -1,9 +1,7 @@
 """F# language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -13,9 +11,6 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -1,9 +1,8 @@
 """Go language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -17,9 +16,6 @@ from literalizer._formatters import (
     format_string_backslash,
     passthrough_sequence_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -1,9 +1,7 @@
 """Groovy language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1,9 +1,7 @@
 """Haskell language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -15,9 +13,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1,9 +1,8 @@
 """Java language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -18,9 +17,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -1,9 +1,8 @@
 """JavaScript language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -18,9 +17,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -1,9 +1,8 @@
 """Julia language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -18,9 +17,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -1,9 +1,8 @@
 """Kotlin language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -18,9 +17,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -1,9 +1,7 @@
 """Lua language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -14,9 +12,6 @@ from literalizer._formatters import (
     format_string_backslash,
     passthrough_sequence_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -1,11 +1,9 @@
 """MATLAB language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
+import datetime
 import json
 import re
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -17,9 +15,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 _CONTROL_CHAR_THRESHOLD = 32
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1,9 +1,7 @@
 """Nim language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -1,9 +1,7 @@
 """OCaml language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -13,9 +11,6 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -1,9 +1,7 @@
 """Occam-pi language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -13,9 +11,6 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -1,9 +1,7 @@
 """Perl language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -1,9 +1,7 @@
 """PHP language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -14,9 +12,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -1,9 +1,7 @@
 """PowerShell language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -14,9 +12,6 @@ from literalizer._formatters import (
     format_datetime_iso,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1,9 +1,8 @@
 """Python language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -20,9 +19,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -1,9 +1,8 @@
 """R language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -17,9 +16,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -1,9 +1,8 @@
 """Ruby language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -18,9 +17,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1,9 +1,8 @@
 """Rust language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -17,9 +16,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -1,9 +1,7 @@
 """Scala language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -1,9 +1,7 @@
 """Swift language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -16,9 +14,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -1,9 +1,8 @@
 """TypeScript language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Literal
+import datetime
+from collections.abc import Callable
+from typing import Literal
 
 from beartype import beartype
 
@@ -18,9 +17,6 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 @beartype

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -1,9 +1,7 @@
 """Zig language specification."""
 
-from __future__ import annotations
-
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING
+import datetime
+from collections.abc import Callable
 
 from beartype import beartype
 
@@ -66,9 +64,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     """Format a Zig assignment to an existing ``ZVal`` variable."""
     return f"{name} = {_to_val(value=value)};"
 
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,14 +1,12 @@
 """Tests for literalizer converter."""
 
-from __future__ import annotations
-
 import ast
 import base64
 import dataclasses
 import datetime
 import json
 import textwrap
-from collections.abc import Callable  # noqa: TC003
+from collections.abc import Callable
 
 import pytest
 from beartype import beartype


### PR DESCRIPTION
Without PEP 563 deferred annotation evaluation, type annotations are evaluated at runtime, making imports used in annotations actually required. This eliminates flake8-type-checking violations (TC001/TC002/TC003) that recommended moving these imports to TYPE_CHECKING blocks.

Moved Callable from TYPE_CHECKING to runtime imports in language specs and _formatters.py. Merged CommentedSeq/CommentedSet from TYPE_CHECKING into ruamel.yaml imports in _core.py. Removed all TC noqa suppressions.

Passes all 227 unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily import/type-hint hygiene (removing `__future__` annotations and `TYPE_CHECKING`-only imports) with no behavioral logic changes expected beyond import-time effects.
> 
> **Overview**
> Removes `from __future__ import annotations` and all flake8 `TC001/TC002/TC003` `noqa` suppressions across the core modules and built-in language specs.
> 
> To keep runtime-evaluated annotations valid, this shifts previously `TYPE_CHECKING`-guarded imports (notably `Callable`, `CommentToken`, and `CommentedSeq`/`CommentedSet`) into normal imports in `_language.py`, `_formatters.py`, `_core.py`, and the language spec modules, with a small matching import tweak in `tests/test_converter.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abaa0019dbe4c55f09619c546409368c7aa08737. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->