### PR TITLE
Remove incorrect "(default)" labels from docstrings

### DIFF
--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -97,7 +97,7 @@ class Cpp:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.CPP`` — ``std::chrono::year_month_day`` literal,
               e.g. ``std::chrono::year_month_day{std::chrono::year{2024},
@@ -105,7 +105,7 @@ class Cpp:
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.CPP`` — ``std::chrono::sys_days`` with
               time-of-day durations,

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -47,7 +47,7 @@ class Crystal:
     Args:
         sequence_format: Which Crystal sequence type to use.
 
-            * ``SequenceFormat.ARRAY`` (default) — array literal,
+            * ``SequenceFormat.ARRAY`` — array literal,
               e.g. ``[1, 2, 3]``.
             * ``SequenceFormat.TUPLE`` — tuple literal,
               e.g. ``{1, 2, 3}``.

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -97,14 +97,14 @@ class CSharp:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.CSHARP`` — ``new DateOnly(...)`` call,
               e.g. ``new DateOnly(2024, 1, 15)``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.CSHARP`` — ``new DateTime(...)`` call,
               e.g. ``new DateTime(2024, 1, 15, 12, 30, 0)``.

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -98,14 +98,14 @@ class Dart:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.DART`` — ``DateTime.parse(...)`` call,
               e.g. ``DateTime.parse("2024-01-15")``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.DART`` — ``DateTime.parse(...)`` call,
               e.g. ``DateTime.parse("2024-01-15T12:30:00")``.

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -53,7 +53,7 @@ class Elixir:
     Args:
         sequence_format: Which Elixir sequence type to use.
 
-            * ``SequenceFormat.LIST`` (default) — list literal,
+            * ``SequenceFormat.LIST`` — list literal,
               e.g. ``[1, 2, 3]``.
             * ``SequenceFormat.TUPLE`` — tuple literal,
               e.g. ``{1, 2, 3}``.

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -61,7 +61,7 @@ class Erlang:
     Args:
         sequence_format: Which Erlang sequence type to use.
 
-            * ``SequenceFormat.LIST`` (default) — list literal,
+            * ``SequenceFormat.LIST`` — list literal,
               e.g. ``[1, 2, 3]``.
             * ``SequenceFormat.TUPLE`` — tuple literal,
               e.g. ``{1, 2, 3}``.

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -106,7 +106,7 @@ class Go:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.GO`` — ``time.Date`` call,
               e.g. ``time.Date(2024, time.January, 15, 0, 0, 0, 0,
@@ -114,7 +114,7 @@ class Go:
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.GO`` — ``time.Date`` call,
               e.g. ``time.Date(2024, time.January, 15, 12, 30, 0, 0,

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -90,14 +90,14 @@ class Java:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.JAVA`` — ``LocalDate.of(...)`` call,
               e.g. ``LocalDate.of(2024, 1, 15)``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.INSTANT`` — ``Instant.parse(...)`` call,
               e.g. ``Instant.parse("2024-01-15T12:30:00")``.

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -53,14 +53,14 @@ class JavaScript:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.JS`` — ``new Date(...)`` call,
               e.g. ``new Date("2024-01-15")``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.JS`` — ``new Date(...)`` call,
               e.g. ``new Date("2024-01-15T12:30:00")``.

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -47,21 +47,21 @@ class Julia:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.JULIA`` — ``Date(...)`` constructor call,
               e.g. ``Date(2024, 1, 15)``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.JULIA`` — ``DateTime(...)`` constructor
               call, e.g. ``DateTime(2024, 1, 15, 12, 30, 0)``.
 
         sequence_format: Which Julia sequence type to use.
 
-            * ``SequenceFormat.ARRAY`` (default) — array literal,
+            * ``SequenceFormat.ARRAY`` — array literal,
               e.g. ``[1, 2, 3]``.
             * ``SequenceFormat.TUPLE`` — tuple literal,
               e.g. ``(1, 2, 3)``.

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -114,14 +114,14 @@ class Kotlin:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.KOTLIN`` — ``LocalDate.of(...)`` call,
               e.g. ``LocalDate.of(2024, 1, 15)``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.KOTLIN`` — ``LocalDateTime.of(...)`` call,
               e.g. ``LocalDateTime.of(2024, 1, 15, 12, 30, 0)``.

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -124,14 +124,14 @@ class Python:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.PYTHON`` — ``datetime.date`` constructor call,
               e.g. ``datetime.date(year=2024, month=1, day=15)``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.PYTHON`` — ``datetime.datetime`` constructor
               call, e.g. ``datetime.datetime(year=2024, month=1,
@@ -141,21 +141,21 @@ class Python:
 
         bytes_format: How to format :class:`bytes` values.
 
-            * ``BytesFormat.HEX`` (default) — lowercase hex string,
+            * ``BytesFormat.HEX`` — lowercase hex string,
               e.g. ``"48656c6c6f"``.
             * ``BytesFormat.PYTHON`` — Python bytes literal,
               e.g. ``b'Hello'``.
 
         sequence_format: Which Python sequence type to use.
 
-            * ``SequenceFormat.TUPLE`` (default) — tuple literal,
+            * ``SequenceFormat.TUPLE`` — tuple literal,
               e.g. ``(1, 2, 3)``.
             * ``SequenceFormat.LIST`` — list literal,
               e.g. ``[1, 2, 3]``.
 
         set_format: Which Python set type to use.
 
-            * ``SetFormat.SET`` (default) — mutable set literal,
+            * ``SetFormat.SET`` — mutable set literal,
               e.g. ``{1, 2, 3}``.
             * ``SetFormat.FROZENSET`` — immutable frozenset,
               e.g. ``frozenset({1, 2, 3})``.
@@ -163,7 +163,7 @@ class Python:
         variable_type_hints: Whether to add inline type hints to
             variable declarations.
 
-            * ``VariableTypeHints.NONE`` (default) — bare assignment,
+            * ``VariableTypeHints.NONE`` — bare assignment,
               e.g. ``my_var = {...}``.
             * ``VariableTypeHints.INLINE`` — with type annotation,
               e.g. ``my_var: dict[str, Any] = {...}``.

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -84,21 +84,21 @@ class R:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.R`` — ``as.Date(...)`` call,
               e.g. ``as.Date("2024-01-15")``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.R`` — ``as.POSIXct(...)`` call,
               e.g. ``as.POSIXct("2024-01-15T12:30:00")``.
 
         empty_dict_key: How to handle empty-string dict keys.
 
-            * ``EmptyDictKey.POSITIONAL`` (default) — emit as an unnamed
+            * ``EmptyDictKey.POSITIONAL`` — emit as an unnamed
               positional list element.
             * ``EmptyDictKey.ERROR`` — raise
               :class:`~literalizer.exceptions.EmptyDictKeyError`.

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -53,14 +53,14 @@ class Ruby:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.RUBY`` — ``Date.new(...)`` call,
               e.g. ``Date.new(2024, 1, 15)``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.RUBY`` — ``Time.new(...)`` call,
               e.g. ``Time.new(2024, 1, 15, 12, 30, 0)``.

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -58,7 +58,7 @@ class Rust:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.RUST`` —
               ``NaiveDate::from_ymd_opt(...)`` call,
@@ -67,7 +67,7 @@ class Rust:
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.RUST`` —
               ``NaiveDateTime::new(...)`` call, e.g.
@@ -77,7 +77,7 @@ class Rust:
 
         sequence_format: Which Rust sequence type to use.
 
-            * ``SequenceFormat.VEC`` (default) — ``vec![]`` macro,
+            * ``SequenceFormat.VEC`` — ``vec![]`` macro,
               e.g. ``vec![1, 2, 3]``.  Because ``Vec`` is
               homogeneous, mixed-type sequences have all elements
               coerced to strings.

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -53,14 +53,14 @@ class TypeScript:
     Args:
         date_format: How to format :class:`datetime.date` values.
 
-            * ``DateFormat.ISO`` (default) — ISO 8601 string,
+            * ``DateFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15"``.
             * ``DateFormat.JS`` — ``new Date(...)`` call,
               e.g. ``new Date("2024-01-15")``.
 
         datetime_format: How to format :class:`datetime.datetime` values.
 
-            * ``DatetimeFormat.ISO`` (default) — ISO 8601 string,
+            * ``DatetimeFormat.ISO`` — ISO 8601 string,
               e.g. ``"2024-01-15T12:30:00"``.
             * ``DatetimeFormat.JS`` — ``new Date(...)`` call,
               e.g. ``new Date("2024-01-15T12:30:00")``.


### PR DESCRIPTION
Parameters across 16 language classes were documented as "(default)" in their docstrings, but were actually required keyword arguments with no default values in the function signatures. This removes the misleading "(default)" labels from all affected parameters.