### PR TITLE
Split _check_heterogeneous into detection and raising functions

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -85,53 +85,45 @@ def _all_scalars_heterogeneous(
 
 
 @beartype
+def _has_heterogeneous(*, data: Value) -> bool:
+    """Recursively check whether data contains any heterogeneous
+    all-scalar collections.
+    """
+    if isinstance(data, ordereddict):
+        omap_vals: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        return any(
+            _has_heterogeneous(data=v) for v in omap_vals
+        ) or _all_scalars_heterogeneous(values=omap_vals)
+
+    if isinstance(data, dict):
+        dict_vals = list(data.values())
+        return any(
+            _has_heterogeneous(data=v) for v in dict_vals
+        ) or _all_scalars_heterogeneous(values=dict_vals)
+
+    if isinstance(data, set):
+        items: list[Value] = list(data)
+        return _all_scalars_heterogeneous(values=items)
+
+    if isinstance(data, list):
+        return any(
+            _has_heterogeneous(data=v) for v in data
+        ) or _all_scalars_heterogeneous(values=data)
+
+    return False
+
+
+@beartype
 def _check_heterogeneous(*, data: Value) -> None:
     """Recursively check for heterogeneous all-scalar collections and
     raise if found.
     """
-    if isinstance(data, ordereddict):
-        for v in data.values():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-            _check_heterogeneous(data=v)  # pyright: ignore[reportUnknownArgumentType]
-        omap_vals: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-        if _all_scalars_heterogeneous(values=omap_vals):
-            msg = (
-                "Collection contains heterogeneous scalar types "
-                "that would be coerced to strings"
-            )
-            raise HeterogeneousCoercionError(msg)
-        return
-
-    if isinstance(data, dict):
-        for v in data.values():
-            _check_heterogeneous(data=v)
-        if _all_scalars_heterogeneous(values=list(data.values())):
-            msg = (
-                "Collection contains heterogeneous scalar types "
-                "that would be coerced to strings"
-            )
-            raise HeterogeneousCoercionError(msg)
-        return
-
-    if isinstance(data, set):
-        items: list[Value] = list(data)
-        if _all_scalars_heterogeneous(values=items):
-            msg = (
-                "Collection contains heterogeneous scalar types "
-                "that would be coerced to strings"
-            )
-            raise HeterogeneousCoercionError(msg)
-        return
-
-    if isinstance(data, list):
-        for v in data:
-            _check_heterogeneous(data=v)
-        if _all_scalars_heterogeneous(values=data):
-            msg = (
-                "Collection contains heterogeneous scalar types "
-                "that would be coerced to strings"
-            )
-            raise HeterogeneousCoercionError(msg)
-        return
+    if _has_heterogeneous(data=data):
+        msg = (
+            "Collection contains heterogeneous scalar types "
+            "that would be coerced to strings"
+        )
+        raise HeterogeneousCoercionError(msg)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Extract `_has_heterogeneous() -> bool` for pure detection logic that recursively checks whether data contains heterogeneous all-scalar collections
- Simplify `_check_heterogeneous()` to a thin wrapper that calls `_has_heterogeneous` and raises `HeterogeneousCoercionError` if it returns `True`
- Eliminates duplicated error message across 4 branches

## Test plan
- [x] All 5143 existing tests pass
- [x] Pre-commit hooks (ruff, mypy, pyright, ty, pyrefly) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that reorganizes heterogeneous-scalar detection into a pure boolean helper; behavior should be equivalent but relies on the new recursion logic matching prior early-return/raise paths.
> 
> **Overview**
> Refactors heterogeneous scalar coercion detection by extracting `_has_heterogeneous()` (pure `bool` recursion) and rewriting `_check_heterogeneous()` as a thin wrapper that raises `HeterogeneousCoercionError` with a single centralized message.
> 
> This removes duplicated raise/message logic across the `dict`/`list`/`set`/`ordereddict` branches while preserving the existing call site in `_literalize` when `error_on_coercion` is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e9663a320e13e6e6926dc855c57ee5a5cc63c04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->