### PR TITLE
Remove duplicate _discover_varname_cases

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1665,24 +1665,6 @@ def _discover_cases() -> list[tuple[str, str, Path]]:
 _CASES = _discover_cases()
 
 
-@beartype
-def _discover_varname_cases() -> list[tuple[str, str, Path]]:
-    """Return ``(case_name, language, input_path)`` tuples for variable-
-    name
-    tests.
-    """
-    cases: list[tuple[str, str, Path]] = []
-    for case_dir in sorted(_CASES_DIR.iterdir()):
-        cases.extend(
-            (case_dir.name, lang_name, case_dir / "input.yaml")
-            for lang_name in _LANGUAGES
-        )
-    return cases
-
-
-_VARNAME_CASES = _discover_varname_cases()
-
-
 @pytest.mark.parametrize(
     argnames=("_case_name", "language", "input_path"),
     argvalues=_CASES,
@@ -1713,8 +1695,8 @@ def test_golden_file(
 
 @pytest.mark.parametrize(
     argnames=("_case_name", "language", "input_path"),
-    argvalues=_VARNAME_CASES,
-    ids=[f"{c[0]}/{c[1]}" for c in _VARNAME_CASES],
+    argvalues=_CASES,
+    ids=[f"{c[0]}/{c[1]}" for c in _CASES],
 )
 def test_golden_file_with_variable_name(
     _case_name: str,


### PR DESCRIPTION
Removes the duplicate `_discover_varname_cases()` function and `_VARNAME_CASES` variable, which were identical to `_discover_cases()` and `_CASES`. Reuses `_CASES` for the `test_golden_file_with_variable_name` parametrization. This eliminates unnecessary duplication in the test configuration.

All 1435 integration tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only refactor that removes duplicated case discovery logic and reuses the existing case list for variable-name golden tests.
> 
> **Overview**
> Removes the redundant `_discover_varname_cases()`/`_VARNAME_CASES` duplication in `tests/integration/test_integration.py`.
> 
> `test_golden_file_with_variable_name` now reuses the existing `_CASES` parametrization, keeping the test matrix the same while simplifying integration test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4400ab1daafdac4f4ce90f0c399f425800dd1bfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->