### PR TITLE
Use ALL_LANGUAGES in tests instead of hardcoded language lists

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -25,6 +25,7 @@ from pytest_regressions.file_regression import FileRegressionFixture
 import literalizer
 import literalizer.languages
 from literalizer.exceptions import NullInCollectionError
+from literalizer.languages import ALL_LANGUAGES
 
 _CASES_REL = Path("tests") / "integration" / "cases"
 
@@ -1698,6 +1699,11 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
 }
 
+_COVERED_LANGUAGES = frozenset(cfg.lang_cls for cfg in _LANGUAGES.values())
+assert _COVERED_LANGUAGES == ALL_LANGUAGES, (
+    f"Missing from integration tests: {ALL_LANGUAGES - _COVERED_LANGUAGES}"
+)
+
 
 @dataclasses.dataclass
 class _VariantCase:
@@ -2050,14 +2056,22 @@ def test_format_variant_golden_file(
     )
 
 
-@pytest.mark.parametrize(
-    argnames="lang_config",
-    argvalues=_LANGUAGES.values(),
-    ids=list(_LANGUAGES),
+_SORTED_LANGUAGES: list[literalizer.LanguageCls] = sorted(
+    ALL_LANGUAGES,
+    key=lambda c: c.__name__,
 )
-def test_format_enumeration_properties(lang_config: _LanguageConfig) -> None:
+
+
+@pytest.mark.parametrize(
+    argnames="language_cls",
+    argvalues=_SORTED_LANGUAGES,
+    ids=[c.__name__ for c in _SORTED_LANGUAGES],
+)
+def test_format_enumeration_properties(
+    language_cls: literalizer.LanguageCls,
+) -> None:
     """Every language exposes iterable format-enumeration properties."""
-    spec = lang_config.lang_cls()
+    spec = language_cls()
     assert issubclass(spec.bytes_formats, enum.Enum)
     assert len(spec.bytes_formats) >= 1
     assert issubclass(spec.sequence_formats, enum.Enum)

--- a/tests/test_class_enum_access.py
+++ b/tests/test_class_enum_access.py
@@ -1,90 +1,26 @@
 """Test class-level format Enum access via the LanguageCls meta-class."""
 
+import pytest
+
 from literalizer import LanguageCls
-from literalizer.languages import (
-    Ada,
-    Bash,
-    Cpp,
-    Python,
+from literalizer.languages import ALL_LANGUAGES
+
+_SORTED_LANGUAGES: list[LanguageCls] = sorted(
+    ALL_LANGUAGES,
+    key=lambda c: c.__name__,
 )
 
-_LANGUAGE_TYPES: dict[str, LanguageCls] = {
-    "ada": Ada,
-    "bash": Bash,
-    "cpp": Cpp,
-    "python": Python,
-}
 
-_SEQUENCE_FORMATS: dict[tuple[str, str], object] = {
-    (lang_name, member.name.lower()): member
-    for lang_name, lang_cls in _LANGUAGE_TYPES.items()
-    for member in lang_cls.SequenceFormats
-}
-
-_SET_FORMATS: dict[tuple[str, str], object] = {
-    (lang_name, member.name.lower()): member
-    for lang_name, lang_cls in _LANGUAGE_TYPES.items()
-    for member in lang_cls.SetFormats
-}
-
-_BYTES_FORMATS: dict[tuple[str, str], object] = {
-    (lang_name, member.name.lower()): member
-    for lang_name, lang_cls in _LANGUAGE_TYPES.items()
-    for member in lang_cls.BytesFormats
-}
-
-_DATE_FORMATS: dict[tuple[str, str], object] = {
-    (lang_name, member.name.lower()): member
-    for lang_name, lang_cls in _LANGUAGE_TYPES.items()
-    for member in lang_cls.DateFormats
-}
-
-_DATETIME_FORMATS: dict[tuple[str, str], object] = {
-    (lang_name, member.name.lower()): member
-    for lang_name, lang_cls in _LANGUAGE_TYPES.items()
-    for member in lang_cls.DatetimeFormats
-}
-
-_VARIABLE_TYPE_HINTS: dict[tuple[str, str], object] = {
-    (lang_name, member.name.lower()): member
-    for lang_name, lang_cls in _LANGUAGE_TYPES.items()
-    for member in lang_cls.VariableTypeHints
-}
-
-
-def test_sequence_formats_populated() -> None:
-    """Each language contributes at least one sequence format."""
-    for lang_name in _LANGUAGE_TYPES:
-        assert any(k[0] == lang_name for k in _SEQUENCE_FORMATS)
-
-
-def test_set_formats_populated() -> None:
-    """Each language contributes at least one set format."""
-    for lang_name in _LANGUAGE_TYPES:
-        assert any(k[0] == lang_name for k in _SET_FORMATS)
-
-
-def test_bytes_formats_populated() -> None:
-    """Each language contributes at least one bytes format."""
-    for lang_name in _LANGUAGE_TYPES:
-        assert any(k[0] == lang_name for k in _BYTES_FORMATS)
-
-
-def test_date_formats_populated() -> None:
-    """Each language contributes at least one date format."""
-    for lang_name in _LANGUAGE_TYPES:
-        assert any(k[0] == lang_name for k in _DATE_FORMATS)
-
-
-def test_datetime_formats_populated() -> None:
-    """Each language contributes at least one datetime format."""
-    for lang_name in _LANGUAGE_TYPES:
-        assert any(k[0] == lang_name for k in _DATETIME_FORMATS)
-
-
-def test_variable_type_hints_populated() -> None:
-    """Each language contributes at least one variable type hint
-    option.
-    """
-    for lang_name in _LANGUAGE_TYPES:
-        assert any(k[0] == lang_name for k in _VARIABLE_TYPE_HINTS)
+@pytest.mark.parametrize(
+    argnames="language_cls",
+    argvalues=_SORTED_LANGUAGES,
+    ids=[c.__name__ for c in _SORTED_LANGUAGES],
+)
+def test_format_enums_populated(*, language_cls: LanguageCls) -> None:
+    """Every language exposes at least one member in each format Enum."""
+    assert len(language_cls.SequenceFormats) >= 1
+    assert len(language_cls.SetFormats) >= 1
+    assert len(language_cls.BytesFormats) >= 1
+    assert len(language_cls.DateFormats) >= 1
+    assert len(language_cls.DatetimeFormats) >= 1
+    assert len(language_cls.VariableTypeHints) >= 1


### PR DESCRIPTION
## Summary
- Simplify `test_class_enum_access.py` to use `ALL_LANGUAGES` instead of hardcoding 4 languages — now tests all 46 languages via parametrize
- Add a module-level assertion in `test_integration.py` that `_LANGUAGES` covers every entry in `ALL_LANGUAGES`, so new languages can't silently skip integration tests
- Parametrize `test_format_enumeration_properties` directly over `ALL_LANGUAGES` instead of going through the `_LANGUAGES` config dict

## Test plan
- [x] `tests/test_class_enum_access.py` — 46 passed
- [x] `tests/integration/test_integration.py::test_format_enumeration_properties` — 46 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test parametrization and assertions; the main risk is increased test coverage exposing previously-untested languages and causing new failures when languages are added.
> 
> **Overview**
> Tests now derive language coverage from `literalizer.languages.ALL_LANGUAGES` instead of hardcoded subsets.
> 
> `tests/integration/test_integration.py` adds an assertion that the integration `_LANGUAGES` config covers *every* language in `ALL_LANGUAGES`, and parametrizes `test_format_enumeration_properties` directly over the full language set.
> 
> `tests/test_class_enum_access.py` is simplified to a single parametrized test that validates each language’s class-level format Enums are non-empty across all languages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a49990e7e7af3b0c004e92f4eaf5465a4f92b693. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->