### PR TITLE
Fix @beartype placement on language classes

### DIFF
--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -157,6 +157,7 @@ _datetime_format: Callable[[datetime.datetime], str] = format_datetime_iso
 _string_format: Callable[[str], str] = format_string_fortran
 
 
+@beartype
 class Fortran:
     """Fortran language specification."""
 
@@ -170,7 +171,6 @@ class Fortran:
 
         LIST = "list"
 
-    @beartype
     class SetFormat(enum.Enum):
         """Set type options for Fortran."""
 

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -47,6 +47,7 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"* {name}\n@code json\n{value}\n@end"
 
 
+@beartype
 class Norg:
     """Norg markup language specification.
 
@@ -70,7 +71,6 @@ class Norg:
 
         ARRAY = "array"
 
-    @beartype
     class SetFormat(enum.Enum):
         """Set type options for Norg."""
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -127,7 +127,6 @@ class ObjectiveC:
 
         ARRAY = "array"
 
-    @beartype
     class SetFormat(enum.Enum):
         """Set type options for Objective-C."""
 

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -60,6 +60,7 @@ def _format_variable_assignment(name: str, value: str) -> str:
     return f"{name}: {value}"
 
 
+@beartype
 class Yaml:
     """YAML language specification.
 
@@ -81,7 +82,6 @@ class Yaml:
 
         SEQUENCE = "sequence"
 
-    @beartype
     class SetFormat(enum.Enum):
         """Set type options for YAML."""
 


### PR DESCRIPTION
In `fortran.py`, `norg.py`, `yaml.py`, and `objective_c.py`, the `@beartype` decorator was incorrectly placed on the inner `SetFormat` enum instead of the outer language class. This moved `@beartype` to the outer class (matching the pattern used in other language files like `python.py`) and removed it from `SetFormat`.