### PR TITLE
Add default values to language __init__ format params

### DIFF
--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -150,10 +150,10 @@ class Ada(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Ada language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -126,10 +126,10 @@ class Bash(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Bash language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -135,10 +135,10 @@ class C(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize C language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -92,10 +92,10 @@ class Clojure(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.VECTOR,
     ) -> None:
         """Initialize Clojure language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -267,10 +267,10 @@ class Cobol(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.SEQUENCE,
     ) -> None:
         """Initialize COBOL language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -97,10 +97,10 @@ class CommonLisp(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Common Lisp language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -154,10 +154,10 @@ class Cpp(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.CPP,
+        datetime_format: DatetimeFormats = DatetimeFormats.CPP,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.INITIALIZER_LIST,
     ) -> None:
         """Initialize Cpp language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -102,10 +102,10 @@ class Crystal(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Crystal language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -151,10 +151,10 @@ class CSharp(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.CSHARP,
+        datetime_format: DatetimeFormats = DatetimeFormats.CSHARP,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize CSharp language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -153,10 +153,10 @@ class D(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize D language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -152,10 +152,10 @@ class Dart(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.DART,
+        datetime_format: DatetimeFormats = DatetimeFormats.DART,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Dart language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -108,10 +108,10 @@ class Elixir(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Elixir language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -116,10 +116,10 @@ class Erlang(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.BINARY,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Erlang language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -209,10 +209,10 @@ class Fortran(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Fortran language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -153,10 +153,10 @@ class FSharp(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize FSharp language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -162,10 +162,10 @@ class Go(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.GO,
+        datetime_format: DatetimeFormats = DatetimeFormats.GO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.SLICE,
     ) -> None:
         """Initialize Go language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -92,10 +92,10 @@ class Groovy(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Groovy language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -142,10 +142,10 @@ class Haskell(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Haskell language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -94,10 +94,10 @@ class Hcl(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize HCL language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -148,10 +148,10 @@ class Java(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.JAVA,
+        datetime_format: DatetimeFormats = DatetimeFormats.INSTANT,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Java language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -107,10 +107,10 @@ class JavaScript(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.JS,
+        datetime_format: DatetimeFormats = DatetimeFormats.JS,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize JavaScript language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -109,10 +109,10 @@ class Julia(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.JULIA,
+        datetime_format: DatetimeFormats = DatetimeFormats.JULIA,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Julia language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -168,10 +168,10 @@ class Kotlin(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.KOTLIN,
+        datetime_format: DatetimeFormats = DatetimeFormats.KOTLIN,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Kotlin language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -108,10 +108,10 @@ class Lua(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.TABLE,
     ) -> None:
         """Initialize Lua language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -162,10 +162,10 @@ class Matlab(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.CELL_ARRAY,
     ) -> None:
         """Initialize Matlab language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -111,10 +111,10 @@ class Mojo(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Mojo language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -92,10 +92,10 @@ class Nim(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Nim language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -108,10 +108,10 @@ class Norg(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Norg language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -165,10 +165,10 @@ class ObjectiveC(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.OBJC,
+        datetime_format: DatetimeFormats = DatetimeFormats.OBJC,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Objective-C language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -157,10 +157,10 @@ class OCaml(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize OCaml language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -142,10 +142,10 @@ class Occam(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Occam language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -92,10 +92,10 @@ class Perl(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Perl language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -108,10 +108,10 @@ class Php(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.PHP,
+        datetime_format: DatetimeFormats = DatetimeFormats.PHP,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Php language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -118,10 +118,10 @@ class PowerShell(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize PowerShell language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -220,12 +220,12 @@ class Python(metaclass=HasFormatEnums):
     def __init__(  # noqa: PLR0915  # pylint: disable=too-many-statements
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
-        set_format: SetFormats,
-        variable_type_hints: VariableTypeHints,
+        date_format: DateFormats = DateFormats.PYTHON,
+        datetime_format: DatetimeFormats = DatetimeFormats.PYTHON,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.TUPLE,
+        set_format: SetFormats = SetFormats.SET,
+        variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
     ) -> None:
         """Initialize Python language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -159,11 +159,11 @@ class R(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        empty_dict_key: EmptyDictKey,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.R,
+        datetime_format: DatetimeFormats = DatetimeFormats.R,
+        empty_dict_key: EmptyDictKey = EmptyDictKey.POSITIONAL,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize R language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -92,10 +92,10 @@ class Racket(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Racket language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -107,10 +107,10 @@ class Ruby(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.RUBY,
+        datetime_format: DatetimeFormats = DatetimeFormats.RUBY,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Ruby language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -132,10 +132,10 @@ class Rust(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.RUST,
+        datetime_format: DatetimeFormats = DatetimeFormats.RUST,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.VEC,
     ) -> None:
         """Initialize Rust language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -142,10 +142,10 @@ class Scala(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
     ) -> None:
         """Initialize Scala language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -98,10 +98,10 @@ class Swift(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Swift language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -146,10 +146,10 @@ class Toml(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.TOML,
+        datetime_format: DatetimeFormats = DatetimeFormats.TOML,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize TOML language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -107,10 +107,10 @@ class TypeScript(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.JS,
+        datetime_format: DatetimeFormats = DatetimeFormats.JS,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize TypeScript language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -137,10 +137,10 @@ class VisualBasic(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize VisualBasic language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -119,10 +119,10 @@ class Yaml(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.YAML,
+        datetime_format: DatetimeFormats = DatetimeFormats.YAML,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.SEQUENCE,
     ) -> None:
         """Initialize YAML language specification."""
         self.sequence_format = sequence_format

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -129,10 +129,10 @@ class Zig(metaclass=HasFormatEnums):
     def __init__(
         self,
         *,
-        date_format: DateFormats,
-        datetime_format: DatetimeFormats,
-        bytes_format: BytesFormats,
-        sequence_format: SequenceFormats,
+        date_format: DateFormats = DateFormats.ISO,
+        datetime_format: DatetimeFormats = DatetimeFormats.ISO,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.ARRAY,
     ) -> None:
         """Initialize Zig language specification."""
         self.sequence_format = sequence_format

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -153,9 +153,6 @@ var x = {content};"""
 def _rust_array_spec() -> literalizer.languages.Rust:
     """Create a Rust spec for array format."""
     return literalizer.languages.Rust(
-        date_format=literalizer.languages.Rust.date_formats.RUST,
-        datetime_format=literalizer.languages.Rust.datetime_formats.RUST,
-        bytes_format=literalizer.languages.Rust.bytes_formats.HEX,
         sequence_format=literalizer.languages.Rust.sequence_formats.ARRAY,
     )
 
@@ -246,12 +243,7 @@ _OCCAM_LIT_TYPE = (
 @beartype
 def _wrap_fsharp(content: str) -> str:
     """Wrap in an F# module with a custom Val discriminated union."""
-    fsharp = literalizer.languages.FSharp(
-        date_format=literalizer.languages.FSharp.date_formats.ISO,
-        datetime_format=literalizer.languages.FSharp.datetime_formats.ISO,
-        bytes_format=literalizer.languages.FSharp.bytes_formats.HEX,
-        sequence_format=literalizer.languages.FSharp.sequence_formats.LIST,
-    )
+    fsharp = literalizer.languages.FSharp()
     typed = fsharp.format_sequence_entry(content)
     return (
         "module Check\n\n" + _FSHARP_VAL_TYPE + "\n" + f"let x: Val = {typed}"
@@ -261,12 +253,7 @@ def _wrap_fsharp(content: str) -> str:
 @beartype
 def _wrap_ocaml(content: str) -> str:
     """Wrap in an OCaml module with a custom val_t variant type."""
-    ocaml = literalizer.languages.OCaml(
-        date_format=literalizer.languages.OCaml.date_formats.ISO,
-        datetime_format=literalizer.languages.OCaml.datetime_formats.ISO,
-        bytes_format=literalizer.languages.OCaml.bytes_formats.HEX,
-        sequence_format=literalizer.languages.OCaml.sequence_formats.LIST,
-    )
+    ocaml = literalizer.languages.OCaml()
     typed = ocaml.format_sequence_entry(content)
     return (
         "module Check = struct\n\n"
@@ -294,12 +281,7 @@ def _wrap_ocaml_varname(content: str) -> str:
 @beartype
 def _wrap_occam(content: str) -> str:
     """Wrap in an occam-pi PROC with a custom ``LIT`` mobile data type."""
-    occam = literalizer.languages.Occam(
-        date_format=literalizer.languages.Occam.date_formats.ISO,
-        datetime_format=literalizer.languages.Occam.datetime_formats.ISO,
-        bytes_format=literalizer.languages.Occam.bytes_formats.HEX,
-        sequence_format=literalizer.languages.Occam.sequence_formats.LIST,
-    )
+    occam = literalizer.languages.Occam()
     typed = occam.format_sequence_entry(content)
     return (
         _OCCAM_LIT_TYPE
@@ -611,12 +593,7 @@ def _wrap_groovy(content: str) -> str:
 @beartype
 def _wrap_ada(content: str) -> str:
     """Wrap in an Ada procedure with a local variable assignment."""
-    ada = literalizer.languages.Ada(
-        date_format=literalizer.languages.Ada.date_formats.ISO,
-        datetime_format=literalizer.languages.Ada.datetime_formats.ISO,
-        bytes_format=literalizer.languages.Ada.bytes_formats.HEX,
-        sequence_format=literalizer.languages.Ada.sequence_formats.LIST,
-    )
+    ada = literalizer.languages.Ada()
     typed = ada.format_sequence_entry(content)
     indented = typed.replace("\n", "\n   ")
     return (
@@ -697,12 +674,7 @@ def _wrap_norg(content: str) -> str:
 @beartype
 def _wrap_d(content: str) -> str:
     """Wrap in a D function with ``std.json`` imported."""
-    d_lang = literalizer.languages.D(
-        date_format=literalizer.languages.D.date_formats.ISO,
-        datetime_format=literalizer.languages.D.datetime_formats.ISO,
-        bytes_format=literalizer.languages.D.bytes_formats.HEX,
-        sequence_format=literalizer.languages.D.sequence_formats.ARRAY,
-    )
+    d_lang = literalizer.languages.D()
     typed = d_lang.format_sequence_entry(content)
     return f"import std.json;\n\nvoid _check() {{\n    auto _v = {typed};\n}}"
 
@@ -756,12 +728,7 @@ _C_PREAMBLE = (
 @beartype
 def _wrap_c(content: str) -> str:
     """Wrap in a C function with the _CVal/_CKV type definitions."""
-    c_lang = literalizer.languages.C(
-        date_format=literalizer.languages.C.date_formats.ISO,
-        datetime_format=literalizer.languages.C.datetime_formats.ISO,
-        bytes_format=literalizer.languages.C.bytes_formats.HEX,
-        sequence_format=literalizer.languages.C.sequence_formats.ARRAY,
-    )
+    c_lang = literalizer.languages.C()
     typed = c_lang.format_sequence_entry(content)
     return (
         _C_PREAMBLE
@@ -986,12 +953,7 @@ def _wrap_zig(content: str) -> str:
     """Wrap in a Zig main function with ``ZVal``/``ZKV`` type
     definitions.
     """
-    zig = literalizer.languages.Zig(
-        date_format=literalizer.languages.Zig.date_formats.ISO,
-        datetime_format=literalizer.languages.Zig.datetime_formats.ISO,
-        bytes_format=literalizer.languages.Zig.bytes_formats.HEX,
-        sequence_format=literalizer.languages.Zig.sequence_formats.ARRAY,
-    )
+    zig = literalizer.languages.Zig()
     typed = zig.format_sequence_entry(content)
     indented = typed.replace("\n", "\n    ")
     return (
@@ -1220,12 +1182,7 @@ def _wrap_fortran(content: str) -> str:
     """Wrap in a self-contained Fortran program with the ``fval_m``
     module embedded.
     """
-    fortran = literalizer.languages.Fortran(
-        date_format=literalizer.languages.Fortran.date_formats.ISO,
-        datetime_format=literalizer.languages.Fortran.datetime_formats.ISO,
-        bytes_format=literalizer.languages.Fortran.bytes_formats.HEX,
-        sequence_format=literalizer.languages.Fortran.sequence_formats.LIST,
-    )
+    fortran = literalizer.languages.Fortran()
     typed = fortran.format_sequence_entry(content)
     continued = _add_fortran_continuation(content=typed)
     return (
@@ -1548,12 +1505,7 @@ def _wrap_cobol(content: str) -> str:
         data_body = stripped
     else:
         # Scalar literal - convert to a DATA entry
-        cobol = literalizer.languages.Cobol(
-            date_format=literalizer.languages.Cobol.date_formats.ISO,
-            datetime_format=literalizer.languages.Cobol.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Cobol.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Cobol.sequence_formats.SEQUENCE,
-        )
+        cobol = literalizer.languages.Cobol()
         entry = cobol.format_sequence_entry(scalar)
         data_body = f"    {entry}"
     return (
@@ -1585,555 +1537,322 @@ def _wrap_cobol_combined(declaration: str, assignment: str) -> str:
 
 _LANGUAGES: dict[str, _LanguageConfig] = {
     "ada": _LanguageConfig(
-        spec=literalizer.languages.Ada(
-            date_format=literalizer.languages.Ada.date_formats.ISO,
-            datetime_format=literalizer.languages.Ada.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Ada.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Ada.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Ada(),
         extension=".adb",
         wrap=_wrap_ada,
         varname_wrap=_wrap_ada_varname,
         combined_wrap=_wrap_ada_combined,
     ),
     "bash": _LanguageConfig(
-        spec=literalizer.languages.Bash(
-            date_format=literalizer.languages.Bash.date_formats.ISO,
-            datetime_format=literalizer.languages.Bash.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Bash.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Bash.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Bash(),
         extension=".sh",
         wrap=_wrap_bash,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "c": _LanguageConfig(
-        spec=literalizer.languages.C(
-            date_format=literalizer.languages.C.date_formats.ISO,
-            datetime_format=literalizer.languages.C.datetime_formats.ISO,
-            bytes_format=literalizer.languages.C.bytes_formats.HEX,
-            sequence_format=literalizer.languages.C.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.C(),
         extension=".c",
         wrap=_wrap_c,
         varname_wrap=_wrap_c_varname,
         combined_wrap=_wrap_c_combined,
     ),
     "cobol": _LanguageConfig(
-        spec=literalizer.languages.Cobol(
-            date_format=literalizer.languages.Cobol.date_formats.ISO,
-            datetime_format=literalizer.languages.Cobol.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Cobol.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Cobol.sequence_formats.SEQUENCE,
-        ),
+        spec=literalizer.languages.Cobol(),
         extension=".cob",
         wrap=_wrap_cobol,
         varname_wrap=_wrap_cobol_varname,
         combined_wrap=_wrap_cobol_combined,
     ),
     "d": _LanguageConfig(
-        spec=literalizer.languages.D(
-            date_format=literalizer.languages.D.date_formats.ISO,
-            datetime_format=literalizer.languages.D.datetime_formats.ISO,
-            bytes_format=literalizer.languages.D.bytes_formats.HEX,
-            sequence_format=literalizer.languages.D.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.D(),
         extension=".d",
         wrap=_wrap_d,
         varname_wrap=_wrap_d_varname,
         combined_wrap=_wrap_d_combined,
     ),
     "common_lisp": _LanguageConfig(
-        spec=literalizer.languages.CommonLisp(
-            date_format=literalizer.languages.CommonLisp.date_formats.ISO,
-            datetime_format=literalizer.languages.CommonLisp.datetime_formats.ISO,
-            bytes_format=literalizer.languages.CommonLisp.bytes_formats.HEX,
-            sequence_format=literalizer.languages.CommonLisp.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.CommonLisp(),
         extension=".lisp",
         wrap=_wrap_identity,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "clojure": _LanguageConfig(
-        spec=literalizer.languages.Clojure(
-            date_format=literalizer.languages.Clojure.date_formats.ISO,
-            datetime_format=literalizer.languages.Clojure.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Clojure.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Clojure.sequence_formats.VECTOR,
-        ),
+        spec=literalizer.languages.Clojure(),
         extension=".clj",
         wrap=_wrap_identity,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "python": _LanguageConfig(
-        spec=literalizer.languages.Python(
-            date_format=literalizer.languages.Python.date_formats.PYTHON,
-            datetime_format=literalizer.languages.Python.datetime_formats.PYTHON,
-            bytes_format=literalizer.languages.Python.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Python.sequence_formats.TUPLE,
-            set_format=literalizer.languages.Python.set_formats.SET,
-            variable_type_hints=literalizer.languages.Python.VariableTypeHints.NONE,
-        ),
+        spec=literalizer.languages.Python(),
         extension=".py",
         wrap=_wrap_python,
         varname_wrap=_wrap_python,
         combined_wrap=_wrap_python_combined,
     ),
     "javascript": _LanguageConfig(
-        spec=literalizer.languages.JavaScript(
-            date_format=literalizer.languages.JavaScript.date_formats.JS,
-            datetime_format=literalizer.languages.JavaScript.datetime_formats.JS,
-            bytes_format=literalizer.languages.JavaScript.bytes_formats.HEX,
-            sequence_format=literalizer.languages.JavaScript.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.JavaScript(),
         extension=".js",
         wrap=_wrap_js,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_js_combined,
     ),
     "typescript": _LanguageConfig(
-        spec=literalizer.languages.TypeScript(
-            date_format=literalizer.languages.TypeScript.date_formats.JS,
-            datetime_format=literalizer.languages.TypeScript.datetime_formats.JS,
-            bytes_format=literalizer.languages.TypeScript.bytes_formats.HEX,
-            sequence_format=literalizer.languages.TypeScript.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.TypeScript(),
         extension=".ts",
         wrap=_wrap_js,
         varname_wrap=_wrap_ts_varname,
         combined_wrap=_wrap_ts_combined,
     ),
     "kotlin": _LanguageConfig(
-        spec=literalizer.languages.Kotlin(
-            date_format=literalizer.languages.Kotlin.date_formats.KOTLIN,
-            datetime_format=literalizer.languages.Kotlin.datetime_formats.KOTLIN,
-            bytes_format=literalizer.languages.Kotlin.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Kotlin.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Kotlin(),
         extension=".kts",
         wrap=_wrap_kotlin,
         varname_wrap=_wrap_kotlin_varname,
         combined_wrap=_wrap_kotlin_combined,
     ),
     "ruby": _LanguageConfig(
-        spec=literalizer.languages.Ruby(
-            date_format=literalizer.languages.Ruby.date_formats.RUBY,
-            datetime_format=literalizer.languages.Ruby.datetime_formats.RUBY,
-            bytes_format=literalizer.languages.Ruby.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Ruby.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Ruby(),
         extension=".rb",
         wrap=_wrap_ruby,
         varname_wrap=_wrap_ruby,
         combined_wrap=lambda d, a: _wrap_ruby(content=d + "\n" + a),
     ),
     "go": _LanguageConfig(
-        spec=literalizer.languages.Go(
-            date_format=literalizer.languages.Go.date_formats.GO,
-            datetime_format=literalizer.languages.Go.datetime_formats.GO,
-            bytes_format=literalizer.languages.Go.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Go.sequence_formats.SLICE,
-        ),
+        spec=literalizer.languages.Go(),
         extension=".go",
         wrap=_wrap_go,
         varname_wrap=_wrap_go_varname,
         combined_wrap=lambda d, a: _wrap_go_varname(content=d + "\n" + a),
     ),
     "java": _LanguageConfig(
-        spec=literalizer.languages.Java(
-            date_format=literalizer.languages.Java.date_formats.JAVA,
-            datetime_format=literalizer.languages.Java.datetime_formats.INSTANT,
-            bytes_format=literalizer.languages.Java.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Java.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Java(),
         extension=".java",
         wrap=_wrap_java,
         varname_wrap=_wrap_java_varname,
         combined_wrap=lambda d, a: _wrap_java_varname(content=d + "\n" + a),
     ),
     "csharp": _LanguageConfig(
-        spec=literalizer.languages.CSharp(
-            date_format=literalizer.languages.CSharp.date_formats.CSHARP,
-            datetime_format=literalizer.languages.CSharp.datetime_formats.CSHARP,
-            bytes_format=literalizer.languages.CSharp.bytes_formats.HEX,
-            sequence_format=literalizer.languages.CSharp.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.CSharp(),
         extension=".cs",
         wrap=_wrap_csharp,
         varname_wrap=_wrap_csharp_varname,
         combined_wrap=lambda d, a: _wrap_csharp_varname(content=d + "\n" + a),
     ),
     "dart": _LanguageConfig(
-        spec=literalizer.languages.Dart(
-            date_format=literalizer.languages.Dart.date_formats.DART,
-            datetime_format=literalizer.languages.Dart.datetime_formats.DART,
-            bytes_format=literalizer.languages.Dart.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Dart.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Dart(),
         extension=".dart",
         wrap=_wrap_dart,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_dart_combined,
     ),
     "swift": _LanguageConfig(
-        spec=literalizer.languages.Swift(
-            date_format=literalizer.languages.Swift.date_formats.ISO,
-            datetime_format=literalizer.languages.Swift.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Swift.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Swift.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Swift(),
         extension=".swift",
         wrap=_wrap_swift,
         varname_wrap=_wrap_swift_varname,
         combined_wrap=_wrap_swift_combined,
     ),
     "cpp": _LanguageConfig(
-        spec=literalizer.languages.Cpp(
-            date_format=literalizer.languages.Cpp.date_formats.CPP,
-            datetime_format=literalizer.languages.Cpp.datetime_formats.CPP,
-            bytes_format=literalizer.languages.Cpp.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Cpp.sequence_formats.INITIALIZER_LIST,
-        ),
+        spec=literalizer.languages.Cpp(),
         extension=".cpp",
         wrap=_wrap_cpp,
         varname_wrap=_wrap_cpp_varname,
         combined_wrap=lambda d, a: _wrap_cpp_varname(content=d + "\n" + a),
     ),
     "rust": _LanguageConfig(
-        spec=literalizer.languages.Rust(
-            date_format=literalizer.languages.Rust.date_formats.RUST,
-            datetime_format=literalizer.languages.Rust.datetime_formats.RUST,
-            bytes_format=literalizer.languages.Rust.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Rust.sequence_formats.VEC,
-        ),
+        spec=literalizer.languages.Rust(),
         extension=".rs",
         wrap=_wrap_rust,
         varname_wrap=_wrap_rust_varname,
         combined_wrap=_wrap_rust_combined,
     ),
     "haskell": _LanguageConfig(
-        spec=literalizer.languages.Haskell(
-            date_format=literalizer.languages.Haskell.date_formats.ISO,
-            datetime_format=literalizer.languages.Haskell.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Haskell.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Haskell.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Haskell(),
         extension=".hs",
         wrap=_wrap_haskell,
         varname_wrap=_wrap_haskell_varname,
         combined_wrap=lambda d, _a: _wrap_haskell_varname(content=d),
     ),
     "hcl": _LanguageConfig(
-        spec=literalizer.languages.Hcl(
-            date_format=literalizer.languages.Hcl.date_formats.ISO,
-            datetime_format=literalizer.languages.Hcl.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Hcl.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Hcl.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Hcl(),
         extension=".hcl",
         wrap=_wrap_hcl,
         varname_wrap=_wrap_identity,
         combined_wrap=lambda d, _a: d,
     ),
     "julia": _LanguageConfig(
-        spec=literalizer.languages.Julia(
-            date_format=literalizer.languages.Julia.date_formats.JULIA,
-            datetime_format=literalizer.languages.Julia.datetime_formats.JULIA,
-            bytes_format=literalizer.languages.Julia.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Julia.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Julia(),
         extension=".jl",
         wrap=_wrap_julia,
         varname_wrap=_wrap_julia,
         combined_wrap=lambda d, a: _wrap_julia(content=d + "\n" + a),
     ),
     "lua": _LanguageConfig(
-        spec=literalizer.languages.Lua(
-            date_format=literalizer.languages.Lua.date_formats.ISO,
-            datetime_format=literalizer.languages.Lua.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Lua.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Lua.sequence_formats.TABLE,
-        ),
+        spec=literalizer.languages.Lua(),
         extension=".lua",
         wrap=_wrap_lua,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "perl": _LanguageConfig(
-        spec=literalizer.languages.Perl(
-            date_format=literalizer.languages.Perl.date_formats.ISO,
-            datetime_format=literalizer.languages.Perl.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Perl.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Perl.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Perl(),
         extension=".pl",
         wrap=_wrap_perl,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "php": _LanguageConfig(
-        spec=literalizer.languages.Php(
-            date_format=literalizer.languages.Php.date_formats.PHP,
-            datetime_format=literalizer.languages.Php.datetime_formats.PHP,
-            bytes_format=literalizer.languages.Php.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Php.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Php(),
         extension=".php",
         wrap=_wrap_php,
         varname_wrap=_wrap_php_varname,
         combined_wrap=lambda d, a: _wrap_php_varname(content=d + "\n" + a),
     ),
     "elixir": _LanguageConfig(
-        spec=literalizer.languages.Elixir(
-            date_format=literalizer.languages.Elixir.date_formats.ISO,
-            datetime_format=literalizer.languages.Elixir.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Elixir.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Elixir.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Elixir(),
         extension=".ex",
         wrap=_wrap_elixir,
         varname_wrap=_wrap_elixir_varname,
         combined_wrap=lambda d, _a: _wrap_elixir_varname(content=d),
     ),
     "erlang": _LanguageConfig(
-        spec=literalizer.languages.Erlang(
-            date_format=literalizer.languages.Erlang.date_formats.ISO,
-            datetime_format=literalizer.languages.Erlang.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Erlang.bytes_formats.BINARY,
-            sequence_format=literalizer.languages.Erlang.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Erlang(),
         extension=".erl",
         wrap=_wrap_erlang,
         varname_wrap=_wrap_erlang_varname,
         combined_wrap=lambda d, _a: _wrap_erlang_varname(content=d),
     ),
     "fsharp": _LanguageConfig(
-        spec=literalizer.languages.FSharp(
-            date_format=literalizer.languages.FSharp.date_formats.ISO,
-            datetime_format=literalizer.languages.FSharp.datetime_formats.ISO,
-            bytes_format=literalizer.languages.FSharp.bytes_formats.HEX,
-            sequence_format=literalizer.languages.FSharp.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.FSharp(),
         extension=".fs",
         wrap=_wrap_fsharp,
         varname_wrap=_wrap_fsharp_varname,
         combined_wrap=lambda d, _a: _wrap_fsharp_varname(content=d),
     ),
     "ocaml": _LanguageConfig(
-        spec=literalizer.languages.OCaml(
-            date_format=literalizer.languages.OCaml.date_formats.ISO,
-            datetime_format=literalizer.languages.OCaml.datetime_formats.ISO,
-            bytes_format=literalizer.languages.OCaml.bytes_formats.HEX,
-            sequence_format=literalizer.languages.OCaml.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.OCaml(),
         extension=".ml",
         wrap=_wrap_ocaml,
         varname_wrap=_wrap_ocaml_varname,
         combined_wrap=lambda d, _a: _wrap_ocaml_varname(content=d),
     ),
     "occam": _LanguageConfig(
-        spec=literalizer.languages.Occam(
-            date_format=literalizer.languages.Occam.date_formats.ISO,
-            datetime_format=literalizer.languages.Occam.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Occam.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Occam.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Occam(),
         extension=".occ",
         wrap=_wrap_occam,
         varname_wrap=_wrap_occam_varname,
         combined_wrap=lambda d, _a: _wrap_occam_varname(content=d),
     ),
     "groovy": _LanguageConfig(
-        spec=literalizer.languages.Groovy(
-            date_format=literalizer.languages.Groovy.date_formats.ISO,
-            datetime_format=literalizer.languages.Groovy.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Groovy.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Groovy.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Groovy(),
         extension=".groovy",
         wrap=_wrap_groovy,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "scala": _LanguageConfig(
-        spec=literalizer.languages.Scala(
-            date_format=literalizer.languages.Scala.date_formats.ISO,
-            datetime_format=literalizer.languages.Scala.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Scala.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Scala.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Scala(),
         extension=".scala",
         wrap=_wrap_scala,
         varname_wrap=_wrap_scala_varname,
         combined_wrap=_wrap_scala_combined,
     ),
     "r": _LanguageConfig(
-        spec=literalizer.languages.R(
-            date_format=literalizer.languages.R.date_formats.R,
-            datetime_format=literalizer.languages.R.datetime_formats.R,
-            empty_dict_key=literalizer.languages.R.EmptyDictKey.POSITIONAL,
-            bytes_format=literalizer.languages.R.bytes_formats.HEX,
-            sequence_format=literalizer.languages.R.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.R(),
         extension=".R",
         wrap=_wrap_r,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "racket": _LanguageConfig(
-        spec=literalizer.languages.Racket(
-            date_format=literalizer.languages.Racket.date_formats.ISO,
-            datetime_format=literalizer.languages.Racket.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Racket.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Racket.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Racket(),
         extension=".rkt",
         wrap=_wrap_racket,
         varname_wrap=_wrap_racket,
         combined_wrap=_wrap_racket_combined,
     ),
     "crystal": _LanguageConfig(
-        spec=literalizer.languages.Crystal(
-            date_format=literalizer.languages.Crystal.date_formats.ISO,
-            datetime_format=literalizer.languages.Crystal.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Crystal.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Crystal.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Crystal(),
         extension=".cr",
         wrap=_wrap_crystal,
         varname_wrap=_wrap_crystal_varname,
         combined_wrap=_wrap_crystal_combined,
     ),
     "matlab": _LanguageConfig(
-        spec=literalizer.languages.Matlab(
-            date_format=literalizer.languages.Matlab.date_formats.ISO,
-            datetime_format=literalizer.languages.Matlab.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Matlab.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Matlab.sequence_formats.CELL_ARRAY,
-        ),
+        spec=literalizer.languages.Matlab(),
         extension=".m",
         wrap=_wrap_matlab,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "mojo": _LanguageConfig(
-        spec=literalizer.languages.Mojo(
-            date_format=literalizer.languages.Mojo.date_formats.ISO,
-            datetime_format=literalizer.languages.Mojo.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Mojo.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Mojo.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Mojo(),
         extension=".mojo",
         wrap=_wrap_mojo,
         varname_wrap=_wrap_mojo_varname,
         combined_wrap=_wrap_mojo_combined,
     ),
     "nim": _LanguageConfig(
-        spec=literalizer.languages.Nim(
-            date_format=literalizer.languages.Nim.date_formats.ISO,
-            datetime_format=literalizer.languages.Nim.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Nim.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Nim.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Nim(),
         extension=".nim",
         wrap=_wrap_nim,
         varname_wrap=_wrap_nim_varname,
         combined_wrap=_wrap_nim_combined,
     ),
     "norg": _LanguageConfig(
-        spec=literalizer.languages.Norg(
-            date_format=literalizer.languages.Norg.date_formats.ISO,
-            datetime_format=literalizer.languages.Norg.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Norg.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Norg.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Norg(),
         extension=".norg",
         wrap=_wrap_norg,
         varname_wrap=_wrap_identity,
         combined_wrap=lambda d, _a: d,
     ),
     "vb": _LanguageConfig(
-        spec=literalizer.languages.VisualBasic(
-            date_format=literalizer.languages.VisualBasic.date_formats.ISO,
-            datetime_format=literalizer.languages.VisualBasic.datetime_formats.ISO,
-            bytes_format=literalizer.languages.VisualBasic.bytes_formats.HEX,
-            sequence_format=literalizer.languages.VisualBasic.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.VisualBasic(),
         extension=".vb",
         wrap=_wrap_vb,
         varname_wrap=_wrap_vb_varname,
         combined_wrap=_wrap_vb_combined,
     ),
     "zig": _LanguageConfig(
-        spec=literalizer.languages.Zig(
-            date_format=literalizer.languages.Zig.date_formats.ISO,
-            datetime_format=literalizer.languages.Zig.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Zig.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Zig.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Zig(),
         extension=".zig",
         wrap=_wrap_zig,
         varname_wrap=_wrap_zig_varname,
         combined_wrap=_wrap_zig_combined,
     ),
     "powershell": _LanguageConfig(
-        spec=literalizer.languages.PowerShell(
-            date_format=literalizer.languages.PowerShell.date_formats.ISO,
-            datetime_format=literalizer.languages.PowerShell.datetime_formats.ISO,
-            bytes_format=literalizer.languages.PowerShell.bytes_formats.HEX,
-            sequence_format=literalizer.languages.PowerShell.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.PowerShell(),
         extension=".ps1",
         wrap=_wrap_powershell,
         varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     "toml": _LanguageConfig(
-        spec=literalizer.languages.Toml(
-            date_format=literalizer.languages.Toml.date_formats.TOML,
-            datetime_format=literalizer.languages.Toml.datetime_formats.TOML,
-            bytes_format=literalizer.languages.Toml.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Toml.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Toml(),
         extension=".toml",
         wrap=_wrap_toml,
         varname_wrap=_wrap_identity,
         combined_wrap=lambda d, _a: d,
     ),
     "objective_c": _LanguageConfig(
-        spec=literalizer.languages.ObjectiveC(
-            date_format=literalizer.languages.ObjectiveC.date_formats.OBJC,
-            datetime_format=literalizer.languages.ObjectiveC.datetime_formats.OBJC,
-            bytes_format=literalizer.languages.ObjectiveC.bytes_formats.HEX,
-            sequence_format=literalizer.languages.ObjectiveC.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.ObjectiveC(),
         extension=".m",
         wrap=_wrap_objc,
         varname_wrap=_wrap_objc_varname,
         combined_wrap=_wrap_objc_combined,
     ),
     "fortran": _LanguageConfig(
-        spec=literalizer.languages.Fortran(
-            date_format=literalizer.languages.Fortran.date_formats.ISO,
-            datetime_format=literalizer.languages.Fortran.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Fortran.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Fortran.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Fortran(),
         extension=".f90",
         wrap=_wrap_fortran,
         varname_wrap=_wrap_fortran_varname,
         combined_wrap=_wrap_fortran_combined,
     ),
     "yaml": _LanguageConfig(
-        spec=literalizer.languages.Yaml(
-            date_format=literalizer.languages.Yaml.date_formats.YAML,
-            datetime_format=literalizer.languages.Yaml.datetime_formats.YAML,
-            bytes_format=literalizer.languages.Yaml.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Yaml.sequence_formats.SEQUENCE,
-        ),
+        spec=literalizer.languages.Yaml(),
         extension=".yaml",
         wrap=_wrap_identity,
         varname_wrap=_wrap_identity,
@@ -2144,157 +1863,81 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
 
 _DATE_VARIANTS: dict[str, _Variant] = {
     "python_native": _Variant(
-        spec=literalizer.languages.Python(
-            date_format=literalizer.languages.Python.date_formats.PYTHON,
-            datetime_format=literalizer.languages.Python.datetime_formats.PYTHON,
-            bytes_format=literalizer.languages.Python.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Python.sequence_formats.TUPLE,
-            set_format=literalizer.languages.Python.set_formats.SET,
-            variable_type_hints=literalizer.languages.Python.VariableTypeHints.NONE,
-        ),
+        spec=literalizer.languages.Python(),
         extension=".py",
         wrap=_wrap_python,
     ),
     "python_epoch": _Variant(
         spec=literalizer.languages.Python(
-            date_format=literalizer.languages.Python.date_formats.PYTHON,
             datetime_format=literalizer.languages.Python.datetime_formats.EPOCH,
-            bytes_format=literalizer.languages.Python.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Python.sequence_formats.TUPLE,
-            set_format=literalizer.languages.Python.set_formats.SET,
-            variable_type_hints=literalizer.languages.Python.VariableTypeHints.NONE,
         ),
         extension=".py",
         wrap=_wrap_python,
     ),
     "js_native": _Variant(
-        spec=literalizer.languages.JavaScript(
-            date_format=literalizer.languages.JavaScript.date_formats.JS,
-            datetime_format=literalizer.languages.JavaScript.datetime_formats.JS,
-            bytes_format=literalizer.languages.JavaScript.bytes_formats.HEX,
-            sequence_format=literalizer.languages.JavaScript.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.JavaScript(),
         extension=".js",
         wrap=_wrap_js,
     ),
     "ts_native": _Variant(
-        spec=literalizer.languages.TypeScript(
-            date_format=literalizer.languages.TypeScript.date_formats.JS,
-            datetime_format=literalizer.languages.TypeScript.datetime_formats.JS,
-            bytes_format=literalizer.languages.TypeScript.bytes_formats.HEX,
-            sequence_format=literalizer.languages.TypeScript.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.TypeScript(),
         extension=".ts",
         wrap=_wrap_js,
     ),
     "kotlin_native": _Variant(
-        spec=literalizer.languages.Kotlin(
-            date_format=literalizer.languages.Kotlin.date_formats.KOTLIN,
-            datetime_format=literalizer.languages.Kotlin.datetime_formats.KOTLIN,
-            bytes_format=literalizer.languages.Kotlin.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Kotlin.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Kotlin(),
         extension=".kts",
         wrap=_wrap_kotlin_time,
     ),
     "ruby_native": _Variant(
-        spec=literalizer.languages.Ruby(
-            date_format=literalizer.languages.Ruby.date_formats.RUBY,
-            datetime_format=literalizer.languages.Ruby.datetime_formats.RUBY,
-            bytes_format=literalizer.languages.Ruby.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Ruby.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Ruby(),
         extension=".rb",
         wrap=_wrap_ruby_date,
     ),
     "go_native": _Variant(
-        spec=literalizer.languages.Go(
-            date_format=literalizer.languages.Go.date_formats.GO,
-            datetime_format=literalizer.languages.Go.datetime_formats.GO,
-            bytes_format=literalizer.languages.Go.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Go.sequence_formats.SLICE,
-        ),
+        spec=literalizer.languages.Go(),
         extension=".go",
         wrap=_wrap_go_time,
     ),
     "java_instant": _Variant(
-        spec=literalizer.languages.Java(
-            date_format=literalizer.languages.Java.date_formats.JAVA,
-            datetime_format=literalizer.languages.Java.datetime_formats.INSTANT,
-            bytes_format=literalizer.languages.Java.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Java.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Java(),
         extension=".java",
         wrap=_wrap_java_time,
     ),
     "java_zoned": _Variant(
         spec=literalizer.languages.Java(
-            date_format=literalizer.languages.Java.date_formats.JAVA,
             datetime_format=literalizer.languages.Java.datetime_formats.ZONED,
-            bytes_format=literalizer.languages.Java.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Java.sequence_formats.ARRAY,
         ),
         extension=".java",
         wrap=_wrap_java_time,
     ),
     "csharp_native": _Variant(
-        spec=literalizer.languages.CSharp(
-            date_format=literalizer.languages.CSharp.date_formats.CSHARP,
-            datetime_format=literalizer.languages.CSharp.datetime_formats.CSHARP,
-            bytes_format=literalizer.languages.CSharp.bytes_formats.HEX,
-            sequence_format=literalizer.languages.CSharp.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.CSharp(),
         extension=".cs",
         wrap=_wrap_csharp_date,
     ),
     "dart_native": _Variant(
-        spec=literalizer.languages.Dart(
-            date_format=literalizer.languages.Dart.date_formats.DART,
-            datetime_format=literalizer.languages.Dart.datetime_formats.DART,
-            bytes_format=literalizer.languages.Dart.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Dart.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.Dart(),
         extension=".dart",
         wrap=_wrap_dart,
     ),
     "cpp_native": _Variant(
-        spec=literalizer.languages.Cpp(
-            date_format=literalizer.languages.Cpp.date_formats.CPP,
-            datetime_format=literalizer.languages.Cpp.datetime_formats.CPP,
-            bytes_format=literalizer.languages.Cpp.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Cpp.sequence_formats.INITIALIZER_LIST,
-        ),
+        spec=literalizer.languages.Cpp(),
         extension=".cpp",
         wrap=_wrap_cpp_chrono,
     ),
     "rust_native": _Variant(
-        spec=literalizer.languages.Rust(
-            date_format=literalizer.languages.Rust.date_formats.RUST,
-            datetime_format=literalizer.languages.Rust.datetime_formats.RUST,
-            bytes_format=literalizer.languages.Rust.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Rust.sequence_formats.VEC,
-        ),
+        spec=literalizer.languages.Rust(),
         extension=".rs",
         wrap=_wrap_rust_chrono,
     ),
     "julia_native": _Variant(
-        spec=literalizer.languages.Julia(
-            date_format=literalizer.languages.Julia.date_formats.JULIA,
-            datetime_format=literalizer.languages.Julia.datetime_formats.JULIA,
-            bytes_format=literalizer.languages.Julia.bytes_formats.HEX,
-            sequence_format=literalizer.languages.Julia.sequence_formats.ARRAY,
-        ),
+        spec=literalizer.languages.Julia(),
         extension=".jl",
         wrap=_wrap_julia_dates,
     ),
     "r_native": _Variant(
-        spec=literalizer.languages.R(
-            date_format=literalizer.languages.R.date_formats.R,
-            datetime_format=literalizer.languages.R.datetime_formats.R,
-            empty_dict_key=literalizer.languages.R.EmptyDictKey.POSITIONAL,
-            bytes_format=literalizer.languages.R.bytes_formats.HEX,
-            sequence_format=literalizer.languages.R.sequence_formats.LIST,
-        ),
+        spec=literalizer.languages.R(),
         extension=".R",
         wrap=_wrap_r,
     ),
@@ -2304,21 +1947,13 @@ _DATE_VARIANTS: dict[str, _Variant] = {
 _SEQUENCE_VARIANTS: dict[str, _Variant] = {
     "python_list": _Variant(
         spec=literalizer.languages.Python(
-            date_format=literalizer.languages.Python.date_formats.PYTHON,
-            datetime_format=literalizer.languages.Python.datetime_formats.PYTHON,
-            bytes_format=literalizer.languages.Python.bytes_formats.HEX,
             sequence_format=literalizer.languages.Python.sequence_formats.LIST,
-            set_format=literalizer.languages.Python.set_formats.SET,
-            variable_type_hints=literalizer.languages.Python.VariableTypeHints.NONE,
         ),
         extension=".py",
         wrap=_wrap_identity,
     ),
     "julia_tuple": _Variant(
         spec=literalizer.languages.Julia(
-            date_format=literalizer.languages.Julia.date_formats.JULIA,
-            datetime_format=literalizer.languages.Julia.datetime_formats.JULIA,
-            bytes_format=literalizer.languages.Julia.bytes_formats.HEX,
             sequence_format=literalizer.languages.Julia.sequence_formats.TUPLE,
         ),
         extension=".jl",
@@ -2326,9 +1961,6 @@ _SEQUENCE_VARIANTS: dict[str, _Variant] = {
     ),
     "elixir_tuple": _Variant(
         spec=literalizer.languages.Elixir(
-            date_format=literalizer.languages.Elixir.date_formats.ISO,
-            datetime_format=literalizer.languages.Elixir.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Elixir.bytes_formats.HEX,
             sequence_format=literalizer.languages.Elixir.sequence_formats.TUPLE,
         ),
         extension=".ex",
@@ -2336,9 +1968,6 @@ _SEQUENCE_VARIANTS: dict[str, _Variant] = {
     ),
     "erlang_tuple": _Variant(
         spec=literalizer.languages.Erlang(
-            date_format=literalizer.languages.Erlang.date_formats.ISO,
-            datetime_format=literalizer.languages.Erlang.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Erlang.bytes_formats.BINARY,
             sequence_format=literalizer.languages.Erlang.sequence_formats.TUPLE,
         ),
         extension=".erl",
@@ -2346,9 +1975,6 @@ _SEQUENCE_VARIANTS: dict[str, _Variant] = {
     ),
     "crystal_tuple": _Variant(
         spec=literalizer.languages.Crystal(
-            date_format=literalizer.languages.Crystal.date_formats.ISO,
-            datetime_format=literalizer.languages.Crystal.datetime_formats.ISO,
-            bytes_format=literalizer.languages.Crystal.bytes_formats.HEX,
             sequence_format=literalizer.languages.Crystal.sequence_formats.TUPLE,
         ),
         extension=".cr",
@@ -2361,9 +1987,6 @@ _SEQUENCE_VARIANTS: dict[str, _Variant] = {
     ),
     "rust_tuple": _Variant(
         spec=literalizer.languages.Rust(
-            date_format=literalizer.languages.Rust.date_formats.RUST,
-            datetime_format=literalizer.languages.Rust.datetime_formats.RUST,
-            bytes_format=literalizer.languages.Rust.bytes_formats.HEX,
             sequence_format=literalizer.languages.Rust.sequence_formats.TUPLE,
         ),
         extension=".rs",
@@ -2532,12 +2155,7 @@ def _build_variant_cases() -> list[_VariantCase]:
     set_variants: dict[str, _Variant] = {
         "python_frozenset": _Variant(
             spec=literalizer.languages.Python(
-                date_format=literalizer.languages.Python.date_formats.PYTHON,
-                datetime_format=literalizer.languages.Python.datetime_formats.PYTHON,
-                bytes_format=literalizer.languages.Python.bytes_formats.HEX,
-                sequence_format=literalizer.languages.Python.sequence_formats.TUPLE,
                 set_format=literalizer.languages.Python.set_formats.FROZENSET,
-                variable_type_hints=literalizer.languages.Python.VariableTypeHints.NONE,
             ),
             extension=".py",
             wrap=_wrap_identity,
@@ -2554,11 +2172,6 @@ def _build_variant_cases() -> list[_VariantCase]:
     variable_type_hints_variants: dict[str, _Variant] = {
         "python_inline": _Variant(
             spec=literalizer.languages.Python(
-                date_format=literalizer.languages.Python.date_formats.PYTHON,
-                datetime_format=literalizer.languages.Python.datetime_formats.PYTHON,
-                bytes_format=literalizer.languages.Python.bytes_formats.HEX,
-                sequence_format=literalizer.languages.Python.sequence_formats.TUPLE,
-                set_format=literalizer.languages.Python.set_formats.SET,
                 variable_type_hints=literalizer.languages.Python.VariableTypeHints.INLINE,
             ),
             extension=".py",


### PR DESCRIPTION
## Summary
- Add default values (first enum member) to every language class's `__init__` format parameters, so callers can write `Go()` instead of `Go(date_format=Go.date_formats.GO, datetime_format=Go.datetime_formats.GO, bytes_format=Go.bytes_formats.HEX, sequence_format=Go.sequence_formats.SLICE)`
- Simplify integration tests by ~390 lines, replacing verbose spec constructions with bare constructor calls (or single-override calls for variants)

## Test plan
- [x] All 5176 integration tests pass
- [x] All pre-commit hooks pass (mypy, pyright, ty, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API ergonomics change: constructors now provide defaults for format enums and tests are updated to rely on those defaults; behavior should be unchanged when using the previous explicit values, but any accidental reliance on missing-arg errors would no longer surface.
> 
> **Overview**
> Makes all language spec constructors callable with no arguments by adding sensible default values for `date_format`, `datetime_format`, `bytes_format`, and `sequence_format` (plus Python’s `set_format`/`variable_type_hints` and R’s `empty_dict_key`).
> 
> Updates integration tests to stop passing verbose, redundant enum arguments and instead use bare constructors (or only override the single variant field), significantly shrinking test setup code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12a5d2e6e6f75f9de70f6a177ba995d69bbc21ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->