### PR TITLE
Document Mojo heterogeneous collection limitation

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -49,7 +49,14 @@ _string_format: Callable[[str], str] = format_string_backslash
 
 
 class Mojo:
-    """Mojo language specification."""
+    """Mojo language specification.
+
+    Mojo does not support heterogeneous collections — every element in a
+    list must share a single type.  When a collection contains scalar
+    values of mixed types (e.g. ``[1, 2.5, 3]``), **all values are
+    coerced to their string representations** so that the resulting
+    literal is valid Mojo (e.g. ``["1", "2.5", "3"]``).
+    """
 
     @beartype
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary

- Adds documentation to the `Mojo` class docstring explaining that Mojo does not support heterogeneous collections, so mixed-type scalar values are coerced to strings.

## Test plan

- [ ] Verify the docs render correctly with the updated docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no runtime behavior modifications.
> 
> **Overview**
> Documents Mojo’s lack of heterogeneous collection support by expanding the `Mojo` class docstring to state that mixed-type scalar lists are coerced to string literals (e.g. `[1, 2.5, 3]` -> `["1", "2.5", "3"]`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d52d5638754da3c854946592de1b5b598549b5ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->