### PR TITLE
Add missing @beartype decorators to private helpers and __init__ methods

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -24,6 +24,7 @@ from literalizer._types import Scalar, Value
 from literalizer.exceptions import JSONParseError, YAMLParseError
 
 
+@beartype
 def _scalar_type_bucket(*, value: Value) -> type | None:
     """Return the type bucket for a scalar, or ``None`` for
     collections.
@@ -47,6 +48,7 @@ def _scalar_type_bucket(*, value: Value) -> type | None:
     return None
 
 
+@beartype
 def _coerce_scalar_to_str(*, value: Value) -> str:
     """Convert a scalar to its string representation."""
     if isinstance(value, bool):
@@ -64,6 +66,7 @@ def _coerce_scalar_to_str(*, value: Value) -> str:
     return repr(value)
 
 
+@beartype
 def _all_scalars_heterogeneous(
     *,
     values: Sequence[Value],
@@ -78,6 +81,7 @@ def _all_scalars_heterogeneous(
     return len(buckets) > 1
 
 
+@beartype
 def _coerce_heterogeneous(*, data: Value) -> Value:
     """Recursively coerce heterogeneous all-scalar collections to
     strings.
@@ -249,6 +253,7 @@ def _wrap_body(
     return f"{opening.rstrip()}\n{body}\n{closing}"
 
 
+@beartype
 def _coerce_yaml_keys(*, data: object) -> Value:
     """Recursively convert non-string dict keys to their string form.
 

--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -22,6 +22,7 @@ from literalizer._types import Value
 _JSON_NATIVE_TYPES = (str, int, float, bool, type(None), list, dict)
 
 
+@beartype
 def _all_json_native(values: Value) -> bool:
     """Check whether every scalar in *values* is a JSON-native type.
 
@@ -521,6 +522,7 @@ def format_string_backslash_dollar(value: str) -> str:
     return f'"{escaped}"'
 
 
+@beartype
 def _vb_string_parts(value: str) -> list[str]:  # noqa: C901,PLR0912  # pylint: disable=too-complex,too-many-branches
     """Generate VB.NET string parts for control character handling."""
     vb_control_char_threshold = 32

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -104,6 +104,7 @@ _string_format: Callable[[str], str] = format_string_backslash
 class D:
     """D language specification."""
 
+    @beartype
     def __init__(self) -> None:
         """Initialize D language specification."""
         self.null_literal = "null"

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 _CONTROL_CHAR_THRESHOLD = 32
 
 
+@beartype
 def _decode_matlab_string_expr(expr: str) -> str:
     r"""Decode a MATLAB string expression back to its raw string value.
 
@@ -44,6 +45,7 @@ def _decode_matlab_string_expr(expr: str) -> str:
     return "".join(raw)
 
 
+@beartype
 def _matlab_char_key(s: str) -> str:
     """Build a MATLAB char-array expression for a struct key.
 
@@ -111,6 +113,7 @@ _string_format: Callable[[str], str] = format_string_matlab
 class Matlab:
     """MATLAB language specification."""
 
+    @beartype
     def __init__(self) -> None:
         """Initialize Matlab language specification."""
         self.null_literal = "[]"

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -35,6 +35,7 @@ def _format_sequence_entry(item: str) -> str:
     return item
 
 
+@beartype
 def _format_string(value: str) -> str:
     """Format a string using PowerShell back-tick escaping."""
     escaped = (
@@ -47,11 +48,13 @@ def _format_string(value: str) -> str:
     return f'"{escaped}"'
 
 
+@beartype
 def _format_variable_declaration(name: str, value: str) -> str:
     """Format a PowerShell variable declaration."""
     return f"${name} = {value}"
 
 
+@beartype
 def _format_variable_assignment(name: str, value: str) -> str:
     """Format a PowerShell variable assignment."""
     return f"${name} = {value}"
@@ -66,6 +69,7 @@ _string_format: Callable[[str], str] = _format_string
 class PowerShell:
     """PowerShell language specification."""
 
+    @beartype
     def __init__(self) -> None:
         """Initialize PowerShell language specification."""
         self.null_literal = "$null"


### PR DESCRIPTION
Adds `@beartype` decorators to annotated functions that were missing them across `_core.py`, `_formatters.py`, and the D, MATLAB, and PowerShell language modules. This covers 5 private helpers in `_core.py`, 2 in `_formatters.py`, the `__init__` methods of `D`, `Matlab`, and `PowerShell`, and helper functions `_decode_matlab_string_expr`, `_matlab_char_key`, `_format_string`, `_format_variable_declaration`, and `_format_variable_assignment` in the MATLAB and PowerShell modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds runtime type-checking decorators to already-annotated helpers and constructors, with no functional logic changes beyond potential new type errors on invalid inputs.
> 
> **Overview**
> Adds missing `@beartype` decorators to several already-type-annotated internal helper functions in `_core.py` and `_formatters.py`.
> 
> Also decorates helper functions and the `__init__` constructors for the `D`, `Matlab`, and `PowerShell` language specs so these modules get consistent runtime type checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 123de743470d9da7a13d981f941a893d40510ca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->