### PR TITLE
Move variable type hint formatter selection onto the enum

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -341,10 +341,13 @@ class Python(metaclass=LanguageCls):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.supports_collection_comments = True
-        self.format_variable_declaration = variable_type_hints.formatter(
-            sequence_config=self.sequence_format_config,
-            set_config=self.set_format_config,
+        decl_fmt: Callable[[str, str, Value], str] = (
+            variable_type_hints.formatter(
+                sequence_config=self.sequence_format_config,
+                set_config=self.set_format_config,
+            )
         )
+        self.format_variable_declaration = decl_fmt
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )


### PR DESCRIPTION
## Summary
- Extract the inline type hint closure from `Python.__init__` into a module-level `_format_inline_type_hint_declaration` function
- Add a `formatter()` method to `VariableTypeHints` so each enum member knows how to produce its own declaration formatter
- `__init__` now just calls `variable_type_hints.formatter(...)` instead of containing conditional logic

## Test plan
- [x] All 5708 existing tests pass
- [x] All pre-commit and pre-push hooks pass (pyright-verifytypes, mypy, ruff, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that rehomes existing inline type-hint formatting logic without changing the emitted syntax. Main risk is minor regression in how the formatter is selected/bound for different sequence/set configs.
> 
> **Overview**
> Refactors `src/literalizer/languages/python.py` to centralize variable-declaration formatting for type hints.
> 
> The inline type-hint declaration logic is extracted into `_format_inline_type_hint_declaration`, and `VariableTypeHints` gains a `formatter()` method (using `functools.partial`) so `Python.__init__` simply asks the enum for the correct `format_variable_declaration` implementation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4beaee4f7dfb73788c7bd671b3f063ae2508871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->