### PR TITLE
Java: extend typed array openers to boolean and float element types

### DIFF
--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -33,15 +33,28 @@ def _format_java_collection_open(values: list[Any]) -> str:
     """Return a typed Java array opener inferred from element types.
 
     Returns ``"new String[]{"`` when all elements are strings,
-    ``"new int[]{"`` when all elements are non-boolean integers, and
-    ``"new Object[]{"`` otherwise.
+    ``"new boolean[]{"`` when all elements are booleans,
+    ``"new int[]{"`` when all elements are non-boolean integers,
+    ``"new double[]{"`` when all elements are non-boolean numeric
+    (float, or mixed int and float), and ``"new Object[]{"`` otherwise.
     """
     if values and all(isinstance(v, str) for v in values):
         return "new String[]{"
+    if values and all(isinstance(v, bool) for v in values):
+        return "new boolean[]{"
     if values and all(
         isinstance(v, int) and not isinstance(v, bool) for v in values
     ):
         return "new int[]{"
+    if (
+        values
+        and all(
+            isinstance(v, (int, float)) and not isinstance(v, bool)
+            for v in values
+        )
+        and any(isinstance(v, float) for v in values)
+    ):
+        return "new double[]{"
     return "new Object[]{"
 
 

--- a/tests/integration/cases/bool_list/java.java
+++ b/tests/integration/cases/bool_list/java.java
@@ -1,7 +1,7 @@
 import java.util.Map;
 import java.util.Set;
 class Check {
-    Object x = new Object[]{
+    Object x = new boolean[]{
     true,
     false,
     true

--- a/tests/integration/cases/bool_list/java_combined.java
+++ b/tests/integration/cases/bool_list/java_combined.java
@@ -2,12 +2,12 @@ import java.util.Map;
 import java.util.Set;
 class Check {
     public static void check() {
-var my_data = new Object[]{
+var my_data = new boolean[]{
     true,
     false,
     true
 };
-my_data = new Object[]{
+my_data = new boolean[]{
     true,
     false,
     true

--- a/tests/integration/cases/bool_list/java_varname.java
+++ b/tests/integration/cases/bool_list/java_varname.java
@@ -2,7 +2,7 @@ import java.util.Map;
 import java.util.Set;
 class Check {
     public static void check() {
-var my_data = new Object[]{
+var my_data = new boolean[]{
     true,
     false,
     true

--- a/tests/integration/cases/float_list/java.java
+++ b/tests/integration/cases/float_list/java.java
@@ -1,7 +1,7 @@
 import java.util.Map;
 import java.util.Set;
 class Check {
-    Object x = new Object[]{
+    Object x = new double[]{
     1.1,
     2.2,
     3.3

--- a/tests/integration/cases/float_list/java_combined.java
+++ b/tests/integration/cases/float_list/java_combined.java
@@ -2,12 +2,12 @@ import java.util.Map;
 import java.util.Set;
 class Check {
     public static void check() {
-var my_data = new Object[]{
+var my_data = new double[]{
     1.1,
     2.2,
     3.3
 };
-my_data = new Object[]{
+my_data = new double[]{
     1.1,
     2.2,
     3.3

--- a/tests/integration/cases/float_list/java_varname.java
+++ b/tests/integration/cases/float_list/java_varname.java
@@ -2,7 +2,7 @@ import java.util.Map;
 import java.util.Set;
 class Check {
     public static void check() {
-var my_data = new Object[]{
+var my_data = new double[]{
     1.1,
     2.2,
     3.3


### PR DESCRIPTION
Extends _format_java_collection_open with support for two new typed array openers:

- new boolean[]{ when all elements are booleans
- new double[]{ when all elements are floats, or mixed int and float (no booleans)

Boolean check is placed before the integer check since bool is a subclass of int in Python. Float check requires at least one float value to distinguish from pure integer lists. Updates golden test files for bool_list and float_list cases accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow change to Java literal generation (array opener inference) with updated golden integration tests, impacting only emitted code formatting for boolean/numeric lists.
> 
> **Overview**
> Java literalization now emits *typed array initializers* for additional element types: boolean-only lists use `new boolean[]{...}` and float/mixed int+float (excluding booleans) lists use `new double[]{...}` instead of falling back to `new Object[]{...}`.
> 
> Integration golden outputs for the `bool_list` and `float_list` Java cases are updated to match the new typed array openers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55481986366404cde3e0b64ba22ba6e0a75b5d0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->