### PR TITLE
Add missing languages to README supported languages list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,10 @@ literalizer
 Supported languages
 -------------------
 
-Ada, Bash, C, C#, C++, Clojure, Crystal, D, Dart, Elixir, Erlang, F#, Go,
-Groovy, Haskell, Java, JavaScript, Julia, Kotlin, Lua, MATLAB, Nim, OCaml,
-Occam-pi, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, Swift,
-TypeScript, Zig.
+Ada, Bash, C, C#, C++, Clojure, COBOL, Common Lisp, Crystal, D, Dart, Elixir,
+Erlang, F#, Go, Groovy, Haskell, HCL, Java, JavaScript, Julia, Kotlin, Lua,
+MATLAB, Mojo, Nim, OCaml, Occam-pi, Perl, PHP, PowerShell, Python, R, Racket,
+Ruby, Rust, Scala, Swift, TOML, TypeScript, Visual Basic, Zig.
 
 Installation
 ------------


### PR DESCRIPTION
## Summary

The README's supported languages list was missing 7 languages that are defined in `literalizer.languages`: COBOL, Common Lisp, HCL, Mojo, Racket, TOML, and Visual Basic. This updates the list from 35 to 42 languages to match the actual codebase.

## Test plan

- [x] Verify the list matches `src/literalizer/languages/__init__.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code or behavior is modified.
> 
> **Overview**
> Aligns `README.rst`’s **Supported languages** list with the actual set of built-in language specs by adding the previously omitted entries (e.g., `COBOL`, `Common Lisp`, `HCL`, `Mojo`, `Racket`, `TOML`, `Visual Basic`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36482da76b87703985ef4b2017e53b61401cf724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->