### PR TITLE
Use format properties for default in date/datetime variant builders

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1765,9 +1765,9 @@ def _build_date_variants() -> dict[str, _Variant]:
     variants: dict[str, _Variant] = {}
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
-        default_member = next(iter(spec.date_formats))
+        default_format = spec.format_date
         for fmt in list(spec.date_formats):
-            if fmt is default_member:
+            if fmt is default_format:
                 continue
             variant_key = f"{lang_name}_date_{fmt.name.lower()}"
             variants[variant_key] = _Variant(
@@ -1787,9 +1787,9 @@ def _build_datetime_variants() -> dict[str, _Variant]:
     variants: dict[str, _Variant] = {}
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
-        default_member = next(iter(spec.datetime_formats))
+        default_format = spec.format_datetime
         for fmt in list(spec.datetime_formats):
-            if fmt is default_member:
+            if fmt is default_format:
                 continue
             variant_key = f"{lang_name}_datetime_{fmt.name.lower()}"
             variants[variant_key] = _Variant(


### PR DESCRIPTION
## Summary
- Refactor `_build_date_variants` and `_build_datetime_variants` to use `spec.format_date` / `spec.format_datetime` properties to find the default format, instead of `next(iter(...))`. This matches the pattern used by the sequence variant builder (`spec.sequence_format`).

## Test plan
- [x] All 39 format variant golden file tests pass
- [x] mypy, pyright, and pyrefly all pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that changes how the “default” date/datetime format is identified when generating golden-file variants.
> 
> **Overview**
> Updates integration test variant builders so `_build_date_variants` and `_build_datetime_variants` detect the default format via `spec.format_date` / `spec.format_datetime` instead of assuming `next(iter(spec.*_formats))` is the default, aligning date/datetime behavior with other variant builders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f48d32f3fa96d6362d49c15ca20e6d2fb3ca4752. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->