### PR TITLE
Use dict literal for Python OrderedDict omap output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,9 +298,6 @@ overrides = [ { module = "tests.integration.cases.*", disable_error_code = [ "va
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
-project_excludes = [
-    "tests/integration/cases",
-]
 
 [tool.pyright]
 enableTypeIgnoreComments = false

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
 
 @beartype
 def _format_python_omap_entry(key: str, value: str) -> str:
-    """Format one Python ``OrderedDict`` entry as a ``(key, value)`` tuple."""
-    return f"({key}, {value})"
+    """Format one Python ``OrderedDict`` entry as a dict entry."""
+    return f"{key}: {value}"
 
 
 @beartype
@@ -271,8 +271,8 @@ class Python:
         self.format_set_entry: Callable[[str], str] = passthrough_set_entry
         self.comment_prefix = "#"
         self.comment_suffix = ""
-        self.omap_open = "OrderedDict(["
-        self.omap_close = "])"
+        self.omap_open = "OrderedDict({"
+        self.omap_close = "})"
         self.format_omap_entry: Callable[[str, str], str] = (
             _format_python_omap_entry
         )

--- a/tests/integration/cases/omap/python.py
+++ b/tests/integration/cases/omap/python.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
-OrderedDict([
-    ("name", "Alice"),
-    ("age", 30),
-    ("active", True),
-])
+OrderedDict({
+    "name": "Alice",
+    "age": 30,
+    "active": True,
+})

--- a/tests/integration/cases/omap/python_combined.py
+++ b/tests/integration/cases/omap/python_combined.py
@@ -1,11 +1,11 @@
 from collections import OrderedDict
-my_data = OrderedDict([
-    ("name", "Alice"),
-    ("age", 30),
-    ("active", True),
-])
-my_data = OrderedDict([
-    ("name", "Alice"),
-    ("age", 30),
-    ("active", True),
-])
+my_data = OrderedDict({
+    "name": "Alice",
+    "age": 30,
+    "active": True,
+})
+my_data = OrderedDict({
+    "name": "Alice",
+    "age": 30,
+    "active": True,
+})

--- a/tests/integration/cases/omap/python_varname.py
+++ b/tests/integration/cases/omap/python_varname.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
-my_data = OrderedDict([
-    ("name", "Alice"),
-    ("age", 30),
-    ("active", True),
-])
+my_data = OrderedDict({
+    "name": "Alice",
+    "age": 30,
+    "active": True,
+})


### PR DESCRIPTION
## Summary
- Removes pyrefly `project_excludes` for `tests/integration/cases`, which was masking type errors
- Changes Python omap output from `OrderedDict([("k", v), ...])` (list of tuples) to `OrderedDict({"k": v, ...})` (dict literal), which pyrefly can type-check without `no-matching-overload` errors
- Regenerates affected golden test files

## Test plan
- [x] `uv run --all-extras pyrefly check .` passes with 0 errors
- [x] All 4854 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only Python code-generation formatting for ordered maps and updates golden integration outputs; potential impact is limited to consumers relying on the previous `OrderedDict([(...), ...])` textual form.
> 
> **Overview**
> Python `omap`/`OrderedDict` literal generation is changed from a list-of-tuples form (`OrderedDict([("k", v), ...])`) to a dict-literal form (`OrderedDict({"k": v, ...})`), including updating the per-entry formatter accordingly.
> 
> Removes the `pyrefly` configuration exclude for `tests/integration/cases` and regenerates the affected `omap` Python golden integration test files to match the new output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8962f55613388568cd9bab03a35cb7e5ab4bbbac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->