### PR TITLE
Cache Octave apt packages in CI

### DIFF
--- a/.github/workflows/lint-matlab.yml
+++ b/.github/workflows/lint-matlab.yml
@@ -14,7 +14,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Octave
-        run: sudo apt-get install -y octave
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: octave
+          version: 1.0
       # Octave is a practical CI substitute, but it accepts some
       # double-quoted backslash escapes (e.g. \") that MATLAB rejects.
       - name: Check MATLAB syntax (Octave-compatible files)


### PR DESCRIPTION
The lint-matlab job was taking 15+ minutes due to `apt-get install octave` downloading and compiling Octave's large dependency tree. This change uses awalsh128/cache-apt-pkgs-action to cache the packages, reducing subsequent runs to seconds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that swaps `apt-get install octave` for an apt package caching action; main risk is CI failures if the third-party action or cache versioning misbehaves.
> 
> **Overview**
> Speeds up the `lint-matlab` GitHub Actions job by replacing the direct `apt-get install -y octave` step with `awalsh128/cache-apt-pkgs-action@v1` to cache Octave’s apt packages (versioned via `version: 1.0`).
> 
> No lint logic changes beyond how Octave is installed; subsequent CI runs should avoid re-downloading the dependency tree.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e2e1bc30bac1bc47b52c1c2624b53c1f43f32b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->