### PR TITLE
Add BLOCK comment format to 25 languages

### DIFF
--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -119,6 +119,10 @@ class CommonLisp(metaclass=HasFormatEnums):
             prefix=";",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="#|",
+            suffix=" |#",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -176,6 +176,10 @@ class Cpp(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -173,6 +173,10 @@ class CSharp(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -175,6 +175,10 @@ class D(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -174,6 +174,10 @@ class Dart(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -175,6 +175,10 @@ class FSharp(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="(*",
+            suffix=" *)",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -184,6 +184,10 @@ class Go(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -114,6 +114,10 @@ class Groovy(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -164,6 +164,10 @@ class Haskell(metaclass=HasFormatEnums):
             prefix="--",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="{-",
+            suffix=" -}",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -116,6 +116,10 @@ class Hcl(metaclass=HasFormatEnums):
             prefix="#",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -170,6 +170,10 @@ class Java(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -129,6 +129,10 @@ class JavaScript(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -137,6 +137,10 @@ class Julia(metaclass=HasFormatEnums):
             prefix="#",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="#=",
+            suffix=" =#",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -190,6 +190,10 @@ class Kotlin(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -130,6 +130,10 @@ class Lua(metaclass=HasFormatEnums):
             prefix="--",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="--[[",
+            suffix=" ]]",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -184,6 +184,10 @@ class Matlab(metaclass=HasFormatEnums):
             prefix="%",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="%{",
+            suffix=" %}",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -114,6 +114,10 @@ class Nim(metaclass=HasFormatEnums):
             prefix="#",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="#[",
+            suffix=" ]#",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -187,6 +187,10 @@ class ObjectiveC(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -130,6 +130,10 @@ class Php(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -140,6 +140,10 @@ class PowerShell(metaclass=HasFormatEnums):
             prefix="#",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="<#",
+            suffix=" #>",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -114,6 +114,10 @@ class Racket(metaclass=HasFormatEnums):
             prefix=";",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="#|",
+            suffix=" |#",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -166,6 +166,10 @@ class Rust(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -164,6 +164,10 @@ class Scala(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -120,6 +120,10 @@ class Swift(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -129,6 +129,10 @@ class TypeScript(metaclass=HasFormatEnums):
             prefix="//",
             suffix="",
         )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/tests/integration/cases/comments/common_lisp_block.lisp
+++ b/tests/integration/cases/comments/common_lisp_block.lisp
@@ -1,0 +1,7 @@
+(list
+    #| Server configuration |#
+    (cons "host" "localhost")  #| default host |#
+    (cons "port" 8080)
+    #| Enable debug mode |#
+    (cons "debug" t)
+)

--- a/tests/integration/cases/comments/cpp_block.cpp
+++ b/tests/integration/cases/comments/cpp_block.cpp
@@ -1,0 +1,18 @@
+#include <initializer_list>
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+struct _Any {
+    template<class T> _Any(T&&) noexcept {}
+    _Any(std::initializer_list<_Any>) noexcept {}
+};
+void _check() {
+    [[maybe_unused]] _Any _v = {
+    /* Server configuration */
+    {"host", "localhost"},  /* default host */
+    {"port", 8080},
+    /* Enable debug mode */
+    {"debug", true},
+};
+}

--- a/tests/integration/cases/comments/csharp_block.cs
+++ b/tests/integration/cases/comments/csharp_block.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+var x = new Dictionary<string, object> {
+    /* Server configuration */
+    ["host"] = "localhost",  /* default host */
+    ["port"] = 8080,
+    /* Enable debug mode */
+    ["debug"] = true
+};

--- a/tests/integration/cases/comments/d_block.d
+++ b/tests/integration/cases/comments/d_block.d
@@ -1,0 +1,11 @@
+import std.json;
+
+void _check() {
+    auto _v = JSONValue([
+    /* Server configuration */
+    "host": JSONValue("localhost"),  /* default host */
+    "port": JSONValue(8080),
+    /* Enable debug mode */
+    "debug": JSONValue(true),
+]);
+}

--- a/tests/integration/cases/comments/dart_block.dart
+++ b/tests/integration/cases/comments/dart_block.dart
@@ -1,0 +1,7 @@
+final x = {
+    /* Server configuration */
+    "host": "localhost",  /* default host */
+    "port": 8080,
+    /* Enable debug mode */
+    "debug": true,
+};

--- a/tests/integration/cases/comments/fsharp_block.fs
+++ b/tests/integration/cases/comments/fsharp_block.fs
@@ -1,0 +1,19 @@
+module Check
+
+type Val =
+    | FNull
+    | FBool of bool
+    | FInt of int64
+    | FFloat of float
+    | FStr of string
+    | FList of Val list
+    | FMap of (string * Val) list
+    | FSet of Val list
+
+let x: Val = FMap [
+    (* Server configuration *)
+    ("host", FStr "localhost");  (* default host *)
+    ("port", FInt 8080L);
+    (* Enable debug mode *)
+    ("debug", FBool true)
+]

--- a/tests/integration/cases/comments/go_block.go
+++ b/tests/integration/cases/comments/go_block.go
@@ -1,0 +1,9 @@
+package main
+
+var _ = map[string]any{
+    /* Server configuration */
+    "host": "localhost",  /* default host */
+    "port": 8080,
+    /* Enable debug mode */
+    "debug": true,
+}

--- a/tests/integration/cases/comments/groovy_block.groovy
+++ b/tests/integration/cases/comments/groovy_block.groovy
@@ -1,0 +1,7 @@
+def x = [
+    /* Server configuration */
+    "host": "localhost",  /* default host */
+    "port": 8080,
+    /* Enable debug mode */
+    "debug": true,
+]

--- a/tests/integration/cases/comments/haskell_block.hs
+++ b/tests/integration/cases/comments/haskell_block.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Check where
+import Data.String (IsString(fromString))
+data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)] | HSet [Val]
+instance IsString Val where
+    fromString = HStr
+instance Num Val where
+    fromInteger = HInt
+    a + b = error "not implemented"
+    a * b = error "not implemented"
+    abs a = error "not implemented"
+    signum a = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional Val where
+    fromRational r = HFloat (realToFrac r)
+    a / b = error "not implemented"
+x :: Val
+x = HMap [
+    {- Server configuration -}
+    ("host", "localhost"),  {- default host -}
+    ("port", 8080),
+    {- Enable debug mode -}
+    ("debug", HBool True)
+    ]

--- a/tests/integration/cases/comments/hcl_block.hcl
+++ b/tests/integration/cases/comments/hcl_block.hcl
@@ -1,0 +1,7 @@
+_ = {
+    /* Server configuration */
+    "host" = "localhost",  /* default host */
+    "port" = 8080,
+    /* Enable debug mode */
+    "debug" = true,
+}

--- a/tests/integration/cases/comments/java_block.java
+++ b/tests/integration/cases/comments/java_block.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+import java.util.Set;
+class Check {
+    Object x = Map.ofEntries(
+    /* Server configuration */
+    Map.entry("host", "localhost"),  /* default host */
+    Map.entry("port", 8080),
+    /* Enable debug mode */
+    Map.entry("debug", true)
+);
+}

--- a/tests/integration/cases/comments/javascript_block.js
+++ b/tests/integration/cases/comments/javascript_block.js
@@ -1,0 +1,9 @@
+void (
+{
+    /* Server configuration */
+    "host": "localhost",  /* default host */
+    "port": 8080,
+    /* Enable debug mode */
+    "debug": true,
+}
+)

--- a/tests/integration/cases/comments/julia_block.jl
+++ b/tests/integration/cases/comments/julia_block.jl
@@ -1,0 +1,7 @@
+Dict(
+    #= Server configuration =#
+    "host" => "localhost",  #= default host =#
+    "port" => 8080,
+    #= Enable debug mode =#
+    "debug" => true,
+)

--- a/tests/integration/cases/comments/kotlin_block.kts
+++ b/tests/integration/cases/comments/kotlin_block.kts
@@ -1,0 +1,7 @@
+val x: Any? = mapOf<String, Any?>(
+    /* Server configuration */
+    "host" to "localhost",  /* default host */
+    "port" to 8080,
+    /* Enable debug mode */
+    "debug" to true,
+)

--- a/tests/integration/cases/comments/lua_block.lua
+++ b/tests/integration/cases/comments/lua_block.lua
@@ -1,0 +1,7 @@
+local _ = {
+    --[[ Server configuration ]]
+    ["host"] = "localhost",  --[[ default host ]]
+    ["port"] = 8080,
+    --[[ Enable debug mode ]]
+    ["debug"] = true,
+}

--- a/tests/integration/cases/comments/matlab_block.m
+++ b/tests/integration/cases/comments/matlab_block.m
@@ -1,0 +1,7 @@
+x = struct(
+    %{ Server configuration %}
+    'host', "localhost",  %{ default host %}
+    'port', 8080,
+    %{ Enable debug mode %}
+    'debug', true
+);

--- a/tests/integration/cases/comments/nim_block.nim
+++ b/tests/integration/cases/comments/nim_block.nim
@@ -1,0 +1,8 @@
+import json
+let _ = %*{
+    #[ Server configuration ]#
+    "host": "localhost",  #[ default host ]#
+    "port": 8080,
+    #[ Enable debug mode ]#
+    "debug": true
+}

--- a/tests/integration/cases/comments/objective_c_block.m
+++ b/tests/integration/cases/comments/objective_c_block.m
@@ -1,0 +1,44 @@
+typedef signed char BOOL;
+#define YES ((BOOL)1)
+#define NO ((BOOL)0)
+@interface NSObject
++ (instancetype)alloc;
+- (instancetype)init;
+@end
+@interface NSString : NSObject
+@end
+@interface NSNumber : NSObject
++ (instancetype)numberWithBool:(BOOL)value;
++ (instancetype)numberWithChar:(signed char)value;
++ (instancetype)numberWithInt:(int)value;
++ (instancetype)numberWithUnsignedInt:(unsigned int)value;
++ (instancetype)numberWithLong:(long)value;
++ (instancetype)numberWithUnsignedLong:(unsigned long)value;
++ (instancetype)numberWithLongLong:(long long)value;
++ (instancetype)numberWithUnsignedLongLong:(unsigned long long)value;
++ (instancetype)numberWithFloat:(float)value;
++ (instancetype)numberWithDouble:(double)value;
+@end
+@interface NSArray : NSObject
++ (instancetype)arrayWithObjects:(const id [])objects count:(unsigned long)cnt;
+@end
+@interface NSDictionary : NSObject
++ (instancetype)dictionaryWithObjects:(const id [])objects forKeys:(const id [])keys count:(unsigned long)cnt;
+@end
+@interface NSNull : NSObject
++ (instancetype)null;
+@end
+@interface NSSet : NSObject
++ (instancetype)set;
++ (instancetype)setWithArray:(NSArray *)array;
+@end
+void _check(void) {
+    id _v = @{
+    /* Server configuration */
+    @"host": @"localhost",  /* default host */
+    @"port": @(8080),
+    /* Enable debug mode */
+    @"debug": @YES,
+};
+    (void)_v;
+}

--- a/tests/integration/cases/comments/php_block.php
+++ b/tests/integration/cases/comments/php_block.php
@@ -1,0 +1,8 @@
+<?php
+$x = [
+    /* Server configuration */
+    "host" => "localhost",  /* default host */
+    "port" => 8080,
+    /* Enable debug mode */
+    "debug" => true,
+];

--- a/tests/integration/cases/comments/powershell_block.ps1
+++ b/tests/integration/cases/comments/powershell_block.ps1
@@ -1,0 +1,7 @@
+$x = @{
+    <# Server configuration #>
+    "host" = "localhost";  <# default host #>
+    "port" = 8080;
+    <# Enable debug mode #>
+    "debug" = $true
+}

--- a/tests/integration/cases/comments/racket_block.rkt
+++ b/tests/integration/cases/comments/racket_block.rkt
@@ -1,0 +1,8 @@
+#lang racket
+(hash
+    #| Server configuration |#
+    "host" "localhost"  #| default host |#
+    "port" 8080
+    #| Enable debug mode |#
+    "debug" #t
+)

--- a/tests/integration/cases/comments/rust_block.rs
+++ b/tests/integration/cases/comments/rust_block.rs
@@ -1,0 +1,10 @@
+use std::collections::{HashMap};
+fn main() {
+    let _ = HashMap::from([
+        /* Server configuration */
+        ("host", "localhost"),  /* default host */
+        ("port", "8080"),
+        /* Enable debug mode */
+        ("debug", "True"),
+    ]);
+}

--- a/tests/integration/cases/comments/scala_block.scala
+++ b/tests/integration/cases/comments/scala_block.scala
@@ -1,0 +1,9 @@
+object Check {
+val x: Any = Map(
+    /* Server configuration */
+    "host" -> "localhost",  /* default host */
+    "port" -> 8080,
+    /* Enable debug mode */
+    "debug" -> true,
+)
+}

--- a/tests/integration/cases/comments/swift_block.swift
+++ b/tests/integration/cases/comments/swift_block.swift
@@ -1,0 +1,7 @@
+let x: Any? = [
+    /* Server configuration */
+    "host": "localhost",  /* default host */
+    "port": 8080,
+    /* Enable debug mode */
+    "debug": true,
+]

--- a/tests/integration/cases/comments/typescript_block.ts
+++ b/tests/integration/cases/comments/typescript_block.ts
@@ -1,0 +1,9 @@
+void (
+{
+    /* Server configuration */
+    "host": "localhost",  /* default host */
+    "port": 8080,
+    /* Enable debug mode */
+    "debug": true,
+}
+)


### PR DESCRIPTION
## Summary

Adds a `BLOCK` `CommentFormats` enum member to 25 languages that support both line and block comment syntax, addressing the comment_format section of #261. Each language gets the appropriate block comment delimiters (e.g. `/* */` for C-family, `{- -}` for Haskell, `#= =#` for Julia, etc.). Golden test files for all new variants are included.

## Test plan

- [x] All 5493 existing tests pass
- [x] 25 new variant golden files generated and verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new `BLOCK` comment-format enum options and corresponding golden fixtures without changing existing defaults, but it expands the public formatting surface and could affect consumers that iterate over comment-format enums.
> 
> **Overview**
> Adds a new `BLOCK` member to `CommentFormats` for ~25 language specs, providing each language’s native block-comment delimiters alongside the existing line-comment style.
> 
> Adds new integration golden files under `tests/integration/cases/comments/*_block.*` to validate rendering of collection comments using the new block comment format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9aa034536de9d9bf85bc26c3d7b7492c1ae83246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->