### PR TITLE
Remove LanguageSpec dataclass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Next
 ----
 
+- Removed ``LanguageSpec`` dataclass. Use the ``Language`` protocol directly to define custom languages.
+
 2026.03.20.3
 ------------
 
@@ -32,7 +34,7 @@ Next
 ----------
 
 
-- Added ``format_sequence_entry`` to the ``Language`` protocol and ``LanguageSpec`` dataclass, mirroring the existing ``format_set_entry`` field. All built-in languages use the new ``passthrough_sequence_entry`` formatter.
+- Added ``format_sequence_entry`` to the ``Language`` protocol, mirroring the existing ``format_set_entry`` field. All built-in languages use the new ``passthrough_sequence_entry`` formatter.
 
 2026.03.17.2
 ------------

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -5,11 +5,10 @@ from literalizer._core import (
     literalize_yaml,
 )
 from literalizer._formatters import fixed_dict_open, fixed_sequence_open
-from literalizer._language import Language, LanguageSpec
+from literalizer._language import Language
 
 __all__ = [
     "Language",
-    "LanguageSpec",
     "fixed_dict_open",
     "fixed_sequence_open",
     "literalize_json",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1,6 +1,5 @@
 """Language protocol and internal spec dataclass."""
 
-import dataclasses
 import datetime
 import enum
 from collections.abc import Callable
@@ -19,7 +18,7 @@ class Language(Protocol):
     :data:`~literalizer.languages.PYTHON`,
     :data:`~literalizer.languages.JAVASCRIPT`). To support additional
     languages or override defaults, write a class that provides all the
-    required attributes, or use :class:`~literalizer.LanguageSpec`.
+    required attributes.
     """
 
     null_literal: str
@@ -194,54 +193,3 @@ class Language(Protocol):
     def sequence_format(self) -> enum.Enum:
         """The sequence format chosen for this language instance."""
         ...  # pylint: disable=unnecessary-ellipsis
-
-
-@dataclasses.dataclass
-class LanguageSpec:
-    """Dataclass implementing :class:`Language`.
-
-    Use this to build fully custom language specifications without
-    writing a dedicated class.
-    """
-
-    null_literal: str
-    true_literal: str
-    false_literal: str
-    sequence_open: Callable[[list[Value]], str]
-    sequence_close: str
-    dict_open: Callable[[dict[str, Value]], str]
-    dict_close: str
-    format_dict_entry: Callable[[str, str], str]
-    multiline_trailing_comma: bool
-    single_element_trailing_comma: bool
-    format_bytes: Callable[[bytes], str]
-    format_date: Callable[[datetime.date], str]
-    format_datetime: Callable[[datetime.datetime], str]
-    empty_sequence: str | None
-    empty_dict: str | None
-    set_open: str
-    set_close: str
-    empty_set: str | None
-    format_sequence_entry: Callable[[str], str]
-    format_set_entry: Callable[[str], str]
-    comment_prefix: str
-    comment_suffix: str
-    omap_open: str
-    omap_close: str
-    format_omap_entry: Callable[[str, str], str]
-    multiline_close_indent: str
-    element_separator: str
-    skip_null_dict_values: bool
-    coerce_heterogeneous_scalars_to_strings: bool
-    coerce_heterogeneous_sibling_lists_to_strings: bool
-    format_variable_declaration: Callable[[str, str], str]
-    """Callable ``(name, value) -> str`` for a new variable
-    declaration.
-    """
-    format_variable_assignment: Callable[[str, str], str]
-    """Callable ``(name, value) -> str`` for an assignment to an existing
-    variable.
-    """
-    format_string: Callable[[str], str]
-    supports_collection_comments: bool
-    sequence_format: enum.Enum

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -7,20 +7,8 @@ import pytest
 
 from literalizer import (
     Language,
-    LanguageSpec,
     literalize_json,
     literalize_yaml,
-)
-from literalizer._formatters import (
-    dict_entry_with_separator,
-    fixed_dict_open,
-    fixed_sequence_open,
-    format_bytes_hex,
-    format_date_iso,
-    format_datetime_iso,
-    format_string_backslash,
-    passthrough_sequence_entry,
-    passthrough_set_entry,
 )
 from literalizer.languages import (
     Cobol,
@@ -442,64 +430,6 @@ def test_java_typed_array_opener(
         variable_name=None,
         new_variable=True,
         error_on_coercion=False,
-    )
-    assert result == expected
-
-
-def test_custom_language() -> None:
-    """A custom Language works as a language."""
-    custom = LanguageSpec(
-        null_literal="NIL",
-        true_literal="YES",
-        false_literal="NO",
-        sequence_open=fixed_sequence_open(open_str="<"),
-        sequence_close=">",
-        dict_open=fixed_dict_open(open_str="{"),
-        dict_close="}",
-        format_dict_entry=dict_entry_with_separator(separator=" -> "),
-        multiline_trailing_comma=True,
-        single_element_trailing_comma=False,
-        format_string=format_string_backslash,
-        format_bytes=format_bytes_hex,
-        format_date=format_date_iso,
-        format_datetime=format_datetime_iso,
-        empty_sequence=None,
-        empty_dict=None,
-        set_open="<",
-        set_close=">",
-        empty_set=None,
-        format_sequence_entry=passthrough_sequence_entry,
-        format_set_entry=passthrough_set_entry,
-        comment_prefix="//",
-        comment_suffix="",
-        omap_open="{",
-        omap_close="}",
-        format_omap_entry=lambda key, value: f"{key}: {value}",
-        multiline_close_indent="",
-        element_separator=", ",
-        skip_null_dict_values=False,
-        coerce_heterogeneous_scalars_to_strings=False,
-        coerce_heterogeneous_sibling_lists_to_strings=False,
-        supports_collection_comments=True,
-        format_variable_declaration=PYTHON.format_variable_declaration,
-        format_variable_assignment=PYTHON.format_variable_assignment,
-        sequence_format=Python.SequenceFormat.TUPLE,
-    )
-    result = literalize_json(
-        json_string=json.dumps(obj=[True, None, "hi"]),
-        language=custom,
-        line_prefix="",
-        indent="    ",
-        wrap=False,
-        variable_name=None,
-        new_variable=True,
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        YES,
-        NIL,
-        "hi","""
     )
     assert result == expected
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -3,23 +3,10 @@
 import textwrap
 
 import pytest
-from beartype import beartype
 
 from literalizer import (
     Language,
-    LanguageSpec,
     literalize_yaml,
-)
-from literalizer._formatters import (
-    dict_entry_with_separator,
-    fixed_dict_open,
-    fixed_sequence_open,
-    format_bytes_hex,
-    format_date_iso,
-    format_datetime_iso,
-    format_string_backslash,
-    passthrough_sequence_entry,
-    passthrough_set_entry,
 )
 from literalizer.exceptions import (
     EmptyDictKeyError,
@@ -61,14 +48,6 @@ PYTHON = Python(
     set_format=Python.SetFormat.SET,
     variable_type_hints=Python.VariableTypeHints.NONE,
 )
-
-
-@beartype
-def _format_test_omap_entry(key: str, value: str) -> str:
-    """Format an omap entry for use in custom Language test
-    fixtures.
-    """
-    return f"{key}: {value}"
 
 
 def test_literalize_yaml_empty_sequence() -> None:
@@ -313,72 +292,6 @@ def test_omap_nested_in_sequence() -> None:
         (
             OrderedDict([("name", "Alice"), ("age", 30)]),
         )""",
-    )
-    assert result == expected
-
-
-def test_omap_custom_language_spec() -> None:
-    """An omap with a custom Language calls format_omap_entry."""
-    yaml_string = textwrap.dedent(
-        text="""\
-        !!omap
-        - name: Alice
-        - age: 30
-        """,
-    )
-    custom = LanguageSpec(
-        null_literal="null",
-        true_literal="true",
-        false_literal="false",
-        sequence_open=fixed_sequence_open(open_str="["),
-        sequence_close="]",
-        dict_open=fixed_dict_open(open_str="{"),
-        dict_close="}",
-        format_dict_entry=dict_entry_with_separator(separator=": "),
-        multiline_trailing_comma=True,
-        single_element_trailing_comma=False,
-        format_string=format_string_backslash,
-        format_bytes=format_bytes_hex,
-        format_date=format_date_iso,
-        format_datetime=format_datetime_iso,
-        empty_sequence=None,
-        empty_dict=None,
-        set_open="[",
-        set_close="]",
-        empty_set=None,
-        format_sequence_entry=passthrough_sequence_entry,
-        format_set_entry=passthrough_set_entry,
-        comment_prefix="//",
-        comment_suffix="",
-        omap_open="{",
-        omap_close="}",
-        format_omap_entry=_format_test_omap_entry,
-        multiline_close_indent="",
-        element_separator=", ",
-        skip_null_dict_values=False,
-        coerce_heterogeneous_scalars_to_strings=False,
-        coerce_heterogeneous_sibling_lists_to_strings=False,
-        supports_collection_comments=True,
-        format_variable_declaration=PYTHON.format_variable_declaration,
-        format_variable_assignment=PYTHON.format_variable_assignment,
-        sequence_format=Python.SequenceFormat.TUPLE,
-    )
-    result = literalize_yaml(
-        yaml_string=yaml_string,
-        language=custom,
-        line_prefix="",
-        indent="    ",
-        wrap=True,
-        variable_name=None,
-        new_variable=True,
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        {
-            "name": "Alice",
-            "age": 30,
-        }""",
     )
     assert result == expected
 


### PR DESCRIPTION
## Summary
- Removed the `LanguageSpec` dataclass and its tests. The `Language` protocol is sufficient for defining custom languages.
- Removed custom language tests from `test_languages.py` and `test_yaml.py` along with their unused imports.
- Updated changelog and docstrings to no longer reference `LanguageSpec`.

## Test plan
- [x] All 81 tests in `test_languages.py` and `test_yaml.py` pass
- [x] Pre-commit hooks pass (mypy, pyright, ty, vulture, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)