### PR TITLE
Remove from __future__ import annotations

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1,16 +1,12 @@
 """Language protocol and internal spec dataclass."""
 
-from __future__ import annotations
-
 import dataclasses
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+import datetime
+import enum
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
 
-if TYPE_CHECKING:
-    import datetime
-    import enum
-    from collections.abc import Callable
-
-    from literalizer._types import Value
+from literalizer._types import Value
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/_types.py
+++ b/src/literalizer/_types.py
@@ -1,7 +1,5 @@
 """Type aliases used across the literalizer package."""
 
-from __future__ import annotations
-
 import datetime
 
 type Scalar = (

--- a/src/literalizer/languages/__init__.py
+++ b/src/literalizer/languages/__init__.py
@@ -1,7 +1,5 @@
 """Built-in language specifications for common programming languages."""
 
-from __future__ import annotations
-
 from .ada import Ada
 from .bash import Bash
 from .c import C

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -1,8 +1,8 @@
 """Ada language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -1,8 +1,8 @@
 """Bash language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -26,9 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -1,8 +1,8 @@
 """C language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -1,8 +1,8 @@
 """Clojure language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -1,9 +1,9 @@
 """COBOL language specification (GnuCOBOL free-format)."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 import re
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 _COBOL_CONTROL_CHAR_REPLACEMENTS: dict[str, str] = {

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -1,8 +1,8 @@
 """Common Lisp language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -27,9 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1,7 +1,6 @@
 """C++ language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING, Any
 
@@ -27,7 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -1,8 +1,8 @@
 """Crystal language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -1,7 +1,6 @@
 """C# language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING, Any
 
@@ -27,7 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -1,8 +1,8 @@
 """D language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -1,7 +1,6 @@
 """Dart language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING, Any
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -1,8 +1,8 @@
 """Elixir language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -1,8 +1,8 @@
 """Erlang language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -27,9 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -1,8 +1,8 @@
 """Fortran language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 _FVAL_PREFIXES = (

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -1,8 +1,8 @@
 """F# language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -1,7 +1,6 @@
 """Go language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING, Any
 
@@ -27,7 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -1,8 +1,8 @@
 """Groovy language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1,8 +1,8 @@
 """Haskell language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -27,9 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -1,8 +1,8 @@
 """HCL (HashiCorp Configuration Language) language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1,7 +1,6 @@
 """Java language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING, Any
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -1,7 +1,6 @@
 """JavaScript language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -1,7 +1,6 @@
 """Julia language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -1,7 +1,6 @@
 """Kotlin language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING, Any
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -1,8 +1,8 @@
 """Lua language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -26,9 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -1,9 +1,9 @@
 """MATLAB language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 import re
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 _CONTROL_CHAR_THRESHOLD = 32

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -1,8 +1,8 @@
 """Mojo language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1,8 +1,8 @@
 """Nim language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -1,7 +1,6 @@
 """Norg language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -1,8 +1,8 @@
 """Objective-C language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -21,9 +21,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 _OBJC_PREFIXES = (

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -1,8 +1,8 @@
 """OCaml language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -1,8 +1,8 @@
 """Occam-pi language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -1,8 +1,8 @@
 """Perl language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -1,8 +1,8 @@
 """PHP language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -26,9 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -1,8 +1,8 @@
 """PowerShell language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -26,9 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1,7 +1,6 @@
 """Python language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -30,7 +29,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -1,7 +1,6 @@
 """R language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 from literalizer.exceptions import EmptyDictKeyError
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -1,8 +1,8 @@
 """Racket language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -1,7 +1,6 @@
 """Ruby language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1,7 +1,6 @@
 """Rust language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -27,7 +26,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -1,9 +1,9 @@
 """Scala language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import Any
 
 from beartype import beartype
 
@@ -27,10 +27,6 @@ from literalizer._language import (
     SetFormatConfig,
 )
 from literalizer._types import Value  # noqa: TC001
-
-if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
 
 _SCALA_SCALAR_TYPES: dict[str, str] = {
     "string": "String",

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -1,8 +1,8 @@
 """Swift language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -28,9 +28,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -1,7 +1,6 @@
 """TOML language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 import re
 from typing import TYPE_CHECKING
@@ -26,7 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -1,7 +1,6 @@
 """TypeScript language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -1,7 +1,6 @@
 """Visual Basic (.NET) language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING, Any
 
@@ -28,7 +27,6 @@ from literalizer._language import (
 from literalizer._types import Value  # noqa: TC001
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
 _VB_SCALAR_TYPES: dict[str, str] = {

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -1,7 +1,6 @@
 """YAML language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -26,7 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
     from collections.abc import Callable
 
     from literalizer._types import Value

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -1,8 +1,8 @@
 """Zig language specification."""
 
-from __future__ import annotations
-
+import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -25,9 +25,6 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Callable
-
     from literalizer._types import Value
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -12,12 +12,11 @@ To regenerate all golden files after changing output::
     uv run pytest tests/integration/ --regen-all
 """
 
-from __future__ import annotations
-
 import dataclasses
 import enum
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 from beartype import beartype
@@ -25,9 +24,6 @@ from pytest_regressions.file_regression import FileRegressionFixture
 
 import literalizer
 import literalizer.languages
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 _CASES_REL = Path("tests") / "integration" / "cases"
 

--- a/tests/test_class_enum_access.py
+++ b/tests/test_class_enum_access.py
@@ -1,18 +1,12 @@
 """Test class-level format Enum access via HasFormatEnums."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
+from literalizer import HasFormatEnums
 from literalizer.languages import (
     Ada,
     Bash,
     Cpp,
     Python,
 )
-
-if TYPE_CHECKING:
-    from literalizer import HasFormatEnums
 
 _LANGUAGE_TYPES: dict[str, HasFormatEnums] = {
     "ada": Ada,


### PR DESCRIPTION
Remove `from __future__ import annotations` from all 51 files. The project requires Python >=3.12, so PEP 604 union syntax and other annotation features are available natively. Imports that were previously guarded behind `TYPE_CHECKING` blocks solely due to the future import are moved to runtime where needed, and now-empty `TYPE_CHECKING` blocks are removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical typing/import refactor to rely on Python 3.12+ defaults; main risk is accidental runtime import/typing side effects or lint/type-check differences, but no behavior changes are intended.
> 
> **Overview**
> Removes `from __future__ import annotations` throughout the project and updates imports accordingly (moving some `datetime`/`Callable`/`Value` imports to runtime and deleting now-empty `TYPE_CHECKING` blocks).
> 
> Updates a couple of tests to match the new import strategy (e.g., direct `HasFormatEnums` import and `Callable` typing import).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb128a72f89be74f0732a143f05cda815f1fa476. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->