### PR TITLE
Detect sibling-list heterogeneity in error_on_coercion mode

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -146,7 +146,7 @@ def _has_heterogeneous_sibling_lists(*, data: Value) -> bool:
     combined scalar elements are heterogeneous.
 
     For example, ``[[1, 2], ["a", "b"]]`` returns ``True`` because the
-    sibling sublists have differing element types when combined.
+    sibling sub-lists have differing element types when combined.
     """
     if isinstance(data, (dict, ordereddict)):
         return any(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -544,7 +544,7 @@ def test_error_on_coercion_json_no_raise_homogeneous() -> None:
 
 
 def test_error_on_coercion_json_raises_sibling_lists() -> None:
-    """Error_on_coercion raises for heterogeneous sibling sublists."""
+    """Error_on_coercion raises for heterogeneous sibling sub-lists."""
     with pytest.raises(expected_exception=HeterogeneousCoercionError):
         literalize_json(
             json_string='[[1, 2], ["a", "b"]]',
@@ -560,7 +560,7 @@ def test_error_on_coercion_json_raises_sibling_lists() -> None:
 
 def test_error_on_coercion_json_raises_nested_sibling_lists() -> None:
     """Error_on_coercion raises for nested heterogeneous sibling
-    sublists.
+    sub-lists.
     """
     with pytest.raises(expected_exception=HeterogeneousCoercionError):
         literalize_json(


### PR DESCRIPTION
## Summary
- When `error_on_coercion=True` and `coerce_heterogeneous_sibling_lists_to_strings=True` (e.g. Mojo), cross-list heterogeneity like `[[1, 2], ["a", "b"]]` was silently passing through instead of raising `HeterogeneousCoercionError`
- Added `_has_heterogeneous_sibling_lists` detection function that mirrors the logic in `_coerce_heterogeneous_sibling_lists` but returns a bool
- Called it in `_apply_coercions` when `error_on_coercion=True` so the error-on-coercion contract is upheld

Fixes the issue raised in https://github.com/adamtheturtle/literalizer/pull/369#discussion_r2968349244

## Test plan
- [x] Added `test_error_on_coercion_json_raises_sibling_lists` test
- [x] All 5144 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)