### PR TITLE
Remove pyrefly: ignore[missing-import] from json_to_schema import

### DIFF
--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -7,9 +7,7 @@ from collections.abc import Callable
 from typing import Any
 
 from beartype import beartype
-from json_to_schema import (
-    infer_schema,
-)
+from json_to_schema import infer_schema
 
 from literalizer._types import Value
 


### PR DESCRIPTION
`json_to_schema` ships a `py.typed` marker, so pyrefly can resolve it directly without a suppression comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the `json_to_schema` import style to remove a type-checker suppression, with no functional logic changes.
> 
> **Overview**
> Removes the `pyrefly: ignore[missing-import]` suppression around the `json_to_schema` import in `_formatters.py`, switching to a direct `from json_to_schema import infer_schema` import now that the dependency is type-discoverable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e5ec74aed33ec1ddfa339ece3dea0e27437857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->