### PR TITLE
Restore tests dropped during test_converter.py split

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -303,6 +303,43 @@ def test_literalize_json_invalid() -> None:
         )
 
 
+def test_part1_sample_python() -> None:
+    """Realistic test matching part1_sample_input.json structure."""
+    data = [
+        ["user_1", 1000.0],
+        ["user_1", 1001.0],
+        ["user_1", 1002.0],
+        ["user_1", 1003.0],
+    ]
+    result = literalize_json(
+        json_string=json.dumps(obj=data),
+        language=PYTHON,
+        line_prefix="        ",
+        wrap=False,
+    )
+    expected_lines = [
+        '        ("user_1", 1000.0),',
+        '        ("user_1", 1001.0),',
+        '        ("user_1", 1002.0),',
+        '        ("user_1", 1003.0),',
+    ]
+    assert result.split(sep="\n") == expected_lines
+
+
+def test_part2_sample_go() -> None:
+    """Realistic test matching part2_sample_input.json structure."""
+    data = [["user_1", 49, 1000.0], ["user_9", 10, 1003.0]]
+    result = literalize_json(
+        json_string=json.dumps(obj=data),
+        language=GO,
+        line_prefix="        ",
+        wrap=False,
+    )
+    lines = result.split(sep="\n")
+    assert lines[0] == '        []any{"user_1", 49, 1000.0},'
+    assert lines[1] == '        []any{"user_9", 10, 1003.0},'
+
+
 def test_literalize_json_invalid_is_parse_error() -> None:
     """``JSONParseError`` is a subclass of ``ParseError``."""
     with pytest.raises(expected_exception=ParseError):


### PR DESCRIPTION
## Summary

- Restores `test_part1_sample_python` and `test_part2_sample_go` that were accidentally dropped when `test_converter.py` was split into focused modules in #326
- Both tests are added to `tests/test_json.py` alongside other `literalize_json` tests

Addresses https://github.com/adamtheturtle/literalizer/pull/326#discussion_r2958021247

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds back two test cases only, with no production code changes. Main risk is minor test brittleness if output formatting expectations change.
> 
> **Overview**
> Restores two previously dropped `literalize_json` regression tests in `tests/test_json.py` that use realistic sample-shaped JSON inputs.
> 
> Adds coverage for Python tuple formatting/indentation (`test_part1_sample_python`) and Go slice-of-`any` formatting (`test_part2_sample_go`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a3d3cf564220312405cbe501d1bad9ce6dd842b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->