### PR TITLE
Remove type: ignore[assignment]

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -230,11 +230,11 @@ def _literalize(
             lines.append(f"{effective_prefix}{entry}{sep}")
     else:
         # At this point data must be a list (scalars/dict/set/omap handled)
-        items = data
+        items: list[Value] = list(data)
         last_idx = len(items) - 1
-        for i, item in enumerate(iterable=items):  # type: ignore[assignment]
+        for i, element in enumerate(iterable=items):
             formatted = spec.format_sequence_entry(
-                _format_value(value=item, spec=spec)
+                _format_value(value=element, spec=spec)
             )
             add_sep = i < last_idx or spec.multiline_trailing_comma
             sep = spec.element_separator.strip() if add_sep else ""


### PR DESCRIPTION
Remove type: ignore[assignment] by explicitly annotating the list variable and renaming the loop variable to avoid mypy type unification across branches.

The original code had a type: ignore because mypy unified the 'item' variable across the set branch (where it's Scalar) and the else branch (where it should be Value). Explicitly annotating 'items' as list[Value] and renaming to 'element' in the else branch resolves the type error cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts local typing/variable names in the list formatting path and should not change runtime behavior.
> 
> **Overview**
> Removes the `# type: ignore[assignment]` in `_literalize`’s sequence branch by explicitly materializing/annotating `items` as `list[Value]` and renaming the loop variable to avoid mypy type unification across branches.
> 
> This is a typing-only cleanup intended to keep the formatting logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c3c33ea0b7d83bf715f9df6a6e69d73a2a9355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->