### PR TITLE
Remove unnecessary pyright ignore for reportMissingTypeStubs

### DIFF
--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import Any
 
 from beartype import beartype
-from json_to_schema import (  # pyright: ignore[reportMissingTypeStubs]  # pyrefly: ignore[missing-import]
+from json_to_schema import (  # pyrefly: ignore[missing-import]
     infer_schema,
 )
 


### PR DESCRIPTION
## Summary

- `json_to_schema` now ships type stubs that pyright can find, so the `# pyright: ignore[reportMissingTypeStubs]` comment on the import is no longer needed
- The new pyright version flags it with `reportUnnecessaryTypeIgnoreComment`, breaking CI

## Test plan

- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only change to satisfy updated Pyright linting, with no runtime behavior impact.
> 
> **Overview**
> Removes the `# pyright: ignore[reportMissingTypeStubs]` suppression from the `json_to_schema` import in `_formatters.py` now that the package ships type stubs, preventing `reportUnnecessaryTypeIgnoreComment` CI failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9d9bdeb27d3959e48bf53cd466d4bc80eb184d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->