### PR TITLE
Determine default format from instance attributes, not enum order

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1879,8 +1879,11 @@ def _build_type_hint_variants() -> dict[str, _Variant]:
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
         type_hints_enum = spec.variable_type_hints_formats
+        members = list(type_hints_enum)
+        if len(members) < 2:  # noqa: PLR2004
+            continue
         default_declaration = spec.format_variable_declaration
-        for fmt in list(type_hints_enum):
+        for fmt in members:
             candidate = lang_config.lang_cls(variable_type_hints=fmt)
             if candidate.format_variable_declaration is default_declaration:
                 continue


### PR DESCRIPTION
## Summary
- Date/datetime variant builders now read the default from the instance's `format_date`/`format_datetime` attribute instead of assuming `next(iter(enum))` is the default
- Type-hint variant builder compares `format_variable_declaration` on a constructed instance to detect the default, consistent with how sequence/set/comment variants work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only integration-test variant selection logic; risk is limited to potentially regenerating different golden files if a language’s default format is not the first enum member.
> 
> **Overview**
> Integration golden-file variant builders now **detect default formats via language instance attributes** instead of assuming `next(iter(enum))` is the default.
> 
> For date/datetime variants, the default is taken from `spec.format_date`/`spec.format_datetime`; for variable type-hint variants, the test now skips languages with <2 options and identifies the default by comparing `format_variable_declaration` on a constructed candidate instance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc225d09dadf436396cec1c9f8cf6aab1a3b38f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->