### PR TITLE
Extract _scalar_type_buckets helper from _all_scalars_heterogeneous

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -75,18 +75,31 @@ def _coerce_scalar_to_str(
 
 
 @beartype
+def _scalar_type_buckets(
+    *,
+    values: Sequence[Value],
+) -> set[type] | None:
+    """Return the set of scalar type buckets for *values*.
+
+    Returns ``None`` if any value is not a scalar.
+    """
+    buckets: set[type] = set()
+    for v in values:
+        bucket = _scalar_type_bucket(value=v)
+        if bucket is None:
+            return None
+        buckets.add(bucket)
+    return buckets
+
+
+@beartype
 def _all_scalars_heterogeneous(
     *,
     values: Sequence[Value],
 ) -> bool:
     """Check whether values are all scalars with more than one type."""
-    buckets: set[type] = set()
-    for v in values:
-        bucket = _scalar_type_bucket(value=v)
-        if bucket is None:
-            return False
-        buckets.add(bucket)
-    return len(buckets) > 1
+    buckets = _scalar_type_buckets(values=values)
+    return buckets is not None and len(buckets) > 1
 
 
 @beartype


### PR DESCRIPTION
## Summary

- Extracts the bucket-collection logic from `_all_scalars_heterogeneous` into a new `_scalar_type_buckets` helper that returns the set of scalar type buckets (or `None` if any value is not a scalar).
- `_all_scalars_heterogeneous` becomes a thin wrapper, and the building block is available for future homogeneity/other checks.

## Test plan

- [x] All 291 existing tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that extracts existing bucket-collection logic into a new helper without changing the heterogeneity decision criteria.
> 
> **Overview**
> Refactors `_all_scalars_heterogeneous` by extracting its scalar “type bucket” collection logic into a new `_scalar_type_buckets` helper that returns `set[type]` (or `None` if any element is non-scalar).
> 
> `_all_scalars_heterogeneous` is now a thin wrapper around `_scalar_type_buckets`, preserving the prior behavior while making the bucket set reusable for future checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dce7ecf23e06b67e93d0dac05269c1ed8923359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->