### PR TITLE
Remove default from _VariantCase.variable_name field

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2194,7 +2194,7 @@ class _VariantCase:
     variant_name: str
     variant: _Variant
     case_dir: Path
-    variable_name: str | None = None
+    variable_name: str | None
 
 
 def _build_variant_cases() -> list[_VariantCase]:
@@ -2206,6 +2206,7 @@ def _build_variant_cases() -> list[_VariantCase]:
                 variant_name=variant_name,
                 variant=variant,
                 case_dir=_CASES_DIR / "dates",
+                variable_name=None,
             )
         )
     for variant_name, variant in _SEQUENCE_VARIANTS.items():
@@ -2214,6 +2215,7 @@ def _build_variant_cases() -> list[_VariantCase]:
                 variant_name=variant_name,
                 variant=variant,
                 case_dir=_CASES_DIR / "simple_sequence",
+                variable_name=None,
             )
         )
     for variant_name, variant in _SET_VARIANTS.items():
@@ -2222,6 +2224,7 @@ def _build_variant_cases() -> list[_VariantCase]:
                 variant_name=variant_name,
                 variant=variant,
                 case_dir=_CASES_DIR / "set",
+                variable_name=None,
             )
         )
     variable_type_hints_variants: dict[str, _Variant] = {


### PR DESCRIPTION
## Summary

- Remove the `= None` default from `_VariantCase.variable_name` so all fields must be passed explicitly.
- Add explicit `variable_name=None` at the three call sites that previously relied on the default.

## Test plan

- [x] Pre-commit hooks pass (mypy, pyright, ruff, etc.)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that makes `_VariantCase.variable_name` explicit and updates the few constructors that previously relied on a default.
> 
> **Overview**
> Removes the default value for `_VariantCase.variable_name` in the integration golden-file variant tests, requiring callers to pass the field explicitly.
> 
> Updates the variant-case builders to pass `variable_name=None` for date/sequence/set variants (and keeps explicit `_VARIABLE_NAME` where needed), making construction more intentional and type-checker-friendly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c415e6d1686018758e4f5511036f9bfdfa15f3d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->