### PR TITLE
Include None in _SCALAR_TYPE_HINTS

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -66,6 +66,7 @@ def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
 
 # Ordered by priority: bool before int, datetime before date.
 _SCALAR_TYPE_HINTS: tuple[tuple[type, str], ...] = (
+    (type(None), "None"),
     (bool, "bool"),
     (int, "int"),
     (float, "float"),
@@ -84,8 +85,6 @@ def _python_type_hint(
     set_config: SetFormatConfig,
 ) -> str:
     """Derive a Python type hint from the original data structure."""
-    if data is None:
-        return "None"
     for scalar_type, hint in _SCALAR_TYPE_HINTS:
         if isinstance(data, scalar_type):
             return hint


### PR DESCRIPTION
## Summary

- Add `(type(None), "None")` to `_SCALAR_TYPE_HINTS` instead of special-casing `None` with a separate `if data is None` check in `_python_type_hint`.
- This makes the handling of `None` consistent with all other scalar types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to Python type-hint derivation; behavior should be unchanged except making `None` follow the same matching path as other scalar types.
> 
> **Overview**
> **Simplifies Python type-hint generation for nulls.** `src/literalizer/languages/python.py` now includes `(type(None), "None")` in `_SCALAR_TYPE_HINTS` and removes the separate `if data is None` branch in `_python_type_hint`, making `None` handling consistent with other scalar type checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 274089adb733999fc551f46d49a6f82627d2284e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->