### PR TITLE
Simplify _has_heterogeneous by unifying dict/list branches

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -89,28 +89,18 @@ def _has_heterogeneous(*, data: Value) -> bool:
     """Recursively check whether data contains any heterogeneous
     all-scalar collections.
     """
-    if isinstance(data, ordereddict):
-        omap_vals: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-        return any(
-            _has_heterogeneous(data=v) for v in omap_vals
-        ) or _all_scalars_heterogeneous(values=omap_vals)
+    if isinstance(data, (ordereddict, dict)):
+        children: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    elif isinstance(data, list):
+        children = data
+    elif isinstance(data, set):
+        return _all_scalars_heterogeneous(values=list(data))
+    else:
+        return False
 
-    if isinstance(data, dict):
-        dict_vals = list(data.values())
-        return any(
-            _has_heterogeneous(data=v) for v in dict_vals
-        ) or _all_scalars_heterogeneous(values=dict_vals)
-
-    if isinstance(data, set):
-        items: list[Value] = list(data)
-        return _all_scalars_heterogeneous(values=items)
-
-    if isinstance(data, list):
-        return any(
-            _has_heterogeneous(data=v) for v in data
-        ) or _all_scalars_heterogeneous(values=data)
-
-    return False
+    return any(
+        _has_heterogeneous(data=v) for v in children
+    ) or _all_scalars_heterogeneous(values=children)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Merges the `ordereddict`, `dict`, and `list` branches in `_has_heterogeneous` into a single code path that builds a `children` list with one shared recursion + heterogeneity check at the end.
- The `set` branch stays separate since sets can't contain nested collections (no recursion needed).
- Net reduction of 10 lines with no behavior change.

## Test plan
- [x] All 289 existing tests pass
- [x] All pre-commit hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to heterogeneous-collection detection logic, with intended behavior unchanged. Primary risk is subtle recursion/child-selection differences across collection types.
> 
> **Overview**
> Simplifies `_has_heterogeneous` by consolidating the `ordereddict`, `dict`, and `list` branches into one shared flow that builds a `children` list and then runs the same recursive + scalar-heterogeneity checks.
> 
> Keeps `set` handling as an early-return path (no recursion) and removes duplicated logic, reducing code size without changing external behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbd64691da4be390315c6d9360da724cd6afd8ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->