### PR TITLE
Detect sibling-list heterogeneity in error_on_coercion mode

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -141,6 +141,36 @@ def _has_heterogeneous(*, data: Value) -> bool:
 
 
 @beartype
+def _has_heterogeneous_sibling_lists(*, data: Value) -> bool:
+    """Recursively check whether data contains sibling lists whose
+    combined scalar elements are heterogeneous.
+
+    For example, ``[[1, 2], ["a", "b"]]`` returns ``True`` because the
+    sibling sublists have differing element types when combined.
+    """
+    if isinstance(data, (dict, ordereddict)):
+        return any(
+            _has_heterogeneous_sibling_lists(data=v)  # pyright: ignore[reportUnknownArgumentType]
+            for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        )
+
+    if isinstance(data, list):
+        if any(_has_heterogeneous_sibling_lists(data=v) for v in data):
+            return True
+        sublists: list[list[Value]] = [v for v in data if isinstance(v, list)]
+        if (
+            len(sublists) == len(data)
+            and len(sublists) > 1
+            and _all_scalars_heterogeneous(
+                values=[e for sub in sublists for e in sub],
+            )
+        ):
+            return True
+
+    return False
+
+
+@beartype
 def _check_heterogeneous(*, data: Value) -> None:
     """Recursively check for heterogeneous all-scalar collections and
     raise if found.
@@ -362,6 +392,15 @@ def _apply_coercions(
     if spec.coerce_heterogeneous_scalars_to_strings:
         if error_on_coercion:
             _check_heterogeneous(data=data)
+            if (
+                spec.coerce_heterogeneous_sibling_lists_to_strings
+                and _has_heterogeneous_sibling_lists(data=data)
+            ):
+                msg = (
+                    "Collection contains heterogeneous scalar types "
+                    "that would be coerced to strings"
+                )
+                raise HeterogeneousCoercionError(msg)
         else:
             data = _coerce_heterogeneous_scalars(data=data)
             if spec.coerce_heterogeneous_sibling_lists_to_strings:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -541,3 +541,18 @@ def test_error_on_coercion_json_no_raise_homogeneous() -> None:
         ]"""
     )
     assert result == expected
+
+
+def test_error_on_coercion_json_raises_sibling_lists() -> None:
+    """Error_on_coercion raises for heterogeneous sibling sublists."""
+    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+        literalize_json(
+            json_string='[[1, 2], ["a", "b"]]',
+            language=MOJO,
+            line_prefix="",
+            indent="    ",
+            wrap=True,
+            variable_name=None,
+            new_variable=True,
+            error_on_coercion=True,
+        )


### PR DESCRIPTION
## Summary
- When `error_on_coercion=True` and `coerce_heterogeneous_sibling_lists_to_strings=True` (e.g. Mojo), cross-list heterogeneity like `[[1, 2], ["a", "b"]]` was silently passing through instead of raising `HeterogeneousCoercionError`
- Added `_has_heterogeneous_sibling_lists` detection function that mirrors the logic in `_coerce_heterogeneous_sibling_lists` but returns a bool
- Called it in `_apply_coercions` when `error_on_coercion=True` so the error-on-coercion contract is upheld

Fixes the issue raised in https://github.com/adamtheturtle/literalizer/pull/369#discussion_r2968349244

## Test plan
- [x] Added `test_error_on_coercion_json_raises_sibling_lists` test
- [x] All 5144 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)