### PR TITLE
Document format_variable_declaration and format_variable_assignment parameters

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -161,12 +161,20 @@ class Language(Protocol):
 
     @property
     def format_variable_declaration(self) -> Callable[[str, str], str]:
-        """Callable that formats a new variable declaration."""
+        """Callable that formats a new variable declaration.
+
+        Called as ``format_variable_declaration(name, value)`` where *name* is
+        the variable name and *value* is the already-formatted literal value.
+        """
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
     def format_variable_assignment(self) -> Callable[[str, str], str]:
-        """Callable that formats an assignment to an existing variable."""
+        """Callable that formats an assignment to an existing variable.
+
+        Called as ``format_variable_assignment(name, value)`` where *name* is
+        the variable name and *value* is the already-formatted literal value.
+        """
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
@@ -218,7 +226,13 @@ class LanguageSpec:
     skip_null_dict_values: bool
     coerce_heterogeneous_to_strings: bool
     format_variable_declaration: Callable[[str, str], str]
+    """Callable ``(name, value) -> str`` for a new variable
+    declaration.
+    """
     format_variable_assignment: Callable[[str, str], str]
+    """Callable ``(name, value) -> str`` for an assignment to an existing
+    variable.
+    """
     format_string: Callable[[str], str]
     supports_collection_comments: bool
     sequence_format: enum.Enum


### PR DESCRIPTION
Expands the docstrings on `format_variable_declaration` and `format_variable_assignment` in both the `Language` protocol and the `LanguageSpec` dataclass to document the callable's parameters: `name` (the variable name) and `value` (the already-formatted literal value).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that does not affect runtime behavior.
> 
> **Overview**
> Updates `Language.format_variable_declaration` and `Language.format_variable_assignment` docstrings to explicitly describe the `(name, value)` arguments (variable name and pre-formatted literal value).
> 
> Adds matching inline field documentation on `LanguageSpec.format_variable_declaration` and `LanguageSpec.format_variable_assignment` for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1fd9e2761d2e825430c8bb80ec7e6d9875b8984. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->