### PR TITLE
Remove unnecessary cast to object in literalize_yaml

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1064,7 +1064,7 @@ def literalize_yaml(
         message = f"Invalid YAML: {exc}"
         raise YAMLParseError(message) from exc
     base = _literalize(
-        data=_coerce_yaml_keys(data=cast("object", data)),
+        data=_coerce_yaml_keys(data=data),
         language=language,
         line_prefix=line_prefix,
         indent=indent,


### PR DESCRIPTION
## Summary

- Remove redundant `cast("object", data)` in `literalize_yaml`. The `data` variable (returned by `ruamel_yaml.load`) has type `Any`, which is already assignable to the `object` parameter of `_coerce_yaml_keys` without an explicit cast.

## Test plan

- [x] pyright passes
- [x] mypy passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type-cleanup only, removing an unnecessary `cast("object", data)` before `_coerce_yaml_keys` with no behavior change expected.
> 
> **Overview**
> Simplifies `literalize_yaml` by removing a redundant `cast("object", data)` when passing the parsed YAML value into `_coerce_yaml_keys`, relying on the existing `object` parameter type instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4477ef9edd74f81d24a927dccee8b65a96487289. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->