### PR TITLE
Add __call__ to callable-valued enums to remove ty: ignore[invalid-assignment]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,6 +379,8 @@ ignore_names = [
     "suppress_warnings",
     "templates_path",
     "warning_is_error",
+    # Enum __call__ used implicitly when enum members are passed as callables
+    "__call__",
     # Enum members accessed by consumers iterating SetFormat
     "HASH_SET",
     "MAP_SET",

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -107,6 +107,10 @@ class Ada:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Ada."""
 
@@ -141,7 +145,7 @@ class Ada:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -83,6 +83,10 @@ class Bash:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Bash."""
 
@@ -117,7 +121,7 @@ class Bash:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -92,6 +92,10 @@ class C:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for C."""
 
@@ -126,7 +130,7 @@ class C:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -49,6 +49,10 @@ class Clojure:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Clojure."""
 
@@ -83,7 +87,7 @@ class Clojure:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -224,6 +224,10 @@ class Cobol:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for COBOL."""
 
@@ -258,7 +262,7 @@ class Cobol:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -54,6 +54,10 @@ class CommonLisp:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Common Lisp."""
 
@@ -86,7 +90,7 @@ class CommonLisp:
         self.format_dict_entry: Callable[[str, str], str] = _format_cons_entry
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -112,15 +112,27 @@ class Cpp:
 
         CPP = enum.member(value=format_date_cpp)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime format options for C++."""
 
         CPP = enum.member(value=format_datetime_cpp)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for C++."""
@@ -160,10 +172,10 @@ class Cpp:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -58,6 +58,10 @@ class Crystal:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Crystal."""
 
@@ -100,7 +104,7 @@ class Crystal:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -109,15 +109,27 @@ class CSharp:
 
         CSHARP = enum.member(value=format_date_csharp)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime format options for C#."""
 
         CSHARP = enum.member(value=format_datetime_csharp)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for C#."""
@@ -157,10 +169,10 @@ class CSharp:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -110,6 +110,10 @@ class D:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for D."""
 
@@ -144,7 +148,7 @@ class D:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -110,15 +110,27 @@ class Dart:
 
         DART = enum.member(value=format_date_dart)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime formatting options for Dart."""
 
         DART = enum.member(value=format_datetime_dart)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Dart."""
@@ -158,10 +170,10 @@ class Dart:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
         self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -64,6 +64,10 @@ class Elixir:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Elixir."""
 
@@ -103,7 +107,7 @@ class Elixir:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -72,6 +72,10 @@ class Erlang:
 
         BINARY = enum.member(value=_format_bytes)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Erlang."""
 
@@ -111,7 +115,7 @@ class Erlang:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -166,6 +166,10 @@ class Fortran:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Fortran."""
 
@@ -200,7 +204,7 @@ class Fortran:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -110,6 +110,10 @@ class FSharp:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for F#."""
 
@@ -144,7 +148,7 @@ class FSharp:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -120,15 +120,27 @@ class Go:
 
         GO = enum.member(value=format_date_go)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime format options for Go."""
 
         GO = enum.member(value=format_datetime_go)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Go."""
@@ -168,10 +180,10 @@ class Go:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -49,6 +49,10 @@ class Groovy:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Groovy."""
 
@@ -83,7 +87,7 @@ class Groovy:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -99,6 +99,10 @@ class Haskell:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Haskell."""
 
@@ -133,7 +137,7 @@ class Haskell:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -51,6 +51,10 @@ class Hcl:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for HCL."""
 
@@ -85,7 +89,7 @@ class Hcl:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -105,16 +105,28 @@ class Java:
 
         JAVA = enum.member(value=format_date_java)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime formatting options for Java."""
 
         INSTANT = enum.member(value=format_datetime_java_instant)
         ZONED = enum.member(value=format_datetime_java_zoned)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Java."""
@@ -153,10 +165,10 @@ class Java:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = None

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -65,15 +65,27 @@ class JavaScript:
 
         JS = enum.member(value=format_date_js)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime formatting options for JavaScript."""
 
         JS = enum.member(value=format_datetime_js)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for JavaScript."""
@@ -111,10 +123,10 @@ class JavaScript:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -66,15 +66,27 @@ class Julia:
 
         JULIA = enum.member(value=format_date_julia)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime formatting options for Julia."""
 
         JULIA = enum.member(value=format_datetime_julia)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Julia."""
@@ -119,10 +131,10 @@ class Julia:
             dict_entry_with_separator(separator=" => ")
         )
         self.multiline_trailing_comma = True
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = None

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -126,15 +126,27 @@ class Kotlin:
 
         KOTLIN = enum.member(value=format_date_kotlin)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime format options for Kotlin."""
 
         KOTLIN = enum.member(value=format_datetime_kotlin)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Kotlin."""
@@ -174,10 +186,10 @@ class Kotlin:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = (

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -65,6 +65,10 @@ class Lua:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Lua."""
 
@@ -99,7 +103,7 @@ class Lua:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -119,6 +119,10 @@ class Matlab:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for MATLAB."""
 
@@ -153,7 +157,7 @@ class Matlab:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -68,6 +68,10 @@ class Mojo:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Mojo."""
 
@@ -102,7 +106,7 @@ class Mojo:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -49,6 +49,10 @@ class Nim:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Nim."""
 
@@ -83,7 +87,7 @@ class Nim:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -66,6 +66,10 @@ class Norg:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Norg."""
 
@@ -100,7 +104,7 @@ class Norg:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = format_date_iso
         self.format_datetime: Callable[[datetime.datetime], str] = (
             format_datetime_iso

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -122,6 +122,10 @@ class ObjectiveC:
 
         HEX = enum.member(value=_format_objc_bytes)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Objective-C."""
 
@@ -156,7 +160,7 @@ class ObjectiveC:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -114,6 +114,10 @@ class OCaml:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for OCaml."""
 
@@ -148,7 +152,7 @@ class OCaml:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -99,6 +99,10 @@ class Occam:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Occam."""
 
@@ -133,7 +137,7 @@ class Occam:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -49,6 +49,10 @@ class Perl:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Perl."""
 
@@ -83,7 +87,7 @@ class Perl:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -65,6 +65,10 @@ class Php:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for PHP."""
 
@@ -99,7 +103,7 @@ class Php:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -75,6 +75,10 @@ class PowerShell:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for PowerShell."""
 
@@ -109,7 +113,7 @@ class PowerShell:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -168,17 +168,29 @@ class Python:
 
         PYTHON = enum.member(value=format_date_python)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime formatting options for Python."""
 
         PYTHON = enum.member(value=format_datetime_python)
         EPOCH = enum.member(value=format_datetime_epoch)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options for Python."""
 
         HEX = enum.member(value=format_bytes_hex)
         PYTHON = enum.member(value=format_bytes_python)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Python."""
@@ -233,10 +245,10 @@ class Python:
         )
         self.multiline_trailing_comma = True
 
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -103,10 +103,18 @@ class R:
 
         R = enum.member(value=format_date_r)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime formatting options for R."""
 
         R = enum.member(value=format_datetime_r)
+
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
 
     class EmptyDictKey(enum.Enum):
         """How to handle empty-string dict keys in R.
@@ -118,10 +126,18 @@ class R:
         POSITIONAL = enum.member(value=_format_r_dict_entry_positional)
         ERROR = enum.member(value=_format_r_dict_entry_error)
 
+        def __call__(self, key: str, value: str, /) -> str:
+            """Format a dict entry."""
+            return self.value(key=key, value=value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for R."""
@@ -155,15 +171,13 @@ class R:
             open_str="list("
         )
         self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            empty_dict_key.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        )
+        self.format_dict_entry: Callable[[str, str], str] = empty_dict_key
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = None

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -49,6 +49,10 @@ class Racket:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Racket."""
 
@@ -83,7 +87,7 @@ class Racket:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -65,15 +65,27 @@ class Ruby:
 
         RUBY = enum.member(value=format_date_ruby)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime format options for Ruby."""
 
         RUBY = enum.member(value=format_datetime_ruby)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Ruby."""
@@ -111,10 +123,10 @@ class Ruby:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -88,15 +88,27 @@ class Rust:
 
         RUST = enum.member(value=format_date_rust)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime format options for Rust."""
 
         RUST = enum.member(value=format_datetime_rust)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for Rust."""
@@ -143,10 +155,10 @@ class Rust:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -98,6 +98,10 @@ class Scala:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Scala."""
 
@@ -134,7 +138,7 @@ class Scala:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -55,6 +55,10 @@ class Swift:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Swift."""
 
@@ -89,7 +93,7 @@ class Swift:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -104,6 +104,10 @@ class Toml:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for TOML."""
 
@@ -138,7 +142,7 @@ class Toml:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _format_toml_date
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _format_toml_datetime

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -65,15 +65,27 @@ class TypeScript:
 
         JS = enum.member(value=format_date_js)
 
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value(value=date_value)
+
     class DatetimeFormat(enum.Enum):
         """Datetime formatting options for TypeScript."""
 
         JS = enum.member(value=format_datetime_js)
 
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value(value=dt_value)
+
     class BytesFormat(enum.Enum):
         """Bytes formatting options."""
 
         HEX = enum.member(value=format_bytes_hex)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
 
     class SequenceFormat(enum.Enum):
         """Sequence type options for TypeScript."""
@@ -111,10 +123,10 @@ class TypeScript:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
-        self.format_date: Callable[[datetime.date], str] = date_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+            datetime_format
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -95,6 +95,10 @@ class VisualBasic:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Visual Basic."""
 
@@ -130,7 +134,7 @@ class VisualBasic:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = format_date_iso
         self.format_datetime: Callable[[datetime.datetime], str] = (
             format_datetime_iso

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -77,6 +77,10 @@ class Yaml:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for YAML."""
 
@@ -111,7 +115,7 @@ class Yaml:
         )
         self.multiline_trailing_comma = False
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _format_yaml_date
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _format_yaml_datetime

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -86,6 +86,10 @@ class Zig:
 
         HEX = enum.member(value=format_bytes_hex)
 
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
     class SequenceFormat(enum.Enum):
         """Sequence type options for Zig."""
 
@@ -120,7 +124,7 @@ class Zig:
         )
         self.multiline_trailing_comma = True
         self.single_element_trailing_comma = False
-        self.format_bytes: Callable[[bytes], str] = bytes_format.value  # ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]
+        self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = _date_format
         self.format_datetime: Callable[[datetime.datetime], str] = (
             _datetime_format


### PR DESCRIPTION
## Summary
- Adds `__call__` methods to `BytesFormat`, `DateFormat`, `DatetimeFormat`, and `EmptyDictKey` enums across all 46 language files, making enum instances directly callable with proper type signatures.
- Removes all 70+ `# ty: ignore[invalid-assignment]  # pyrefly: ignore[bad-assignment]` comments by passing enum members directly instead of accessing `.value`.
- Adds `__call__` to vulture's `ignore_names` since it's a dunder method used implicitly.

## Test plan
- [x] `ty check` passes with no diagnostics
- [x] `mypy` passes with no issues
- [x] All 284 tests pass
- [x] `ruff check` passes
- [x] All pre-commit hooks pass (including vulture, pyright, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical refactor across many language specs: formatting behavior should be unchanged, but broad surface-area means any missed enum could cause runtime/type-check regressions.
> 
> **Overview**
> **Makes callable-valued `Enum` members directly invokable across language specs.** Adds `__call__` implementations to `BytesFormat` (and where present `DateFormat`, `DatetimeFormat`, plus R’s `EmptyDictKey`) so enum instances can be passed/stored as `Callable`s without using `.value`.
> 
> Updates each language class to assign `self.format_bytes` / `self.format_date` / `self.format_datetime` (and R’s `format_dict_entry`) to the enum member itself, removing the need for the previous `ty`/`pyrefly` invalid-assignment ignores. Also updates `pyproject.toml` `vulture.ignore_names` to include `__call__` since it’s used implicitly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9823533f69cbe24cb844106ed4d2f635f39e7552. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->