### PR TITLE
Add tuple sequence format for Rust

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -72,6 +72,13 @@ class Rust:
               ``NaiveDateTime::new(...)`` call, e.g.
               ``NaiveDateTime::new(NaiveDate::from_ymd_opt(2024, 1, 15)
               .unwrap(), NaiveTime::from_hms_opt(12, 30, 0).unwrap())``.
+
+        sequence_format: Which Rust sequence type to use.
+
+            * ``SequenceFormat.VEC`` (default) — ``vec![]`` macro,
+              e.g. ``vec![1, 2, 3]``.
+            * ``SequenceFormat.TUPLE`` — tuple literal,
+              e.g. ``(1, 2, 3)``.
     """
 
     class DateFormat(enum.Enum):
@@ -86,20 +93,31 @@ class Rust:
         ISO = enum.member(value=format_datetime_iso)
         RUST = enum.member(value=format_datetime_rust)
 
+    class SequenceFormat(enum.Enum):
+        """Sequence type options for Rust."""
+
+        VEC = "vec"
+        TUPLE = "tuple"
+
     def __init__(
         self,
         *,
         date_format: DateFormat = DateFormat.ISO,
         datetime_format: DatetimeFormat = DatetimeFormat.ISO,
+        sequence_format: SequenceFormat = SequenceFormat.VEC,
     ) -> None:
         """Initialize Rust language specification."""
         self.null_literal = "None"
         self.true_literal = "true"
         self.false_literal = "false"
-        self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
-            open_str="vec!["
-        )
-        self.sequence_close = "]"
+        self.sequence_open: Callable[[list[Value]], str]
+        self.sequence_close: str
+        if sequence_format == Rust.SequenceFormat.TUPLE:
+            self.sequence_open = fixed_sequence_open(open_str="(")
+            self.sequence_close = ")"
+        else:
+            self.sequence_open = fixed_sequence_open(open_str="vec![")
+            self.sequence_close = "]"
         self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
             open_str="HashMap::from(["
         )

--- a/tests/integration/cases/simple_sequence/rust_tuple.rs
+++ b/tests/integration/cases/simple_sequence/rust_tuple.rs
@@ -1,0 +1,10 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+fn main() {
+    let _ = (
+        1,
+        "hello",
+        true,
+        None,
+    );
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1813,6 +1813,13 @@ _SEQUENCE_VARIANTS: dict[str, _SequenceVariant] = {
         extension=".cr",
         wrap=_wrap_crystal,
     ),
+    "rust_tuple": _SequenceVariant(
+        spec=literalizer.languages.Rust(
+            sequence_format=literalizer.languages.Rust.SequenceFormat.TUPLE,
+        ),
+        extension=".rs",
+        wrap=_wrap_rust,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Adds `SequenceFormat` enum to Rust language spec with `VEC` (default) and `TUPLE` variants
- When `TUPLE` is selected, sequences render as `(a, b, c)` instead of `vec![a, b, c]`
- Adds integration test and golden file for the new variant

Closes #354

## Test plan
- [x] New `rust_tuple` sequence format golden file test passes
- [x] All 107 existing Rust tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated formatting option in the Rust literalizer plus a golden integration test, with the default `vec![]` behavior unchanged.
> 
> **Overview**
> Adds a Rust `SequenceFormat` option so YAML sequences can be rendered either as the default `vec![...]` or as a tuple literal `(...)` when explicitly requested.
> 
> Extends integration coverage by introducing a new `rust_tuple` sequence-variant golden file for the `simple_sequence` case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59daac9f4eae3439bfcf60d865e51c4ab396a5eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->