### PR TITLE
Fix Any import detection and consolidate datetime wrapping

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1167,8 +1167,10 @@ def _python_imports(content: str) -> str:
     imports: list[str] = []
     if "OrderedDict(" in content:
         imports.append("from collections import OrderedDict")
-    if "Any]" in content:
+    if "[Any" in content or "Any]" in content:
         imports.append("from typing import Any")
+    if "datetime." in content:
+        imports.append("import datetime")
     if not imports:
         return ""
     return "\n".join(imports) + "\n"
@@ -1185,12 +1187,6 @@ def _wrap_python_combined(declaration: str, assignment: str) -> str:
     """Join declaration and assignment with imports prepended."""
     combined = declaration + "\n" + assignment
     return _python_imports(content=combined) + combined
-
-
-@beartype
-def _wrap_python_datetime(content: str) -> str:
-    """Wrap with a datetime import for native Python date literals."""
-    return f"import datetime\n{content}"
 
 
 @beartype
@@ -1924,7 +1920,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
             variable_type_hints=literalizer.languages.Python.VariableTypeHints.NONE,
         ),
         extension=".py",
-        wrap=_wrap_python_datetime,
+        wrap=_wrap_python,
     ),
     "python_epoch": _DateVariant(
         spec=literalizer.languages.Python(


### PR DESCRIPTION
## Summary
- Broadened `Any` import detection in `_python_imports` to check for both `[Any` and `Any]`, fixing the miss on `tuple[Any, ...]` patterns
- Added `datetime.` import detection to `_python_imports`, making `_wrap_python_datetime` redundant
- Removed `_wrap_python_datetime` and replaced its single usage with `_wrap_python`

Addresses review comments from #364.

## Test plan
- [x] All 4854 integration tests pass
- [x] mypy passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only changes that adjust how Python golden files are wrapped with imports; the main risk is needing to regenerate or updating expected outputs if import preambles change.
> 
> **Overview**
> Improves Python integration-test wrapping so generated golden files include needed imports more reliably.
> 
> `_python_imports` now detects `Any` used in both `tuple[Any, ...]` and `list[Any]`-style annotations, and auto-adds `import datetime` when `datetime.` literals are present. This removes the dedicated `_wrap_python_datetime` helper and switches the `python_native` date variant to use the general `_wrap_python` wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f73a4df5ad1f959ee07d0dc148e82b8305d715e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->