### PR TITLE
Add missing @beartype decorators

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -353,6 +353,7 @@ def prepend_collection_comments(
     Returns *base* unchanged when there are no comments.
     """
 
+    @beartype
     def _fmt(text: str) -> str:
         """Format *text* as a comment line using the outer parameters."""
         return _format_comment(

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -79,6 +79,7 @@ def _to_fval(value: str) -> str:
     return value  # pragma: no cover
 
 
+@beartype
 def _fortran_comment_pos(line: str) -> int | None:
     """Return the index of the ``!`` comment character in *line* that
     lies outside any string literal, or ``None`` if there is no comment.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1108,6 +1108,7 @@ _FORTRAN_PREAMBLE = (
 )
 
 
+@beartype
 def _fortran_comment_pos(line: str) -> int | None:
     """Return the index of the ``!`` comment in *line* outside strings."""
     in_single_quote = False
@@ -1982,6 +1983,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
 }
 
 
+@beartype
 def _build_date_variants() -> dict[str, _Variant]:
     """Build datetime-format variants for all languages with date wrapping.
 
@@ -2006,6 +2008,7 @@ def _build_date_variants() -> dict[str, _Variant]:
 _DATE_VARIANTS: dict[str, _Variant] = _build_date_variants()
 
 
+@beartype
 def _build_sequence_variants() -> dict[str, _Variant]:
     """Build sequence-format variants for all languages with multiple
     formats.
@@ -2032,6 +2035,7 @@ def _build_sequence_variants() -> dict[str, _Variant]:
 _SEQUENCE_VARIANTS: dict[str, _Variant] = _build_sequence_variants()
 
 
+@beartype
 def _build_set_variants() -> dict[str, _Variant]:
     """Build set-format variants for all languages with multiple formats.
 
@@ -2197,6 +2201,7 @@ class _VariantCase:
     variable_name: str | None = None
 
 
+@beartype
 def _build_variant_cases() -> list[_VariantCase]:
     """Collect all format-variant golden-file test cases."""
     cases: list[_VariantCase] = []


### PR DESCRIPTION
## Summary
- Add `@beartype` to 7 functions that were missing it: `_fmt` nested function in `_comments.py`, `_fortran_comment_pos` in `fortran.py`, and 5 helper functions in the integration test file (`_fortran_comment_pos`, `_build_date_variants`, `_build_sequence_variants`, `_build_set_variants`, `_build_variant_cases`).

## Test plan
- [x] All 291 tests pass
- [x] Pre-commit hooks (mypy, pyright, ruff, etc.) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding runtime type-checking via `@beartype`, with the main impact being potential new `BeartypeCallHintParamViolation` errors if these helpers are ever called with unexpected types (plus minor overhead).
> 
> **Overview**
> Adds missing `@beartype` runtime type-checking to a few helper functions.
> 
> This includes the nested `_fmt` formatter in `src/literalizer/_comments.py`, `_fortran_comment_pos` in `src/literalizer/languages/fortran.py`, and several integration-test helper builders in `tests/integration/test_integration.py` (date/sequence/set variant case construction).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d73105fe60bd6c113f4fa09b5c3b3568965a2cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->