### PR TITLE
Retry lint-mojo to work around nondeterministic Mojo crash

### DIFF
--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Check Mojo syntax
         uses: nick-fields/retry@v3
         with:
+          timeout_minutes: 10
           max_attempts: 3
           command: |-
             set -o pipefail


### PR DESCRIPTION
## Summary

- Wraps the Mojo syntax check step with `nick-fields/retry@v3` (up to 3 attempts) to work around a nondeterministic runtime crash (segfault in `libKGENCompilerRTShared.so`) in Mojo 0.26.2.0
- The crash was causing intermittent `lint-mojo` CI failures on identical code

## Test plan

- [ ] Verify the lint-mojo job passes on this PR's CI run
- [ ] If it fails on the first attempt, confirm it retries and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that wraps the existing Mojo lint command in a retry loop; main risk is slightly longer CI time or masking a persistent failure until retries exhaust.
> 
> **Overview**
> The `lint-mojo` GitHub Actions workflow now wraps the Mojo syntax-check command with `nick-fields/retry@v3` (up to 3 attempts, 10-minute timeout) to mitigate intermittent Mojo runtime segfaults.
> 
> The underlying lint command and its error filtering remain the same; only execution is retried on failure and the workflow documents the upstream crash issue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78a93d549bd64aba104f09dfa624dd1a9c13a04d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->