### PR TITLE
Emit typed constructors for empty Mojo collections

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -106,7 +106,7 @@ class Mojo(metaclass=HasFormatEnums):
             close="]",
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
-            empty_sequence=None,
+            empty_sequence="List[String]()",
         )
 
         @property
@@ -122,7 +122,7 @@ class Mojo(metaclass=HasFormatEnums):
         SET = SetFormatConfig(
             open_str="[",
             close="]",
-            empty_set=None,
+            empty_set="Set[String]()",
         )
 
     class CommentFormats(enum.Enum):
@@ -172,7 +172,7 @@ class Mojo(metaclass=HasFormatEnums):
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(separator=": "),
-            empty_dict=None,
+            empty_dict="Dict[String, String]()",
         )
         self.multiline_trailing_comma = True
         self.format_bytes: Callable[[bytes], str] = bytes_format

--- a/tests/integration/cases/nested_deep_empty/mojo.mojo
+++ b/tests/integration/cases/nested_deep_empty/mojo.mojo
@@ -1,4 +1,4 @@
 def main():
     _ = [
-        [[], []],
+        [List[String](), List[String]()],
     ]

--- a/tests/integration/cases/nested_deep_empty/mojo_combined.mojo
+++ b/tests/integration/cases/nested_deep_empty/mojo_combined.mojo
@@ -1,7 +1,7 @@
 def main():
     var my_data = [
-        [[], []],
+        [List[String](), List[String]()],
     ]
     my_data = [
-        [[], []],
+        [List[String](), List[String]()],
     ]

--- a/tests/integration/cases/nested_deep_empty/mojo_varname.mojo
+++ b/tests/integration/cases/nested_deep_empty/mojo_varname.mojo
@@ -1,4 +1,4 @@
 def main():
     var my_data = [
-        [[], []],
+        [List[String](), List[String]()],
     ]

--- a/tests/integration/cases/nested_empty_inner/mojo.mojo
+++ b/tests/integration/cases/nested_empty_inner/mojo.mojo
@@ -1,5 +1,5 @@
 def main():
     _ = [
-        [],
-        [],
+        List[String](),
+        List[String](),
     ]

--- a/tests/integration/cases/nested_empty_inner/mojo_combined.mojo
+++ b/tests/integration/cases/nested_empty_inner/mojo_combined.mojo
@@ -1,9 +1,9 @@
 def main():
     var my_data = [
-        [],
-        [],
+        List[String](),
+        List[String](),
     ]
     my_data = [
-        [],
-        [],
+        List[String](),
+        List[String](),
     ]

--- a/tests/integration/cases/nested_empty_inner/mojo_varname.mojo
+++ b/tests/integration/cases/nested_empty_inner/mojo_varname.mojo
@@ -1,5 +1,5 @@
 def main():
     var my_data = [
-        [],
-        [],
+        List[String](),
+        List[String](),
     ]


### PR DESCRIPTION
## Summary
- Empty Mojo sequences now emit `List[String]()` instead of `[]`
- Empty Mojo sets now emit `Set[String]()` instead of `[]`
- Empty Mojo dicts now emit `Dict[String, String]()` instead of `{}`

This mirrors how Rust emits `Vec::<String>::new()` for empty vectors, ensuring valid Mojo output that includes the required type information.

## Test plan
- [x] All existing Mojo integration tests pass
- [x] Golden files regenerated for `nested_deep_empty` and `nested_empty_inner` test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mojo literal generation for empty lists/sets/dicts to emit typed constructor calls, which may affect downstream consumers expecting `[]`/`{}` output but is localized to Mojo formatting.
> 
> **Overview**
> Mojo output for *empty collections* is changed to emit typed constructor forms: empty lists become `List[String]()`, empty sets become `Set[String]()`, and empty dicts become `Dict[String, String]()`.
> 
> Integration test golden outputs for nested empty-list cases are updated to match the new Mojo rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba7a591a2e6c3702b15910bfa1fe8a7ab1479455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->