### PR TITLE
Add BytesFormat enum to all language classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Usage
        language=Go(
            date_format=Go.DateFormat.ISO,
            datetime_format=Go.DatetimeFormat.ISO,
+           bytes_format=Go.BytesFormat.HEX,
            sequence_format=Go.SequenceFormat.SLICE,
        ),
        line_prefix="",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,6 +42,7 @@ Usage
        language=Go(
            date_format=Go.DateFormat.ISO,
            datetime_format=Go.DatetimeFormat.ISO,
+           bytes_format=Go.BytesFormat.HEX,
            sequence_format=Go.SequenceFormat.SLICE,
        ),
        line_prefix="",

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -93,7 +93,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} := {_to_ada_val(value=value)};"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_ada
@@ -103,6 +102,11 @@ _string_format: Callable[[str], str] = format_string_ada
 class Ada:
     """Ada language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Ada."""
 
@@ -111,6 +115,7 @@ class Ada:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Ada language specification."""
@@ -131,7 +136,7 @@ class Ada:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -69,7 +69,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name}={value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -79,6 +78,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Bash:
     """Bash language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Bash."""
 
@@ -87,6 +91,7 @@ class Bash:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Bash language specification."""
@@ -107,7 +112,7 @@ class Bash:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -78,7 +78,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {_to_val(value=value)};"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -88,6 +87,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class C:
     """C language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for C."""
 
@@ -96,6 +100,7 @@ class C:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize C language specification."""
@@ -116,7 +121,7 @@ class C:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -35,7 +35,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"(def {name} {value})"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -45,6 +44,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Clojure:
     """Clojure language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Clojure."""
 
@@ -53,6 +57,7 @@ class Clojure:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Clojure language specification."""
@@ -73,7 +78,7 @@ class Clojure:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -205,7 +205,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"MOVE {scalar} TO {cob_name}."
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = _format_string_cobol
@@ -220,6 +219,11 @@ class Cobol:
     sequences / dicts become group items with 05-level sub-items.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for COBOL."""
 
@@ -228,6 +232,7 @@ class Cobol:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize COBOL language specification."""
@@ -248,7 +253,7 @@ class Cobol:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -40,7 +40,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"(setf *{name}* {value})"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -50,6 +49,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class CommonLisp:
     """Common Lisp language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Common Lisp."""
 
@@ -58,6 +62,7 @@ class CommonLisp:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Common Lisp language specification."""
@@ -76,7 +81,7 @@ class CommonLisp:
         self.format_dict_entry: Callable[[str, str], str] = _format_cons_entry
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -125,6 +125,11 @@ class Cpp:
         ISO = enum.member(value=format_datetime_iso)
         CPP = enum.member(value=format_datetime_cpp)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for C++."""
 
@@ -135,6 +140,7 @@ class Cpp:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Cpp language specification."""
@@ -157,7 +163,7 @@ class Cpp:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -35,7 +35,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -54,6 +53,11 @@ class Crystal:
               e.g. ``{1, 2, 3}``.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Crystal."""
 
@@ -63,6 +67,7 @@ class Crystal:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Crystal language specification."""
@@ -90,7 +95,7 @@ class Crystal:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -122,6 +122,11 @@ class CSharp:
         ISO = enum.member(value=format_datetime_iso)
         CSHARP = enum.member(value=format_datetime_csharp)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for C#."""
 
@@ -132,6 +137,7 @@ class CSharp:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize CSharp language specification."""
@@ -154,7 +160,7 @@ class CSharp:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -96,7 +96,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {_to_val(value=value)};"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -106,6 +105,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class D:
     """D language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for D."""
 
@@ -114,6 +118,7 @@ class D:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize D language specification."""
@@ -134,7 +139,7 @@ class D:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -123,6 +123,11 @@ class Dart:
         ISO = enum.member(value=format_datetime_iso)
         DART = enum.member(value=format_datetime_dart)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Dart."""
 
@@ -133,6 +138,7 @@ class Dart:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Dart language specification."""
@@ -155,7 +161,7 @@ class Dart:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -41,7 +41,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -60,6 +59,11 @@ class Elixir:
               e.g. ``{1, 2, 3}``.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Elixir."""
 
@@ -69,6 +73,7 @@ class Elixir:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Elixir language specification."""
@@ -93,7 +98,7 @@ class Elixir:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -49,7 +49,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{erlang_name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = _format_bytes
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -68,6 +67,11 @@ class Erlang:
               e.g. ``{1, 2, 3}``.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        BINARY = enum.member(value=_format_bytes)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Erlang."""
 
@@ -77,6 +81,7 @@ class Erlang:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Erlang language specification."""
@@ -101,7 +106,7 @@ class Erlang:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -152,7 +152,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {continued}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_fortran
@@ -160,6 +159,11 @@ _string_format: Callable[[str], str] = format_string_fortran
 
 class Fortran:
     """Fortran language specification."""
+
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Fortran."""
@@ -170,6 +174,7 @@ class Fortran:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Fortran language specification."""
@@ -190,7 +195,7 @@ class Fortran:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -96,7 +96,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"let {name}: Val = {_to_val(value=value)}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -106,6 +105,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class FSharp:
     """F# language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for F#."""
 
@@ -114,6 +118,7 @@ class FSharp:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize FSharp language specification."""
@@ -134,7 +139,7 @@ class FSharp:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -133,6 +133,11 @@ class Go:
         ISO = enum.member(value=format_datetime_iso)
         GO = enum.member(value=format_datetime_go)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Go."""
 
@@ -143,6 +148,7 @@ class Go:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Go language specification."""
@@ -165,7 +171,7 @@ class Go:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -35,7 +35,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash_dollar
@@ -45,6 +44,11 @@ _string_format: Callable[[str], str] = format_string_backslash_dollar
 class Groovy:
     """Groovy language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Groovy."""
 
@@ -53,6 +57,7 @@ class Groovy:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Groovy language specification."""
@@ -73,7 +78,7 @@ class Groovy:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -46,7 +46,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -95,6 +94,11 @@ class Haskell:
     let numeric literals resolve to ``HInt`` / ``HFloat``.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Haskell."""
 
@@ -103,6 +107,7 @@ class Haskell:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Haskell language specification."""
@@ -123,7 +128,7 @@ class Haskell:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -37,7 +37,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -47,6 +46,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Hcl:
     """HCL (HashiCorp Configuration Language) language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for HCL."""
 
@@ -55,6 +59,7 @@ class Hcl:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize HCL language specification."""
@@ -75,7 +80,7 @@ class Hcl:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -119,6 +119,11 @@ class Java:
         INSTANT = enum.member(value=format_datetime_java_instant)
         ZONED = enum.member(value=format_datetime_java_zoned)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Java."""
 
@@ -129,6 +134,7 @@ class Java:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Java language specification."""
@@ -150,7 +156,7 @@ class Java:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -78,6 +78,11 @@ class JavaScript:
         ISO = enum.member(value=format_datetime_iso)
         JS = enum.member(value=format_datetime_js)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for JavaScript."""
 
@@ -88,6 +93,7 @@ class JavaScript:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize JavaScript language specification."""
@@ -108,7 +114,7 @@ class JavaScript:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -79,6 +79,11 @@ class Julia:
         ISO = enum.member(value=format_datetime_iso)
         JULIA = enum.member(value=format_datetime_julia)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Julia."""
 
@@ -90,6 +95,7 @@ class Julia:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Julia language specification."""
@@ -116,7 +122,7 @@ class Julia:
             dict_entry_with_separator(separator=" => ")
         )
         self.multiline_trailing_comma = True
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -139,6 +139,11 @@ class Kotlin:
         ISO = enum.member(value=format_datetime_iso)
         KOTLIN = enum.member(value=format_datetime_kotlin)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Kotlin."""
 
@@ -149,6 +154,7 @@ class Kotlin:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Kotlin language specification."""
@@ -171,7 +177,7 @@ class Kotlin:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -51,7 +51,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -61,6 +60,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Lua:
     """Lua language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Lua."""
 
@@ -69,6 +73,7 @@ class Lua:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Lua language specification."""
@@ -89,7 +94,7 @@ class Lua:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -105,7 +105,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value};"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_matlab
@@ -115,6 +114,11 @@ _string_format: Callable[[str], str] = format_string_matlab
 class Matlab:
     """MATLAB language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for MATLAB."""
 
@@ -123,6 +127,7 @@ class Matlab:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Matlab language specification."""
@@ -143,7 +148,7 @@ class Matlab:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -43,7 +43,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -64,6 +63,11 @@ class Mojo:
     same string (e.g. ``{1, "1"}`` both become ``"1"``).
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Mojo."""
 
@@ -72,6 +76,7 @@ class Mojo:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Mojo language specification."""
@@ -92,7 +97,7 @@ class Mojo:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -35,7 +35,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = %*{value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -45,6 +44,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Nim:
     """Nim language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Nim."""
 
@@ -53,6 +57,7 @@ class Nim:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Nim language specification."""
@@ -73,7 +78,7 @@ class Nim:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -60,6 +60,11 @@ class Norg:
     verbatim tag: ``* name`` then ``@code json`` / ``@end``.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Norg."""
 
@@ -69,6 +74,7 @@ class Norg:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Norg language specification."""
@@ -89,7 +95,7 @@ class Norg:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = format_date_iso
         self.format_datetime: Callable[[datetime.datetime], str] = (
             format_datetime_iso

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -108,7 +108,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value};"
 
 
-_bytes_format: Callable[[bytes], str] = _format_objc_bytes
 _date_format: Callable[[datetime.date], str] = _format_objc_date
 _datetime_format: Callable[[datetime.datetime], str] = _format_objc_datetime
 _string_format: Callable[[str], str] = _format_objc_string
@@ -117,6 +116,11 @@ _string_format: Callable[[str], str] = _format_objc_string
 @beartype
 class ObjectiveC:
     """Objective-C language specification."""
+
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=_format_objc_bytes)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Objective-C."""
@@ -127,6 +131,7 @@ class ObjectiveC:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Objective-C language specification."""
@@ -147,7 +152,7 @@ class ObjectiveC:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -100,7 +100,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return _format_variable_declaration(name=name, value=value)
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -110,6 +109,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class OCaml:
     """OCaml language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for OCaml."""
 
@@ -118,6 +122,7 @@ class OCaml:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize OCaml language specification."""
@@ -138,7 +143,7 @@ class OCaml:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -85,7 +85,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} := {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -95,6 +94,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Occam:
     """Occam-pi language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Occam."""
 
@@ -103,6 +107,7 @@ class Occam:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Occam language specification."""
@@ -123,7 +128,7 @@ class Occam:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -35,7 +35,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"${name} = {value};"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -45,6 +44,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Perl:
     """Perl language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Perl."""
 
@@ -53,6 +57,7 @@ class Perl:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Perl language specification."""
@@ -73,7 +78,7 @@ class Perl:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -51,7 +51,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"${name} = {value};"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = _format_date
 _datetime_format: Callable[[datetime.datetime], str] = _format_datetime
 _string_format: Callable[[str], str] = format_string_backslash
@@ -61,6 +60,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Php:
     """PHP language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for PHP."""
 
@@ -69,6 +73,7 @@ class Php:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Php language specification."""
@@ -89,7 +94,7 @@ class Php:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -61,7 +61,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"${name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = _format_string
@@ -71,6 +70,11 @@ _string_format: Callable[[str], str] = _format_string
 class PowerShell:
     """PowerShell language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for PowerShell."""
 
@@ -79,6 +83,7 @@ class PowerShell:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize PowerShell language specification."""
@@ -99,7 +104,7 @@ class PowerShell:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -126,6 +126,11 @@ class R:
         POSITIONAL = enum.member(value=_format_r_dict_entry_positional)
         ERROR = enum.member(value=_format_r_dict_entry_error)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for R."""
 
@@ -137,6 +142,7 @@ class R:
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
         empty_dict_key: EmptyDictKey,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize R language specification."""
@@ -157,7 +163,7 @@ class R:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -35,7 +35,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"(set! {name} {value})"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -45,6 +44,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Racket:
     """Racket language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Racket."""
 
@@ -53,6 +57,7 @@ class Racket:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Racket language specification."""
@@ -73,7 +78,7 @@ class Racket:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -78,6 +78,11 @@ class Ruby:
         ISO = enum.member(value=format_datetime_iso)
         RUBY = enum.member(value=format_datetime_ruby)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Ruby."""
 
@@ -88,6 +93,7 @@ class Ruby:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Ruby language specification."""
@@ -108,7 +114,7 @@ class Ruby:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -101,6 +101,11 @@ class Rust:
         ISO = enum.member(value=format_datetime_iso)
         RUST = enum.member(value=format_datetime_rust)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Rust."""
 
@@ -113,6 +118,7 @@ class Rust:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Rust language specification."""
@@ -140,7 +146,7 @@ class Rust:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -84,7 +84,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -94,6 +93,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Scala:
     """Scala language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Scala."""
 
@@ -102,6 +106,7 @@ class Scala:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Scala language specification."""
@@ -124,7 +129,7 @@ class Scala:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -41,7 +41,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {value}"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -51,6 +50,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Swift:
     """Swift language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Swift."""
 
@@ -59,6 +63,7 @@ class Swift:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Swift language specification."""
@@ -79,7 +84,7 @@ class Swift:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -99,6 +99,11 @@ class Toml:
     datetime literals, which are a distinct TOML type.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for TOML."""
 
@@ -107,6 +112,7 @@ class Toml:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize TOML language specification."""
@@ -127,7 +133,7 @@ class Toml:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _format_toml_date
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _format_toml_datetime

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -78,6 +78,11 @@ class TypeScript:
         ISO = enum.member(value=format_datetime_iso)
         JS = enum.member(value=format_datetime_js)
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for TypeScript."""
 
@@ -88,6 +93,7 @@ class TypeScript:
         *,
         date_format: DateFormat,
         datetime_format: DatetimeFormat,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize TypeScript language specification."""
@@ -108,7 +114,7 @@ class TypeScript:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -90,6 +90,11 @@ class VisualBasic:
     variable name is supplied.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Visual Basic."""
 
@@ -98,6 +103,7 @@ class VisualBasic:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize VisualBasic language specification."""
@@ -119,7 +125,7 @@ class VisualBasic:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = format_date_iso
         self.format_datetime: Callable[[datetime.datetime], str] = (
             format_datetime_iso

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -71,6 +71,11 @@ class Yaml:
     datetime literals, which YAML parsers interpret as typed values.
     """
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for YAML."""
 
@@ -80,6 +85,7 @@ class Yaml:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize YAML language specification."""
@@ -100,7 +106,7 @@ class Yaml:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = format_bytes_hex
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _format_yaml_date
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _format_yaml_datetime

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -72,7 +72,6 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name} = {_to_val(value=value)};"
 
 
-_bytes_format: Callable[[bytes], str] = format_bytes_hex
 _date_format: Callable[[datetime.date], str] = format_date_iso
 _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_backslash
@@ -82,6 +81,11 @@ _string_format: Callable[[str], str] = format_string_backslash
 class Zig:
     """Zig language specification."""
 
+    class BytesFormat(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Zig."""
 
@@ -90,6 +94,7 @@ class Zig:
     def __init__(
         self,
         *,
+        bytes_format: BytesFormat,
         sequence_format: SequenceFormat,
     ) -> None:
         """Initialize Zig language specification."""
@@ -110,7 +115,7 @@ class Zig:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = _bytes_format
+        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -151,6 +151,7 @@ def _rust_array_spec() -> literalizer.languages.Rust:
     return literalizer.languages.Rust(
         date_format=literalizer.languages.Rust.DateFormat.ISO,
         datetime_format=literalizer.languages.Rust.DatetimeFormat.ISO,
+        bytes_format=literalizer.languages.Rust.BytesFormat.HEX,
         sequence_format=literalizer.languages.Rust.SequenceFormat.ARRAY,
     )
 
@@ -210,6 +211,7 @@ _OCCAM_LIT_TYPE = (
 def _wrap_fsharp(content: str) -> str:
     """Wrap in an F# module with a custom Val discriminated union."""
     fsharp = literalizer.languages.FSharp(
+        bytes_format=literalizer.languages.FSharp.BytesFormat.HEX,
         sequence_format=literalizer.languages.FSharp.SequenceFormat.LIST,
     )
     typed = fsharp.format_sequence_entry(content)
@@ -222,6 +224,7 @@ def _wrap_fsharp(content: str) -> str:
 def _wrap_ocaml(content: str) -> str:
     """Wrap in an OCaml module with a custom val_t variant type."""
     ocaml = literalizer.languages.OCaml(
+        bytes_format=literalizer.languages.OCaml.BytesFormat.HEX,
         sequence_format=literalizer.languages.OCaml.SequenceFormat.LIST,
     )
     typed = ocaml.format_sequence_entry(content)
@@ -252,6 +255,7 @@ def _wrap_ocaml_varname(content: str) -> str:
 def _wrap_occam(content: str) -> str:
     """Wrap in an occam-pi PROC with a custom ``LIT`` mobile data type."""
     occam = literalizer.languages.Occam(
+        bytes_format=literalizer.languages.Occam.BytesFormat.HEX,
         sequence_format=literalizer.languages.Occam.SequenceFormat.LIST,
     )
     typed = occam.format_sequence_entry(content)
@@ -558,6 +562,7 @@ def _wrap_groovy(content: str) -> str:
 def _wrap_ada(content: str) -> str:
     """Wrap in an Ada procedure with a local variable assignment."""
     ada = literalizer.languages.Ada(
+        bytes_format=literalizer.languages.Ada.BytesFormat.HEX,
         sequence_format=literalizer.languages.Ada.SequenceFormat.LIST,
     )
     typed = ada.format_sequence_entry(content)
@@ -641,6 +646,7 @@ def _wrap_norg(content: str) -> str:
 def _wrap_d(content: str) -> str:
     """Wrap in a D function with ``std.json`` imported."""
     d_lang = literalizer.languages.D(
+        bytes_format=literalizer.languages.D.BytesFormat.HEX,
         sequence_format=literalizer.languages.D.SequenceFormat.ARRAY,
     )
     typed = d_lang.format_sequence_entry(content)
@@ -697,6 +703,7 @@ _C_PREAMBLE = (
 def _wrap_c(content: str) -> str:
     """Wrap in a C function with the _CVal/_CKV type definitions."""
     c_lang = literalizer.languages.C(
+        bytes_format=literalizer.languages.C.BytesFormat.HEX,
         sequence_format=literalizer.languages.C.SequenceFormat.ARRAY,
     )
     typed = c_lang.format_sequence_entry(content)
@@ -922,6 +929,7 @@ def _wrap_zig(content: str) -> str:
     definitions.
     """
     zig = literalizer.languages.Zig(
+        bytes_format=literalizer.languages.Zig.BytesFormat.HEX,
         sequence_format=literalizer.languages.Zig.SequenceFormat.ARRAY,
     )
     typed = zig.format_sequence_entry(content)
@@ -1148,6 +1156,7 @@ def _wrap_fortran(content: str) -> str:
     module embedded.
     """
     fortran = literalizer.languages.Fortran(
+        bytes_format=literalizer.languages.Fortran.BytesFormat.HEX,
         sequence_format=literalizer.languages.Fortran.SequenceFormat.LIST,
     )
     typed = fortran.format_sequence_entry(content)
@@ -1476,6 +1485,7 @@ def _wrap_cobol(content: str) -> str:
     else:
         # Scalar literal - convert to a DATA entry
         cobol = literalizer.languages.Cobol(
+            bytes_format=literalizer.languages.Cobol.BytesFormat.HEX,
             sequence_format=literalizer.languages.Cobol.SequenceFormat.SEQUENCE,
         )
         entry = cobol.format_sequence_entry(scalar)
@@ -1510,7 +1520,8 @@ def _wrap_cobol_combined(declaration: str, assignment: str) -> str:
 _LANGUAGES: dict[str, _LanguageConfig] = {
     "ada": _LanguageConfig(
         spec=literalizer.languages.Ada(
-            sequence_format=literalizer.languages.Ada.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Ada.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Ada.SequenceFormat.LIST,
         ),
         extension=".adb",
         wrap=_wrap_ada,
@@ -1519,7 +1530,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "bash": _LanguageConfig(
         spec=literalizer.languages.Bash(
-            sequence_format=literalizer.languages.Bash.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Bash.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Bash.SequenceFormat.ARRAY,
         ),
         extension=".sh",
         wrap=_wrap_bash,
@@ -1528,7 +1540,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "c": _LanguageConfig(
         spec=literalizer.languages.C(
-            sequence_format=literalizer.languages.C.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.C.BytesFormat.HEX,
+            sequence_format=literalizer.languages.C.SequenceFormat.ARRAY,
         ),
         extension=".c",
         wrap=_wrap_c,
@@ -1537,7 +1550,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "cobol": _LanguageConfig(
         spec=literalizer.languages.Cobol(
-            sequence_format=literalizer.languages.Cobol.SequenceFormat.SEQUENCE
+            bytes_format=literalizer.languages.Cobol.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Cobol.SequenceFormat.SEQUENCE,
         ),
         extension=".cob",
         wrap=_wrap_cobol,
@@ -1546,7 +1560,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "d": _LanguageConfig(
         spec=literalizer.languages.D(
-            sequence_format=literalizer.languages.D.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.D.BytesFormat.HEX,
+            sequence_format=literalizer.languages.D.SequenceFormat.ARRAY,
         ),
         extension=".d",
         wrap=_wrap_d,
@@ -1555,7 +1570,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "common_lisp": _LanguageConfig(
         spec=literalizer.languages.CommonLisp(
-            sequence_format=literalizer.languages.CommonLisp.SequenceFormat.LIST
+            bytes_format=literalizer.languages.CommonLisp.BytesFormat.HEX,
+            sequence_format=literalizer.languages.CommonLisp.SequenceFormat.LIST,
         ),
         extension=".lisp",
         wrap=_wrap_identity,
@@ -1564,7 +1580,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "clojure": _LanguageConfig(
         spec=literalizer.languages.Clojure(
-            sequence_format=literalizer.languages.Clojure.SequenceFormat.VECTOR
+            bytes_format=literalizer.languages.Clojure.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Clojure.SequenceFormat.VECTOR,
         ),
         extension=".clj",
         wrap=_wrap_identity,
@@ -1589,6 +1606,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.JavaScript(
             date_format=literalizer.languages.JavaScript.DateFormat.ISO,
             datetime_format=literalizer.languages.JavaScript.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.JavaScript.BytesFormat.HEX,
             sequence_format=literalizer.languages.JavaScript.SequenceFormat.ARRAY,
         ),
         extension=".js",
@@ -1600,6 +1618,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.TypeScript(
             date_format=literalizer.languages.TypeScript.DateFormat.ISO,
             datetime_format=literalizer.languages.TypeScript.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.TypeScript.BytesFormat.HEX,
             sequence_format=literalizer.languages.TypeScript.SequenceFormat.ARRAY,
         ),
         extension=".ts",
@@ -1611,6 +1630,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Kotlin(
             date_format=literalizer.languages.Kotlin.DateFormat.ISO,
             datetime_format=literalizer.languages.Kotlin.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Kotlin.BytesFormat.HEX,
             sequence_format=literalizer.languages.Kotlin.SequenceFormat.LIST,
         ),
         extension=".kts",
@@ -1622,6 +1642,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Ruby(
             date_format=literalizer.languages.Ruby.DateFormat.ISO,
             datetime_format=literalizer.languages.Ruby.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Ruby.BytesFormat.HEX,
             sequence_format=literalizer.languages.Ruby.SequenceFormat.ARRAY,
         ),
         extension=".rb",
@@ -1633,6 +1654,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Go(
             date_format=literalizer.languages.Go.DateFormat.ISO,
             datetime_format=literalizer.languages.Go.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Go.BytesFormat.HEX,
             sequence_format=literalizer.languages.Go.SequenceFormat.SLICE,
         ),
         extension=".go",
@@ -1644,6 +1666,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Java(
             date_format=literalizer.languages.Java.DateFormat.ISO,
             datetime_format=literalizer.languages.Java.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Java.BytesFormat.HEX,
             sequence_format=literalizer.languages.Java.SequenceFormat.ARRAY,
         ),
         extension=".java",
@@ -1655,6 +1678,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.CSharp(
             date_format=literalizer.languages.CSharp.DateFormat.ISO,
             datetime_format=literalizer.languages.CSharp.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.CSharp.BytesFormat.HEX,
             sequence_format=literalizer.languages.CSharp.SequenceFormat.ARRAY,
         ),
         extension=".cs",
@@ -1666,6 +1690,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Dart(
             date_format=literalizer.languages.Dart.DateFormat.ISO,
             datetime_format=literalizer.languages.Dart.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Dart.BytesFormat.HEX,
             sequence_format=literalizer.languages.Dart.SequenceFormat.LIST,
         ),
         extension=".dart",
@@ -1675,7 +1700,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "swift": _LanguageConfig(
         spec=literalizer.languages.Swift(
-            sequence_format=literalizer.languages.Swift.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Swift.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Swift.SequenceFormat.ARRAY,
         ),
         extension=".swift",
         wrap=_wrap_swift,
@@ -1686,6 +1712,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Cpp(
             date_format=literalizer.languages.Cpp.DateFormat.ISO,
             datetime_format=literalizer.languages.Cpp.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Cpp.BytesFormat.HEX,
             sequence_format=literalizer.languages.Cpp.SequenceFormat.INITIALIZER_LIST,
         ),
         extension=".cpp",
@@ -1697,6 +1724,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Rust(
             date_format=literalizer.languages.Rust.DateFormat.ISO,
             datetime_format=literalizer.languages.Rust.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Rust.BytesFormat.HEX,
             sequence_format=literalizer.languages.Rust.SequenceFormat.VEC,
         ),
         extension=".rs",
@@ -1706,7 +1734,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "haskell": _LanguageConfig(
         spec=literalizer.languages.Haskell(
-            sequence_format=literalizer.languages.Haskell.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Haskell.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Haskell.SequenceFormat.LIST,
         ),
         extension=".hs",
         wrap=_wrap_haskell,
@@ -1715,7 +1744,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "hcl": _LanguageConfig(
         spec=literalizer.languages.Hcl(
-            sequence_format=literalizer.languages.Hcl.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Hcl.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Hcl.SequenceFormat.LIST,
         ),
         extension=".hcl",
         wrap=_wrap_hcl,
@@ -1726,6 +1756,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         spec=literalizer.languages.Julia(
             date_format=literalizer.languages.Julia.DateFormat.ISO,
             datetime_format=literalizer.languages.Julia.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Julia.BytesFormat.HEX,
             sequence_format=literalizer.languages.Julia.SequenceFormat.ARRAY,
         ),
         extension=".jl",
@@ -1735,7 +1766,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "lua": _LanguageConfig(
         spec=literalizer.languages.Lua(
-            sequence_format=literalizer.languages.Lua.SequenceFormat.TABLE
+            bytes_format=literalizer.languages.Lua.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Lua.SequenceFormat.TABLE,
         ),
         extension=".lua",
         wrap=_wrap_lua,
@@ -1744,7 +1776,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "perl": _LanguageConfig(
         spec=literalizer.languages.Perl(
-            sequence_format=literalizer.languages.Perl.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Perl.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Perl.SequenceFormat.ARRAY,
         ),
         extension=".pl",
         wrap=_wrap_perl,
@@ -1753,7 +1786,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "php": _LanguageConfig(
         spec=literalizer.languages.Php(
-            sequence_format=literalizer.languages.Php.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Php.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Php.SequenceFormat.ARRAY,
         ),
         extension=".php",
         wrap=_wrap_php,
@@ -1762,6 +1796,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "elixir": _LanguageConfig(
         spec=literalizer.languages.Elixir(
+            bytes_format=literalizer.languages.Elixir.BytesFormat.HEX,
             sequence_format=literalizer.languages.Elixir.SequenceFormat.LIST,
         ),
         extension=".ex",
@@ -1771,6 +1806,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "erlang": _LanguageConfig(
         spec=literalizer.languages.Erlang(
+            bytes_format=literalizer.languages.Erlang.BytesFormat.BINARY,
             sequence_format=literalizer.languages.Erlang.SequenceFormat.LIST,
         ),
         extension=".erl",
@@ -1780,7 +1816,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "fsharp": _LanguageConfig(
         spec=literalizer.languages.FSharp(
-            sequence_format=literalizer.languages.FSharp.SequenceFormat.LIST
+            bytes_format=literalizer.languages.FSharp.BytesFormat.HEX,
+            sequence_format=literalizer.languages.FSharp.SequenceFormat.LIST,
         ),
         extension=".fs",
         wrap=_wrap_fsharp,
@@ -1789,7 +1826,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "ocaml": _LanguageConfig(
         spec=literalizer.languages.OCaml(
-            sequence_format=literalizer.languages.OCaml.SequenceFormat.LIST
+            bytes_format=literalizer.languages.OCaml.BytesFormat.HEX,
+            sequence_format=literalizer.languages.OCaml.SequenceFormat.LIST,
         ),
         extension=".ml",
         wrap=_wrap_ocaml,
@@ -1798,7 +1836,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "occam": _LanguageConfig(
         spec=literalizer.languages.Occam(
-            sequence_format=literalizer.languages.Occam.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Occam.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Occam.SequenceFormat.LIST,
         ),
         extension=".occ",
         wrap=_wrap_occam,
@@ -1807,7 +1846,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "groovy": _LanguageConfig(
         spec=literalizer.languages.Groovy(
-            sequence_format=literalizer.languages.Groovy.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Groovy.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Groovy.SequenceFormat.LIST,
         ),
         extension=".groovy",
         wrap=_wrap_groovy,
@@ -1816,7 +1856,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "scala": _LanguageConfig(
         spec=literalizer.languages.Scala(
-            sequence_format=literalizer.languages.Scala.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Scala.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Scala.SequenceFormat.LIST,
         ),
         extension=".scala",
         wrap=_wrap_scala,
@@ -1828,6 +1869,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
             date_format=literalizer.languages.R.DateFormat.ISO,
             datetime_format=literalizer.languages.R.DatetimeFormat.ISO,
             empty_dict_key=literalizer.languages.R.EmptyDictKey.POSITIONAL,
+            bytes_format=literalizer.languages.R.BytesFormat.HEX,
             sequence_format=literalizer.languages.R.SequenceFormat.LIST,
         ),
         extension=".R",
@@ -1837,7 +1879,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "racket": _LanguageConfig(
         spec=literalizer.languages.Racket(
-            sequence_format=literalizer.languages.Racket.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Racket.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Racket.SequenceFormat.LIST,
         ),
         extension=".rkt",
         wrap=_wrap_racket,
@@ -1846,6 +1889,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "crystal": _LanguageConfig(
         spec=literalizer.languages.Crystal(
+            bytes_format=literalizer.languages.Crystal.BytesFormat.HEX,
             sequence_format=literalizer.languages.Crystal.SequenceFormat.ARRAY,
         ),
         extension=".cr",
@@ -1855,7 +1899,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "matlab": _LanguageConfig(
         spec=literalizer.languages.Matlab(
-            sequence_format=literalizer.languages.Matlab.SequenceFormat.CELL_ARRAY
+            bytes_format=literalizer.languages.Matlab.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Matlab.SequenceFormat.CELL_ARRAY,
         ),
         extension=".m",
         wrap=_wrap_matlab,
@@ -1864,7 +1909,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "mojo": _LanguageConfig(
         spec=literalizer.languages.Mojo(
-            sequence_format=literalizer.languages.Mojo.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Mojo.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Mojo.SequenceFormat.LIST,
         ),
         extension=".mojo",
         wrap=_wrap_mojo,
@@ -1873,7 +1919,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "nim": _LanguageConfig(
         spec=literalizer.languages.Nim(
-            sequence_format=literalizer.languages.Nim.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Nim.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Nim.SequenceFormat.ARRAY,
         ),
         extension=".nim",
         wrap=_wrap_nim,
@@ -1882,7 +1929,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "norg": _LanguageConfig(
         spec=literalizer.languages.Norg(
-            sequence_format=literalizer.languages.Norg.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Norg.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Norg.SequenceFormat.ARRAY,
         ),
         extension=".norg",
         wrap=_wrap_norg,
@@ -1891,7 +1939,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "vb": _LanguageConfig(
         spec=literalizer.languages.VisualBasic(
-            sequence_format=literalizer.languages.VisualBasic.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.VisualBasic.BytesFormat.HEX,
+            sequence_format=literalizer.languages.VisualBasic.SequenceFormat.ARRAY,
         ),
         extension=".vb",
         wrap=_wrap_vb,
@@ -1900,7 +1949,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "zig": _LanguageConfig(
         spec=literalizer.languages.Zig(
-            sequence_format=literalizer.languages.Zig.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Zig.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Zig.SequenceFormat.ARRAY,
         ),
         extension=".zig",
         wrap=_wrap_zig,
@@ -1909,7 +1959,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "powershell": _LanguageConfig(
         spec=literalizer.languages.PowerShell(
-            sequence_format=literalizer.languages.PowerShell.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.PowerShell.BytesFormat.HEX,
+            sequence_format=literalizer.languages.PowerShell.SequenceFormat.ARRAY,
         ),
         extension=".ps1",
         wrap=_wrap_powershell,
@@ -1918,7 +1969,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "toml": _LanguageConfig(
         spec=literalizer.languages.Toml(
-            sequence_format=literalizer.languages.Toml.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.Toml.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Toml.SequenceFormat.ARRAY,
         ),
         extension=".toml",
         wrap=_wrap_toml,
@@ -1927,7 +1979,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "objective_c": _LanguageConfig(
         spec=literalizer.languages.ObjectiveC(
-            sequence_format=literalizer.languages.ObjectiveC.SequenceFormat.ARRAY
+            bytes_format=literalizer.languages.ObjectiveC.BytesFormat.HEX,
+            sequence_format=literalizer.languages.ObjectiveC.SequenceFormat.ARRAY,
         ),
         extension=".m",
         wrap=_wrap_objc,
@@ -1936,7 +1989,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "fortran": _LanguageConfig(
         spec=literalizer.languages.Fortran(
-            sequence_format=literalizer.languages.Fortran.SequenceFormat.LIST
+            bytes_format=literalizer.languages.Fortran.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Fortran.SequenceFormat.LIST,
         ),
         extension=".f90",
         wrap=_wrap_fortran,
@@ -1945,7 +1999,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     "yaml": _LanguageConfig(
         spec=literalizer.languages.Yaml(
-            sequence_format=literalizer.languages.Yaml.SequenceFormat.SEQUENCE
+            bytes_format=literalizer.languages.Yaml.BytesFormat.HEX,
+            sequence_format=literalizer.languages.Yaml.SequenceFormat.SEQUENCE,
         ),
         extension=".yaml",
         wrap=_wrap_identity,
@@ -1984,6 +2039,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.JavaScript(
             date_format=literalizer.languages.JavaScript.DateFormat.JS,
             datetime_format=literalizer.languages.JavaScript.DatetimeFormat.JS,
+            bytes_format=literalizer.languages.JavaScript.BytesFormat.HEX,
             sequence_format=literalizer.languages.JavaScript.SequenceFormat.ARRAY,
         ),
         extension=".js",
@@ -1993,6 +2049,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.TypeScript(
             date_format=literalizer.languages.TypeScript.DateFormat.JS,
             datetime_format=literalizer.languages.TypeScript.DatetimeFormat.JS,
+            bytes_format=literalizer.languages.TypeScript.BytesFormat.HEX,
             sequence_format=literalizer.languages.TypeScript.SequenceFormat.ARRAY,
         ),
         extension=".ts",
@@ -2002,6 +2059,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Kotlin(
             date_format=literalizer.languages.Kotlin.DateFormat.KOTLIN,
             datetime_format=literalizer.languages.Kotlin.DatetimeFormat.KOTLIN,
+            bytes_format=literalizer.languages.Kotlin.BytesFormat.HEX,
             sequence_format=literalizer.languages.Kotlin.SequenceFormat.LIST,
         ),
         extension=".kts",
@@ -2011,6 +2069,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Ruby(
             date_format=literalizer.languages.Ruby.DateFormat.RUBY,
             datetime_format=literalizer.languages.Ruby.DatetimeFormat.RUBY,
+            bytes_format=literalizer.languages.Ruby.BytesFormat.HEX,
             sequence_format=literalizer.languages.Ruby.SequenceFormat.ARRAY,
         ),
         extension=".rb",
@@ -2020,6 +2079,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Go(
             date_format=literalizer.languages.Go.DateFormat.GO,
             datetime_format=literalizer.languages.Go.DatetimeFormat.GO,
+            bytes_format=literalizer.languages.Go.BytesFormat.HEX,
             sequence_format=literalizer.languages.Go.SequenceFormat.SLICE,
         ),
         extension=".go",
@@ -2029,6 +2089,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Java(
             date_format=literalizer.languages.Java.DateFormat.JAVA,
             datetime_format=literalizer.languages.Java.DatetimeFormat.INSTANT,
+            bytes_format=literalizer.languages.Java.BytesFormat.HEX,
             sequence_format=literalizer.languages.Java.SequenceFormat.ARRAY,
         ),
         extension=".java",
@@ -2038,6 +2099,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Java(
             date_format=literalizer.languages.Java.DateFormat.JAVA,
             datetime_format=literalizer.languages.Java.DatetimeFormat.ZONED,
+            bytes_format=literalizer.languages.Java.BytesFormat.HEX,
             sequence_format=literalizer.languages.Java.SequenceFormat.ARRAY,
         ),
         extension=".java",
@@ -2047,6 +2109,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.CSharp(
             date_format=literalizer.languages.CSharp.DateFormat.CSHARP,
             datetime_format=literalizer.languages.CSharp.DatetimeFormat.CSHARP,
+            bytes_format=literalizer.languages.CSharp.BytesFormat.HEX,
             sequence_format=literalizer.languages.CSharp.SequenceFormat.ARRAY,
         ),
         extension=".cs",
@@ -2056,6 +2119,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Dart(
             date_format=literalizer.languages.Dart.DateFormat.DART,
             datetime_format=literalizer.languages.Dart.DatetimeFormat.DART,
+            bytes_format=literalizer.languages.Dart.BytesFormat.HEX,
             sequence_format=literalizer.languages.Dart.SequenceFormat.LIST,
         ),
         extension=".dart",
@@ -2065,6 +2129,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Cpp(
             date_format=literalizer.languages.Cpp.DateFormat.CPP,
             datetime_format=literalizer.languages.Cpp.DatetimeFormat.CPP,
+            bytes_format=literalizer.languages.Cpp.BytesFormat.HEX,
             sequence_format=literalizer.languages.Cpp.SequenceFormat.INITIALIZER_LIST,
         ),
         extension=".cpp",
@@ -2074,6 +2139,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Rust(
             date_format=literalizer.languages.Rust.DateFormat.RUST,
             datetime_format=literalizer.languages.Rust.DatetimeFormat.RUST,
+            bytes_format=literalizer.languages.Rust.BytesFormat.HEX,
             sequence_format=literalizer.languages.Rust.SequenceFormat.VEC,
         ),
         extension=".rs",
@@ -2083,6 +2149,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
         spec=literalizer.languages.Julia(
             date_format=literalizer.languages.Julia.DateFormat.JULIA,
             datetime_format=literalizer.languages.Julia.DatetimeFormat.JULIA,
+            bytes_format=literalizer.languages.Julia.BytesFormat.HEX,
             sequence_format=literalizer.languages.Julia.SequenceFormat.ARRAY,
         ),
         extension=".jl",
@@ -2093,6 +2160,7 @@ _DATE_VARIANTS: dict[str, _DateVariant] = {
             date_format=literalizer.languages.R.DateFormat.R,
             datetime_format=literalizer.languages.R.DatetimeFormat.R,
             empty_dict_key=literalizer.languages.R.EmptyDictKey.POSITIONAL,
+            bytes_format=literalizer.languages.R.BytesFormat.HEX,
             sequence_format=literalizer.languages.R.SequenceFormat.LIST,
         ),
         extension=".R",
@@ -2118,6 +2186,7 @@ _SEQUENCE_VARIANTS: dict[str, _SequenceVariant] = {
         spec=literalizer.languages.Julia(
             date_format=literalizer.languages.Julia.DateFormat.ISO,
             datetime_format=literalizer.languages.Julia.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Julia.BytesFormat.HEX,
             sequence_format=literalizer.languages.Julia.SequenceFormat.TUPLE,
         ),
         extension=".jl",
@@ -2125,6 +2194,7 @@ _SEQUENCE_VARIANTS: dict[str, _SequenceVariant] = {
     ),
     "elixir_tuple": _SequenceVariant(
         spec=literalizer.languages.Elixir(
+            bytes_format=literalizer.languages.Elixir.BytesFormat.HEX,
             sequence_format=literalizer.languages.Elixir.SequenceFormat.TUPLE,
         ),
         extension=".ex",
@@ -2132,6 +2202,7 @@ _SEQUENCE_VARIANTS: dict[str, _SequenceVariant] = {
     ),
     "erlang_tuple": _SequenceVariant(
         spec=literalizer.languages.Erlang(
+            bytes_format=literalizer.languages.Erlang.BytesFormat.BINARY,
             sequence_format=literalizer.languages.Erlang.SequenceFormat.TUPLE,
         ),
         extension=".erl",
@@ -2139,6 +2210,7 @@ _SEQUENCE_VARIANTS: dict[str, _SequenceVariant] = {
     ),
     "crystal_tuple": _SequenceVariant(
         spec=literalizer.languages.Crystal(
+            bytes_format=literalizer.languages.Crystal.BytesFormat.HEX,
             sequence_format=literalizer.languages.Crystal.SequenceFormat.TUPLE,
         ),
         extension=".cr",
@@ -2153,6 +2225,7 @@ _SEQUENCE_VARIANTS: dict[str, _SequenceVariant] = {
         spec=literalizer.languages.Rust(
             date_format=literalizer.languages.Rust.DateFormat.ISO,
             datetime_format=literalizer.languages.Rust.DatetimeFormat.ISO,
+            bytes_format=literalizer.languages.Rust.BytesFormat.HEX,
             sequence_format=literalizer.languages.Rust.SequenceFormat.TUPLE,
         ),
         extension=".rs",

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -18,11 +18,13 @@ from literalizer.languages import (
 GO = Go(
     date_format=Go.DateFormat.ISO,
     datetime_format=Go.DatetimeFormat.ISO,
+    bytes_format=Go.BytesFormat.HEX,
     sequence_format=Go.SequenceFormat.SLICE,
 )
 JAVASCRIPT = JavaScript(
     date_format=JavaScript.DateFormat.ISO,
     datetime_format=JavaScript.DatetimeFormat.ISO,
+    bytes_format=JavaScript.BytesFormat.HEX,
     sequence_format=JavaScript.SequenceFormat.ARRAY,
 )
 PYTHON = Python(
@@ -36,6 +38,7 @@ PYTHON = Python(
 RUBY = Ruby(
     date_format=Ruby.DateFormat.ISO,
     datetime_format=Ruby.DatetimeFormat.ISO,
+    bytes_format=Ruby.BytesFormat.HEX,
     sequence_format=Ruby.SequenceFormat.ARRAY,
 )
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -45,6 +45,7 @@ PYTHON = Python(
 JAVA = Java(
     date_format=Java.DateFormat.ISO,
     datetime_format=Java.DatetimeFormat.ISO,
+    bytes_format=Java.BytesFormat.HEX,
     sequence_format=Java.SequenceFormat.ARRAY,
 )
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -27,21 +27,25 @@ from literalizer.languages import (
 CPP = Cpp(
     date_format=Cpp.DateFormat.ISO,
     datetime_format=Cpp.DatetimeFormat.ISO,
+    bytes_format=Cpp.BytesFormat.HEX,
     sequence_format=Cpp.SequenceFormat.INITIALIZER_LIST,
 )
 CSHARP = CSharp(
     date_format=CSharp.DateFormat.ISO,
     datetime_format=CSharp.DatetimeFormat.ISO,
+    bytes_format=CSharp.BytesFormat.HEX,
     sequence_format=CSharp.SequenceFormat.ARRAY,
 )
 GO = Go(
     date_format=Go.DateFormat.ISO,
     datetime_format=Go.DatetimeFormat.ISO,
+    bytes_format=Go.BytesFormat.HEX,
     sequence_format=Go.SequenceFormat.SLICE,
 )
 JAVASCRIPT = JavaScript(
     date_format=JavaScript.DateFormat.ISO,
     datetime_format=JavaScript.DatetimeFormat.ISO,
+    bytes_format=JavaScript.BytesFormat.HEX,
     sequence_format=JavaScript.SequenceFormat.ARRAY,
 )
 PYTHON = Python(
@@ -55,6 +59,7 @@ PYTHON = Python(
 RUBY = Ruby(
     date_format=Ruby.DateFormat.ISO,
     datetime_format=Ruby.DatetimeFormat.ISO,
+    bytes_format=Ruby.BytesFormat.HEX,
     sequence_format=Ruby.SequenceFormat.ARRAY,
 )
 
@@ -489,6 +494,7 @@ def test_literalize_json_invalid_is_parse_error() -> None:
 
 
 MOJO = Mojo(
+    bytes_format=Mojo.BytesFormat.HEX,
     sequence_format=Mojo.SequenceFormat.LIST,
 )
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -40,39 +40,47 @@ from literalizer.languages import (
 )
 
 COBOL = Cobol(
+    bytes_format=Cobol.BytesFormat.HEX,
     sequence_format=Cobol.SequenceFormat.SEQUENCE,
 )
 CPP = Cpp(
     date_format=Cpp.DateFormat.ISO,
     datetime_format=Cpp.DatetimeFormat.ISO,
+    bytes_format=Cpp.BytesFormat.HEX,
     sequence_format=Cpp.SequenceFormat.INITIALIZER_LIST,
 )
 FORTRAN = Fortran(
+    bytes_format=Fortran.BytesFormat.HEX,
     sequence_format=Fortran.SequenceFormat.LIST,
 )
 CSHARP = CSharp(
     date_format=CSharp.DateFormat.ISO,
     datetime_format=CSharp.DatetimeFormat.ISO,
+    bytes_format=CSharp.BytesFormat.HEX,
     sequence_format=CSharp.SequenceFormat.ARRAY,
 )
 GO = Go(
     date_format=Go.DateFormat.ISO,
     datetime_format=Go.DatetimeFormat.ISO,
+    bytes_format=Go.BytesFormat.HEX,
     sequence_format=Go.SequenceFormat.SLICE,
 )
 JAVA = Java(
     date_format=Java.DateFormat.ISO,
     datetime_format=Java.DatetimeFormat.ISO,
+    bytes_format=Java.BytesFormat.HEX,
     sequence_format=Java.SequenceFormat.ARRAY,
 )
 JAVASCRIPT = JavaScript(
     date_format=JavaScript.DateFormat.ISO,
     datetime_format=JavaScript.DatetimeFormat.ISO,
+    bytes_format=JavaScript.BytesFormat.HEX,
     sequence_format=JavaScript.SequenceFormat.ARRAY,
 )
 KOTLIN = Kotlin(
     date_format=Kotlin.DateFormat.ISO,
     datetime_format=Kotlin.DatetimeFormat.ISO,
+    bytes_format=Kotlin.BytesFormat.HEX,
     sequence_format=Kotlin.SequenceFormat.LIST,
 )
 PYTHON = Python(
@@ -86,19 +94,23 @@ PYTHON = Python(
 RUBY = Ruby(
     date_format=Ruby.DateFormat.ISO,
     datetime_format=Ruby.DatetimeFormat.ISO,
+    bytes_format=Ruby.BytesFormat.HEX,
     sequence_format=Ruby.SequenceFormat.ARRAY,
 )
 RUST = Rust(
     date_format=Rust.DateFormat.ISO,
     datetime_format=Rust.DatetimeFormat.ISO,
+    bytes_format=Rust.BytesFormat.HEX,
     sequence_format=Rust.SequenceFormat.VEC,
 )
 TOML = Toml(
+    bytes_format=Toml.BytesFormat.HEX,
     sequence_format=Toml.SequenceFormat.ARRAY,
 )
 TYPESCRIPT = TypeScript(
     date_format=TypeScript.DateFormat.ISO,
     datetime_format=TypeScript.DatetimeFormat.ISO,
+    bytes_format=TypeScript.BytesFormat.HEX,
     sequence_format=TypeScript.SequenceFormat.ARRAY,
 )
 
@@ -505,7 +517,10 @@ def test_matlab_string_escaping(*, yaml_string: str, expected: str) -> None:
     """
     result = literalize_yaml(
         yaml_string=yaml_string,
-        language=Matlab(sequence_format=Matlab.SequenceFormat.CELL_ARRAY),
+        language=Matlab(
+            bytes_format=Matlab.BytesFormat.HEX,
+            sequence_format=Matlab.SequenceFormat.CELL_ARRAY,
+        ),
         line_prefix="",
         indent="    ",
         wrap=False,
@@ -525,7 +540,10 @@ def test_matlab_dict_key_with_quote() -> None:
     yaml_string = '{"hello \\"world\\"": 1}\n'
     result = literalize_yaml(
         yaml_string=yaml_string,
-        language=Matlab(sequence_format=Matlab.SequenceFormat.CELL_ARRAY),
+        language=Matlab(
+            bytes_format=Matlab.BytesFormat.HEX,
+            sequence_format=Matlab.SequenceFormat.CELL_ARRAY,
+        ),
         line_prefix="",
         indent="    ",
         wrap=False,

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -34,53 +34,65 @@ from literalizer.languages import (
 )
 
 CLOJURE = Clojure(
+    bytes_format=Clojure.BytesFormat.HEX,
     sequence_format=Clojure.SequenceFormat.VECTOR,
 )
 CPP = Cpp(
     date_format=Cpp.DateFormat.ISO,
     datetime_format=Cpp.DatetimeFormat.ISO,
+    bytes_format=Cpp.BytesFormat.HEX,
     sequence_format=Cpp.SequenceFormat.INITIALIZER_LIST,
 )
 CSHARP = CSharp(
     date_format=CSharp.DateFormat.ISO,
     datetime_format=CSharp.DatetimeFormat.ISO,
+    bytes_format=CSharp.BytesFormat.HEX,
     sequence_format=CSharp.SequenceFormat.ARRAY,
 )
 DART = Dart(
     date_format=Dart.DateFormat.ISO,
     datetime_format=Dart.DatetimeFormat.ISO,
+    bytes_format=Dart.BytesFormat.HEX,
     sequence_format=Dart.SequenceFormat.LIST,
 )
 ELIXIR = Elixir(
+    bytes_format=Elixir.BytesFormat.HEX,
     sequence_format=Elixir.SequenceFormat.LIST,
 )
 FSHARP = FSharp(
+    bytes_format=FSharp.BytesFormat.HEX,
     sequence_format=FSharp.SequenceFormat.LIST,
 )
 GO = Go(
     date_format=Go.DateFormat.ISO,
     datetime_format=Go.DatetimeFormat.ISO,
+    bytes_format=Go.BytesFormat.HEX,
     sequence_format=Go.SequenceFormat.SLICE,
 )
 HASKELL = Haskell(
+    bytes_format=Haskell.BytesFormat.HEX,
     sequence_format=Haskell.SequenceFormat.LIST,
 )
 JAVA = Java(
     date_format=Java.DateFormat.ISO,
     datetime_format=Java.DatetimeFormat.ISO,
+    bytes_format=Java.BytesFormat.HEX,
     sequence_format=Java.SequenceFormat.ARRAY,
 )
 JAVASCRIPT = JavaScript(
     date_format=JavaScript.DateFormat.ISO,
     datetime_format=JavaScript.DatetimeFormat.ISO,
+    bytes_format=JavaScript.BytesFormat.HEX,
     sequence_format=JavaScript.SequenceFormat.ARRAY,
 )
 KOTLIN = Kotlin(
     date_format=Kotlin.DateFormat.ISO,
     datetime_format=Kotlin.DatetimeFormat.ISO,
+    bytes_format=Kotlin.BytesFormat.HEX,
     sequence_format=Kotlin.SequenceFormat.LIST,
 )
 PHP = Php(
+    bytes_format=Php.BytesFormat.HEX,
     sequence_format=Php.SequenceFormat.ARRAY,
 )
 PYTHON = Python(
@@ -102,22 +114,27 @@ PYTHON_INLINE_HINTS = Python(
 RUBY = Ruby(
     date_format=Ruby.DateFormat.ISO,
     datetime_format=Ruby.DatetimeFormat.ISO,
+    bytes_format=Ruby.BytesFormat.HEX,
     sequence_format=Ruby.SequenceFormat.ARRAY,
 )
 RUST = Rust(
     date_format=Rust.DateFormat.ISO,
     datetime_format=Rust.DatetimeFormat.ISO,
+    bytes_format=Rust.BytesFormat.HEX,
     sequence_format=Rust.SequenceFormat.VEC,
 )
 SCALA = Scala(
+    bytes_format=Scala.BytesFormat.HEX,
     sequence_format=Scala.SequenceFormat.LIST,
 )
 SWIFT = Swift(
+    bytes_format=Swift.BytesFormat.HEX,
     sequence_format=Swift.SequenceFormat.ARRAY,
 )
 TYPESCRIPT = TypeScript(
     date_format=TypeScript.DateFormat.ISO,
     datetime_format=TypeScript.DatetimeFormat.ISO,
+    bytes_format=TypeScript.BytesFormat.HEX,
     sequence_format=TypeScript.SequenceFormat.ARRAY,
 )
 
@@ -190,6 +207,7 @@ _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {
         date_format=R.DateFormat.ISO,
         datetime_format=R.DatetimeFormat.ISO,
         empty_dict_key=R.EmptyDictKey.POSITIONAL,
+        bytes_format=R.BytesFormat.HEX,
         sequence_format=R.SequenceFormat.LIST,
     ): _VariableSyntax(declaration="my_var <- 42", assignment="my_var <- 42"),
 }

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -40,14 +40,17 @@ from literalizer.languages import (
 GO = Go(
     date_format=Go.DateFormat.ISO,
     datetime_format=Go.DatetimeFormat.ISO,
+    bytes_format=Go.BytesFormat.HEX,
     sequence_format=Go.SequenceFormat.SLICE,
 )
 JAVASCRIPT = JavaScript(
     date_format=JavaScript.DateFormat.ISO,
     datetime_format=JavaScript.DatetimeFormat.ISO,
+    bytes_format=JavaScript.BytesFormat.HEX,
     sequence_format=JavaScript.SequenceFormat.ARRAY,
 )
 MOJO = Mojo(
+    bytes_format=Mojo.BytesFormat.HEX,
     sequence_format=Mojo.SequenceFormat.LIST,
 )
 PYTHON = Python(
@@ -429,6 +432,7 @@ def test_java_native_dates() -> None:
     spec = Java(
         date_format=Java.DateFormat.JAVA,
         datetime_format=Java.DatetimeFormat.INSTANT,
+        bytes_format=Java.BytesFormat.HEX,
         sequence_format=Java.SequenceFormat.ARRAY,
     )
     result = literalize_yaml(
@@ -451,6 +455,7 @@ def test_ruby_native_dates() -> None:
     spec = Ruby(
         date_format=Ruby.DateFormat.RUBY,
         datetime_format=Ruby.DatetimeFormat.RUBY,
+        bytes_format=Ruby.BytesFormat.HEX,
         sequence_format=Ruby.SequenceFormat.ARRAY,
     )
     result = literalize_yaml(
@@ -610,6 +615,7 @@ def test_r_empty_dict_key_positional() -> None:
         date_format=R.DateFormat.ISO,
         datetime_format=R.DatetimeFormat.ISO,
         empty_dict_key=R.EmptyDictKey.POSITIONAL,
+        bytes_format=R.BytesFormat.HEX,
         sequence_format=R.SequenceFormat.LIST,
     )
     yaml_string = '{"": "value"}\n'
@@ -632,6 +638,7 @@ def test_r_empty_dict_key_positional_is_default() -> None:
         date_format=R.DateFormat.ISO,
         datetime_format=R.DatetimeFormat.ISO,
         empty_dict_key=R.EmptyDictKey.POSITIONAL,
+        bytes_format=R.BytesFormat.HEX,
         sequence_format=R.SequenceFormat.LIST,
     )
     yaml_string = '{"": "value"}\n'
@@ -654,6 +661,7 @@ def test_r_empty_dict_key_error() -> None:
         date_format=R.DateFormat.ISO,
         datetime_format=R.DatetimeFormat.ISO,
         empty_dict_key=R.EmptyDictKey.ERROR,
+        bytes_format=R.BytesFormat.HEX,
         sequence_format=R.SequenceFormat.LIST,
     )
     yaml_string = '{"": "value"}\n'
@@ -676,6 +684,7 @@ def test_r_empty_dict_key_error_non_empty_key_ok() -> None:
         date_format=R.DateFormat.ISO,
         datetime_format=R.DatetimeFormat.ISO,
         empty_dict_key=R.EmptyDictKey.ERROR,
+        bytes_format=R.BytesFormat.HEX,
         sequence_format=R.SequenceFormat.LIST,
     )
     yaml_string = '{"key": "value"}\n'


### PR DESCRIPTION
## Summary
- Adds a `BytesFormat` enum to all 46 language classes that were missing one, so consumers can uniformly iterate `lang_cls.BytesFormat` without `hasattr` guards
- Each language's `BytesFormat` has a single `HEX` member (except Erlang which uses `BINARY` for its native binary literal format)
- The `bytes_format` parameter is now a required keyword argument in every language class `__init__`

Closes #378

## Test plan
- [x] All 5143 existing tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly, vulture, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)