### PR TITLE
Move TYPE_CHECKING imports to top of file

### DIFF
--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -14,6 +14,9 @@ from literalizer._formatters import (
     format_string_ada,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_ada_val(value: str) -> str:
@@ -92,10 +95,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_ada
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Ada:

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -15,6 +15,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_bash_value(item: str) -> str:
@@ -68,10 +71,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Bash:

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -14,6 +14,9 @@ from literalizer._formatters import (
     format_string_backslash,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_val(value: str) -> str:
@@ -77,10 +80,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class C:

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_variable_declaration(name: str, value: str) -> str:
@@ -34,10 +37,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Clojure:

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -18,6 +18,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_cpp_dict_entry(key: str, value: str) -> str:
@@ -47,10 +50,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "cpp": format_datetime_cpp,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Cpp:

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_variable_declaration(name: str, value: str) -> str:
@@ -34,10 +37,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Crystal:

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -18,6 +18,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_csharp_dict_entry(key: str, value: str) -> str:
@@ -47,10 +50,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "csharp": format_datetime_csharp,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class CSharp:

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -14,6 +14,9 @@ from literalizer._formatters import (
     format_string_backslash,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_val(value: str) -> str:
@@ -95,10 +98,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class D:

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -19,6 +19,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_dart_omap_entry(key: str, value: str) -> str:
@@ -48,10 +51,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "dart": format_datetime_dart,
 }
 _string_format: Callable[[str], str] = format_string_backslash_dollar
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Dart:

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_elixir_omap_entry(key: str, value: str) -> str:
@@ -40,10 +43,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Elixir:

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -16,6 +16,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_erlang_omap_entry(key: str, value: str) -> str:
@@ -48,10 +51,6 @@ _bytes_format: Callable[[bytes], str] = _format_bytes
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Erlang:

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -14,6 +14,9 @@ from literalizer._formatters import (
     format_string_backslash,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_val(value: str) -> str:
@@ -95,10 +98,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class FSharp:

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -18,6 +18,9 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_go_set_entry(item: str) -> str:
@@ -56,10 +59,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "go": format_datetime_go,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Go:

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_variable_declaration(name: str, value: str) -> str:
@@ -34,10 +37,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash_dollar
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Groovy:

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -16,6 +16,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_haskell_dict_entry(key: str, value: str) -> str:
@@ -45,10 +48,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Haskell:

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -19,6 +19,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_java_dict_entry(key: str, value: str) -> str:
@@ -49,10 +52,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "zoned": format_datetime_java_zoned,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Java:

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -19,6 +19,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_js_omap_entry(key: str, value: str) -> str:
@@ -48,10 +51,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "js": format_datetime_js,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class JavaScript:

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -19,6 +19,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_julia_omap_entry(key: str, value: str) -> str:
@@ -42,10 +45,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "julia": format_datetime_julia,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Julia:

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -19,6 +19,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_kotlin_omap_entry(key: str, value: str) -> str:
@@ -48,10 +51,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "kotlin": format_datetime_kotlin,
 }
 _string_format: Callable[[str], str] = format_string_backslash_dollar
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Kotlin:

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -15,6 +15,9 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_lua_dict_entry(key: str, value: str) -> str:
@@ -50,10 +53,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Lua:

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 _CONTROL_CHAR_THRESHOLD = 32
 
 
@@ -102,10 +105,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_matlab
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Matlab:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_variable_declaration(name: str, value: str) -> str:
@@ -34,10 +37,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Nim:

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -14,6 +14,9 @@ from literalizer._formatters import (
     format_string_backslash,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_val(value: str) -> str:
@@ -99,10 +102,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class OCaml:

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -14,6 +14,9 @@ from literalizer._formatters import (
     format_string_backslash,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_val(value: str) -> str:
@@ -84,10 +87,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Occam:

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_variable_declaration(name: str, value: str) -> str:
@@ -34,10 +37,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Perl:

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -15,6 +15,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_php_omap_entry(key: str, value: str) -> str:
@@ -50,10 +53,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = _format_date
 _datetime_format: Callable[[datetime.datetime], str] = _format_datetime
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Php:

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -15,6 +15,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_sequence_entry(item: str) -> str:
@@ -57,10 +60,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = _format_string
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class PowerShell:

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -21,6 +21,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_python_omap_entry(key: str, value: str) -> str:
@@ -56,10 +59,6 @@ _bytes_formats: dict[str, Callable[[bytes], str]] = {
     "hex": format_bytes_hex,
     "python": format_bytes_python,
 }
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Python:

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -18,6 +18,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_r_dict_entry(key: str, value: str) -> str:
@@ -60,10 +63,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "r": format_datetime_r,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class R:

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -19,6 +19,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_ruby_omap_entry(key: str, value: str) -> str:
@@ -48,10 +51,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "ruby": format_datetime_ruby,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Ruby:

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -18,6 +18,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_rust_dict_entry(key: str, value: str) -> str:
@@ -53,10 +56,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "rust": format_datetime_rust,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Rust:

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_scala_omap_entry(key: str, value: str) -> str:
@@ -40,10 +43,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Scala:

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -17,6 +17,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_swift_omap_entry(key: str, value: str) -> str:
@@ -40,10 +43,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Swift:

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -19,6 +19,9 @@ from literalizer._formatters import (
     passthrough_set_entry,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _format_ts_omap_entry(key: str, value: str) -> str:
@@ -48,10 +51,6 @@ _datetime_formats: dict[str, Callable[[datetime.datetime], str]] = {
     "js": format_datetime_js,
 }
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class TypeScript:

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -14,6 +14,9 @@ from literalizer._formatters import (
     format_string_backslash,
 )
 
+if TYPE_CHECKING:
+    from literalizer._types import Value
+
 
 @beartype
 def _to_val(value: str) -> str:
@@ -71,10 +74,6 @@ _bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
-
-
-if TYPE_CHECKING:
-    from literalizer._types import Value
 
 
 class Zig:


### PR DESCRIPTION
Move all TYPE_CHECKING import blocks to the top of files, right after other imports. This follows PEP 8 conventions and improves readability by consolidating all imports in one location. Applied across all 35 language specification files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely organizational change that only reorders `TYPE_CHECKING` import blocks in language spec modules; runtime behavior should be unchanged aside from potential import-time edge cases.
> 
> **Overview**
> Standardizes import layout across the `src/literalizer/languages/*` modules by moving the `if TYPE_CHECKING: from literalizer._types import Value` block up to the top of each file (immediately after other imports).
> 
> No formatting/serialization logic changes are introduced; this is a consistency/readability cleanup aligned with PEP 8.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b987fff40ede77ce792c2dbdf02dc8642dcef28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->