### PR TITLE
Fix Rust vec! preamble and VEC heterogeneous coercion

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -167,7 +167,7 @@ class Rust:
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_to_strings: bool = (
-            sequence_format != Rust.SequenceFormat.TUPLE
+            sequence_format == Rust.SequenceFormat.ARRAY
         )
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (

--- a/tests/integration/cases/comments/rust.rs
+++ b/tests/integration/cases/comments/rust.rs
@@ -23,8 +23,8 @@ fn main() {
     let _ = HashMap::from(vec![
         // Server configuration
         ("host", "localhost"),  // default host
-        ("port", "8080"),
+        ("port", 8080),
         // Enable debug mode
-        ("debug", "True"),
+        ("debug", true),
     ]);
 }

--- a/tests/integration/cases/comments/rust_combined.rs
+++ b/tests/integration/cases/comments/rust_combined.rs
@@ -24,9 +24,9 @@ fn main() {
         let my_data = HashMap::from(vec![
             // Server configuration
             ("host", "localhost"),  // default host
-            ("port", "8080"),
+            ("port", 8080),
             // Enable debug mode
-            ("debug", "True"),
+            ("debug", true),
         ]);
         let _ = my_data;
     }
@@ -34,9 +34,9 @@ fn main() {
     my_data = HashMap::from(vec![
         // Server configuration
         ("host", "localhost"),  // default host
-        ("port", "8080"),
+        ("port", 8080),
         // Enable debug mode
-        ("debug", "True"),
+        ("debug", true),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/comments/rust_varname.rs
+++ b/tests/integration/cases/comments/rust_varname.rs
@@ -23,9 +23,9 @@ fn main() {
     let my_data = HashMap::from(vec![
         // Server configuration
         ("host", "localhost"),  // default host
-        ("port", "8080"),
+        ("port", 8080),
         // Enable debug mode
-        ("debug", "True"),
+        ("debug", true),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/dates/rust_native.rs
+++ b/tests/integration/cases/dates/rust_native.rs
@@ -22,7 +22,7 @@ impl HashMap {
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 fn main() {
     let _ = HashMap::from(vec![
-        ("date", "2024-01-15"),
-        ("datetime", "2024-01-15T12:30:00+00:00"),
+        ("date", NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()),
+        ("datetime", NaiveDateTime::new(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(), NaiveTime::from_hms_opt(12, 30, 0).unwrap())),
     ]);
 }

--- a/tests/integration/cases/dict_with_nulls/rust.rs
+++ b/tests/integration/cases/dict_with_nulls/rust.rs
@@ -22,7 +22,7 @@ impl HashMap {
 fn main() {
     let _ = HashMap::from(vec![
         ("name", "Alice"),
-        ("score", "None"),
-        ("age", "30"),
+        ("score", None::<()>),
+        ("age", 30),
     ]);
 }

--- a/tests/integration/cases/dict_with_nulls/rust_combined.rs
+++ b/tests/integration/cases/dict_with_nulls/rust_combined.rs
@@ -23,16 +23,16 @@ fn main() {
     {
         let my_data = HashMap::from(vec![
             ("name", "Alice"),
-            ("score", "None"),
-            ("age", "30"),
+            ("score", None::<()>),
+            ("age", 30),
         ]);
         let _ = my_data;
     }
     let my_data;
     my_data = HashMap::from(vec![
         ("name", "Alice"),
-        ("score", "None"),
-        ("age", "30"),
+        ("score", None::<()>),
+        ("age", 30),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/dict_with_nulls/rust_varname.rs
+++ b/tests/integration/cases/dict_with_nulls/rust_varname.rs
@@ -22,8 +22,8 @@ impl HashMap {
 fn main() {
     let my_data = HashMap::from(vec![
         ("name", "Alice"),
-        ("score", "None"),
-        ("age", "30"),
+        ("score", None::<()>),
+        ("age", 30),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/mixed_number_dict/rust.rs
+++ b/tests/integration/cases/mixed_number_dict/rust.rs
@@ -21,8 +21,8 @@ impl HashMap {
 }
 fn main() {
     let _ = HashMap::from(vec![
-        ("a", "1"),
-        ("b", "2.5"),
-        ("c", "3"),
+        ("a", 1),
+        ("b", 2.5),
+        ("c", 3),
     ]);
 }

--- a/tests/integration/cases/mixed_number_dict/rust_combined.rs
+++ b/tests/integration/cases/mixed_number_dict/rust_combined.rs
@@ -22,17 +22,17 @@ impl HashMap {
 fn main() {
     {
         let my_data = HashMap::from(vec![
-            ("a", "1"),
-            ("b", "2.5"),
-            ("c", "3"),
+            ("a", 1),
+            ("b", 2.5),
+            ("c", 3),
         ]);
         let _ = my_data;
     }
     let my_data;
     my_data = HashMap::from(vec![
-        ("a", "1"),
-        ("b", "2.5"),
-        ("c", "3"),
+        ("a", 1),
+        ("b", 2.5),
+        ("c", 3),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/mixed_number_dict/rust_varname.rs
+++ b/tests/integration/cases/mixed_number_dict/rust_varname.rs
@@ -21,9 +21,9 @@ impl HashMap {
 }
 fn main() {
     let my_data = HashMap::from(vec![
-        ("a", "1"),
-        ("b", "2.5"),
-        ("c", "3"),
+        ("a", 1),
+        ("b", 2.5),
+        ("c", 3),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/mixed_number_list/rust.rs
+++ b/tests/integration/cases/mixed_number_list/rust.rs
@@ -17,8 +17,8 @@ macro_rules! vec {
 }
 fn main() {
     let _ = vec![
-        "1",
-        "2.5",
-        "3",
+        1,
+        2.5,
+        3,
     ];
 }

--- a/tests/integration/cases/mixed_number_list/rust_combined.rs
+++ b/tests/integration/cases/mixed_number_list/rust_combined.rs
@@ -18,17 +18,17 @@ macro_rules! vec {
 fn main() {
     {
         let my_data = vec![
-            "1",
-            "2.5",
-            "3",
+            1,
+            2.5,
+            3,
         ];
         let _ = my_data;
     }
     let my_data;
     my_data = vec![
-        "1",
-        "2.5",
-        "3",
+        1,
+        2.5,
+        3,
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/mixed_number_list/rust_varname.rs
+++ b/tests/integration/cases/mixed_number_list/rust_varname.rs
@@ -17,9 +17,9 @@ macro_rules! vec {
 }
 fn main() {
     let my_data = vec![
-        "1",
-        "2.5",
-        "3",
+        1,
+        2.5,
+        3,
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/rust.rs
+++ b/tests/integration/cases/nested_collection_multi_space_string/rust.rs
@@ -21,6 +21,6 @@ impl HashMap {
 }
 fn main() {
     let _ = vec![
-        HashMap::from(vec![("key", "hello   world"), ("value", "1")]),
+        HashMap::from(vec![("key", "hello   world"), ("value", 1)]),
     ];
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/rust_combined.rs
+++ b/tests/integration/cases/nested_collection_multi_space_string/rust_combined.rs
@@ -22,13 +22,13 @@ impl HashMap {
 fn main() {
     {
         let my_data = vec![
-            HashMap::from(vec![("key", "hello   world"), ("value", "1")]),
+            HashMap::from(vec![("key", "hello   world"), ("value", 1)]),
         ];
         let _ = my_data;
     }
     let my_data;
     my_data = vec![
-        HashMap::from(vec![("key", "hello   world"), ("value", "1")]),
+        HashMap::from(vec![("key", "hello   world"), ("value", 1)]),
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/rust_varname.rs
+++ b/tests/integration/cases/nested_collection_multi_space_string/rust_varname.rs
@@ -21,7 +21,7 @@ impl HashMap {
 }
 fn main() {
     let my_data = vec![
-        HashMap::from(vec![("key", "hello   world"), ("value", "1")]),
+        HashMap::from(vec![("key", "hello   world"), ("value", 1)]),
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/nested_mixed_inner/rust.rs
+++ b/tests/integration/cases/nested_mixed_inner/rust.rs
@@ -17,7 +17,7 @@ macro_rules! vec {
 }
 fn main() {
     let _ = vec![
-        vec!["1", "a"],
-        vec!["2", "b"],
+        vec![1, "a"],
+        vec![2, "b"],
     ];
 }

--- a/tests/integration/cases/nested_mixed_inner/rust_combined.rs
+++ b/tests/integration/cases/nested_mixed_inner/rust_combined.rs
@@ -18,15 +18,15 @@ macro_rules! vec {
 fn main() {
     {
         let my_data = vec![
-            vec!["1", "a"],
-            vec!["2", "b"],
+            vec![1, "a"],
+            vec![2, "b"],
         ];
         let _ = my_data;
     }
     let my_data;
     my_data = vec![
-        vec!["1", "a"],
-        vec!["2", "b"],
+        vec![1, "a"],
+        vec![2, "b"],
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/nested_mixed_inner/rust_varname.rs
+++ b/tests/integration/cases/nested_mixed_inner/rust_varname.rs
@@ -17,8 +17,8 @@ macro_rules! vec {
 }
 fn main() {
     let my_data = vec![
-        vec!["1", "a"],
-        vec!["2", "b"],
+        vec![1, "a"],
+        vec![2, "b"],
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/omap/rust.rs
+++ b/tests/integration/cases/omap/rust.rs
@@ -22,7 +22,7 @@ impl HashMap {
 fn main() {
     let _ = HashMap::from(vec![
         ("name", "Alice"),
-        ("age", "30"),
-        ("active", "True"),
+        ("age", 30),
+        ("active", true),
     ]);
 }

--- a/tests/integration/cases/omap/rust_combined.rs
+++ b/tests/integration/cases/omap/rust_combined.rs
@@ -23,16 +23,16 @@ fn main() {
     {
         let my_data = HashMap::from(vec![
             ("name", "Alice"),
-            ("age", "30"),
-            ("active", "True"),
+            ("age", 30),
+            ("active", true),
         ]);
         let _ = my_data;
     }
     let my_data;
     my_data = HashMap::from(vec![
         ("name", "Alice"),
-        ("age", "30"),
-        ("active", "True"),
+        ("age", 30),
+        ("active", true),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/omap/rust_varname.rs
+++ b/tests/integration/cases/omap/rust_varname.rs
@@ -22,8 +22,8 @@ impl HashMap {
 fn main() {
     let my_data = HashMap::from(vec![
         ("name", "Alice"),
-        ("age", "30"),
-        ("active", "True"),
+        ("age", 30),
+        ("active", true),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/scalars/rust.rs
+++ b/tests/integration/cases/scalars/rust.rs
@@ -17,10 +17,10 @@ macro_rules! vec {
 }
 fn main() {
     let _ = vec![
-        "42",
-        "3.14",
-        "True",
-        "False",
+        42,
+        3.14,
+        true,
+        false,
         "hello \"world\"",
     ];
 }

--- a/tests/integration/cases/scalars/rust_combined.rs
+++ b/tests/integration/cases/scalars/rust_combined.rs
@@ -18,20 +18,20 @@ macro_rules! vec {
 fn main() {
     {
         let my_data = vec![
-            "42",
-            "3.14",
-            "True",
-            "False",
+            42,
+            3.14,
+            true,
+            false,
             "hello \"world\"",
         ];
         let _ = my_data;
     }
     let my_data;
     my_data = vec![
-        "42",
-        "3.14",
-        "True",
-        "False",
+        42,
+        3.14,
+        true,
+        false,
         "hello \"world\"",
     ];
     let _ = my_data;

--- a/tests/integration/cases/scalars/rust_varname.rs
+++ b/tests/integration/cases/scalars/rust_varname.rs
@@ -17,10 +17,10 @@ macro_rules! vec {
 }
 fn main() {
     let my_data = vec![
-        "42",
-        "3.14",
-        "True",
-        "False",
+        42,
+        3.14,
+        true,
+        false,
         "hello \"world\"",
     ];
     let _ = my_data;

--- a/tests/integration/cases/sequence_of_dicts/rust.rs
+++ b/tests/integration/cases/sequence_of_dicts/rust.rs
@@ -21,7 +21,7 @@ impl HashMap {
 }
 fn main() {
     let _ = vec![
-        HashMap::from(vec![("name", "Alice"), ("age", "30")]),
-        HashMap::from(vec![("name", "Bob"), ("age", "25")]),
+        HashMap::from(vec![("name", "Alice"), ("age", 30)]),
+        HashMap::from(vec![("name", "Bob"), ("age", 25)]),
     ];
 }

--- a/tests/integration/cases/sequence_of_dicts/rust_combined.rs
+++ b/tests/integration/cases/sequence_of_dicts/rust_combined.rs
@@ -22,15 +22,15 @@ impl HashMap {
 fn main() {
     {
         let my_data = vec![
-            HashMap::from(vec![("name", "Alice"), ("age", "30")]),
-            HashMap::from(vec![("name", "Bob"), ("age", "25")]),
+            HashMap::from(vec![("name", "Alice"), ("age", 30)]),
+            HashMap::from(vec![("name", "Bob"), ("age", 25)]),
         ];
         let _ = my_data;
     }
     let my_data;
     my_data = vec![
-        HashMap::from(vec![("name", "Alice"), ("age", "30")]),
-        HashMap::from(vec![("name", "Bob"), ("age", "25")]),
+        HashMap::from(vec![("name", "Alice"), ("age", 30)]),
+        HashMap::from(vec![("name", "Bob"), ("age", 25)]),
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/sequence_of_dicts/rust_varname.rs
+++ b/tests/integration/cases/sequence_of_dicts/rust_varname.rs
@@ -21,8 +21,8 @@ impl HashMap {
 }
 fn main() {
     let my_data = vec![
-        HashMap::from(vec![("name", "Alice"), ("age", "30")]),
-        HashMap::from(vec![("name", "Bob"), ("age", "25")]),
+        HashMap::from(vec![("name", "Alice"), ("age", 30)]),
+        HashMap::from(vec![("name", "Bob"), ("age", 25)]),
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/simple_dict/rust.rs
+++ b/tests/integration/cases/simple_dict/rust.rs
@@ -22,8 +22,8 @@ impl HashMap {
 fn main() {
     let _ = HashMap::from(vec![
         ("name", "Alice"),
-        ("age", "30"),
-        ("active", "True"),
-        ("score", "None"),
+        ("age", 30),
+        ("active", true),
+        ("score", None::<()>),
     ]);
 }

--- a/tests/integration/cases/simple_dict/rust_combined.rs
+++ b/tests/integration/cases/simple_dict/rust_combined.rs
@@ -23,18 +23,18 @@ fn main() {
     {
         let my_data = HashMap::from(vec![
             ("name", "Alice"),
-            ("age", "30"),
-            ("active", "True"),
-            ("score", "None"),
+            ("age", 30),
+            ("active", true),
+            ("score", None::<()>),
         ]);
         let _ = my_data;
     }
     let my_data;
     my_data = HashMap::from(vec![
         ("name", "Alice"),
-        ("age", "30"),
-        ("active", "True"),
-        ("score", "None"),
+        ("age", 30),
+        ("active", true),
+        ("score", None::<()>),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/simple_dict/rust_varname.rs
+++ b/tests/integration/cases/simple_dict/rust_varname.rs
@@ -22,9 +22,9 @@ impl HashMap {
 fn main() {
     let my_data = HashMap::from(vec![
         ("name", "Alice"),
-        ("age", "30"),
-        ("active", "True"),
-        ("score", "None"),
+        ("age", 30),
+        ("active", true),
+        ("score", None::<()>),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/simple_sequence/rust.rs
+++ b/tests/integration/cases/simple_sequence/rust.rs
@@ -17,9 +17,9 @@ macro_rules! vec {
 }
 fn main() {
     let _ = vec![
-        "1",
+        1,
         "hello",
-        "True",
-        "None",
+        true,
+        None::<()>,
     ];
 }

--- a/tests/integration/cases/simple_sequence/rust_array.rs
+++ b/tests/integration/cases/simple_sequence/rust_array.rs
@@ -1,20 +1,3 @@
-struct V;
-impl From<i32> for V { fn from(_: i32) -> Self { V } }
-impl From<i64> for V { fn from(_: i64) -> Self { V } }
-impl From<f64> for V { fn from(_: f64) -> Self { V } }
-impl From<bool> for V { fn from(_: bool) -> Self { V } }
-impl From<&str> for V { fn from(_: &str) -> Self { V } }
-impl<T> From<Option<T>> for V { fn from(_: Option<T>) -> Self { V } }
-impl<T> From<std::vec::Vec<T>> for V { fn from(_: std::vec::Vec<T>) -> Self { V } }
-impl<A, B> From<(A, B)> for V { fn from(_: (A, B)) -> Self { V } }
-macro_rules! vec {
-    () => { ::std::vec::Vec::<V>::new() };
-    ($($e:expr),+ $(,)?) => {{
-        let mut _v = ::std::vec::Vec::<V>::new();
-        $(_v.push(<V as From<_>>::from($e));)+
-        _v
-    }};
-}
 fn main() {
     let _ = [
         "1",

--- a/tests/integration/cases/simple_sequence/rust_combined.rs
+++ b/tests/integration/cases/simple_sequence/rust_combined.rs
@@ -18,19 +18,19 @@ macro_rules! vec {
 fn main() {
     {
         let my_data = vec![
-            "1",
+            1,
             "hello",
-            "True",
-            "None",
+            true,
+            None::<()>,
         ];
         let _ = my_data;
     }
     let my_data;
     my_data = vec![
-        "1",
+        1,
         "hello",
-        "True",
-        "None",
+        true,
+        None::<()>,
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/simple_sequence/rust_tuple.rs
+++ b/tests/integration/cases/simple_sequence/rust_tuple.rs
@@ -1,20 +1,3 @@
-struct V;
-impl From<i32> for V { fn from(_: i32) -> Self { V } }
-impl From<i64> for V { fn from(_: i64) -> Self { V } }
-impl From<f64> for V { fn from(_: f64) -> Self { V } }
-impl From<bool> for V { fn from(_: bool) -> Self { V } }
-impl From<&str> for V { fn from(_: &str) -> Self { V } }
-impl<T> From<Option<T>> for V { fn from(_: Option<T>) -> Self { V } }
-impl<T> From<std::vec::Vec<T>> for V { fn from(_: std::vec::Vec<T>) -> Self { V } }
-impl<A, B> From<(A, B)> for V { fn from(_: (A, B)) -> Self { V } }
-macro_rules! vec {
-    () => { ::std::vec::Vec::<V>::new() };
-    ($($e:expr),+ $(,)?) => {{
-        let mut _v = ::std::vec::Vec::<V>::new();
-        $(_v.push(<V as From<_>>::from($e));)+
-        _v
-    }};
-}
 fn main() {
     let _ = (
         1,

--- a/tests/integration/cases/simple_sequence/rust_varname.rs
+++ b/tests/integration/cases/simple_sequence/rust_varname.rs
@@ -17,10 +17,10 @@ macro_rules! vec {
 }
 fn main() {
     let my_data = vec![
-        "1",
+        1,
         "hello",
-        "True",
-        "None",
+        true,
+        None::<()>,
     ];
     let _ = my_data;
 }

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/rust.rs
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/rust.rs
@@ -1,20 +1,3 @@
-struct V;
-impl From<i32> for V { fn from(_: i32) -> Self { V } }
-impl From<i64> for V { fn from(_: i64) -> Self { V } }
-impl From<f64> for V { fn from(_: f64) -> Self { V } }
-impl From<bool> for V { fn from(_: bool) -> Self { V } }
-impl From<&str> for V { fn from(_: &str) -> Self { V } }
-impl<T> From<Option<T>> for V { fn from(_: Option<T>) -> Self { V } }
-impl<T> From<std::vec::Vec<T>> for V { fn from(_: std::vec::Vec<T>) -> Self { V } }
-impl<A, B> From<(A, B)> for V { fn from(_: (A, B)) -> Self { V } }
-macro_rules! vec {
-    () => { ::std::vec::Vec::<V>::new() };
-    ($($e:expr),+ $(,)?) => {{
-        let mut _v = ::std::vec::Vec::<V>::new();
-        $(_v.push(<V as From<_>>::from($e));)+
-        _v
-    }};
-}
 fn main() {
     let _ = "hello \"world\" -- not a comment";
 }

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/rust_combined.rs
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/rust_combined.rs
@@ -1,20 +1,3 @@
-struct V;
-impl From<i32> for V { fn from(_: i32) -> Self { V } }
-impl From<i64> for V { fn from(_: i64) -> Self { V } }
-impl From<f64> for V { fn from(_: f64) -> Self { V } }
-impl From<bool> for V { fn from(_: bool) -> Self { V } }
-impl From<&str> for V { fn from(_: &str) -> Self { V } }
-impl<T> From<Option<T>> for V { fn from(_: Option<T>) -> Self { V } }
-impl<T> From<std::vec::Vec<T>> for V { fn from(_: std::vec::Vec<T>) -> Self { V } }
-impl<A, B> From<(A, B)> for V { fn from(_: (A, B)) -> Self { V } }
-macro_rules! vec {
-    () => { ::std::vec::Vec::<V>::new() };
-    ($($e:expr),+ $(,)?) => {{
-        let mut _v = ::std::vec::Vec::<V>::new();
-        $(_v.push(<V as From<_>>::from($e));)+
-        _v
-    }};
-}
 fn main() {
     {
         let my_data = "hello \"world\" -- not a comment";

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/rust_varname.rs
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/rust_varname.rs
@@ -1,20 +1,3 @@
-struct V;
-impl From<i32> for V { fn from(_: i32) -> Self { V } }
-impl From<i64> for V { fn from(_: i64) -> Self { V } }
-impl From<f64> for V { fn from(_: f64) -> Self { V } }
-impl From<bool> for V { fn from(_: bool) -> Self { V } }
-impl From<&str> for V { fn from(_: &str) -> Self { V } }
-impl<T> From<Option<T>> for V { fn from(_: Option<T>) -> Self { V } }
-impl<T> From<std::vec::Vec<T>> for V { fn from(_: std::vec::Vec<T>) -> Self { V } }
-impl<A, B> From<(A, B)> for V { fn from(_: (A, B)) -> Self { V } }
-macro_rules! vec {
-    () => { ::std::vec::Vec::<V>::new() };
-    ($($e:expr),+ $(,)?) => {{
-        let mut _v = ::std::vec::Vec::<V>::new();
-        $(_v.push(<V as From<_>>::from($e));)+
-        _v
-    }};
-}
 fn main() {
     let my_data = "hello \"world\" -- not a comment";
     let _ = my_data;

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -138,7 +138,7 @@ _RUST_HASHSET_STUB = (
 @beartype
 def _rust_preamble(content: str) -> str:
     """Build a Rust preamble with only the stubs needed by content."""
-    preamble = _RUST_VEC_PREAMBLE
+    preamble = _RUST_VEC_PREAMBLE if "vec!" in content else ""
     if "HashMap" in content:
         preamble += _RUST_HASHMAP_STUB
     if "HashSet" in content:


### PR DESCRIPTION
## Summary

Addresses review feedback from #362:

- **Conditional vec! preamble**: `_rust_preamble` now only includes the `macro_rules! vec` block when `vec!` actually appears in the content, eliminating unused macro warnings in scalar-only golden files.
- **VEC coercion removed**: `coerce_heterogeneous_to_strings` is now only enabled for `ARRAY` format, not `VEC`. The VEC `vec!` macro already handles mixed types via `From<_>`, so the coercion was unnecessarily converting native chrono dates to ISO strings.

## Test plan

- [x] All 4854 integration tests pass
- [x] Golden files regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Rust output semantics for mixed/typed values (e.g., numbers, bools, `None`, chrono dates) and could affect downstream expectations of generated code, though the change is localized to Rust formatting and test wrappers.
> 
> **Overview**
> **Rust literal output now preserves native scalar types in `vec!` mode.** `coerce_heterogeneous_to_strings` is restricted to `ARRAY` sequences, so `VEC` output no longer coerces mixed values (numbers/bools/nulls/dates) into strings.
> 
> **Integration Rust wrappers now avoid unused macro warnings.** The Rust test preamble only includes the `macro_rules! vec` block when `vec!` appears in the generated content, and Rust golden files are regenerated to reflect the new typed literals and slimmer preambles for scalar-only cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 493fc31c303963cc14eb15c482a54ee6ed9a2646. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->