### PR TITLE
Remove "cannot emit an empty" error suppression from Mojo lint

### DIFF
--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -37,11 +37,7 @@ jobs:
           set -o pipefail
           find tests/integration/cases -name "*.mojo" -print0 | \
             while IFS= read -r -d '' f; do
-              if ! output=$(mojo run "$f" 2>&1); then
-                if ! printf "%s" "$output" | grep -qE \
-                  "cannot emit an empty"; then
-                  printf "%s\n" "$output" >&2
-                  exit 1
-                fi
+              if ! mojo run "$f"; then
+                exit 1
               fi
             done


### PR DESCRIPTION
## Summary
- Remove the grep filter that suppressed "cannot emit an empty" errors in the Mojo lint CI workflow
- No current `.mojo` test files trigger this error, so the suppression was dead code
- The check now fails immediately on any non-zero exit from `mojo run`

## Test plan
- [x] Verified locally that all `.mojo` files pass `mojo run` without errors
- [ ] CI lint-mojo job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that makes the Mojo lint job stricter; potential impact is increased CI failures if the previously suppressed error reappears.
> 
> **Overview**
> The `lint-mojo` GitHub Actions workflow no longer suppresses the Mojo compiler error message "cannot emit an empty".
> 
> The syntax check now fails the job on any non-zero exit from `mojo run` for `.mojo` files in `tests/integration/cases`, instead of filtering that specific error and continuing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c3c67d9094c1f705c6c7c15bf0aa218b3763aa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->