### PR TITLE
Replace `in` assertions with exact `==` comparisons in tests

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -199,36 +199,60 @@ def test_format_datetime_epoch() -> None:
 def test_format_date_cpp() -> None:
     """``format_date_cpp`` returns a year_month_day literal."""
     result = format_date_cpp(value=_SAMPLE_DATE)
-    assert "std::chrono::year{2024}" in result
-    assert "std::chrono::month{1}" in result
-    assert "std::chrono::day{15}" in result
+    expected = (
+        "std::chrono::year_month_day{"
+        "std::chrono::year{2024}, "
+        "std::chrono::month{1}, "
+        "std::chrono::day{15}}"
+    )
+    assert result == expected
 
 
 def test_format_datetime_cpp() -> None:
     """``format_datetime_cpp`` returns a sys_days expression."""
     result = format_datetime_cpp(value=_SAMPLE_DATETIME)
-    assert "std::chrono::sys_days" in result
-    assert "std::chrono::hours{12}" in result
-    assert "std::chrono::minutes{30}" in result
+    expected = (
+        "std::chrono::sys_days{"
+        "std::chrono::year_month_day{"
+        "std::chrono::year{2024}, "
+        "std::chrono::month{1}, "
+        "std::chrono::day{15}}}"
+        " + std::chrono::hours{12}"
+        " + std::chrono::minutes{30}"
+    )
+    assert result == expected
 
 
 def test_format_datetime_cpp_midnight() -> None:
     """``format_datetime_cpp`` at midnight omits zero time components."""
     midnight = datetime.datetime.fromisoformat("2024-01-15T00:00:00")
     result = format_datetime_cpp(value=midnight)
-    assert "std::chrono::sys_days" in result
-    assert "hours" not in result
-    assert "minutes" not in result
-    assert "seconds" not in result
-    assert "microseconds" not in result
+    expected = (
+        "std::chrono::sys_days{"
+        "std::chrono::year_month_day{"
+        "std::chrono::year{2024}, "
+        "std::chrono::month{1}, "
+        "std::chrono::day{15}}}"
+    )
+    assert result == expected
 
 
 def test_format_datetime_cpp_seconds_and_microseconds() -> None:
     """``format_datetime_cpp`` includes seconds and microseconds."""
     dt = datetime.datetime.fromisoformat("2024-01-15T12:30:45.123456")
     result = format_datetime_cpp(value=dt)
-    assert "std::chrono::seconds{45}" in result
-    assert "std::chrono::microseconds{123456}" in result
+    expected = (
+        "std::chrono::sys_days{"
+        "std::chrono::year_month_day{"
+        "std::chrono::year{2024}, "
+        "std::chrono::month{1}, "
+        "std::chrono::day{15}}}"
+        " + std::chrono::hours{12}"
+        " + std::chrono::minutes{30}"
+        " + std::chrono::seconds{45}"
+        " + std::chrono::microseconds{123456}"
+    )
+    assert result == expected
 
 
 def test_default_format_date_is_iso() -> None:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -419,7 +419,8 @@ def test_toml_integer_dict_key() -> None:
         line_prefix="",
         wrap=True,
     )
-    assert '1 = "value"' in result
+    expected = '{\n    1 = "value"\n}'
+    assert result == expected
 
 
 def test_toml_non_quoted_dict_key() -> None:
@@ -476,15 +477,21 @@ def test_cobol_level_number_cap() -> None:
         line_prefix="    ",
         wrap=True,
     )
-    # Level 49 is the max; deeper nesting stays at 49.
-    max_cobol_level = 49
-    assert "49 F-VALUE" in result
-    # No level number should exceed 49.
-    for line in result.splitlines():
-        stripped = line.lstrip()
-        if stripped and stripped[:2].isdigit():
-            level = int(stripped[:2])
-            assert level <= max_cobol_level
+    expected = (
+        "\n"
+        "        05 F-A.\n"
+        "10 F-B.\n"
+        "15 F-C.\n"
+        "20 F-D.\n"
+        "25 F-E.\n"
+        "30 F-F.\n"
+        "35 F-G.\n"
+        "40 F-H.\n"
+        "45 F-I.\n"
+        '49 F-VALUE PIC X(4) VALUE "deep".\n'
+        "    "
+    )
+    assert result == expected
 
 
 def test_cobol_key_name_trailing_hyphen_after_truncation() -> None:

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -374,8 +374,8 @@ def test_coerce_heterogeneous_bytes_in_collection() -> None:
         language=MOJO,
         wrap=True,
     )
-    assert '"48656c6c6f"' in result
-    assert '"42"' in result
+    expected = '{\n    "key1": "48656c6c6f",\n    "key2": "42",\n}'
+    assert result == expected
 
 
 def test_coerce_heterogeneous_set() -> None:
@@ -392,8 +392,8 @@ def test_coerce_heterogeneous_set() -> None:
         language=MOJO,
         wrap=True,
     )
-    assert '"1"' in result
-    assert '"hello"' in result
+    expected = '[\n    "1",\n    "hello",\n]'
+    assert result == expected
 
 
 def test_coerce_homogeneous_omap_no_coercion() -> None:
@@ -410,5 +410,5 @@ def test_coerce_homogeneous_omap_no_coercion() -> None:
         language=MOJO,
         wrap=True,
     )
-    assert '"Alice"' in result
-    assert '"Paris"' in result
+    expected = '[\n    ("name", "Alice"),\n    ("city", "Paris"),\n]'
+    assert result == expected


### PR DESCRIPTION
Replace all `assert X in result` style assertions with `assert result == expected` using an `expected` variable. This makes tests stricter by checking the full output rather than just substrings, catching regressions that substring checks would miss. Changes span `test_formatters.py` (C++ date/datetime formatters), `test_yaml.py` (MOJO coercion tests), and `test_languages.py` (TOML integer key and COBOL level cap tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to tests, but they may expose previously-accepted output formatting differences and cause CI failures if formatting is unstable.
> 
> **Overview**
> Updates multiple tests to assert full rendered output strings (via `expected` + `==`) instead of using substring `in` checks.
> 
> This tightens coverage for C++ date/datetime formatting, TOML integer-key wrapping, COBOL deep-nesting level output, and MOJO YAML coercion cases, making output formatting regressions easier to catch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 049a8b0b077c597a6a35cf479ff9745b873791f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->