### PR TITLE
Remove redundant _wrap_rust_chrono function

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -402,19 +402,6 @@ def _wrap_java_varname(content: str) -> str:
 
 
 @beartype
-def _wrap_rust_chrono(content: str) -> str:
-    """Wrap in a Rust main function with chrono imports."""
-    indented = content.replace("\n", "\n    ")
-    return (
-        _rust_collections_use(content=content)
-        + _rust_chrono_use(content=content)
-        + "fn main() {\n"
-        f"    let _ = {indented};\n"
-        "}"
-    )
-
-
-@beartype
 def _wrap_csharp_varname(content: str) -> str:
     """Wrap a C# top-level variable declaration with required imports."""
     needs_system = "DateOnly" in content or "DateTime" in content
@@ -2275,7 +2262,7 @@ _DATE_VARIANTS: dict[str, _Variant] = {
             sequence_format=literalizer.languages.Rust.sequence_formats.VEC,
         ),
         extension=".rs",
-        wrap=_wrap_rust_chrono,
+        wrap=_wrap_rust,
     ),
     "julia_native": _Variant(
         spec=literalizer.languages.Julia(


### PR DESCRIPTION
## Summary
- Remove `_wrap_rust_chrono`, which was identical to `_wrap_rust`, and replace its single usage with `_wrap_rust`
- Eliminates divergence risk where changes to `_rust_chrono_use` wouldn't propagate to `_wrap_rust_chrono`

Addresses review feedback from #415.

## Test plan
- [x] `rust_native` integration test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test refactor: removes an unused duplicate wrapper and updates a single integration-test variant to call the existing `_wrap_rust`, with no production code changes.
> 
> **Overview**
> Removes the redundant integration-test helper `_wrap_rust_chrono` and switches the `rust_native` golden-file variant to use the existing `_wrap_rust` wrapper instead.
> 
> This reduces duplicated wrapper logic in `tests/integration/test_integration.py` and avoids future divergence in Rust import/wrapping behavior across variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bba4f1400d60241a6bd602057f4e5eecda5a171. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->