### PR TITLE
Run Kotlin syntax checks in parallel

### DIFF
--- a/.github/workflows/lint-kotlin.yml
+++ b/.github/workflows/lint-kotlin.yml
@@ -19,6 +19,4 @@ jobs:
         run: |-
           set -o pipefail
           find tests/integration/cases -name "*.kts" -print0 | \
-            while IFS= read -r -d '' f; do
-              kotlinc -script "$f" || exit 1
-            done
+            xargs -0 -P "$(nproc)" -n 1 kotlinc -script


### PR DESCRIPTION
Replace the sequential `while` loop with `xargs -P "$(nproc)" -n 1` to run `kotlinc -script` invocations in parallel across all available CPU cores. With 106 `.kts` test files each requiring a separate JVM startup, parallelism significantly reduces wall-clock time for the lint-kotlin CI job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that alters how Kotlin scripts are linted by running checks in parallel; low risk aside from potential increased resource usage or different failure ordering.
> 
> **Overview**
> Speeds up the `Lint Kotlin` GitHub Actions job by replacing the sequential loop over `.kts` files with a parallel `xargs -P "$(nproc)"` invocation of `kotlinc -script` across all test scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99853d7729d29f02e08ad71a2c077a8a615f9600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->