### PR TITLE
Combine four format-variant golden-file tests into one

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2344,34 +2344,6 @@ def test_golden_file_combined_variable_forms(
     )
 
 
-@beartype
-def _check_format_variant_golden_file(
-    variant_name: str,
-    variant: _Variant,
-    case_dir: Path,
-    file_regression: FileRegressionFixture,
-    variable_name: str | None = None,
-) -> None:
-    """Run a format-variant golden-file check."""
-    yaml_string = (case_dir / "input.yaml").read_text()
-    result = literalizer.literalize_yaml(
-        yaml_string=yaml_string,
-        language=variant.spec,
-        line_prefix="",
-        indent="    ",
-        wrap=True,
-        variable_name=variable_name,
-        new_variable=True,
-        error_on_coercion=False,
-    )
-    wrapped = variant.wrap(result)
-    file_regression.check(
-        contents=wrapped + "\n",
-        extension=variant.extension,
-        fullpath=case_dir / (variant_name + variant.extension),
-    )
-
-
 @dataclasses.dataclass
 class _VariantCase:
     """A format-variant golden-file test case."""
@@ -2464,10 +2436,22 @@ def test_format_variant_golden_file(
     """Test format-variant options (dates, sequences, sets, type hints)
     against golden files.
     """
-    _check_format_variant_golden_file(
-        variant_name=variant_case.variant_name,
-        variant=variant_case.variant,
-        case_dir=variant_case.case_dir,
-        file_regression=file_regression,
+    variant = variant_case.variant
+    yaml_string = (variant_case.case_dir / "input.yaml").read_text()
+    result = literalizer.literalize_yaml(
+        yaml_string=yaml_string,
+        language=variant.spec,
+        line_prefix="",
+        indent="    ",
+        wrap=True,
         variable_name=variant_case.variable_name,
+        new_variable=True,
+        error_on_coercion=False,
+    )
+    wrapped = variant.wrap(result)
+    file_regression.check(
+        contents=wrapped + "\n",
+        extension=variant.extension,
+        fullpath=variant_case.case_dir
+        / (variant_case.variant_name + variant.extension),
     )


### PR DESCRIPTION
## Summary
- Unifies `test_date_format_golden_file`, `test_sequence_format_golden_file`, `test_set_format_golden_file`, and `test_variable_type_hints_golden_file` into a single `test_format_variant_golden_file` parametrized over a `_VariantCase` dataclass.
- Removes duplicate test boilerplate and module-level case-dir variables.
- Net reduction of 18 lines with no change in test coverage (4854 tests pass).

## Test plan
- [x] All 4854 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)