### PR TITLE
Move set format config into SetFormats enum

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -24,6 +24,15 @@ class SequenceFormatConfig:
     empty_sequence: str | None
 
 
+@dataclasses.dataclass(frozen=True)
+class SetFormatConfig:
+    """Configuration for a single set format."""
+
+    open_str: str
+    close: str
+    empty_set: str | None
+
+
 class SequenceFormat(Protocol):
     """Protocol for sequence format Enum members."""
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_ada,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -152,7 +156,11 @@ class Ada(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Ada."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="ASet'(",
+            close=")",
+            empty_set="ASet'(1 .. 0 => ANull)",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -167,6 +175,7 @@ class Ada(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Ada language specification."""
         self.sequence_format = sequence_format
@@ -197,9 +206,9 @@ class Ada(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "AMap'(1 .. 0 => ANull)"
-        self.set_open = "ASet'("
-        self.set_close = ")"
-        self.empty_set: str | None = "ASet'(1 .. 0 => ANull)"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = _to_ada_val
         self.format_set_entry: Callable[[str], str] = _to_ada_val
         self.comment_prefix = "--"

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -16,7 +16,11 @@ from literalizer._formatters import (
     format_string_backslash,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -128,7 +132,11 @@ class Bash(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Bash."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="(",
+            close=")",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -143,6 +151,7 @@ class Bash(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Bash language specification."""
         self.sequence_format = sequence_format
@@ -173,9 +182,9 @@ class Bash(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "("
-        self.set_close = ")"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             _format_bash_sequence_entry
         )

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -137,7 +141,11 @@ class C(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for C."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="((_CVal){.a = (_CVal[]){",
+            close="}})",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -152,6 +160,7 @@ class C(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize C language specification."""
         self.sequence_format = sequence_format
@@ -182,9 +191,9 @@ class C(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "((_CVal){.a = (_CVal[]){"
-        self.set_close = "}})"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = _format_c_list_entry
         self.format_set_entry: Callable[[str], str] = _format_c_set_entry
         self.comment_prefix = "//"

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -94,7 +98,11 @@ class Clojure(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Clojure."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="#{",
+            close="}",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -109,6 +117,7 @@ class Clojure(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.VECTOR,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Clojure language specification."""
         self.sequence_format = sequence_format
@@ -139,9 +148,9 @@ class Clojure(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "#{"
-        self.set_close = "}"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_date_iso,
     format_datetime_iso,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -269,7 +273,11 @@ class Cobol(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for COBOL."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="",
+            close="",
+            empty_set="05 FILLER PIC X(1) VALUE SPACES.",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -284,6 +292,7 @@ class Cobol(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.SEQUENCE,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize COBOL language specification."""
         self.sequence_format = sequence_format
@@ -314,9 +323,9 @@ class Cobol(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "05 FILLER PIC X(1) VALUE SPACES."
-        self.set_open = ""
-        self.set_close = ""
-        self.empty_set: str | None = "05 FILLER PIC X(1) VALUE SPACES."
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             _format_cobol_sequence_entry
         )

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -99,7 +103,11 @@ class CommonLisp(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Common Lisp."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="(list ",
+            close=")",
+            empty_set="nil",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -114,6 +122,7 @@ class CommonLisp(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Common Lisp language specification."""
         self.sequence_format = sequence_format
@@ -142,9 +151,9 @@ class CommonLisp(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "nil"
-        self.set_open = "(list "
-        self.set_close = ")"
-        self.empty_set: str | None = "nil"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     typed_dict_open,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -156,7 +160,11 @@ class Cpp(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for C++."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="{",
+            close="}",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -171,6 +179,7 @@ class Cpp(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.CPP,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.INITIALIZER_LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Cpp language specification."""
         self.sequence_format = sequence_format
@@ -204,9 +213,9 @@ class Cpp(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "{"
-        self.set_close = "}"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -110,7 +114,11 @@ class Crystal(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Crystal."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="Set{",
+            close="}",
+            empty_set="Set(Nil).new",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -125,6 +133,7 @@ class Crystal(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Crystal language specification."""
         self.sequence_format = sequence_format
@@ -155,9 +164,9 @@ class Crystal(metaclass=HasFormatEnums):
         )
         self.format_string: Callable[[str], str] = _string_format
         self.empty_dict: str | None = "{} of Nil => Nil"
-        self.set_open = "Set{"
-        self.set_close = "}"
-        self.empty_set: str | None = "Set(Nil).new"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     typed_dict_open,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -153,7 +157,11 @@ class CSharp(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for C#."""
 
-        HASH_SET = "hash_set"
+        HASH_SET = SetFormatConfig(
+            open_str="new HashSet<object> {",
+            close="}",
+            empty_set="new HashSet<object>()",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -168,6 +176,7 @@ class CSharp(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.CSHARP,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.HASH_SET,
     ) -> None:
         """Initialize CSharp language specification."""
         self.sequence_format = sequence_format
@@ -201,9 +210,9 @@ class CSharp(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "new HashSet<object> {"
-        self.set_close = "}"
-        self.empty_set: str | None = "new HashSet<object>()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -155,7 +159,11 @@ class D(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for D."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="JSONValue([",
+            close="])",
+            empty_set='parseJSON("[]")',
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -170,6 +178,7 @@ class D(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize D language specification."""
         self.sequence_format = sequence_format
@@ -200,9 +209,9 @@ class D(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = 'parseJSON("{}")'
-        self.set_open = "JSONValue(["
-        self.set_close = "])"
-        self.empty_set: str | None = 'parseJSON("[]")'
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             _format_d_sequence_entry
         )

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     typed_dict_open,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -154,7 +158,11 @@ class Dart(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Dart."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="{",
+            close="}",
+            empty_set="<dynamic>{}",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -169,6 +177,7 @@ class Dart(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.DART,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Dart language specification."""
         self.sequence_format = sequence_format
@@ -203,9 +212,9 @@ class Dart(metaclass=HasFormatEnums):
         )
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "{"
-        self.set_close = "}"
-        self.empty_set: str | None = "<dynamic>{}"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -116,7 +120,11 @@ class Elixir(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Elixir."""
 
-        MAP_SET = "map_set"
+        MAP_SET = SetFormatConfig(
+            open_str="MapSet.new([",
+            close="])",
+            empty_set="MapSet.new()",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -131,6 +139,7 @@ class Elixir(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.MAP_SET,
     ) -> None:
         """Initialize Elixir language specification."""
         self.sequence_format = sequence_format
@@ -161,9 +170,9 @@ class Elixir(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "MapSet.new(["
-        self.set_close = "])"
-        self.empty_set: str | None = "MapSet.new()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -124,7 +128,11 @@ class Erlang(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Erlang."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="sets:from_list([",
+            close="])",
+            empty_set="sets:from_list([])",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -139,6 +147,7 @@ class Erlang(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.BINARY,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Erlang language specification."""
         self.sequence_format = sequence_format
@@ -169,9 +178,9 @@ class Erlang(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "sets:from_list(["
-        self.set_close = "])"
-        self.empty_set: str | None = "sets:from_list([])"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_fortran,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -211,7 +215,11 @@ class Fortran(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Fortran."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="fset([fval_t :: ",
+            close="])",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -226,6 +234,7 @@ class Fortran(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Fortran language specification."""
         self.sequence_format = sequence_format
@@ -256,9 +265,9 @@ class Fortran(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "fset([fval_t :: "
-        self.set_close = "])"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = _to_fval
         self.format_set_entry: Callable[[str], str] = _to_fval
         self.comment_prefix = "!"

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -155,7 +159,11 @@ class FSharp(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for F#."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="FSet [",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -170,6 +178,7 @@ class FSharp(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize FSharp language specification."""
         self.sequence_format = sequence_format
@@ -200,9 +209,9 @@ class FSharp(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "FSet ["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_set_entry: Callable[[str], str] = _format_fsharp_set_entry
         self.comment_prefix = "//"
         self.comment_suffix = ""

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     typed_dict_open,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -164,7 +168,11 @@ class Go(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Go."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="map[any]struct{}{",
+            close="}",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -179,6 +187,7 @@ class Go(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.GO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.SLICE,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Go language specification."""
         self.sequence_format = sequence_format
@@ -212,9 +221,9 @@ class Go(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "map[any]struct{}{"
-        self.set_close = "}"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -94,7 +98,11 @@ class Groovy(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Groovy."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="] as Set<Object>",
+            empty_set="[] as Set<Object>",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -109,6 +117,7 @@ class Groovy(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Groovy language specification."""
         self.sequence_format = sequence_format
@@ -139,9 +148,9 @@ class Groovy(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "[:]"
-        self.set_open = "["
-        self.set_close = "] as Set<Object>"
-        self.empty_set: str | None = "[] as Set<Object>"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -144,7 +148,11 @@ class Haskell(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Haskell."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="HSet [",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -159,6 +167,7 @@ class Haskell(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Haskell language specification."""
         self.sequence_format = sequence_format
@@ -189,9 +198,9 @@ class Haskell(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "HSet ["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -96,7 +100,11 @@ class Hcl(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for HCL."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -111,6 +119,7 @@ class Hcl(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize HCL language specification."""
         self.sequence_format = sequence_format
@@ -141,9 +150,9 @@ class Hcl(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_set_entry,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -150,7 +154,11 @@ class Java(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Java."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="Set.of(",
+            close=")",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -165,6 +173,7 @@ class Java(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.INSTANT,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Java language specification."""
         self.sequence_format = sequence_format
@@ -196,9 +205,9 @@ class Java(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "Set.of("
-        self.set_close = ")"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -109,7 +113,11 @@ class JavaScript(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for JavaScript."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="new Set([",
+            close="])",
+            empty_set="new Set()",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -124,6 +132,7 @@ class JavaScript(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.JS,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize JavaScript language specification."""
         self.sequence_format = sequence_format
@@ -155,9 +164,9 @@ class JavaScript(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "new Set(["
-        self.set_close = "])"
-        self.empty_set: str | None = "new Set()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -117,7 +121,11 @@ class Julia(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Julia."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="Set([",
+            close="])",
+            empty_set="Set()",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -132,6 +140,7 @@ class Julia(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.JULIA,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Julia language specification."""
         self.sequence_format = sequence_format
@@ -162,9 +171,9 @@ class Julia(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "Dict()"
-        self.set_open = "Set(["
-        self.set_close = "])"
-        self.empty_set: str | None = "Set()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     typed_dict_open,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -170,7 +174,11 @@ class Kotlin(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Kotlin."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="setOf<Any?>(",
+            close=")",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -185,6 +193,7 @@ class Kotlin(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.KOTLIN,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Kotlin language specification."""
         self.sequence_format = sequence_format
@@ -220,9 +229,9 @@ class Kotlin(metaclass=HasFormatEnums):
         )
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "setOf<Any?>("
-        self.set_close = ")"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -16,7 +16,11 @@ from literalizer._formatters import (
     format_string_backslash,
     passthrough_sequence_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -110,7 +114,11 @@ class Lua(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Lua."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="{",
+            close="}",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -125,6 +133,7 @@ class Lua(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.TABLE,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Lua language specification."""
         self.sequence_format = sequence_format
@@ -155,9 +164,9 @@ class Lua(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "{"
-        self.set_close = "}"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -164,7 +168,11 @@ class Matlab(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for MATLAB."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="{",
+            close="}",
+            empty_set="{}",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -179,6 +187,7 @@ class Matlab(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.CELL_ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Matlab language specification."""
         self.sequence_format = sequence_format
@@ -209,9 +218,9 @@ class Matlab(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "struct()"
-        self.set_open = "{"
-        self.set_close = "}"
-        self.empty_set: str | None = "{}"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -113,7 +117,11 @@ class Mojo(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Mojo."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -128,6 +136,7 @@ class Mojo(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Mojo language specification."""
         self.sequence_format = sequence_format
@@ -158,9 +167,9 @@ class Mojo(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -94,7 +98,11 @@ class Nim(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Nim."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -109,6 +117,7 @@ class Nim(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Nim language specification."""
         self.sequence_format = sequence_format
@@ -139,9 +148,9 @@ class Nim(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -110,7 +114,11 @@ class Norg(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Norg."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -125,6 +133,7 @@ class Norg(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Norg language specification."""
         self.sequence_format = sequence_format
@@ -155,9 +164,9 @@ class Norg(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -11,7 +11,11 @@ from literalizer._formatters import (
     fixed_dict_open,
     fixed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -167,7 +171,11 @@ class ObjectiveC(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Objective-C."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[NSSet setWithArray:@[",
+            close="]]",
+            empty_set="[NSSet set]",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -182,6 +190,7 @@ class ObjectiveC(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.OBJC,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Objective-C language specification."""
         self.sequence_format = sequence_format
@@ -212,9 +221,9 @@ class ObjectiveC(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "@{}"
-        self.set_open = "[NSSet setWithArray:@["
-        self.set_close = "]]"
-        self.empty_set: str | None = "[NSSet set]"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = _to_objc_val
         self.format_set_entry: Callable[[str], str] = _to_objc_val
         self.comment_prefix = "//"

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -159,7 +163,11 @@ class OCaml(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for OCaml."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="OSet [",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -174,6 +182,7 @@ class OCaml(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize OCaml language specification."""
         self.sequence_format = sequence_format
@@ -204,9 +213,9 @@ class OCaml(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "OSet ["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_set_entry: Callable[[str], str] = _format_ocaml_set_entry
         self.comment_prefix = "(*"
         self.comment_suffix = " *)"

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -144,7 +148,11 @@ class Occam(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Occam."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="MOBILE LIT(lit.set; MOBILE []MOBILE LIT [",
+            close="])",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -159,6 +167,7 @@ class Occam(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Occam language specification."""
         self.sequence_format = sequence_format
@@ -189,9 +198,9 @@ class Occam(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "MOBILE LIT(lit.set; MOBILE []MOBILE LIT ["
-        self.set_close = "])"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             _format_occam_list_entry
         )

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -94,7 +98,11 @@ class Perl(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Perl."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -109,6 +117,7 @@ class Perl(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Perl language specification."""
         self.sequence_format = sequence_format
@@ -139,9 +148,9 @@ class Perl(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -16,7 +16,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -110,7 +114,11 @@ class Php(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for PHP."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -125,6 +133,7 @@ class Php(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.PHP,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Php language specification."""
         self.sequence_format = sequence_format
@@ -155,9 +164,9 @@ class Php(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -16,7 +16,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -120,7 +124,11 @@ class PowerShell(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for PowerShell."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="@(",
+            close=")",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -135,6 +143,7 @@ class PowerShell(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize PowerShell language specification."""
         self.sequence_format = sequence_format
@@ -165,9 +174,9 @@ class PowerShell(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "@("
-        self.set_close = ")"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             _format_sequence_entry
         )

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -20,7 +20,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -221,8 +225,16 @@ class Python(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Python."""
 
-        SET = "set"
-        FROZENSET = "frozenset"
+        SET = SetFormatConfig(
+            open_str="{",
+            close="}",
+            empty_set="set()",
+        )
+        FROZENSET = SetFormatConfig(
+            open_str="frozenset({",
+            close="})",
+            empty_set="frozenset()",
+        )
 
     class VariableTypeHints(enum.Enum):
         """Variable type hint options for Python."""
@@ -277,17 +289,9 @@ class Python(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open: str
-        self.set_close: str
-        self.empty_set: str | None
-        if set_format == Python.set_formats.FROZENSET:
-            self.set_open = "frozenset({"
-            self.set_close = "})"
-            self.empty_set = "frozenset()"
-        else:
-            self.set_open = "{"
-            self.set_close = "}"
-            self.empty_set = "set()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 from literalizer.exceptions import EmptyDictKeyError
 
 if TYPE_CHECKING:
@@ -161,7 +165,11 @@ class R(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for R."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="list(",
+            close=")",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -177,6 +185,7 @@ class R(metaclass=HasFormatEnums):
         empty_dict_key: EmptyDictKey = EmptyDictKey.POSITIONAL,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize R language specification."""
         self.sequence_format = sequence_format
@@ -205,9 +214,9 @@ class R(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "list("
-        self.set_close = ")"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -94,7 +98,11 @@ class Racket(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Racket."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="(set ",
+            close=")",
+            empty_set="(set)",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -109,6 +117,7 @@ class Racket(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Racket language specification."""
         self.sequence_format = sequence_format
@@ -139,9 +148,9 @@ class Racket(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "(hash)"
-        self.set_open = "(set "
-        self.set_close = ")"
-        self.empty_set: str | None = "(set)"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -109,7 +113,11 @@ class Ruby(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Ruby."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="Set.new([",
+            close="])",
+            empty_set="Set.new",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -124,6 +132,7 @@ class Ruby(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.RUBY,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Ruby language specification."""
         self.sequence_format = sequence_format
@@ -155,9 +164,9 @@ class Ruby(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "Set.new(["
-        self.set_close = "])"
-        self.empty_set: str | None = "Set.new"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -146,7 +150,11 @@ class Rust(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Rust."""
 
-        HASH_SET = "hash_set"
+        HASH_SET = SetFormatConfig(
+            open_str="HashSet::from([",
+            close="])",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -161,6 +169,7 @@ class Rust(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.RUST,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.VEC,
+        set_format: SetFormats = SetFormats.HASH_SET,
     ) -> None:
         """Initialize Rust language specification."""
         self.sequence_format = sequence_format
@@ -192,9 +201,9 @@ class Rust(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "HashSet::from(["
-        self.set_close = "])"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     typed_dict_open,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 from literalizer._types import Value  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -144,7 +148,11 @@ class Scala(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Scala."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="Set(",
+            close=")",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -159,6 +167,7 @@ class Scala(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Scala language specification."""
         self.sequence_format = sequence_format
@@ -191,9 +200,9 @@ class Scala(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "Set("
-        self.set_close = ")"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -100,7 +104,11 @@ class Swift(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Swift."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="Set<AnyHashable>([",
+            close="])",
+            empty_set="Set<AnyHashable>()",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -115,6 +123,7 @@ class Swift(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Swift language specification."""
         self.sequence_format = sequence_format
@@ -145,9 +154,9 @@ class Swift(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = "[String: Any]()"
-        self.set_open = "Set<AnyHashable>(["
-        self.set_close = "])"
-        self.empty_set: str | None = "Set<AnyHashable>()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -16,7 +16,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -148,7 +152,11 @@ class Toml(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for TOML."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -163,6 +171,7 @@ class Toml(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.TOML,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize TOML language specification."""
         self.sequence_format = sequence_format
@@ -193,9 +202,9 @@ class Toml(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -18,7 +18,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -109,7 +113,11 @@ class TypeScript(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for TypeScript."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="new Set([",
+            close="])",
+            empty_set="new Set()",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -124,6 +132,7 @@ class TypeScript(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.JS,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize TypeScript language specification."""
         self.sequence_format = sequence_format
@@ -155,9 +164,9 @@ class TypeScript(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "new Set(["
-        self.set_close = "])"
-        self.empty_set: str | None = "new Set()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -17,7 +17,11 @@ from literalizer._formatters import (
     passthrough_set_entry,
     typed_sequence_open,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 from literalizer._types import Value  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -139,7 +143,11 @@ class VisualBasic(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Visual Basic."""
 
-        HASH_SET = "hash_set"
+        HASH_SET = SetFormatConfig(
+            open_str="New HashSet(Of Object) From {",
+            close="}",
+            empty_set="New HashSet(Of Object)()",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -154,6 +162,7 @@ class VisualBasic(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.HASH_SET,
     ) -> None:
         """Initialize VisualBasic language specification."""
         self.sequence_format = sequence_format
@@ -185,9 +194,9 @@ class VisualBasic(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_vb
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "New HashSet(Of Object) From {"
-        self.set_close = "}"
-        self.empty_set: str | None = "New HashSet(Of Object)()"
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -16,7 +16,11 @@ from literalizer._formatters import (
     passthrough_sequence_entry,
     passthrough_set_entry,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -121,7 +125,11 @@ class Yaml(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for YAML."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str="[",
+            close="]",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -136,6 +144,7 @@ class Yaml(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.YAML,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.SEQUENCE,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize YAML language specification."""
         self.sequence_format = sequence_format
@@ -166,9 +175,9 @@ class Yaml(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = format_string_backslash
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = "["
-        self.set_close = "]"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -15,7 +15,11 @@ from literalizer._formatters import (
     format_datetime_iso,
     format_string_backslash,
 )
-from literalizer._language import HasFormatEnums, SequenceFormatConfig
+from literalizer._language import (
+    HasFormatEnums,
+    SequenceFormatConfig,
+    SetFormatConfig,
+)
 
 if TYPE_CHECKING:
     import datetime
@@ -131,7 +135,11 @@ class Zig(metaclass=HasFormatEnums):
     class SetFormats(enum.Enum):
         """Set type options for Zig."""
 
-        SET = "set"
+        SET = SetFormatConfig(
+            open_str=".{ .set = &.{",
+            close="}}",
+            empty_set=None,
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats
@@ -146,6 +154,7 @@ class Zig(metaclass=HasFormatEnums):
         datetime_format: DatetimeFormats = DatetimeFormats.ISO,
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.ARRAY,
+        set_format: SetFormats = SetFormats.SET,
     ) -> None:
         """Initialize Zig language specification."""
         self.sequence_format = sequence_format
@@ -176,9 +185,9 @@ class Zig(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = _string_format
         self.empty_sequence: str | None = fmt.empty_sequence
         self.empty_dict: str | None = None
-        self.set_open = ".{ .set = &.{"
-        self.set_close = "}}"
-        self.empty_set: str | None = None
+        self.set_open: str = set_format.value.open_str
+        self.set_close: str = set_format.value.close
+        self.empty_set: str | None = set_format.value.empty_set
         self.format_sequence_entry: Callable[[str], str] = (
             _format_zig_sequence_entry
         )


### PR DESCRIPTION
## Summary

- Adds a `SetFormatConfig` frozen dataclass to `_language.py` holding `open_str`, `close`, and `empty_set`
- Each `SetFormats` enum member across all 47 languages now uses `SetFormatConfig` as its value, making the enum the single source of truth for set-format-specific properties
- Eliminates the if/elif chain in Python's `__init__` for SET vs FROZENSET
- Adds `set_format` as an `__init__` parameter (with default) across all languages, matching the existing `sequence_format` pattern

## Test plan

- [x] All 5467 existing tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pyright, pyright-verifytypes, ty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all language spec constructors by adding a new `set_format` parameter and centralizing set delimiters/empty-literals in enums; broad surface-area change could impact formatting output or downstream initialization code, though behavior is largely a refactor.
> 
> **Overview**
> **Refactors set literal configuration across all language specs.** Introduces a frozen `SetFormatConfig` dataclass (in `_language.py`) and updates each language’s `SetFormats` enum members to store `open_str`/`close`/`empty_set` there instead of hardcoded instance attributes.
> 
> Each language `__init__` now accepts a `set_format` parameter (defaulting to the existing behavior) and assigns `set_open`/`set_close`/`empty_set` from `set_format.value`. Python’s set vs `frozenset` selection is simplified by moving the branching into `SetFormats` config values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e9edf7e8ef182c424a22ffce51bda62484e9e8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->