### PR TITLE
Add Java sequence_format option (ARRAY | LIST)

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -18,6 +18,7 @@ class SequenceFormatConfig:
     supports_heterogeneity: bool
     single_element_trailing_comma: bool
     empty_sequence: str | None
+    schema_to_opener: Callable[..., str | None] | None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -146,6 +146,7 @@ class Ada(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence="AList'(1 .. 0 => ANull)",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -122,6 +122,7 @@ class Bash(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -131,6 +131,7 @@ class C(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -88,6 +88,7 @@ class Clojure(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -262,6 +262,7 @@ class Cobol(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence="05 FILLER PIC X(1) VALUE SPACES.",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -93,6 +93,7 @@ class CommonLisp(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence="nil",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -151,6 +151,7 @@ class Cpp(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -97,6 +97,7 @@ class Crystal(metaclass=HasFormatEnums):
             empty_sequence="[] of Nil",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
+            schema_to_opener=None,
         )
         TUPLE = SequenceFormatConfig(
             open_str="{",
@@ -104,6 +105,7 @@ class Crystal(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -148,6 +148,7 @@ class CSharp(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence="Array.Empty<object>()",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -149,6 +149,7 @@ class D(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence='parseJSON("[]")',
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -149,6 +149,7 @@ class Dart(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -103,6 +103,7 @@ class Elixir(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
         TUPLE = SequenceFormatConfig(
             open_str="{",
@@ -110,6 +111,7 @@ class Elixir(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -111,6 +111,7 @@ class Erlang(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
         TUPLE = SequenceFormatConfig(
             open_str="{",
@@ -118,6 +119,7 @@ class Erlang(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -206,6 +206,7 @@ class Fortran(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -149,6 +149,7 @@ class FSharp(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -159,6 +159,7 @@ class Go(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -88,6 +88,7 @@ class Groovy(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -138,6 +138,7 @@ class Haskell(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -90,6 +90,7 @@ class Hcl(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -8,6 +8,7 @@ from beartype import beartype
 
 from literalizer._formatters import (
     fixed_dict_open,
+    fixed_sequence_open,
     format_bytes_hex,
     format_date_java,
     format_datetime_java_instant,
@@ -104,6 +105,13 @@ class Java(metaclass=HasFormatEnums):
             * ``datetime_formats.ZONED`` — ``ZonedDateTime.of(...)`` call,
               e.g. ``ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0,
               ZoneId.of("UTC"))``.
+
+        sequence_format: How to format sequences.
+
+            * ``sequence_formats.ARRAY`` — Java array literal,
+              e.g. ``new Object[]{1, 2, 3}``.
+            * ``sequence_formats.LIST`` — ``List.of(...)`` call,
+              e.g. ``List.of(1, 2, 3)``.
     """
 
     extension = ".java"
@@ -145,6 +153,15 @@ class Java(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=_java_schema_to_opener,
+        )
+        LIST = SequenceFormatConfig(
+            open_str="List.of(",
+            close=")",
+            supports_heterogeneity=True,
+            single_element_trailing_comma=False,
+            empty_sequence="List.of()",
+            schema_to_opener=None,
         )
 
         @property
@@ -207,10 +224,17 @@ class Java(metaclass=HasFormatEnums):
         fmt = sequence_format.value
         self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format_config: SetFormatConfig = set_format.value
-        self.sequence_open: Callable[[list[Value]], str] = typed_sequence_open(
-            schema_to_opener=_java_schema_to_opener,
-            fallback=fmt.open_str,
-        )
+        if fmt.schema_to_opener is not None:
+            self.sequence_open: Callable[[list[Value]], str] = (
+                typed_sequence_open(
+                    schema_to_opener=fmt.schema_to_opener,
+                    fallback=fmt.open_str,
+                )
+            )
+        else:
+            self.sequence_open = fixed_sequence_open(
+                open_str=fmt.open_str,
+            )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="Map.ofEntries("),
             close=")",

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -104,6 +104,7 @@ class JavaScript(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -105,6 +105,7 @@ class Julia(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
         TUPLE = SequenceFormatConfig(
             open_str="(",
@@ -112,6 +113,7 @@ class Julia(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=True,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -165,6 +165,7 @@ class Kotlin(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -104,6 +104,7 @@ class Lua(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -158,6 +158,7 @@ class Matlab(metaclass=HasFormatEnums):
             empty_sequence="{}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -107,6 +107,7 @@ class Mojo(metaclass=HasFormatEnums):
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
             empty_sequence="List[String]()",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -88,6 +88,7 @@ class Nim(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -105,6 +105,7 @@ class Norg(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -161,6 +161,7 @@ class ObjectiveC(metaclass=HasFormatEnums):
             empty_sequence="@[]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -153,6 +153,7 @@ class OCaml(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -139,6 +139,7 @@ class Occam(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -88,6 +88,7 @@ class Perl(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -104,6 +104,7 @@ class Php(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -114,6 +114,7 @@ class PowerShell(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -209,6 +209,7 @@ class Python(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=True,
             empty_sequence=None,
+            schema_to_opener=None,
         )
         LIST = SequenceFormatConfig(
             open_str="[",
@@ -216,6 +217,7 @@ class Python(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -156,6 +156,7 @@ class R(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -88,6 +88,7 @@ class Racket(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence="(list)",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -104,6 +104,7 @@ class Ruby(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -127,6 +127,7 @@ class Rust(metaclass=HasFormatEnums):
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
             empty_sequence="Vec::<String>::new()",
+            schema_to_opener=None,
         )
         ARRAY = SequenceFormatConfig(
             open_str="[",
@@ -134,6 +135,7 @@ class Rust(metaclass=HasFormatEnums):
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
         TUPLE = SequenceFormatConfig(
             open_str="(",
@@ -141,6 +143,7 @@ class Rust(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -139,6 +139,7 @@ class Scala(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -94,6 +94,7 @@ class Swift(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence="[Any]()",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -143,6 +143,7 @@ class Toml(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -104,6 +104,7 @@ class TypeScript(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -135,6 +135,7 @@ class VisualBasic(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence="New Object() {}",
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -116,6 +116,7 @@ class Yaml(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -125,6 +125,7 @@ class Zig(metaclass=HasFormatEnums):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             empty_sequence=None,
+            schema_to_opener=None,
         )
 
         @property

--- a/tests/integration/cases/simple_sequence/java_list.java
+++ b/tests/integration/cases/simple_sequence/java_list.java
@@ -1,0 +1,11 @@
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+class Check {
+    Object x = List.of(
+    1,
+    "hello",
+    true,
+    null
+);
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -78,8 +78,9 @@ def _java_time_imports(content: str) -> str:
 def _wrap_java(content: str) -> str:
     """Wrap in a Java class with necessary imports."""
     time_imports = _java_time_imports(content=content)
+    list_import = "import java.util.List;\n" if "List.of(" in content else ""
     return f"""\
-{time_imports}import java.util.Map;
+{time_imports}{list_import}import java.util.Map;
 import java.util.Set;
 class Check {{
     Object x = {content};
@@ -364,8 +365,10 @@ def _wrap_go_varname(content: str) -> str:
 def _wrap_java_varname(content: str) -> str:
     """Wrap a Java var declaration in a static method."""
     time_imports = _java_time_imports(content=content)
+    list_import = "import java.util.List;\n" if "List.of(" in content else ""
     return (
         f"{time_imports}"
+        f"{list_import}"
         "import java.util.Map;\n"
         "import java.util.Set;\n"
         "class Check {\n"


### PR DESCRIPTION
## Summary
- Add `LIST` variant to Java's `sequence_format` option, producing `List.of(...)` instead of `new Object[]{...}`
- Default remains `ARRAY` (no behavior change for existing users)
- Part of #261 (sequence format section)

## Test plan
- [x] New golden file `java_list.java` for the LIST variant
- [x] All 5484 existing tests pass
- [x] Pre-commit hooks (pyright, mypy, ruff, etc.) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Java output mode and changes the `SequenceFormatConfig` shape across all languages, which could break downstream code constructing these configs or affect sequence opening behavior for Java when schema-based typing is expected.
> 
> **Overview**
> Adds a new Java `sequence_format` variant (`LIST`) that formats sequences as `List.of(...)` (including an `empty_sequence` of `List.of()`), while keeping the default `ARRAY` behavior.
> 
> Refactors `SequenceFormatConfig` to carry an optional `schema_to_opener` callback and updates all language sequence format definitions accordingly; Java now chooses between `typed_sequence_open` (when a schema opener is provided) and `fixed_sequence_open`.
> 
> Updates Java integration wrapping to conditionally import `java.util.List` and adds a new golden integration case for the Java `List.of(...)` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f06335330db2485ae9ac618d3adca7c048b4e68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->