### PR TITLE
Move dict format config into DictFormatConfig object

### DIFF
--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -7,6 +7,7 @@ from literalizer._core import (
 from literalizer._formatters import fixed_dict_open, fixed_sequence_open
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     Language,
     OmapFormatConfig,
@@ -16,6 +17,7 @@ from literalizer._language import (
 
 __all__ = [
     "CommentConfig",
+    "DictFormatConfig",
     "HasFormatEnums",
     "Language",
     "OmapFormatConfig",

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -368,7 +368,7 @@ def _format_scalar(*, value: Scalar, spec: Language) -> str:
 @beartype
 def _build_dict_entry(*, key_str: str, val_str: str, spec: Language) -> str:
     """Format a single dict key-value entry using the language spec."""
-    return spec.format_dict_entry(key_str, val_str)
+    return spec.dict_format_config.format_entry(key_str, val_str)
 
 
 @beartype
@@ -413,8 +413,9 @@ def _format_value(*, value: Value, spec: Language) -> str:
             for k, v in value.items()
             if not (spec.skip_null_dict_values and v is None)
         }
-        if not dict_items and spec.empty_dict is not None:
-            return spec.empty_dict
+        dict_cfg = spec.dict_format_config
+        if not dict_items and dict_cfg.empty_dict is not None:
+            return dict_cfg.empty_dict
         pairs = [
             _build_dict_entry(
                 key_str=_format_value(value=k, spec=spec),
@@ -424,7 +425,7 @@ def _format_value(*, value: Value, spec: Language) -> str:
             for k, v in dict_items.items()
         ]
         joined = spec.element_separator.join(pairs)
-        return spec.dict_open(dict_items) + joined + spec.dict_close
+        return dict_cfg.open_fn(dict_items) + joined + dict_cfg.close
 
     if isinstance(value, set):
         return _format_set_value(value=value, spec=spec)
@@ -464,8 +465,9 @@ def _wrap_body(
         opening = f"{line_prefix}{omap_cfg.open_str}"
         closing = f"{close_prefix}{omap_cfg.close}"
     elif isinstance(data, dict):
-        opening = f"{line_prefix}{spec.dict_open(data)}"
-        closing = f"{close_prefix}{spec.dict_close}"
+        dict_cfg = spec.dict_format_config
+        opening = f"{line_prefix}{dict_cfg.open_fn(data)}"
+        closing = f"{close_prefix}{dict_cfg.close}"
     elif isinstance(data, set):
         opening = f"{line_prefix}{spec.set_format_config.open_str}"
         closing = f"{close_prefix}{spec.set_format_config.close}"

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -42,6 +42,16 @@ class CommentConfig:
 
 
 @dataclasses.dataclass(frozen=True)
+class DictFormatConfig:
+    """Configuration for dict formatting."""
+
+    open_fn: Callable[[dict[str, Value]], str]
+    close: str
+    format_entry: Callable[[str, str], str]
+    empty_dict: str | None
+
+
+@dataclasses.dataclass(frozen=True)
 class OmapFormatConfig:
     """Configuration for ordered-map formatting."""
 
@@ -144,25 +154,8 @@ class Language(Protocol):
     sequence_format_config: SequenceFormatConfig
     """Configuration for the chosen sequence format."""
 
-    @property
-    def dict_open(self) -> Callable[[dict[str, Value]], str]:
-        """Callable that returns the opening delimiter for a dict literal.
-
-        Receives the dict about to be formatted, so the delimiter can depend
-        on the value types when needed.  For a fixed delimiter use
-        :func:`~literalizer.fixed_dict_open`.
-        """
-        ...  # pylint: disable=unnecessary-ellipsis
-
-    dict_close: str
-    """The closing delimiter for dict literals."""
-
-    @property
-    def format_dict_entry(self) -> Callable[[str, str], str]:
-        """Callable that formats a dict entry from a pre-formatted key and
-        value string.
-        """
-        ...  # pylint: disable=unnecessary-ellipsis
+    dict_format_config: DictFormatConfig
+    """Configuration for dict formatting."""
 
     multiline_trailing_comma: bool
     """Whether to append a trailing comma after the last entry."""
@@ -187,9 +180,6 @@ class Language(Protocol):
         literal.
         """
         ...  # pylint: disable=unnecessary-ellipsis
-
-    empty_dict: str | None
-    """Override for empty dict literals, or ``None``."""
 
     set_format_config: SetFormatConfig
     """Configuration for the chosen set format."""

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -190,12 +191,11 @@ class Ada(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="AMap'("
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_ada_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="AMap'("),
+            close=")",
+            format_entry=_format_ada_dict_entry,
+            empty_dict="AMap'(1 .. 0 => ANull)",
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -204,7 +204,6 @@ class Ada(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "AMap'(1 .. 0 => ANull)"
         self.format_sequence_entry: Callable[[str], str] = _to_ada_val
         self.format_set_entry: Callable[[str], str] = _to_ada_val
         self.comment_config: CommentConfig = CommentConfig(

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -18,6 +18,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -166,12 +167,11 @@ class Bash(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="("
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_bash_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="("),
+            close=")",
+            format_entry=_format_bash_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -180,7 +180,6 @@ class Bash(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             _format_bash_sequence_entry
         )

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -175,12 +176,11 @@ class C(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="((_CVal){.m = (_CKV[]){"
-        )
-        self.dict_close = "}})"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_c_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="((_CVal){.m = (_CKV[]){"),
+            close="}})",
+            format_entry=_format_c_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -189,7 +189,6 @@ class C(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = _format_c_list_entry
         self.format_set_entry: Callable[[str], str] = _format_c_set_entry
         self.comment_config: CommentConfig = CommentConfig(

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -132,12 +133,11 @@ class Clojure(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -146,7 +146,6 @@ class Clojure(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -306,12 +307,11 @@ class Cobol(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str=""
-        )
-        self.dict_close = ""
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_cobol_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str=""),
+            close="",
+            format_entry=_format_cobol_dict_entry,
+            empty_dict="05 FILLER PIC X(1) VALUE SPACES.",
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -320,7 +320,6 @@ class Cobol(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "05 FILLER PIC X(1) VALUE SPACES."
         self.format_sequence_entry: Callable[[str], str] = (
             _format_cobol_sequence_entry
         )

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -137,11 +138,12 @@ class CommonLisp(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="(list "
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="(list "),
+            close=")",
+            format_entry=_format_cons_entry,
+            empty_dict="nil",
         )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = _format_cons_entry
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = date_format
@@ -149,7 +151,6 @@ class CommonLisp(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "nil"
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -195,13 +196,14 @@ class Cpp(metaclass=HasFormatEnums):
             schema_to_opener=_cpp_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = typed_dict_open(
-            schema_to_opener=_cpp_dict_schema_to_opener,
-            fallback="{",
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_cpp_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=typed_dict_open(
+                schema_to_opener=_cpp_dict_schema_to_opener,
+                fallback="{",
+            ),
+            close="}",
+            format_entry=_format_cpp_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -211,7 +213,6 @@ class Cpp(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -148,12 +149,11 @@ class Crystal(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" => ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" => "),
+            empty_dict="{} of Nil => Nil",
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -162,7 +162,6 @@ class Crystal(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "{} of Nil => Nil"
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -192,13 +193,14 @@ class CSharp(metaclass=HasFormatEnums):
             schema_to_opener=_csharp_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = typed_dict_open(
-            schema_to_opener=_csharp_dict_schema_to_opener,
-            fallback="new Dictionary<string, object> {",
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_csharp_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=typed_dict_open(
+                schema_to_opener=_csharp_dict_schema_to_opener,
+                fallback="new Dictionary<string, object> {",
+            ),
+            close="}",
+            format_entry=_format_csharp_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -208,7 +210,6 @@ class CSharp(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -193,12 +194,11 @@ class D(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="JSONValue(["
-        )
-        self.dict_close = "])"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_d_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="JSONValue(["),
+            close="])",
+            format_entry=_format_d_dict_entry,
+            empty_dict='parseJSON("{}")',
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -207,7 +207,6 @@ class D(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = 'parseJSON("{}")'
         self.format_sequence_entry: Callable[[str], str] = (
             _format_d_sequence_entry
         )

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -193,13 +194,14 @@ class Dart(metaclass=HasFormatEnums):
             schema_to_opener=_dart_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = typed_dict_open(
-            schema_to_opener=_dart_dict_schema_to_opener,
-            fallback="{",
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=typed_dict_open(
+                schema_to_opener=_dart_dict_schema_to_opener,
+                fallback="{",
+            ),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -210,7 +212,6 @@ class Dart(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar
         )
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -154,12 +155,11 @@ class Elixir(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="%{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" => ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="%{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" => "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -168,7 +168,6 @@ class Elixir(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -162,12 +163,11 @@ class Erlang(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="#{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" => ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="#{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" => "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -176,7 +176,6 @@ class Erlang(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -249,12 +250,11 @@ class Fortran(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="fmap([fval_t :: "
-        )
-        self.dict_close = "])"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_fortran_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="fmap([fval_t :: "),
+            close="])",
+            format_entry=_format_fortran_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -263,7 +263,6 @@ class Fortran(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = _to_fval
         self.format_set_entry: Callable[[str], str] = _to_fval
         self.comment_config: CommentConfig = CommentConfig(

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -193,12 +194,11 @@ class FSharp(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="FMap ["
-        )
-        self.dict_close = "]"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_fsharp_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="FMap ["),
+            close="]",
+            format_entry=_format_fsharp_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -207,7 +207,6 @@ class FSharp(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_set_entry: Callable[[str], str] = _format_fsharp_set_entry
         self.comment_config: CommentConfig = CommentConfig(
             prefix="//",

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -203,13 +204,14 @@ class Go(metaclass=HasFormatEnums):
             schema_to_opener=_go_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = typed_dict_open(
-            schema_to_opener=_go_dict_schema_to_opener,
-            fallback="map[string]any{",
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=typed_dict_open(
+                schema_to_opener=_go_dict_schema_to_opener,
+                fallback="map[string]any{",
+            ),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -219,7 +221,6 @@ class Go(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -132,12 +133,11 @@ class Groovy(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="["
-        )
-        self.dict_close = "]"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="["),
+            close="]",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict="[:]",
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -146,7 +146,6 @@ class Groovy(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "[:]"
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -182,12 +183,11 @@ class Haskell(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="HMap ["
-        )
-        self.dict_close = "]"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_haskell_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="HMap ["),
+            close="]",
+            format_entry=_format_haskell_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -196,7 +196,6 @@ class Haskell(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -134,12 +135,11 @@ class Hcl(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" = ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" = "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -148,7 +148,6 @@ class Hcl(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -189,12 +190,11 @@ class Java(metaclass=HasFormatEnums):
             schema_to_opener=_java_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="Map.ofEntries("
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_java_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="Map.ofEntries("),
+            close=")",
+            format_entry=_format_java_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -203,7 +203,6 @@ class Java(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -147,12 +148,11 @@ class JavaScript(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -162,7 +162,6 @@ class JavaScript(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -155,12 +156,11 @@ class Julia(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="Dict("
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" => ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="Dict("),
+            close=")",
+            format_entry=dict_entry_with_separator(separator=" => "),
+            empty_dict="Dict()",
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -169,7 +169,6 @@ class Julia(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = "Dict()"
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -209,13 +210,14 @@ class Kotlin(metaclass=HasFormatEnums):
             schema_to_opener=_kotlin_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = typed_dict_open(
-            schema_to_opener=_kotlin_dict_schema_to_opener,
-            fallback="mapOf<String, Any?>(",
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" to ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=typed_dict_open(
+                schema_to_opener=_kotlin_dict_schema_to_opener,
+                fallback="mapOf<String, Any?>(",
+            ),
+            close=")",
+            format_entry=dict_entry_with_separator(separator=" to "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -227,7 +229,6 @@ class Kotlin(metaclass=HasFormatEnums):
         self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar
         )
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -18,6 +18,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -148,12 +149,11 @@ class Lua(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_lua_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=_format_lua_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -162,7 +162,6 @@ class Lua(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -202,12 +203,11 @@ class Matlab(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="struct("
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_matlab_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="struct("),
+            close=")",
+            format_entry=_format_matlab_dict_entry,
+            empty_dict="struct()",
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -216,7 +216,6 @@ class Matlab(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "struct()"
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -151,12 +152,11 @@ class Mojo(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -165,7 +165,6 @@ class Mojo(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -132,12 +133,11 @@ class Nim(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -146,7 +146,6 @@ class Nim(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -148,12 +149,11 @@ class Norg(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -162,7 +162,6 @@ class Norg(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -13,6 +13,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -205,12 +206,11 @@ class ObjectiveC(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="@{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_objc_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="@{"),
+            close="}",
+            format_entry=_format_objc_dict_entry,
+            empty_dict="@{}",
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -219,7 +219,6 @@ class ObjectiveC(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "@{}"
         self.format_sequence_entry: Callable[[str], str] = _to_objc_val
         self.format_set_entry: Callable[[str], str] = _to_objc_val
         self.comment_config: CommentConfig = CommentConfig(

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -197,12 +198,11 @@ class OCaml(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="OMap ["
-        )
-        self.dict_close = "]"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_ocaml_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="OMap ["),
+            close="]",
+            format_entry=_format_ocaml_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -211,7 +211,6 @@ class OCaml(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_set_entry: Callable[[str], str] = _format_ocaml_set_entry
         self.comment_config: CommentConfig = CommentConfig(
             prefix="(*",

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -182,12 +183,13 @@ class Occam(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT ["
-        )
-        self.dict_close = "])"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_occam_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(
+                open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
+            ),
+            close="])",
+            format_entry=_format_occam_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -196,7 +198,6 @@ class Occam(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             _format_occam_list_entry
         )

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -132,12 +133,11 @@ class Perl(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" => ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" => "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -146,7 +146,6 @@ class Perl(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -18,6 +18,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -148,12 +149,11 @@ class Php(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="["
-        )
-        self.dict_close = "]"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" => ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="["),
+            close="]",
+            format_entry=dict_entry_with_separator(separator=" => "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -162,7 +162,6 @@ class Php(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -18,6 +18,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -158,12 +159,11 @@ class PowerShell(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="@{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" = ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="@{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" = "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -172,7 +172,6 @@ class PowerShell(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             _format_sequence_entry
         )

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -22,6 +22,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -271,12 +272,11 @@ class Python(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
 
@@ -287,7 +287,6 @@ class Python(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -200,11 +201,12 @@ class R(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="list("
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="list("),
+            close=")",
+            format_entry=empty_dict_key,
+            empty_dict=None,
         )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = empty_dict_key
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = date_format
@@ -212,7 +214,6 @@ class R(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -132,12 +133,11 @@ class Racket(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="(hash "
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="(hash "),
+            close=")",
+            format_entry=dict_entry_with_separator(separator=" "),
+            empty_dict="(hash)",
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -146,7 +146,6 @@ class Racket(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "(hash)"
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -147,12 +148,11 @@ class Ruby(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" => ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=" => "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -162,7 +162,6 @@ class Ruby(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -184,12 +185,11 @@ class Rust(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="HashMap::from(["
-        )
-        self.dict_close = "])"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_rust_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="HashMap::from(["),
+            close="])",
+            format_entry=_format_rust_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -199,7 +199,6 @@ class Rust(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -183,13 +184,14 @@ class Scala(metaclass=HasFormatEnums):
             schema_to_opener=_scala_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = typed_dict_open(
-            schema_to_opener=_scala_dict_schema_to_opener,
-            fallback="Map(",
-        )
-        self.dict_close = ")"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=" -> ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=typed_dict_open(
+                schema_to_opener=_scala_dict_schema_to_opener,
+                fallback="Map(",
+            ),
+            close=")",
+            format_entry=dict_entry_with_separator(separator=" -> "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -198,7 +200,6 @@ class Scala(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -138,12 +139,11 @@ class Swift(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="["
-        )
-        self.dict_close = "]"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="["),
+            close="]",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict="[String: Any]()",
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -152,7 +152,6 @@ class Swift(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = "[String: Any]()"
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -18,6 +18,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -186,12 +187,11 @@ class Toml(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_toml_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=_format_toml_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -200,7 +200,6 @@ class Toml(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -20,6 +20,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -147,12 +148,11 @@ class TypeScript(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -162,7 +162,6 @@ class TypeScript(metaclass=HasFormatEnums):
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -19,6 +19,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -178,12 +179,13 @@ class VisualBasic(metaclass=HasFormatEnums):
             schema_to_opener=_vb_schema_to_opener,
             fallback=fmt.open_str,
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="New Dictionary(Of String, Object) From {",
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_vb_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(
+                open_str="New Dictionary(Of String, Object) From {",
+            ),
+            close="}",
+            format_entry=_format_vb_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -192,7 +194,6 @@ class VisualBasic(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_vb
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -18,6 +18,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -159,12 +160,11 @@ class Yaml(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str="{"
-        )
-        self.dict_close = "}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            dict_entry_with_separator(separator=": ")
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
         )
         self.multiline_trailing_comma = False
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -173,7 +173,6 @@ class Yaml(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = format_string_backslash
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry
         )

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -17,6 +17,7 @@ from literalizer._formatters import (
 )
 from literalizer._language import (
     CommentConfig,
+    DictFormatConfig,
     HasFormatEnums,
     OmapFormatConfig,
     SequenceFormatConfig,
@@ -169,12 +170,11 @@ class Zig(metaclass=HasFormatEnums):
         self.sequence_open: Callable[[list[Value]], str] = fixed_sequence_open(
             open_str=fmt.open_str
         )
-        self.dict_open: Callable[[dict[str, Value]], str] = fixed_dict_open(
-            open_str=".{ .map = &.{"
-        )
-        self.dict_close = "}}"
-        self.format_dict_entry: Callable[[str, str], str] = (
-            _format_zig_dict_entry
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str=".{ .map = &.{"),
+            close="}}",
+            format_entry=_format_zig_dict_entry,
+            empty_dict=None,
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format
@@ -183,7 +183,6 @@ class Zig(metaclass=HasFormatEnums):
             datetime_format
         )
         self.format_string: Callable[[str], str] = _string_format
-        self.empty_dict: str | None = None
         self.format_sequence_entry: Callable[[str], str] = (
             _format_zig_sequence_entry
         )

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -533,7 +533,7 @@ def test_toml_non_quoted_dict_key() -> None:
     When the key does not start with a double-quote character the
     bare-key optimization is skipped and the key is used verbatim.
     """
-    result = TOML.format_dict_entry("plain_key", '"value"')
+    result = TOML.dict_format_config.format_entry("plain_key", '"value"')
     assert result == 'plain_key = "value"'
 
 


### PR DESCRIPTION
## Summary
- Consolidates four separate dict-related attributes (`dict_open`, `dict_close`, `format_dict_entry`, `empty_dict`) from the `Language` protocol into a single `DictFormatConfig` frozen dataclass
- Follows the same pattern established by `OmapFormatConfig`, `SetFormatConfig`, `SequenceFormatConfig`, and `CommentConfig`
- Updates all 46 language implementations, `_core.py` usage sites, and one test

## Test plan
- [x] All 5467 existing tests pass
- [x] All pre-commit hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dict-literal formatting and the `Language` protocol across all built-in language specs, so any mismatch could change output or break downstream custom `Language` implementations.
> 
> **Overview**
> Moves dict literal formatting from four separate `Language` attributes (`dict_open`, `dict_close`, `format_dict_entry`, `empty_dict`) into a new frozen `DictFormatConfig` and threads this through the public API exports.
> 
> Updates `_core.py` to use `spec.dict_format_config` for dict open/close, entry formatting, and empty-dict overrides, and migrates all language implementations to populate the new config. One TOML test is updated to call `TOML.dict_format_config.format_entry`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee058217b46f51be8559fc2fe41815947b027a07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->