### PR TITLE
Remove unnecessary cast in _literalize

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -685,8 +685,8 @@ def _literalize(
     lines: list[str] = []
 
     is_ordered_map = isinstance(data, ordereddict)
-    if is_ordered_map or isinstance(data, dict):
-        dict_data = cast("dict[str, Value]", data)
+    if isinstance(data, dict):
+        dict_data = data
         entries = [
             (k, v)
             for k, v in dict_data.items()


### PR DESCRIPTION
## Summary
- Remove a `cast("dict[str, Value]", data)` in `_literalize` that is unnecessary because `ordereddict` is a `dict` subclass, so `isinstance(data, dict)` alone covers both cases and lets the type checker narrow the type without an explicit cast.

## Test plan
- [x] mypy, pyright, and all other type checkers pass
- [x] All 5622 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to type narrowing in `_literalize`, with no intended runtime behavior change.
> 
> **Overview**
> Simplifies dict handling in `src/literalizer/_core.py` by removing an unnecessary `cast("dict[str, Value]", data)` in `_literalize` and relying on `isinstance(data, dict)` for type narrowing (including `ordereddict` subclasses). Behavior for ordered maps vs regular dicts is preserved via the existing `is_ordered_map` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc8b328d4f05ae6cd903144f5cdef12964e76a29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->