### PR TITLE
Scala: use AnyRef-typed collections instead of Any

### DIFF
--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -90,10 +90,10 @@ class Scala:
         self.false_literal = "false"
         self.sequence_open: Callable[[list[Value]], str] = typed_sequence_open(
             schema_to_opener=_scala_schema_to_opener,
-            fallback="List(",
+            fallback="List[AnyRef](",
         )
         self.sequence_close = ")"
-        self.dict_open = "Map("
+        self.dict_open = "Map[String, AnyRef]("
         self.dict_close = ")"
         self.format_dict_entry: Callable[[str, str], str] = (
             dict_entry_with_separator(separator=" -> ")
@@ -117,7 +117,7 @@ class Scala:
         self.format_set_entry: Callable[[str], str] = passthrough_set_entry
         self.comment_prefix = "//"
         self.comment_suffix = ""
-        self.omap_open = "scala.collection.immutable.ListMap("
+        self.omap_open = "scala.collection.immutable.ListMap[String, AnyRef]("
         self.omap_close = ")"
         self.format_omap_entry: Callable[[str, str], str] = (
             _format_scala_omap_entry

--- a/tests/integration/cases/binary/scala.scala
+++ b/tests/integration/cases/binary/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
+val x: Any = List[AnyRef](
     "48656c6c6f",
 )
 }

--- a/tests/integration/cases/binary/scala_combined.scala
+++ b/tests/integration/cases/binary/scala_combined.scala
@@ -1,11 +1,11 @@
 object Declaration {
-  val my_data = List(
+  val my_data = List[AnyRef](
       "48656c6c6f",
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
+  my_data = List[AnyRef](
       "48656c6c6f",
   )
 }

--- a/tests/integration/cases/binary/scala_varname.scala
+++ b/tests/integration/cases/binary/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
+val my_data = List[AnyRef](
     "48656c6c6f",
 )
 }

--- a/tests/integration/cases/comments/scala.scala
+++ b/tests/integration/cases/comments/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = Map(
+val x: Any = Map[String, AnyRef](
     // Server configuration
     "host" -> "localhost",  // default host
     "port" -> 8080,

--- a/tests/integration/cases/comments/scala_combined.scala
+++ b/tests/integration/cases/comments/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = Map(
+  val my_data = Map[String, AnyRef](
       // Server configuration
       "host" -> "localhost",  // default host
       "port" -> 8080,
@@ -9,7 +9,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = Map(
+  my_data = Map[String, AnyRef](
       // Server configuration
       "host" -> "localhost",  // default host
       "port" -> 8080,

--- a/tests/integration/cases/comments/scala_varname.scala
+++ b/tests/integration/cases/comments/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = Map(
+val my_data = Map[String, AnyRef](
     // Server configuration
     "host" -> "localhost",  // default host
     "port" -> 8080,

--- a/tests/integration/cases/dates/scala.scala
+++ b/tests/integration/cases/dates/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = Map(
+val x: Any = Map[String, AnyRef](
     "date" -> "2024-01-15",
     "datetime" -> "2024-01-15T12:30:00+00:00",
 )

--- a/tests/integration/cases/dates/scala_combined.scala
+++ b/tests/integration/cases/dates/scala_combined.scala
@@ -1,12 +1,12 @@
 object Declaration {
-  val my_data = Map(
+  val my_data = Map[String, AnyRef](
       "date" -> "2024-01-15",
       "datetime" -> "2024-01-15T12:30:00+00:00",
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = Map(
+  my_data = Map[String, AnyRef](
       "date" -> "2024-01-15",
       "datetime" -> "2024-01-15T12:30:00+00:00",
   )

--- a/tests/integration/cases/dates/scala_varname.scala
+++ b/tests/integration/cases/dates/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = Map(
+val my_data = Map[String, AnyRef](
     "date" -> "2024-01-15",
     "datetime" -> "2024-01-15T12:30:00+00:00",
 )

--- a/tests/integration/cases/deep_nesting/scala.scala
+++ b/tests/integration/cases/deep_nesting/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = Map(
-    "level1" -> Map("level2" -> Map("level3" -> Map("level4" -> Map("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List(Map("name" -> "tag1", "meta" -> Map("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
+val x: Any = Map[String, AnyRef](
+    "level1" -> Map[String, AnyRef]("level2" -> Map[String, AnyRef]("level3" -> Map[String, AnyRef]("level4" -> Map[String, AnyRef]("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List[AnyRef](Map[String, AnyRef]("name" -> "tag1", "meta" -> Map[String, AnyRef]("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
 )
 }

--- a/tests/integration/cases/deep_nesting/scala_combined.scala
+++ b/tests/integration/cases/deep_nesting/scala_combined.scala
@@ -1,11 +1,11 @@
 object Declaration {
-  val my_data = Map(
-      "level1" -> Map("level2" -> Map("level3" -> Map("level4" -> Map("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List(Map("name" -> "tag1", "meta" -> Map("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
+  val my_data = Map[String, AnyRef](
+      "level1" -> Map[String, AnyRef]("level2" -> Map[String, AnyRef]("level3" -> Map[String, AnyRef]("level4" -> Map[String, AnyRef]("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List[AnyRef](Map[String, AnyRef]("name" -> "tag1", "meta" -> Map[String, AnyRef]("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = Map(
-      "level1" -> Map("level2" -> Map("level3" -> Map("level4" -> Map("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List(Map("name" -> "tag1", "meta" -> Map("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
+  my_data = Map[String, AnyRef](
+      "level1" -> Map[String, AnyRef]("level2" -> Map[String, AnyRef]("level3" -> Map[String, AnyRef]("level4" -> Map[String, AnyRef]("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List[AnyRef](Map[String, AnyRef]("name" -> "tag1", "meta" -> Map[String, AnyRef]("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
   )
 }

--- a/tests/integration/cases/deep_nesting/scala_varname.scala
+++ b/tests/integration/cases/deep_nesting/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = Map(
-    "level1" -> Map("level2" -> Map("level3" -> Map("level4" -> Map("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List(Map("name" -> "tag1", "meta" -> Map("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
+val my_data = Map[String, AnyRef](
+    "level1" -> Map[String, AnyRef]("level2" -> Map[String, AnyRef]("level3" -> Map[String, AnyRef]("level4" -> Map[String, AnyRef]("value" -> "deep", "items" -> Array[String]("a", "b"))), "sibling" -> 42), "tags" -> List[AnyRef](Map[String, AnyRef]("name" -> "tag1", "meta" -> Map[String, AnyRef]("priority" -> 1, "labels" -> Array[String]("x", "y"))))),
 )
 }

--- a/tests/integration/cases/dict_with_control_char_keys/scala.scala
+++ b/tests/integration/cases/dict_with_control_char_keys/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = Map(
+val x: Any = Map[String, AnyRef](
     "key\nwith\nnewlines" -> "value1",
     "key\twith\ttabs" -> "value2",
     "" -> "value3",

--- a/tests/integration/cases/dict_with_control_char_keys/scala_combined.scala
+++ b/tests/integration/cases/dict_with_control_char_keys/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = Map(
+  val my_data = Map[String, AnyRef](
       "key\nwith\nnewlines" -> "value1",
       "key\twith\ttabs" -> "value2",
       "" -> "value3",
@@ -7,7 +7,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = Map(
+  my_data = Map[String, AnyRef](
       "key\nwith\nnewlines" -> "value1",
       "key\twith\ttabs" -> "value2",
       "" -> "value3",

--- a/tests/integration/cases/dict_with_control_char_keys/scala_varname.scala
+++ b/tests/integration/cases/dict_with_control_char_keys/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = Map(
+val my_data = Map[String, AnyRef](
     "key\nwith\nnewlines" -> "value1",
     "key\twith\ttabs" -> "value2",
     "" -> "value3",

--- a/tests/integration/cases/dict_with_nulls/scala.scala
+++ b/tests/integration/cases/dict_with_nulls/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = Map(
+val x: Any = Map[String, AnyRef](
     "name" -> "Alice",
     "score" -> null,
     "age" -> 30,

--- a/tests/integration/cases/dict_with_nulls/scala_combined.scala
+++ b/tests/integration/cases/dict_with_nulls/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = Map(
+  val my_data = Map[String, AnyRef](
       "name" -> "Alice",
       "score" -> null,
       "age" -> 30,
@@ -7,7 +7,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = Map(
+  my_data = Map[String, AnyRef](
       "name" -> "Alice",
       "score" -> null,
       "age" -> 30,

--- a/tests/integration/cases/dict_with_nulls/scala_varname.scala
+++ b/tests/integration/cases/dict_with_nulls/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = Map(
+val my_data = Map[String, AnyRef](
     "name" -> "Alice",
     "score" -> null,
     "age" -> 30,

--- a/tests/integration/cases/empty_sequence/scala.scala
+++ b/tests/integration/cases/empty_sequence/scala.scala
@@ -1,6 +1,6 @@
 object Check {
-val x: Any = List(
-    List(),
-    Map(),
+val x: Any = List[AnyRef](
+    List[AnyRef](),
+    Map[String, AnyRef](),
 )
 }

--- a/tests/integration/cases/empty_sequence/scala_combined.scala
+++ b/tests/integration/cases/empty_sequence/scala_combined.scala
@@ -1,13 +1,13 @@
 object Declaration {
-  val my_data = List(
-      List(),
-      Map(),
+  val my_data = List[AnyRef](
+      List[AnyRef](),
+      Map[String, AnyRef](),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
-      List(),
-      Map(),
+  my_data = List[AnyRef](
+      List[AnyRef](),
+      Map[String, AnyRef](),
   )
 }

--- a/tests/integration/cases/empty_sequence/scala_varname.scala
+++ b/tests/integration/cases/empty_sequence/scala_varname.scala
@@ -1,6 +1,6 @@
 object Check {
-val my_data = List(
-    List(),
-    Map(),
+val my_data = List[AnyRef](
+    List[AnyRef](),
+    Map[String, AnyRef](),
 )
 }

--- a/tests/integration/cases/nested/scala.scala
+++ b/tests/integration/cases/nested/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = Map(
-    "users" -> List(Map("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map("name" -> "Carol", "tags" -> Array[String]("guest"))),
+val x: Any = Map[String, AnyRef](
+    "users" -> List[AnyRef](Map[String, AnyRef]("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map[String, AnyRef]("name" -> "Carol", "tags" -> Array[String]("guest"))),
 )
 }

--- a/tests/integration/cases/nested/scala_combined.scala
+++ b/tests/integration/cases/nested/scala_combined.scala
@@ -1,11 +1,11 @@
 object Declaration {
-  val my_data = Map(
-      "users" -> List(Map("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map("name" -> "Carol", "tags" -> Array[String]("guest"))),
+  val my_data = Map[String, AnyRef](
+      "users" -> List[AnyRef](Map[String, AnyRef]("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map[String, AnyRef]("name" -> "Carol", "tags" -> Array[String]("guest"))),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = Map(
-      "users" -> List(Map("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map("name" -> "Carol", "tags" -> Array[String]("guest"))),
+  my_data = Map[String, AnyRef](
+      "users" -> List[AnyRef](Map[String, AnyRef]("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map[String, AnyRef]("name" -> "Carol", "tags" -> Array[String]("guest"))),
   )
 }

--- a/tests/integration/cases/nested/scala_varname.scala
+++ b/tests/integration/cases/nested/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = Map(
-    "users" -> List(Map("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map("name" -> "Carol", "tags" -> Array[String]("guest"))),
+val my_data = Map[String, AnyRef](
+    "users" -> List[AnyRef](Map[String, AnyRef]("name" -> "Bob", "tags" -> Array[String]("admin", "user")), Map[String, AnyRef]("name" -> "Carol", "tags" -> Array[String]("guest"))),
 )
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/scala.scala
+++ b/tests/integration/cases/nested_collection_multi_space_string/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
-    Map("key" -> "hello   world", "value" -> 1),
+val x: Any = List[AnyRef](
+    Map[String, AnyRef]("key" -> "hello   world", "value" -> 1),
 )
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/scala_combined.scala
+++ b/tests/integration/cases/nested_collection_multi_space_string/scala_combined.scala
@@ -1,11 +1,11 @@
 object Declaration {
-  val my_data = List(
-      Map("key" -> "hello   world", "value" -> 1),
+  val my_data = List[AnyRef](
+      Map[String, AnyRef]("key" -> "hello   world", "value" -> 1),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
-      Map("key" -> "hello   world", "value" -> 1),
+  my_data = List[AnyRef](
+      Map[String, AnyRef]("key" -> "hello   world", "value" -> 1),
   )
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/scala_varname.scala
+++ b/tests/integration/cases/nested_collection_multi_space_string/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
-    Map("key" -> "hello   world", "value" -> 1),
+val my_data = List[AnyRef](
+    Map[String, AnyRef]("key" -> "hello   world", "value" -> 1),
 )
 }

--- a/tests/integration/cases/nested_deep_empty/scala.scala
+++ b/tests/integration/cases/nested_deep_empty/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
-    List(List(), List()),
+val x: Any = List[AnyRef](
+    List[AnyRef](List[AnyRef](), List[AnyRef]()),
 )
 }

--- a/tests/integration/cases/nested_deep_empty/scala_combined.scala
+++ b/tests/integration/cases/nested_deep_empty/scala_combined.scala
@@ -1,11 +1,11 @@
 object Declaration {
-  val my_data = List(
-      List(List(), List()),
+  val my_data = List[AnyRef](
+      List[AnyRef](List[AnyRef](), List[AnyRef]()),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
-      List(List(), List()),
+  my_data = List[AnyRef](
+      List[AnyRef](List[AnyRef](), List[AnyRef]()),
   )
 }

--- a/tests/integration/cases/nested_deep_empty/scala_varname.scala
+++ b/tests/integration/cases/nested_deep_empty/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
-    List(List(), List()),
+val my_data = List[AnyRef](
+    List[AnyRef](List[AnyRef](), List[AnyRef]()),
 )
 }

--- a/tests/integration/cases/nested_deep_mixed/scala.scala
+++ b/tests/integration/cases/nested_deep_mixed/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
-    List(Array[Int](1, 2), Array[String]("a", "b")),
+val x: Any = List[AnyRef](
+    List[AnyRef](Array[Int](1, 2), Array[String]("a", "b")),
 )
 }

--- a/tests/integration/cases/nested_deep_mixed/scala_combined.scala
+++ b/tests/integration/cases/nested_deep_mixed/scala_combined.scala
@@ -1,11 +1,11 @@
 object Declaration {
-  val my_data = List(
-      List(Array[Int](1, 2), Array[String]("a", "b")),
+  val my_data = List[AnyRef](
+      List[AnyRef](Array[Int](1, 2), Array[String]("a", "b")),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
-      List(Array[Int](1, 2), Array[String]("a", "b")),
+  my_data = List[AnyRef](
+      List[AnyRef](Array[Int](1, 2), Array[String]("a", "b")),
   )
 }

--- a/tests/integration/cases/nested_deep_mixed/scala_varname.scala
+++ b/tests/integration/cases/nested_deep_mixed/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
-    List(Array[Int](1, 2), Array[String]("a", "b")),
+val my_data = List[AnyRef](
+    List[AnyRef](Array[Int](1, 2), Array[String]("a", "b")),
 )
 }

--- a/tests/integration/cases/nested_empty_inner/scala.scala
+++ b/tests/integration/cases/nested_empty_inner/scala.scala
@@ -1,6 +1,6 @@
 object Check {
-val x: Any = List(
-    List(),
-    List(),
+val x: Any = List[AnyRef](
+    List[AnyRef](),
+    List[AnyRef](),
 )
 }

--- a/tests/integration/cases/nested_empty_inner/scala_combined.scala
+++ b/tests/integration/cases/nested_empty_inner/scala_combined.scala
@@ -1,13 +1,13 @@
 object Declaration {
-  val my_data = List(
-      List(),
-      List(),
+  val my_data = List[AnyRef](
+      List[AnyRef](),
+      List[AnyRef](),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
-      List(),
-      List(),
+  my_data = List[AnyRef](
+      List[AnyRef](),
+      List[AnyRef](),
   )
 }

--- a/tests/integration/cases/nested_empty_inner/scala_varname.scala
+++ b/tests/integration/cases/nested_empty_inner/scala_varname.scala
@@ -1,6 +1,6 @@
 object Check {
-val my_data = List(
-    List(),
-    List(),
+val my_data = List[AnyRef](
+    List[AnyRef](),
+    List[AnyRef](),
 )
 }

--- a/tests/integration/cases/nested_mixed_inner/scala.scala
+++ b/tests/integration/cases/nested_mixed_inner/scala.scala
@@ -1,6 +1,6 @@
 object Check {
-val x: Any = List(
-    List(1, "a"),
-    List(2, "b"),
+val x: Any = List[AnyRef](
+    List[AnyRef](1, "a"),
+    List[AnyRef](2, "b"),
 )
 }

--- a/tests/integration/cases/nested_mixed_inner/scala_combined.scala
+++ b/tests/integration/cases/nested_mixed_inner/scala_combined.scala
@@ -1,13 +1,13 @@
 object Declaration {
-  val my_data = List(
-      List(1, "a"),
-      List(2, "b"),
+  val my_data = List[AnyRef](
+      List[AnyRef](1, "a"),
+      List[AnyRef](2, "b"),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
-      List(1, "a"),
-      List(2, "b"),
+  my_data = List[AnyRef](
+      List[AnyRef](1, "a"),
+      List[AnyRef](2, "b"),
   )
 }

--- a/tests/integration/cases/nested_mixed_inner/scala_varname.scala
+++ b/tests/integration/cases/nested_mixed_inner/scala_varname.scala
@@ -1,6 +1,6 @@
 object Check {
-val my_data = List(
-    List(1, "a"),
-    List(2, "b"),
+val my_data = List[AnyRef](
+    List[AnyRef](1, "a"),
+    List[AnyRef](2, "b"),
 )
 }

--- a/tests/integration/cases/nested_mixed_types/scala.scala
+++ b/tests/integration/cases/nested_mixed_types/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
+val x: Any = List[AnyRef](
     Array[Int](1, 2),
     Array[String]("a", "b"),
 )

--- a/tests/integration/cases/nested_mixed_types/scala_combined.scala
+++ b/tests/integration/cases/nested_mixed_types/scala_combined.scala
@@ -1,12 +1,12 @@
 object Declaration {
-  val my_data = List(
+  val my_data = List[AnyRef](
       Array[Int](1, 2),
       Array[String]("a", "b"),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
+  my_data = List[AnyRef](
       Array[Int](1, 2),
       Array[String]("a", "b"),
   )

--- a/tests/integration/cases/nested_mixed_types/scala_varname.scala
+++ b/tests/integration/cases/nested_mixed_types/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
+val my_data = List[AnyRef](
     Array[Int](1, 2),
     Array[String]("a", "b"),
 )

--- a/tests/integration/cases/nested_sequence/scala.scala
+++ b/tests/integration/cases/nested_sequence/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
+val x: Any = List[AnyRef](
     true,
     "hi",
     Array[Int](1, 2),

--- a/tests/integration/cases/nested_sequence/scala_combined.scala
+++ b/tests/integration/cases/nested_sequence/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = List(
+  val my_data = List[AnyRef](
       true,
       "hi",
       Array[Int](1, 2),
@@ -8,7 +8,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
+  my_data = List[AnyRef](
       true,
       "hi",
       Array[Int](1, 2),

--- a/tests/integration/cases/nested_sequence/scala_varname.scala
+++ b/tests/integration/cases/nested_sequence/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
+val my_data = List[AnyRef](
     true,
     "hi",
     Array[Int](1, 2),

--- a/tests/integration/cases/omap/scala.scala
+++ b/tests/integration/cases/omap/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = scala.collection.immutable.ListMap(
+val x: Any = scala.collection.immutable.ListMap[String, AnyRef](
     "name" -> "Alice",
     "age" -> 30,
     "active" -> true,

--- a/tests/integration/cases/omap/scala_combined.scala
+++ b/tests/integration/cases/omap/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = scala.collection.immutable.ListMap(
+  val my_data = scala.collection.immutable.ListMap[String, AnyRef](
       "name" -> "Alice",
       "age" -> 30,
       "active" -> true,
@@ -7,7 +7,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = scala.collection.immutable.ListMap(
+  my_data = scala.collection.immutable.ListMap[String, AnyRef](
       "name" -> "Alice",
       "age" -> 30,
       "active" -> true,

--- a/tests/integration/cases/omap/scala_varname.scala
+++ b/tests/integration/cases/omap/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = scala.collection.immutable.ListMap(
+val my_data = scala.collection.immutable.ListMap[String, AnyRef](
     "name" -> "Alice",
     "age" -> 30,
     "active" -> true,

--- a/tests/integration/cases/scalars/scala.scala
+++ b/tests/integration/cases/scalars/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
+val x: Any = List[AnyRef](
     42,
     3.14,
     true,

--- a/tests/integration/cases/scalars/scala_combined.scala
+++ b/tests/integration/cases/scalars/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = List(
+  val my_data = List[AnyRef](
       42,
       3.14,
       true,
@@ -9,7 +9,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
+  my_data = List[AnyRef](
       42,
       3.14,
       true,

--- a/tests/integration/cases/scalars/scala_varname.scala
+++ b/tests/integration/cases/scalars/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
+val my_data = List[AnyRef](
     42,
     3.14,
     true,

--- a/tests/integration/cases/sequence_of_dicts/scala.scala
+++ b/tests/integration/cases/sequence_of_dicts/scala.scala
@@ -1,6 +1,6 @@
 object Check {
-val x: Any = List(
-    Map("name" -> "Alice", "age" -> 30),
-    Map("name" -> "Bob", "age" -> 25),
+val x: Any = List[AnyRef](
+    Map[String, AnyRef]("name" -> "Alice", "age" -> 30),
+    Map[String, AnyRef]("name" -> "Bob", "age" -> 25),
 )
 }

--- a/tests/integration/cases/sequence_of_dicts/scala_combined.scala
+++ b/tests/integration/cases/sequence_of_dicts/scala_combined.scala
@@ -1,13 +1,13 @@
 object Declaration {
-  val my_data = List(
-      Map("name" -> "Alice", "age" -> 30),
-      Map("name" -> "Bob", "age" -> 25),
+  val my_data = List[AnyRef](
+      Map[String, AnyRef]("name" -> "Alice", "age" -> 30),
+      Map[String, AnyRef]("name" -> "Bob", "age" -> 25),
   )
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
-      Map("name" -> "Alice", "age" -> 30),
-      Map("name" -> "Bob", "age" -> 25),
+  my_data = List[AnyRef](
+      Map[String, AnyRef]("name" -> "Alice", "age" -> 30),
+      Map[String, AnyRef]("name" -> "Bob", "age" -> 25),
   )
 }

--- a/tests/integration/cases/sequence_of_dicts/scala_varname.scala
+++ b/tests/integration/cases/sequence_of_dicts/scala_varname.scala
@@ -1,6 +1,6 @@
 object Check {
-val my_data = List(
-    Map("name" -> "Alice", "age" -> 30),
-    Map("name" -> "Bob", "age" -> 25),
+val my_data = List[AnyRef](
+    Map[String, AnyRef]("name" -> "Alice", "age" -> 30),
+    Map[String, AnyRef]("name" -> "Bob", "age" -> 25),
 )
 }

--- a/tests/integration/cases/simple_dict/scala.scala
+++ b/tests/integration/cases/simple_dict/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = Map(
+val x: Any = Map[String, AnyRef](
     "name" -> "Alice",
     "age" -> 30,
     "active" -> true,

--- a/tests/integration/cases/simple_dict/scala_combined.scala
+++ b/tests/integration/cases/simple_dict/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = Map(
+  val my_data = Map[String, AnyRef](
       "name" -> "Alice",
       "age" -> 30,
       "active" -> true,
@@ -8,7 +8,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = Map(
+  my_data = Map[String, AnyRef](
       "name" -> "Alice",
       "age" -> 30,
       "active" -> true,

--- a/tests/integration/cases/simple_dict/scala_varname.scala
+++ b/tests/integration/cases/simple_dict/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = Map(
+val my_data = Map[String, AnyRef](
     "name" -> "Alice",
     "age" -> 30,
     "active" -> true,

--- a/tests/integration/cases/simple_sequence/scala.scala
+++ b/tests/integration/cases/simple_sequence/scala.scala
@@ -1,5 +1,5 @@
 object Check {
-val x: Any = List(
+val x: Any = List[AnyRef](
     1,
     "hello",
     true,

--- a/tests/integration/cases/simple_sequence/scala_combined.scala
+++ b/tests/integration/cases/simple_sequence/scala_combined.scala
@@ -1,5 +1,5 @@
 object Declaration {
-  val my_data = List(
+  val my_data = List[AnyRef](
       1,
       "hello",
       true,
@@ -8,7 +8,7 @@ object Declaration {
 }
 object Assignment {
   var my_data: Any = null
-  my_data = List(
+  my_data = List[AnyRef](
       1,
       "hello",
       true,

--- a/tests/integration/cases/simple_sequence/scala_varname.scala
+++ b/tests/integration/cases/simple_sequence/scala_varname.scala
@@ -1,5 +1,5 @@
 object Check {
-val my_data = List(
+val my_data = List[AnyRef](
     1,
     "hello",
     true,


### PR DESCRIPTION
Changes mixed-type Scala collections to use AnyRef type parameters, eliminating the need for manual asInstanceOf casts when using reference equality (eq) comparisons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated Scala literal output for lists/maps/ordered maps by adding explicit type parameters, which may be a breaking formatting change for consumers comparing against prior output. Logic change is localized to Scala code generation and covered by updated integration fixtures.
> 
> **Overview**
> **Scala output now prefers reference-typed collections.** The Scala language spec changes fallback collection openers from untyped `List(`/`Map(`/`ListMap(` to explicitly typed `List[AnyRef](`, `Map[String, AnyRef](`, and `scala.collection.immutable.ListMap[String, AnyRef](`.
> 
> Integration fixtures are updated across many cases (including nested/empty/mixed structures) to expect these typed openers throughout generated Scala snippets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c491a273221795725e31849c5465e208fe8b567a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->