### PR TITLE
Fix lint-matlab CI missing liblapack3

### DIFF
--- a/.github/workflows/lint-matlab.yml
+++ b/.github/workflows/lint-matlab.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Install Octave
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: octave
-          version: 1.0
+          packages: octave liblapack3
+          version: 1.1
       # Octave is a practical CI substitute, but it accepts some
       # double-quoted backslash escapes (e.g. \") that MATLAB rejects.
       - name: Check MATLAB syntax (Octave-compatible files)


### PR DESCRIPTION
## Summary
- Add `liblapack3` to cached apt packages in lint-matlab CI job
- Bump cache version to invalidate stale cache missing the shared library
- Fixes `liblapack.so.3: cannot open shared object file` error from `awalsh128/cache-apt-pkgs-action` not caching Octave's transitive dependency

## Test plan
- [x] CI lint-matlab job should pass with the updated cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds an extra apt package and bumps the cache version; impact is limited to the MATLAB lint workflow.
> 
> **Overview**
> The `lint-matlab` GitHub Actions workflow now installs/caches `liblapack3` alongside `octave` to prevent `liblapack.so.3` runtime failures during the Octave-based syntax check.
> 
> It also bumps the cache `version` to invalidate existing caches that were missing the shared library.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb62ceb17d162a2cf136d753290be99d5730977d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->