### PR TITLE
Separate supported languages docs into their own page

### DIFF
--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -4,12 +4,3 @@ API Reference
 .. automodule:: literalizer
    :undoc-members:
    :members:
-
-.. _languages:
-
-Languages
----------
-
-.. automodule:: literalizer.languages
-   :members:
-   :undoc-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,6 +65,7 @@ Reference
 
    json-api-use-case
    api-reference
+   languages
    release-process
    changelog
    contributing

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -1,0 +1,8 @@
+.. _languages:
+
+Languages
+=========
+
+.. automodule:: literalizer.languages
+   :members:
+   :undoc-members:


### PR DESCRIPTION
Moves the Languages section out of `api-reference.rst` and into a new dedicated `languages.rst` page. The `.. _languages:` anchor is preserved in the new file so existing `:ref:`languages`` cross-references continue to resolve. The new page is added to the toctree in `index.rst`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that reorganizes Sphinx pages; low risk aside from potential navigation or anchor/link issues.
> 
> **Overview**
> Moves the `Languages` section out of `api-reference.rst` into a new dedicated `languages.rst` page while preserving the `.. _languages:` anchor for existing cross-references.
> 
> Updates `index.rst` to include `languages` in the reference toctree so the new page appears in the rendered docs navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71d92e6abdc1d438b705f23d7e8af313c08a31fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->