### PR TITLE
Use textwrap.dedent for multi-line expected strings in tests

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -409,7 +409,13 @@ def test_literalize_json_object() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '{\n    "a": 1,\n    "b": True,\n}'
+    expected = textwrap.dedent(
+        text="""\
+        {
+            "a": 1,
+            "b": True,
+        }"""
+    )
     assert result == expected
 
 
@@ -520,4 +526,12 @@ def test_error_on_coercion_json_no_raise_homogeneous() -> None:
         new_variable=True,
         error_on_coercion=True,
     )
-    assert result == "[\n    1,\n    2,\n    3,\n]"
+    expected = textwrap.dedent(
+        text="""\
+        [
+            1,
+            2,
+            3,
+        ]"""
+    )
+    assert result == expected

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -482,7 +482,13 @@ def test_custom_language() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert result == 'YES,\nNIL,\n"hi",'
+    expected = textwrap.dedent(
+        text="""\
+        YES,
+        NIL,
+        "hi","""
+    )
+    assert result == expected
 
 
 @pytest.mark.parametrize(
@@ -553,7 +559,12 @@ def test_toml_integer_dict_key() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '{\n    1 = "value"\n}'
+    expected = textwrap.dedent(
+        text="""\
+        {
+            1 = "value"
+        }"""
+    )
     assert result == expected
 
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -3,6 +3,7 @@ converter.
 """
 
 import dataclasses
+import textwrap
 
 import pytest
 
@@ -254,7 +255,14 @@ def test_variable_declaration_none_no_wrap() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert result == "(\n    1,\n    2,\n)"
+    expected = textwrap.dedent(
+        text="""\
+        (
+            1,
+            2,
+        )"""
+    )
+    assert result == expected
 
 
 @pytest.mark.parametrize(
@@ -343,7 +351,12 @@ def test_python_inline_type_hints_dict() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = 'my_var: dict[str, Any] = {\n    "a": 1,\n}'
+    expected = textwrap.dedent(
+        text="""\
+        my_var: dict[str, Any] = {
+            "a": 1,
+        }"""
+    )
     assert result == expected
 
 
@@ -359,7 +372,13 @@ def test_python_inline_type_hints_tuple() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = "my_var: tuple[Any, ...] = (\n    1,\n    2,\n)"
+    expected = textwrap.dedent(
+        text="""\
+        my_var: tuple[Any, ...] = (
+            1,
+            2,
+        )"""
+    )
     assert result == expected
 
 
@@ -385,7 +404,13 @@ def test_python_inline_type_hints_list() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = "my_var: list[Any] = [\n    1,\n    2,\n]"
+    expected = textwrap.dedent(
+        text="""\
+        my_var: list[Any] = [
+            1,
+            2,
+        ]"""
+    )
     assert result == expected
 
 
@@ -417,7 +442,12 @@ def test_python_inline_type_hints_set_with_colon_in_string() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = 'my_var: set[Any] = {\n    "a\\": b",\n}'
+    expected = textwrap.dedent(
+        text="""\
+        my_var: set[Any] = {
+            "a\\": b",
+        }"""
+    )
     assert result == expected
 
 
@@ -434,5 +464,12 @@ def test_python_inline_type_hints_set_of_integers() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = "my_var: set[Any] = {\n    1,\n    2,\n    3,\n}"
+    expected = textwrap.dedent(
+        text="""\
+        my_var: set[Any] = {
+            1,
+            2,
+            3,
+        }"""
+    )
     assert result == expected

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -113,7 +113,13 @@ def test_literalize_yaml_mapping() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '{\n    "a": 1,\n    "b": True,\n}'
+    expected = textwrap.dedent(
+        text="""\
+        {
+            "a": 1,
+            "b": True,
+        }"""
+    )
     assert result == expected
 
 
@@ -508,7 +514,13 @@ def test_coerce_heterogeneous_bytes_in_collection() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '{\n    "key1": "48656c6c6f",\n    "key2": "42",\n}'
+    expected = textwrap.dedent(
+        text="""\
+        {
+            "key1": "48656c6c6f",
+            "key2": "42",
+        }"""
+    )
     assert result == expected
 
 
@@ -531,7 +543,13 @@ def test_coerce_heterogeneous_set() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '[\n    "1",\n    "hello",\n]'
+    expected = textwrap.dedent(
+        text="""\
+        [
+            "1",
+            "hello",
+        ]"""
+    )
     assert result == expected
 
 
@@ -553,7 +571,13 @@ def test_coerce_heterogeneous_date_in_collection() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '[\n    "2024-01-15",\n    "42",\n]'
+    expected = textwrap.dedent(
+        text="""\
+        [
+            "2024-01-15",
+            "42",
+        ]"""
+    )
     assert result == expected
 
 
@@ -577,7 +601,13 @@ def test_coerce_heterogeneous_datetime_in_collection() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '[\n    "2024-01-15T12:30:00",\n    "42",\n]'
+    expected = textwrap.dedent(
+        text="""\
+        [
+            "2024-01-15T12:30:00",
+            "42",
+        ]"""
+    )
     assert result == expected
 
 
@@ -600,7 +630,13 @@ def test_coerce_homogeneous_omap_no_coercion() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    expected = '[\n    ("name", "Alice"),\n    ("city", "Paris"),\n]'
+    expected = textwrap.dedent(
+        text="""\
+        [
+            ("name", "Alice"),
+            ("city", "Paris"),
+        ]"""
+    )
     assert result == expected
 
 
@@ -623,7 +659,13 @@ def test_r_empty_dict_key_positional() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert result == 'list(\n    "value"\n)'
+    expected = textwrap.dedent(
+        text="""\
+        list(
+            "value"
+        )"""
+    )
+    assert result == expected
 
 
 def test_r_empty_dict_key_positional_is_default() -> None:
@@ -645,7 +687,13 @@ def test_r_empty_dict_key_positional_is_default() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert result == 'list(\n    "value"\n)'
+    expected = textwrap.dedent(
+        text="""\
+        list(
+            "value"
+        )"""
+    )
+    assert result == expected
 
 
 def test_r_empty_dict_key_error() -> None:
@@ -689,7 +737,13 @@ def test_r_empty_dict_key_error_non_empty_key_ok() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert result == 'list(\n    "key" = "value"\n)'
+    expected = textwrap.dedent(
+        text="""\
+        list(
+            "key" = "value"
+        )"""
+    )
+    assert result == expected
 
 
 def test_error_on_coercion_raises_for_heterogeneous_list() -> None:
@@ -744,7 +798,15 @@ def test_error_on_coercion_no_raise_for_homogeneous() -> None:
         new_variable=True,
         error_on_coercion=True,
     )
-    assert result == "[\n    1,\n    2,\n    3,\n]"
+    expected = textwrap.dedent(
+        text="""\
+        [
+            1,
+            2,
+            3,
+        ]"""
+    )
+    assert result == expected
 
 
 def test_error_on_coercion_no_effect_without_coerce_flag() -> None:
@@ -760,7 +822,15 @@ def test_error_on_coercion_no_effect_without_coerce_flag() -> None:
         new_variable=True,
         error_on_coercion=True,
     )
-    assert result == "(\n    1,\n    2.5,\n    3,\n)"
+    expected = textwrap.dedent(
+        text="""\
+        (
+            1,
+            2.5,
+            3,
+        )"""
+    )
+    assert result == expected
 
 
 def test_error_on_coercion_raises_for_nested_heterogeneous() -> None:
@@ -848,7 +918,14 @@ def test_error_on_coercion_no_raise_for_homogeneous_dict() -> None:
         new_variable=True,
         error_on_coercion=True,
     )
-    assert result == '{\n    "a": 1,\n    "b": 2,\n}'
+    expected = textwrap.dedent(
+        text="""\
+        {
+            "a": 1,
+            "b": 2,
+        }"""
+    )
+    assert result == expected
 
 
 def test_error_on_coercion_no_raise_for_homogeneous_omap() -> None:
@@ -870,7 +947,14 @@ def test_error_on_coercion_no_raise_for_homogeneous_omap() -> None:
         new_variable=True,
         error_on_coercion=True,
     )
-    assert result == '[\n    ("name", "Alice"),\n    ("city", "Paris"),\n]'
+    expected = textwrap.dedent(
+        text="""\
+        [
+            ("name", "Alice"),
+            ("city", "Paris"),
+        ]"""
+    )
+    assert result == expected
 
 
 def test_error_on_coercion_no_raise_for_homogeneous_set() -> None:
@@ -892,4 +976,11 @@ def test_error_on_coercion_no_raise_for_homogeneous_set() -> None:
         new_variable=True,
         error_on_coercion=True,
     )
-    assert result == "[\n    1,\n    2,\n]"
+    expected = textwrap.dedent(
+        text="""\
+        [
+            1,
+            2,
+        ]"""
+    )
+    assert result == expected


### PR DESCRIPTION
## Summary
- Replace `\n`-escaped multi-line expected strings in tests with `textwrap.dedent` triple-quoted strings for readability
- Applies to test_yaml.py (14 strings), test_variables.py (6 strings), test_json.py (2 strings), and test_languages.py (2 strings)
- Strings with embedded `line_prefix` whitespace are left as-is since `textwrap.dedent` cannot preserve a leading prefix cleanly

## Test plan
- [x] All 5143 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that rewrites expected output strings; low risk beyond potential assertion formatting mismatches (indent/trailing newline/comma).
> 
> **Overview**
> Refactors multiple tests to replace `"\n"`-escaped multiline expected strings with `textwrap.dedent` triple-quoted blocks for readability and consistent indentation.
> 
> Updates expected literals across JSON/YAML/language/variable tests (and adds `textwrap` import where needed) without changing converter logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e05afe508e3c128527391bfaa60021d4333589e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->