### PR TITLE
Pass coerced YAML data to formatter to avoid non-string key errors

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1079,8 +1079,9 @@ def literalize_yaml(
     except YAMLError as exc:
         message = f"Invalid YAML: {exc}"
         raise YAMLParseError(message) from exc
+    coerced_data = _coerce_yaml_keys(data=data)
     base = _literalize(
-        data=_coerce_yaml_keys(data=data),
+        data=coerced_data,
         language=language,
         line_prefix=line_prefix,
         indent=indent,
@@ -1114,7 +1115,7 @@ def literalize_yaml(
             if new_variable
             else language.format_variable_assignment
         )
-        result = formatter(variable_name, result, data)
+        result = formatter(variable_name, result, coerced_data)
 
     if resolved.pending is not None:
         result = prepend_collection_comments(


### PR DESCRIPTION
## Summary

- Fixes a bug where raw YAML data with non-string mapping keys (e.g., integers, booleans) was passed directly to the formatter, which expects `dict[str, Value]` and would trigger a beartype type violation at runtime.
- Stores the result of `_coerce_yaml_keys` in a variable and passes it to both `_literalize` and the formatter.

Addresses review feedback from #510.

## Test plan

- [x] All 5708 existing tests pass
- [ ] Verify with a YAML input containing non-string keys (e.g., `1: foo`) and a variable name to confirm the formatter no longer raises a type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to `literalize_yaml` data plumbing to avoid type errors when YAML contains non-string mapping keys; no behavioral changes beyond which data structure is passed to the formatter.
> 
> **Overview**
> Fixes `literalize_yaml` so YAML mapping keys are coerced once via `_coerce_yaml_keys` and the resulting `coerced_data` is passed consistently to both `_literalize` and the variable declaration/assignment formatter, preventing runtime type violations when YAML uses non-string keys (e.g., `1: foo`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f40109bdd1f172893763693cdfad5fe01977dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->