### PR TITLE
Remove module-level variant globals from test_integration

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2005,9 +2005,6 @@ def _build_date_variants() -> dict[str, _Variant]:
     return variants
 
 
-_DATE_VARIANTS: dict[str, _Variant] = _build_date_variants()
-
-
 @beartype
 def _build_sequence_variants() -> dict[str, _Variant]:
     """Build sequence-format variants for all languages with multiple
@@ -2030,9 +2027,6 @@ def _build_sequence_variants() -> dict[str, _Variant]:
                 wrap=lang_config.wrap,
             )
     return variants
-
-
-_SEQUENCE_VARIANTS: dict[str, _Variant] = _build_sequence_variants()
 
 
 @beartype
@@ -2058,9 +2052,6 @@ def _build_set_variants() -> dict[str, _Variant]:
                 wrap=lang_config.set_wrap,
             )
     return variants
-
-
-_SET_VARIANTS: dict[str, _Variant] = _build_set_variants()
 
 
 @beartype
@@ -2210,9 +2201,9 @@ def _build_variant_cases() -> list[_VariantCase]:
     """Collect all format-variant golden-file test cases."""
     cases: list[_VariantCase] = []
     variant_sources: list[tuple[dict[str, _Variant], str]] = [
-        (_DATE_VARIANTS, "dates"),
-        (_SEQUENCE_VARIANTS, "simple_sequence"),
-        (_SET_VARIANTS, "set"),
+        (_build_date_variants(), "dates"),
+        (_build_sequence_variants(), "simple_sequence"),
+        (_build_set_variants(), "set"),
     ]
     for variants, case_dir_name in variant_sources:
         for variant_name, variant in variants.items():


### PR DESCRIPTION
## Summary
- Removed `_DATE_VARIANTS`, `_SEQUENCE_VARIANTS`, and `_SET_VARIANTS` module-level globals
- Replaced them with inline calls to their builder functions directly inside `_build_variant_cases`, their only consumer

## Test plan
- [x] All 24 `test_format_variant_golden_file` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to integration tests; it only changes when variant dictionaries are constructed, not test assertions or golden-file contents.
> 
> **Overview**
> Removes the module-level `_DATE_VARIANTS`, `_SEQUENCE_VARIANTS`, and `_SET_VARIANTS` caches from `tests/integration/test_integration.py`.
> 
> `_build_variant_cases()` now calls `_build_date_variants()`, `_build_sequence_variants()`, and `_build_set_variants()` inline to generate variant sources at case-build time (their only consumer), reducing global initialization in the test module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9521d91a5676ad9fca0b8db3cf59cc94fb9755ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->