### PR TITLE
Remove noqa: TC001 by moving imports into TYPE_CHECKING blocks

### DIFF
--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -3,7 +3,7 @@
 import datetime
 import enum
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from beartype import beartype
 
@@ -26,7 +26,9 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
-from literalizer._types import Value  # noqa: TC001
+
+if TYPE_CHECKING:
+    from literalizer._types import Value
 
 _SCALA_SCALAR_TYPES: dict[str, str] = {
     "string": "String",

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -24,10 +24,11 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
-from literalizer._types import Value  # noqa: TC001
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from literalizer._types import Value
 
 _VB_SCALAR_TYPES: dict[str, str] = {
     "string": "String",


### PR DESCRIPTION
## Summary
- Move `Value` imports into `TYPE_CHECKING` blocks in `scala.py` and `vb.py`, removing the `noqa: TC001` suppressions
- These were the last two `noqa: TC001` comments in the codebase

## Test plan
- [x] `ruff check` passes on both files
- [x] All pre-commit hooks pass (mypy, pyright, ty, pyrefly)
- [x] Both modules import successfully at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type-checking-only import refactor that should not affect runtime behavior, aside from potentially avoiding import-time dependency/cycle issues.
> 
> **Overview**
> Removes the remaining `noqa: TC001` suppressions by moving `Value` imports in `languages/scala.py` and `languages/vb.py` into `TYPE_CHECKING` blocks.
> 
> This keeps the `Value` type available for annotations while avoiding runtime imports in these modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fdac65173e8575188c2f901dc3084707d2c4662. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->