### PR TITLE
Add array sequence format for Rust

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -77,6 +77,8 @@ class Rust:
 
             * ``SequenceFormat.VEC`` (default) — ``vec![]`` macro,
               e.g. ``vec![1, 2, 3]``.
+            * ``SequenceFormat.ARRAY`` — fixed-size array literal,
+              e.g. ``[1, 2, 3]``.
             * ``SequenceFormat.TUPLE`` — tuple literal,
               e.g. ``(1, 2, 3)``.
     """
@@ -97,6 +99,7 @@ class Rust:
         """Sequence type options for Rust."""
 
         VEC = "vec"
+        ARRAY = "array"
         TUPLE = "tuple"
 
     def __init__(
@@ -115,6 +118,9 @@ class Rust:
         if sequence_format == Rust.SequenceFormat.TUPLE:
             self.sequence_open = fixed_sequence_open(open_str="(")
             self.sequence_close = ")"
+        elif sequence_format == Rust.SequenceFormat.ARRAY:
+            self.sequence_open = fixed_sequence_open(open_str="[")
+            self.sequence_close = "]"
         else:
             self.sequence_open = fixed_sequence_open(open_str="vec![")
             self.sequence_close = "]"

--- a/tests/integration/cases/simple_sequence/rust_array.rs
+++ b/tests/integration/cases/simple_sequence/rust_array.rs
@@ -1,0 +1,10 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+fn main() {
+    let _ = [
+        1,
+        "hello",
+        true,
+        None,
+    ];
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1813,6 +1813,13 @@ _SEQUENCE_VARIANTS: dict[str, _SequenceVariant] = {
         extension=".cr",
         wrap=_wrap_crystal,
     ),
+    "rust_array": _SequenceVariant(
+        spec=literalizer.languages.Rust(
+            sequence_format=literalizer.languages.Rust.SequenceFormat.ARRAY,
+        ),
+        extension=".rs",
+        wrap=_wrap_rust,
+    ),
     "rust_tuple": _SequenceVariant(
         spec=literalizer.languages.Rust(
             sequence_format=literalizer.languages.Rust.SequenceFormat.TUPLE,


### PR DESCRIPTION
## Summary
- Adds `SequenceFormat.ARRAY` option to the Rust language spec, producing fixed-size array syntax (`[1, 2, 3]`) as an alternative to the default `vec![1, 2, 3]`.
- Adds golden file test and test variant for the new format.

Closes part of #261.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an opt-in Rust sequence formatting variant and corresponding golden integration coverage, without touching parsing, IO, or security-sensitive logic.
> 
> **Overview**
> Adds a new Rust `SequenceFormat.ARRAY` option so sequences can be emitted as fixed-size array literals (`[ ... ]`) instead of the default `vec![ ... ]` or tuples.
> 
> Extends integration coverage with a new `rust_array` sequence-variant and a golden file (`simple_sequence/rust_array.rs`) validating the generated array syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a184a41f79ba0265a7dc8eebd9f2627e32e0d80b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->