### PR TITLE
Split indent parameter into line_prefix and indent

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,6 @@ Usage
    result = literalize_yaml(
        yaml_string=yaml_config,
        language=Go(),
-       indent="    ",
        wrap=True,
    )
    # result:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,7 +39,6 @@ Usage
    result = literalize_yaml(
        yaml_string=yaml_config,
        language=Go(),
-       indent="    ",
        wrap=True,
    )
    # result:

--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -230,7 +230,7 @@ class YamlCollectionContext:
     trailing: tuple[str, ...]
     comment_prefix: str
     comment_suffix: str
-    indent: str
+    comment_line_prefix: str
     wrap: bool
 
 
@@ -241,7 +241,7 @@ def literalize_yaml_scalar(
     base: str,
     comment_prefix: str,
     comment_suffix: str,
-    indent: str,
+    line_prefix: str,
 ) -> str:
     """Preserve comments for scalar YAML values.
 
@@ -261,7 +261,7 @@ def literalize_yaml_scalar(
             text=comment_text,
             comment_prefix=comment_prefix,
             comment_suffix=comment_suffix,
-            line_prefix=indent,
+            line_prefix=line_prefix,
         )
         for comment_text in scalar_comments.before
     ]
@@ -281,7 +281,7 @@ def literalize_yaml_collection(
     ctx: YamlCollectionContext,
 ) -> str:
     """Preserve comments for sequence/mapping YAML values."""
-    effective_indent = ctx.indent if not ctx.wrap else (ctx.indent or "    ")
+    effective_indent = ctx.comment_line_prefix
     all_lines = ctx.base.split(sep="\n")
 
     if ctx.wrap and len(all_lines) > 1:
@@ -341,7 +341,7 @@ def apply_collection_comments(
     base: str,
     comment_prefix: str,
     comment_suffix: str,
-    indent: str,
+    comment_line_prefix: str,
     wrap: bool,
 ) -> str:
     """Apply extracted comments to a collection literal.
@@ -363,7 +363,7 @@ def apply_collection_comments(
         trailing=collection_comments.trailing,
         comment_prefix=comment_prefix,
         comment_suffix=comment_suffix,
-        indent=indent,
+        comment_line_prefix=comment_line_prefix,
         wrap=wrap,
     )
     return literalize_yaml_collection(ctx=ctx)

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -130,16 +130,24 @@ def _wrap_body(
     is_omap: bool,
     data: list[Value] | dict[str, Value] | set[Scalar],
     spec: Language,
+    line_prefix: str,
 ) -> str:
     """Wrap ``body`` in the language's open/close delimiters."""
     ci = spec.multiline_close_indent
+    close_prefix = f"{line_prefix}{ci}"
     if is_omap:
-        return f"{spec.omap_open}\n{body}\n{ci}{spec.omap_close}"
-    if isinstance(data, dict):
-        return f"{spec.dict_open}\n{body}\n{ci}{spec.dict_close}"
-    if isinstance(data, set):
-        return f"{spec.set_open}\n{body}\n{ci}{spec.set_close}"
-    return f"{spec.sequence_open(data)}\n{body}\n{ci}{spec.sequence_close}"
+        opening = f"{line_prefix}{spec.omap_open}"
+        closing = f"{close_prefix}{spec.omap_close}"
+    elif isinstance(data, dict):
+        opening = f"{line_prefix}{spec.dict_open}"
+        closing = f"{close_prefix}{spec.dict_close}"
+    elif isinstance(data, set):
+        opening = f"{line_prefix}{spec.set_open}"
+        closing = f"{close_prefix}{spec.set_close}"
+    else:
+        opening = f"{line_prefix}{spec.sequence_open(data)}"
+        closing = f"{close_prefix}{spec.sequence_close}"
+    return f"{opening}\n{body}\n{closing}"
 
 
 @beartype(conf=BeartypeConf(is_pep484_tower=True))
@@ -147,6 +155,7 @@ def _literalize(
     *,
     data: Value,
     language: Language,
+    line_prefix: str,
     indent: str,
     wrap: bool,
 ) -> str:
@@ -166,8 +175,13 @@ def _literalize(
         language: A :class:`Language` instance describing how to format
             literals.  Use one of the built-in constants
             (e.g. :data:`PYTHON`, :data:`GO`) or provide your own.
-        indent: String to prepend to each output line (e.g. ``"        "``
-            for 8-space indent, or ``"\t\t"`` for 2-tab indent).
+        line_prefix: String to prepend to every output line
+            (e.g. ``"        "`` for 8-space margin, or ``"\t\t"``
+            for 2-tab margin).  Positions the generated block at
+            the right column in surrounding source code.
+        indent: Indentation step for elements inside delimiters when
+            *wrap* is ``True`` (e.g. ``"    "`` for 4-space indent).
+            Ignored when *wrap* is ``False``.
         wrap: If True, wrap the output in delimiters
             (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
             Ignored for scalar values.
@@ -187,9 +201,9 @@ def _literalize(
         datetime.date,
     )
     if isinstance(data, scalar_types) or data is None:
-        return f"{indent}{_format_scalar(value=data, spec=spec)}"
+        return f"{line_prefix}{_format_scalar(value=data, spec=spec)}"
 
-    effective_indent = indent if not wrap else (indent or "    ")
+    body_prefix = line_prefix + indent if wrap else line_prefix
     lines: list[str] = []
 
     is_omap = isinstance(data, ordereddict)
@@ -218,7 +232,7 @@ def _literalize(
             )
             add_sep = i < last_idx or spec.multiline_trailing_comma
             sep = spec.element_separator.strip() if add_sep else ""
-            lines.append(f"{effective_indent}{entry}{sep}")
+            lines.append(f"{body_prefix}{entry}{sep}")
     elif isinstance(data, set):
         sorted_items = sorted(data, key=lambda v: (type(v).__name__, repr(v)))
         last_idx = len(sorted_items) - 1
@@ -227,7 +241,7 @@ def _literalize(
             entry = spec.format_set_entry(formatted)
             add_sep = i < last_idx or spec.multiline_trailing_comma
             sep = spec.element_separator.strip() if add_sep else ""
-            lines.append(f"{effective_indent}{entry}{sep}")
+            lines.append(f"{body_prefix}{entry}{sep}")
     else:
         # At this point data must be a list (scalars/dict/set/omap handled)
         items: list[Value] = list(data)
@@ -238,14 +252,20 @@ def _literalize(
             )
             add_sep = i < last_idx or spec.multiline_trailing_comma
             sep = spec.element_separator.strip() if add_sep else ""
-            lines.append(f"{effective_indent}{formatted}{sep}")
+            lines.append(f"{body_prefix}{formatted}{sep}")
 
     body = "\n".join(lines)
 
     if not wrap or not body:
         return body
 
-    return _wrap_body(body=body, is_omap=is_omap, data=data, spec=spec)
+    return _wrap_body(
+        body=body,
+        is_omap=is_omap,
+        data=data,
+        spec=spec,
+        line_prefix=line_prefix,
+    )
 
 
 @beartype
@@ -253,7 +273,8 @@ def literalize_json(
     *,
     json_string: str,
     language: Language,
-    indent: str,
+    line_prefix: str = "",
+    indent: str = "    ",
     wrap: bool,
     variable_name: str | None = None,
     new_variable: bool = True,
@@ -268,8 +289,13 @@ def literalize_json(
         language: A :class:`Language` instance describing how to format
             literals.  Use one of the built-in constants
             (e.g. :data:`PYTHON`, :data:`GO`) or provide your own.
-        indent: String to prepend to each output line (e.g. ``"        "``
-            for 8-space indent, or ``"\t\t"`` for 2-tab indent).
+        line_prefix: String to prepend to every output line
+            (e.g. ``"        "`` for 8-space margin, or ``"\t\t"``
+            for 2-tab margin).  Positions the generated block at
+            the right column in surrounding source code.
+        indent: Indentation step for elements inside delimiters when
+            *wrap* is ``True`` (e.g. ``"    "`` for 4-space indent).
+            Ignored when *wrap* is ``False``.
         wrap: If True, wrap the output in delimiters
             (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
         variable_name: If given, wrap the output in a variable
@@ -295,6 +321,7 @@ def literalize_json(
     result = _literalize(
         data=data,
         language=language,
+        line_prefix=line_prefix,
         indent=indent,
         wrap=wrap,
     )
@@ -313,7 +340,8 @@ def literalize_yaml(
     *,
     yaml_string: str,
     language: Language,
-    indent: str,
+    line_prefix: str = "",
+    indent: str = "    ",
     wrap: bool,
     variable_name: str | None = None,
     new_variable: bool = True,
@@ -331,8 +359,13 @@ def literalize_yaml(
         language: A :class:`Language` instance describing how to format
             literals.  Use one of the built-in constants
             (e.g. :data:`PYTHON`, :data:`GO`) or provide your own.
-        indent: String to prepend to each output line (e.g. ``"        "``
-            for 8-space indent, or ``"\t\t"`` for 2-tab indent).
+        line_prefix: String to prepend to every output line
+            (e.g. ``"        "`` for 8-space margin, or ``"\t\t"``
+            for 2-tab margin).  Positions the generated block at
+            the right column in surrounding source code.
+        indent: Indentation step for elements inside delimiters when
+            *wrap* is ``True`` (e.g. ``"    "`` for 4-space indent).
+            Ignored when *wrap* is ``False``.
         wrap: If True, wrap the output in delimiters
             (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
         variable_name: If given, wrap the output in a variable
@@ -358,12 +391,15 @@ def literalize_yaml(
     base = _literalize(
         data=data,
         language=language,
+        line_prefix=line_prefix,
         indent=indent,
         wrap=wrap,
     )
 
     cp = language.comment_prefix
     cs = language.comment_suffix
+
+    comment_line_prefix = line_prefix + indent if wrap else line_prefix
 
     result: str
     if isinstance(data, set):
@@ -376,7 +412,7 @@ def literalize_yaml(
             base=base,
             comment_prefix=cp,
             comment_suffix=cs,
-            indent=indent,
+            comment_line_prefix=comment_line_prefix,
             wrap=wrap,
         )
     elif not isinstance(data, (list, dict)):
@@ -388,7 +424,7 @@ def literalize_yaml(
             base=base,
             comment_prefix=cp,
             comment_suffix=cs,
-            indent=indent,
+            line_prefix=line_prefix,
         )
     elif not base:
         result = base
@@ -432,7 +468,7 @@ def literalize_yaml(
             base=base,
             comment_prefix=cp,
             comment_suffix=cs,
-            indent=indent,
+            comment_line_prefix=comment_line_prefix,
             wrap=wrap,
         )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1431,7 +1431,7 @@ def test_golden_file(
     result = literalizer.literalize_yaml(
         yaml_string=yaml_string,
         language=lang_config.spec,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     wrapped = lang_config.wrap(result)
@@ -1461,7 +1461,7 @@ def test_golden_file_with_variable_name(
     result = literalizer.literalize_yaml(
         yaml_string=yaml_string,
         language=lang_config.spec,
-        indent="",
+        line_prefix="",
         wrap=True,
         variable_name=_VARIABLE_NAME,
     )
@@ -1494,7 +1494,7 @@ def test_golden_file_combined_variable_forms(
     declaration = literalizer.literalize_yaml(
         yaml_string=yaml_string,
         language=lang_config.spec,
-        indent="",
+        line_prefix="",
         wrap=True,
         variable_name=_VARIABLE_NAME,
         new_variable=True,
@@ -1502,7 +1502,7 @@ def test_golden_file_combined_variable_forms(
     assignment = literalizer.literalize_yaml(
         yaml_string=yaml_string,
         language=lang_config.spec,
-        indent="",
+        line_prefix="",
         wrap=True,
         variable_name=_VARIABLE_NAME,
         new_variable=False,
@@ -1541,7 +1541,7 @@ def test_date_format_golden_file(
     result = literalizer.literalize_yaml(
         yaml_string=yaml_string,
         language=variant.spec,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     wrapped = variant.wrap(result)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -122,7 +122,7 @@ def test_language_sequence(*, language: Language, expected: str) -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[[True, None, "hi", [1, 2]]]),
         language=language,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == expected
@@ -133,7 +133,7 @@ def test_ruby_dict() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[{"key": None}]),
         language=RUBY,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '{"key" => nil},'
@@ -145,7 +145,7 @@ def test_dict_python() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=data),
         language=PYTHON,
-        indent="    ",
+        line_prefix="    ",
         wrap=False,
     )
     assert result == '    "user_1": "team_alpha",\n    "user_2": "team_alpha",'
@@ -156,7 +156,7 @@ def test_dict_ruby() -> None:
     result = literalize_json(
         json_string=json.dumps(obj={"user_1": "team_alpha"}),
         language=RUBY,
-        indent="  ",
+        line_prefix="  ",
         wrap=False,
     )
     assert result == '  "user_1" => "team_alpha",'
@@ -167,7 +167,7 @@ def test_dict_wrap() -> None:
     result = literalize_json(
         json_string=json.dumps(obj={"a": 1, "b": 2}),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -187,7 +187,7 @@ def test_java_dict_wrap_no_multiline_trailing_comma() -> None:
     result = literalize_json(
         json_string=json.dumps(obj={"name": "Alice", "age": 30}),
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -206,7 +206,7 @@ def test_java_dict_skips_null_values() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=data),
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -224,7 +224,7 @@ def test_java_dict_skips_null_values_no_wrap() -> None:
     result = literalize_json(
         json_string=json.dumps(obj={"a": None, "b": 1}),
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     expected = 'Map.entry("b", 1)'
@@ -238,7 +238,7 @@ def test_java_dict_all_null_values_wrap() -> None:
     result = literalize_json(
         json_string=json.dumps(obj={"a": None, "b": None}),
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     assert result == "Map.ofEntries()"
@@ -250,7 +250,7 @@ def test_java_yaml_dict_null_values_with_comments() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -277,7 +277,7 @@ def test_java_yaml_dict_null_value_inline_comment_preserved() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -304,7 +304,7 @@ def test_java_yaml_null_value_inline_comment_as_trailing() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -325,7 +325,7 @@ def test_java_yaml_all_null_dict_with_trailing_comments() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = "Map.ofEntries()\n    // trailing"
@@ -346,7 +346,7 @@ def test_java_yaml_omap_skips_null_values() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     omap_inline = (
@@ -362,7 +362,7 @@ def test_java_sequence_wrap_uses_braces() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[1, "hello", True]),
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -392,7 +392,7 @@ def test_java_typed_array_opener(
     result = literalize_json(
         json_string=json.dumps(obj=json_input),
         language=JAVA,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     assert result.startswith(expected_open)
@@ -402,7 +402,10 @@ def test_java_typed_array_opener(
 def test_dict_empty(*, wrap: bool) -> None:
     """An empty dict produces an empty string regardless of wrap."""
     result = literalize_json(
-        json_string=json.dumps(obj={}), language=PYTHON, indent="", wrap=wrap
+        json_string=json.dumps(obj={}),
+        language=PYTHON,
+        line_prefix="",
+        wrap=wrap,
     )
     assert result == ""
 
@@ -412,7 +415,7 @@ def test_integers() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[42, 0, -7]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     expected = textwrap.dedent(
@@ -429,7 +432,7 @@ def test_floats() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[1000.0, 3.14]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     expected = textwrap.dedent(
@@ -445,7 +448,7 @@ def test_string_escaping() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=['say "hi"', "a\\b", "line1\nline2"]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     lines = result.split(sep="\n")
@@ -459,7 +462,7 @@ def test_nested_arrays() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[[[1, 2], [3, 4]]]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == "((1, 2), (3, 4)),"
@@ -470,7 +473,7 @@ def test_dicts() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[{"name": "alice", "age": 30}]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '{"name": "alice", "age": 30},'
@@ -481,7 +484,7 @@ def test_nested_dict_in_sequence() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[["a", {"x": 1}]]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '("a", {"x": 1}),'
@@ -492,7 +495,7 @@ def test_nested_sequence_in_dict() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[{"items": [1, 2]}]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '{"items": (1, 2)},'
@@ -503,7 +506,7 @@ def test_indent_spaces() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[True, False]),
         language=PYTHON,
-        indent="        ",
+        line_prefix="        ",
         wrap=False,
     )
     assert result == "        True,\n        False,"
@@ -514,7 +517,7 @@ def test_indent_tabs() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[True, False]),
         language=GO,
-        indent="\t\t",
+        line_prefix="\t\t",
         wrap=False,
     )
     assert result == "\t\ttrue,\n\t\tfalse,"
@@ -525,7 +528,7 @@ def test_wrap() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[True, False]),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -538,20 +541,15 @@ def test_wrap() -> None:
     assert result == expected
 
 
-def test_wrap_with_indent() -> None:
-    """Wrapping respects the given prefix."""
+def test_wrap_with_line_prefix() -> None:
+    """Wrapping respects the given line_prefix."""
     result = literalize_json(
         json_string=json.dumps(obj=[["a", 1.0]]),
         language=PYTHON,
-        indent="    ",
+        line_prefix="    ",
         wrap=True,
     )
-    expected = textwrap.dedent(
-        text="""\
-        (
-            ("a", 1.0),
-        )"""
-    )
+    expected = '    (\n        ("a", 1.0),\n    )'
     assert result == expected
 
 
@@ -559,7 +557,10 @@ def test_wrap_with_indent() -> None:
 def test_empty_data(*, wrap: bool) -> None:
     """An empty list produces an empty string regardless of wrap."""
     result = literalize_json(
-        json_string=json.dumps(obj=[]), language=PYTHON, indent="", wrap=wrap
+        json_string=json.dumps(obj=[]),
+        language=PYTHON,
+        line_prefix="",
+        wrap=wrap,
     )
     assert result == ""
 
@@ -585,7 +586,7 @@ def test_scalar(
 ) -> None:
     """Scalar values are formatted as native literals."""
     result = literalize_json(
-        json_string=json_string, language=language, indent="", wrap=False
+        json_string=json_string, language=language, line_prefix="", wrap=False
     )
     assert result == expected
 
@@ -593,7 +594,7 @@ def test_scalar(
 def test_scalar_with_indent() -> None:
     """Scalar values respect the prefix parameter."""
     result = literalize_json(
-        json_string="42", language=PYTHON, indent="    ", wrap=False
+        json_string="42", language=PYTHON, line_prefix="    ", wrap=False
     )
     assert result == "    42"
 
@@ -601,7 +602,7 @@ def test_scalar_with_indent() -> None:
 def test_scalar_wrap_ignored() -> None:
     """Wrap is ignored for scalar values."""
     result = literalize_json(
-        json_string="42", language=PYTHON, indent="", wrap=True
+        json_string="42", language=PYTHON, line_prefix="", wrap=True
     )
     assert result == "42"
 
@@ -644,7 +645,7 @@ def test_custom_language() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=[True, None, "hi"]),
         language=custom,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == 'YES,\nNIL,\n"hi",'
@@ -661,7 +662,7 @@ def test_part1_sample_python() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=data),
         language=PYTHON,
-        indent="        ",
+        line_prefix="        ",
         wrap=False,
     )
     expected_lines = [
@@ -679,7 +680,7 @@ def test_part2_sample_go() -> None:
     result = literalize_json(
         json_string=json.dumps(obj=data),
         language=GO,
-        indent="        ",
+        line_prefix="        ",
         wrap=False,
     )
     lines = result.split(sep="\n")
@@ -740,7 +741,7 @@ def test_literalize_json_array() -> None:
     result = literalize_json(
         json_string=json_string,
         language=PYTHON,
-        indent="    ",
+        line_prefix="    ",
         wrap=False,
     )
     expected = '    ("user_1", 1000.0),\n    ("user_2", 2000.0),'
@@ -753,7 +754,7 @@ def test_literalize_json_object() -> None:
     result = literalize_json(
         json_string=json_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = '{\n    "a": 1,\n    "b": True,\n}'
@@ -766,7 +767,7 @@ def test_literalize_json_invalid() -> None:
         literalize_json(
             json_string="not json",
             language=PYTHON,
-            indent="",
+            line_prefix="",
             wrap=False,
         )
 
@@ -777,7 +778,7 @@ def test_literalize_json_invalid_is_parse_error() -> None:
         literalize_json(
             json_string="not json",
             language=PYTHON,
-            indent="",
+            line_prefix="",
             wrap=False,
         )
 
@@ -788,7 +789,7 @@ def test_roundtrip_array(data: list[_JSONValue]) -> None:
     result = literalize_json(
         json_string=json.dumps(obj=data),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     if not data:
@@ -804,7 +805,7 @@ def test_roundtrip_scalar(data: _JSONScalar) -> None:
     result = literalize_json(
         json_string=json.dumps(obj=data),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     parsed = ast.literal_eval(node_or_string=result)
@@ -822,7 +823,7 @@ def test_roundtrip_dict(data: dict[str, _JSONValue]) -> None:
     result = literalize_json(
         json_string=json.dumps(obj=data),
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     if not data:
@@ -856,7 +857,7 @@ def test_roundtrip_yaml_binary_python(data: bytes) -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert ast.literal_eval(node_or_string=result.rstrip(",")) == data.hex()
@@ -867,7 +868,7 @@ def test_literalize_yaml_empty_sequence() -> None:
     result = literalize_yaml(
         yaml_string="[]\n",
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     assert result == ""
@@ -879,7 +880,7 @@ def test_literalize_yaml_sequence() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="    ",
+        line_prefix="    ",
         wrap=False,
     )
     expected = '    ("user_1", 1000.0),\n    ("user_2", 2000.0),'
@@ -892,7 +893,7 @@ def test_literalize_yaml_mapping() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = '{\n    "a": 1,\n    "b": True,\n}'
@@ -905,7 +906,7 @@ def test_literalize_yaml_invalid() -> None:
         literalize_yaml(
             yaml_string=":\n  :\n    - ][",
             language=PYTHON,
-            indent="",
+            line_prefix="",
             wrap=False,
         )
 
@@ -916,7 +917,7 @@ def test_literalize_yaml_invalid_is_parse_error() -> None:
         literalize_yaml(
             yaml_string=":\n  :\n    - ][",
             language=PYTHON,
-            indent="",
+            line_prefix="",
             wrap=False,
         )
 
@@ -944,7 +945,7 @@ def test_literalize_yaml_scalar(
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=language,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == expected
@@ -956,7 +957,7 @@ def test_literalize_yaml_date() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '"2024-01-15",'
@@ -970,7 +971,7 @@ def test_literalize_yaml_datetime() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '"2024-01-15T12:30:00",'
@@ -1176,7 +1177,7 @@ def test_custom_format_date() -> None:
     result = literalize_yaml(
         yaml_string="- 2024-01-15\n",
         language=spec,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == "datetime.date(2024, 1, 15),"
@@ -1188,7 +1189,7 @@ def test_custom_format_datetime() -> None:
     result = literalize_yaml(
         yaml_string="- 2024-01-15T12:30:00\n",
         language=spec,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == "datetime.datetime(2024, 1, 15, 12, 30, 0),"
@@ -1200,7 +1201,7 @@ def test_java_native_dates() -> None:
     result = literalize_yaml(
         yaml_string="- 2024-01-15\n- 2024-01-15T12:30:00\n",
         language=spec,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     lines = result.split(sep="\n")
@@ -1214,7 +1215,7 @@ def test_ruby_native_dates() -> None:
     result = literalize_yaml(
         yaml_string="- 2024-01-15T12:30:00\n",
         language=spec,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == "Time.new(2024, 1, 15, 12, 30, 0),"
@@ -1227,7 +1228,7 @@ def test_yaml_set_inline_in_sequence() -> None:
     result = literalize_yaml(
         yaml_string="- !!set\n  ? a\n  ? b\n",
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '{"a", "b"},'
@@ -1238,7 +1239,7 @@ def test_yaml_set_inline_with_format_set_entry() -> None:
     result = literalize_yaml(
         yaml_string="- !!set\n  ? a\n",
         language=GO,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == 'map[any]struct{}{"a": struct{}{}},'
@@ -1249,7 +1250,7 @@ def test_yaml_empty_set_inline() -> None:
     result = literalize_yaml(
         yaml_string="- !!set {}\n",
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == "set(),"
@@ -1311,7 +1312,7 @@ def test_literalize_yaml_binary() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == '"48656c6c6f",'
@@ -1323,7 +1324,7 @@ def test_custom_format_bytes() -> None:
     result = literalize_yaml(
         yaml_string="- !!binary |\n    SGVsbG8=\n",
         language=spec,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == "b'Hello',"
@@ -1335,7 +1336,7 @@ def test_yaml_comment_sequence_before() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1356,7 +1357,7 @@ def test_yaml_comment_sequence_inline() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1375,7 +1376,7 @@ def test_yaml_comment_mapping() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1396,7 +1397,7 @@ def test_yaml_comment_javascript_prefix() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=JAVASCRIPT,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1415,7 +1416,7 @@ def test_yaml_comment_trailing() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1434,7 +1435,7 @@ def test_yaml_comment_no_wrap() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="    ",
+        line_prefix="    ",
         wrap=False,
     )
     expected = '    # comment\n    "a",\n    "b",'
@@ -1447,7 +1448,7 @@ def test_yaml_comment_scalar() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     expected = "# note\n42"
@@ -1460,7 +1461,7 @@ def test_yaml_comment_scalar_inline() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     expected = "42  # note"
@@ -1473,7 +1474,7 @@ def test_yaml_no_comments_unchanged() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1492,7 +1493,7 @@ def test_yaml_comment_multiple_before_lines() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1540,7 +1541,7 @@ def test_yaml_comment_escaped_quote_in_value() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1558,7 +1559,7 @@ def test_yaml_comment_scalar_quoted_with_hash() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     expected = '"hello # world"  # note'
@@ -1571,7 +1572,7 @@ def test_yaml_comment_double_hash() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1590,7 +1591,7 @@ def test_yaml_comment_block_scalar_not_extracted() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1609,7 +1610,7 @@ def test_yaml_comment_scalar_with_document_markers() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = "# note\n42"
@@ -1622,7 +1623,7 @@ def test_yaml_comment_empty_comment_line() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1642,7 +1643,7 @@ def test_yaml_comment_more_body_lines_than_comments() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1662,7 +1663,7 @@ def test_yaml_comment_scalar_only_comments() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = "# just a comment\nNone"
@@ -1684,7 +1685,7 @@ def test_omap_nested_in_sequence() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1741,7 +1742,7 @@ def test_omap_custom_language_spec() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=custom,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1760,7 +1761,7 @@ def test_yaml_comment_mapping_nested_value_none_token() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
     )
     expected = textwrap.dedent(
@@ -1860,7 +1861,7 @@ def test_variable_declaration_json(
     result = literalize_json(
         json_string="42",
         language=language,
-        indent="",
+        line_prefix="",
         wrap=False,
         variable_name="my_var",
     )
@@ -1877,7 +1878,7 @@ def test_variable_declaration_yaml(
     result = literalize_yaml(
         yaml_string="42\n",
         language=language,
-        indent="",
+        line_prefix="",
         wrap=False,
         variable_name="my_var",
     )
@@ -1889,7 +1890,7 @@ def test_variable_declaration_none_no_wrap() -> None:
     result = literalize_json(
         json_string="[1, 2]",
         language=PYTHON,
-        indent="",
+        line_prefix="",
         wrap=True,
         variable_name=None,
     )
@@ -1908,7 +1909,7 @@ def test_existing_variable_assignment_json(
     result = literalize_json(
         json_string="42",
         language=language,
-        indent="",
+        line_prefix="",
         wrap=False,
         variable_name="my_var",
         new_variable=False,
@@ -1928,7 +1929,7 @@ def test_existing_variable_assignment_yaml(
     result = literalize_yaml(
         yaml_string="42\n",
         language=language,
-        indent="",
+        line_prefix="",
         wrap=False,
         variable_name="my_var",
         new_variable=False,
@@ -1957,7 +1958,7 @@ def test_matlab_string_escaping(*, yaml_string: str, expected: str) -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=Matlab(),
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == expected
@@ -1973,7 +1974,7 @@ def test_matlab_dict_key_with_quote() -> None:
     result = literalize_yaml(
         yaml_string=yaml_string,
         language=Matlab(),
-        indent="",
+        line_prefix="",
         wrap=False,
     )
     assert result == "'hello \"world\"', 1"


### PR DESCRIPTION
## Summary

Split the `indent` parameter into two independent parameters to cleanly separate concerns:
- **`line_prefix`**: Whitespace prepended to every output line (positions the block in surrounding code)
- **`indent`**: Indentation step for elements inside delimiters when wrapping (default 4 spaces)

Removes the internal `effective_indent = indent if not wrap else (indent or "    ")` hack by giving `indent` a sensible default.

## Changes

- Updated `_literalize()`, `_wrap_body()`, `literalize_json()`, and `literalize_yaml()` signatures
- Updated comment handling in `_comments.py` to use `comment_line_prefix` instead of `indent`
- All test calls updated to use `line_prefix=` where needed
- All 235 unit tests pass; integration test imports work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `literalize_json`/`literalize_yaml` API by replacing the old `indent`-as-prefix behavior with a new `line_prefix` parameter and new defaults, which may break existing callers that relied on prior semantics. Output formatting around wrapped blocks and YAML comment alignment could shift if consumers pass custom indentation.
> 
> **Overview**
> Splits the single `indent` parameter into **`line_prefix` (outer margin)** and **`indent` (inner indentation step when `wrap=True`)** across `literalize_json`, `literalize_yaml`, and internal helpers, and sets sensible defaults (4-space `indent`, empty `line_prefix`).
> 
> Updates wrapping and YAML comment formatting to use the new prefixes (including a dedicated `comment_line_prefix`) and revises docs/examples plus unit/integration tests to pass `line_prefix` where the old API used `indent` as a line prefix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d96398fcf3f01f5e3172b7e7426bea9965b1484. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->