### PR TITLE
Remove duplicate _wrap_python_combined for _wrap_combined_newline

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1086,12 +1086,6 @@ def _wrap_python(content: str) -> str:
 
 
 @beartype
-def _wrap_python_combined(declaration: str, assignment: str) -> str:
-    """Join declaration and assignment with a newline."""
-    return declaration + "\n" + assignment
-
-
-@beartype
 def _wrap_ruby(content: str) -> str:
     """Pass through Ruby content unchanged."""
     return content
@@ -1330,7 +1324,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         lang_cls=literalizer.languages.Python,
         wrap=_wrap_python,
         varname_wrap=_wrap_python,
-        combined_wrap=_wrap_python_combined,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.JavaScript.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.JavaScript,


### PR DESCRIPTION
Remove `_wrap_python_combined`, which was identical to `_wrap_combined_newline`, and use `_wrap_combined_newline` in its place for the Python language config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that replaces a duplicate helper with the shared `_wrap_combined_newline`, so behavior should remain identical aside from any inadvertent wrapper selection changes for Python golden tests.
> 
> **Overview**
> Removes the redundant test helper `_wrap_python_combined` (it was identical to `_wrap_combined_newline`).
> 
> Updates the Python integration-test language config to use `_wrap_combined_newline` for `*_combined` golden-file generation instead of the Python-specific wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97e298f916689ec45c9106096506d5583f0489bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->