### PR TITLE
Unify variant builders to return dict[str, _Variant] consistently

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1791,55 +1791,41 @@ class _VariantCase:
 
 
 @beartype
-def _build_date_variants() -> list[_VariantCase]:
+def _build_date_variants() -> dict[str, _Variant]:
     """Build datetime-format variants for scalar dates.
 
     For each language, create a variant for every datetime format,
     using ``varname_wrap`` with a variable name.
     """
-    cases: list[_VariantCase] = []
+    variants: dict[str, _Variant] = {}
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
         for fmt in list(spec.datetime_formats):
             variant_key = f"{lang_name}_date_{fmt.name.lower()}"
-            cases.append(
-                _VariantCase(
-                    variant_name=variant_key,
-                    variant=_Variant(
-                        spec=lang_config.lang_cls(datetime_format=fmt),
-                        wrap=lang_config.varname_wrap,
-                    ),
-                    case_dir_name="scalar_date",
-                    variable_name=_VARIABLE_NAME,
-                )
+            variants[variant_key] = _Variant(
+                spec=lang_config.lang_cls(datetime_format=fmt),
+                wrap=lang_config.varname_wrap,
             )
-    return cases
+    return variants
 
 
 @beartype
-def _build_datetime_variants() -> list[_VariantCase]:
+def _build_datetime_variants() -> dict[str, _Variant]:
     """Build datetime-format variants for scalar datetimes.
 
     For each language, create a variant for every datetime format,
     using ``varname_wrap`` with a variable name.
     """
-    cases: list[_VariantCase] = []
+    variants: dict[str, _Variant] = {}
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
         for fmt in list(spec.datetime_formats):
             variant_key = f"{lang_name}_datetime_{fmt.name.lower()}"
-            cases.append(
-                _VariantCase(
-                    variant_name=variant_key,
-                    variant=_Variant(
-                        spec=lang_config.lang_cls(datetime_format=fmt),
-                        wrap=lang_config.varname_wrap,
-                    ),
-                    case_dir_name="scalar_datetime",
-                    variable_name=_VARIABLE_NAME,
-                )
+            variants[variant_key] = _Variant(
+                spec=lang_config.lang_cls(datetime_format=fmt),
+                wrap=lang_config.varname_wrap,
             )
-    return cases
+    return variants
 
 
 @beartype
@@ -1887,6 +1873,7 @@ def _build_set_variants() -> dict[str, _Variant]:
     return variants
 
 
+@beartype
 def _build_comment_variants() -> dict[str, _Variant]:
     """Build comment-format variants for all languages with multiple
     formats.
@@ -2070,9 +2057,9 @@ def test_golden_file_combined_variable_forms(
 def _build_variant_cases() -> list[_VariantCase]:
     """Collect all format-variant golden-file test cases."""
     cases: list[_VariantCase] = []
-    cases.extend(_build_date_variants())
-    cases.extend(_build_datetime_variants())
     variant_sources: list[tuple[dict[str, _Variant], str, str | None]] = [
+        (_build_date_variants(), "scalar_date", _VARIABLE_NAME),
+        (_build_datetime_variants(), "scalar_datetime", _VARIABLE_NAME),
         (_build_sequence_variants(), "simple_sequence", None),
         (_build_set_variants(), "set", None),
         (_build_comment_variants(), "comments", None),


### PR DESCRIPTION
## Summary
- Changed `_build_date_variants` and `_build_datetime_variants` to return `dict[str, _Variant]` instead of `list[_VariantCase]`, matching all other variant builders.
- Moved `_VariantCase` wrapping into `_build_variant_cases` so all builders are handled uniformly.
- Added missing `@beartype` decorator to `_build_comment_variants`.

## Test plan
- [x] All 5283 integration tests pass
- [x] Pre-commit hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to integration test scaffolding (variant-case construction) and a missing decorator; behavior should only affect test parametrization, with low production risk.
> 
> **Overview**
> Refactors integration test variant generation so `_build_date_variants` and `_build_datetime_variants` now return `dict[str, _Variant]` like the other builders, and moves `_VariantCase` wrapping into `_build_variant_cases` for uniform handling.
> 
> Adds the missing `@beartype` decorator to `_build_comment_variants` to keep runtime type checking consistent across builders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af60cb6c254f4d86e5acbde88dca71d4fc191088. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->