### PR TITLE
Merge dict/list heterogeneous coercion properties

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -517,9 +517,8 @@ def _apply_coercions(
         else:
             data = _coerce_heterogeneous_scalars(data=data)
             data = _coerce_heterogeneous_sibling_lists(data=data)
-    if spec.coerce_heterogeneous_dict_values_to_strings:
+    if spec.coerce_heterogeneous_collection_values_to_strings:
         data = _coerce_mixed_dict_values(data=data)
-    if spec.coerce_heterogeneous_list_values_to_strings:
         data = _coerce_mixed_list_values(data=data)
     return data
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -203,22 +203,14 @@ class Language(Protocol):
     to strings so that every element shares a single type.
     """
 
-    coerce_heterogeneous_dict_values_to_strings: bool
-    """Whether to coerce dict values that span multiple type families
-    (e.g. strings and lists) to strings so every value shares a single
+    coerce_heterogeneous_collection_values_to_strings: bool
+    """Whether to coerce dict values and list elements that span
+    multiple type families to strings so every value shares a single
     type.
 
     For example, ``{"name": "Bob", "tags": ["admin"]}`` becomes
-    ``{"name": "Bob", "tags": "[\"admin\"]"}``.
-    """
-
-    coerce_heterogeneous_list_values_to_strings: bool
-    """Whether to coerce list elements that span multiple type families
-    (e.g. scalars and nested collections) to strings so every element
-    shares a single type.
-
-    For example, ``[true, "hi", [1, 2]]`` becomes
-    ``["True", "hi", "[1, 2]"]``.
+    ``{"name": "Bob", "tags": "[\"admin\"]"}``, and
+    ``[true, "hi", [1, 2]]`` becomes ``["True", "hi", "[1, 2]"]``.
     """
 
     supports_collection_comments: bool

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -197,8 +197,7 @@ class Ada(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -175,8 +175,7 @@ class Bash(metaclass=HasFormatEnums):
         self.element_separator = " "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -182,8 +182,7 @@ class C(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -141,8 +141,7 @@ class Clojure(metaclass=HasFormatEnums):
         self.element_separator = " "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -318,8 +318,7 @@ class Cobol(metaclass=HasFormatEnums):
         self.element_separator = "\n"
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -142,8 +142,7 @@ class CommonLisp(metaclass=HasFormatEnums):
         self.element_separator = " "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -206,8 +206,7 @@ class Cpp(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -157,8 +157,7 @@ class Crystal(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -203,8 +203,7 @@ class CSharp(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -202,8 +202,7 @@ class D(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -205,8 +205,7 @@ class Dart(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -161,8 +161,7 @@ class Elixir(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -169,8 +169,7 @@ class Erlang(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -256,8 +256,7 @@ class Fortran(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -198,8 +198,7 @@ class FSharp(metaclass=HasFormatEnums):
         self.multiline_close_indent = ""
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -214,8 +214,7 @@ class Go(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -141,8 +141,7 @@ class Groovy(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -191,8 +191,7 @@ class Haskell(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -143,8 +143,7 @@ class Hcl(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -198,8 +198,7 @@ class Java(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = True
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -157,8 +157,7 @@ class JavaScript(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -164,8 +164,7 @@ class Julia(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -222,8 +222,7 @@ class Kotlin(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -157,8 +157,7 @@ class Lua(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = True
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -211,8 +211,7 @@ class Matlab(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -160,8 +160,7 @@ class Mojo(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = True
-        self.coerce_heterogeneous_dict_values_to_strings = True
-        self.coerce_heterogeneous_list_values_to_strings = True
+        self.coerce_heterogeneous_collection_values_to_strings = True
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -141,8 +141,7 @@ class Nim(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -157,8 +157,7 @@ class Norg(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -212,8 +212,7 @@ class ObjectiveC(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -202,8 +202,7 @@ class OCaml(metaclass=HasFormatEnums):
         self.multiline_close_indent = ""
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -191,8 +191,7 @@ class Occam(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -141,8 +141,7 @@ class Perl(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -157,8 +157,7 @@ class Php(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -167,8 +167,7 @@ class PowerShell(metaclass=HasFormatEnums):
         self.element_separator = "; "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -287,8 +287,7 @@ class Python(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration_inline_hint

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -207,8 +207,7 @@ class R(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -141,8 +141,7 @@ class Racket(metaclass=HasFormatEnums):
         self.element_separator = " "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -157,8 +157,7 @@ class Ruby(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -195,10 +195,7 @@ class Rust(metaclass=HasFormatEnums):
         self.coerce_heterogeneous_scalars_to_strings: bool = (
             sequence_format != Rust.sequence_formats.TUPLE
         )
-        self.coerce_heterogeneous_dict_values_to_strings: bool = (
-            sequence_format != Rust.sequence_formats.TUPLE
-        )
-        self.coerce_heterogeneous_list_values_to_strings: bool = (
+        self.coerce_heterogeneous_collection_values_to_strings: bool = (
             sequence_format != Rust.sequence_formats.TUPLE
         )
         self.supports_collection_comments = True

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -193,8 +193,7 @@ class Scala(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -147,8 +147,7 @@ class Swift(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -195,8 +195,7 @@ class Toml(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = True
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -157,8 +157,7 @@ class TypeScript(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -187,8 +187,7 @@ class VisualBasic(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = False
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -168,8 +168,7 @@ class Yaml(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -178,8 +178,7 @@ class Zig(metaclass=HasFormatEnums):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.coerce_heterogeneous_scalars_to_strings = False
-        self.coerce_heterogeneous_dict_values_to_strings = False
-        self.coerce_heterogeneous_list_values_to_strings = False
+        self.coerce_heterogeneous_collection_values_to_strings = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str], str] = (
             _format_variable_declaration


### PR DESCRIPTION
## Summary
- Merges `coerce_heterogeneous_dict_values_to_strings` and `coerce_heterogeneous_list_values_to_strings` into a single `coerce_heterogeneous_collection_values_to_strings` property
- Both properties always had the same value across all languages, so no behavior change

Closes #417

## Test plan
- [x] All 291 existing tests pass
- [x] All pre-commit hooks pass (mypy, pyright, ruff, vulture, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional risk (flags were always set identically), but this is a public API/Protocol rename that can break downstream custom `Language` implementations expecting the old `coerce_heterogeneous_*` attributes.
> 
> **Overview**
> **Simplifies heterogeneous coercion configuration** by replacing `coerce_heterogeneous_dict_values_to_strings` and `coerce_heterogeneous_list_values_to_strings` with a single `coerce_heterogeneous_collection_values_to_strings` flag on the `Language` protocol and all built-in language specs.
> 
> Core coercion now checks only this unified flag when deciding whether to stringify mixed *type-family* dict values and list elements (no intended behavior change, but downstream custom languages must rename the attribute).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c82b730132694c39297a6db00fe76b6b032f057d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->