### PR TITLE
Extract shared factories for element-to-type and type-to-opener

### DIFF
--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -196,6 +196,69 @@ def fixed_dict_open(*, open_str: str) -> Callable[[dict[str, Value]], str]:
 
 
 @beartype
+def make_element_to_type(
+    *,
+    scalar_types: dict[type, str],
+    list_template: str,
+) -> Callable[[type | ListType], str | None]:
+    """Create a recursive type resolver from scalar types and a list
+    template.
+
+    The *list_template* must contain ``{inner}`` which will be replaced
+    with the recursively-resolved inner type name.
+
+    Example::
+
+        go_element_to_type = make_element_to_type(
+            scalar_types={str: "string", int: "int"},
+            list_template="[]{inner}",
+        )
+    """
+
+    @beartype
+    def element_to_type(element_type: type | ListType) -> str | None:
+        """Resolve a Python element type to a language type name."""
+        if isinstance(element_type, ListType):
+            inner = element_to_type(element_type=element_type.inner)
+            if inner is None:
+                return None
+            return list_template.format(inner=inner)
+        return scalar_types.get(element_type)
+
+    return element_to_type
+
+
+@beartype
+def make_type_to_opener(
+    *,
+    element_to_type: Callable[[type | ListType], str | None],
+    opener_template: str,
+) -> Callable[[type | ListType], str | None]:
+    """Create a typed collection opener from an element-to-type resolver.
+
+    The *opener_template* must contain ``{type_name}`` which will be
+    replaced with the resolved type name.
+
+    Example::
+
+        go_type_to_opener = make_type_to_opener(
+            element_to_type=go_element_to_type,
+            opener_template="[]{type_name}{{",
+        )
+    """
+
+    @beartype
+    def type_to_opener(element_type: type | ListType) -> str | None:
+        """Resolve a Python element type to a collection opener."""
+        type_name = element_to_type(element_type)
+        if type_name is None:
+            return None
+        return opener_template.format(type_name=type_name)
+
+    return type_to_opener
+
+
+@beartype
 def _typed_sequence_open(
     items: list[Value],
     *,

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -7,10 +7,11 @@ from collections.abc import Callable, Sequence
 from beartype import beartype
 
 from literalizer._formatters import (
-    ListType,
     MixedNumeric,
     format_bytes_hex,
     format_string_backslash,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_dict_open,
@@ -63,34 +64,20 @@ _CPP_SCALAR_TYPES: dict[type, str] = {
     bytes: "std::string",
 }
 
+_cpp_element_to_type = make_element_to_type(
+    scalar_types=_CPP_SCALAR_TYPES,
+    list_template="std::vector<{inner}>",
+)
 
-@beartype
-def _cpp_element_to_type(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a C++ type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _cpp_element_to_type(element_type=element_type.inner)
-        return f"std::vector<{inner}>" if inner is not None else None
-    return _CPP_SCALAR_TYPES.get(element_type)
+_cpp_type_to_opener = make_type_to_opener(
+    element_to_type=_cpp_element_to_type,
+    opener_template="std::vector<{type_name}>{{",
+)
 
-
-@beartype
-def _cpp_type_to_opener(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a C++ initializer-list opener."""
-    type_name = _cpp_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"std::vector<{type_name}>{{"
-
-
-@beartype
-def _cpp_dict_type_to_opener(
-    element_type: type | ListType,
-) -> str | None:
-    """Map a Python element type to a C++ map opener."""
-    type_name = _cpp_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"std::map<std::string, {type_name}>{{"
+_cpp_dict_type_to_opener = make_type_to_opener(
+    element_to_type=_cpp_element_to_type,
+    opener_template="std::map<std::string, {type_name}>{{",
+)
 
 
 @beartype

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -7,10 +7,11 @@ from collections.abc import Callable, Sequence
 from beartype import beartype
 
 from literalizer._formatters import (
-    ListType,
     MixedNumeric,
     format_bytes_hex,
     format_string_backslash,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_dict_open,
@@ -53,34 +54,20 @@ _CSHARP_SCALAR_TYPES: dict[type, str] = {
     datetime.datetime: "DateTime",
 }
 
+_csharp_element_to_type = make_element_to_type(
+    scalar_types=_CSHARP_SCALAR_TYPES,
+    list_template="{inner}[]",
+)
 
-@beartype
-def _csharp_element_to_type(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a C# type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _csharp_element_to_type(element_type=element_type.inner)
-        return f"{inner}[]" if inner is not None else None
-    return _CSHARP_SCALAR_TYPES.get(element_type)
+_csharp_type_to_opener = make_type_to_opener(
+    element_to_type=_csharp_element_to_type,
+    opener_template="new {type_name}[] {{",
+)
 
-
-@beartype
-def _csharp_type_to_opener(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a C# array opener."""
-    type_name = _csharp_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"new {type_name}[] {{"
-
-
-@beartype
-def _csharp_dict_type_to_opener(
-    element_type: type | ListType,
-) -> str | None:
-    """Map a Python element type to a C# dictionary opener."""
-    type_name = _csharp_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"new Dictionary<string, {type_name}> {{"
+_csharp_dict_type_to_opener = make_type_to_opener(
+    element_to_type=_csharp_element_to_type,
+    opener_template="new Dictionary<string, {type_name}> {{",
+)
 
 
 @beartype

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -7,11 +7,12 @@ from collections.abc import Callable, Sequence
 from beartype import beartype
 
 from literalizer._formatters import (
-    ListType,
     MixedNumeric,
     dict_entry_with_separator,
     format_bytes_hex,
     format_string_backslash_dollar,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_dict_open,
@@ -51,34 +52,20 @@ _DART_SCALAR_TYPES: dict[type, str] = {
     datetime.datetime: "DateTime",
 }
 
+_dart_element_to_type = make_element_to_type(
+    scalar_types=_DART_SCALAR_TYPES,
+    list_template="List<{inner}>",
+)
 
-@beartype
-def _dart_element_to_type(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Dart type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _dart_element_to_type(element_type=element_type.inner)
-        return f"List<{inner}>" if inner is not None else None
-    return _DART_SCALAR_TYPES.get(element_type)
+_dart_type_to_opener = make_type_to_opener(
+    element_to_type=_dart_element_to_type,
+    opener_template="<{type_name}>[",
+)
 
-
-@beartype
-def _dart_type_to_opener(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Dart list opener."""
-    type_name = _dart_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"<{type_name}>["
-
-
-@beartype
-def _dart_dict_type_to_opener(
-    element_type: type | ListType,
-) -> str | None:
-    """Map a Python element type to a Dart map opener."""
-    type_name = _dart_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"<String, {type_name}>{{"
+_dart_dict_type_to_opener = make_type_to_opener(
+    element_to_type=_dart_element_to_type,
+    opener_template="<String, {type_name}>{{",
+)
 
 
 @beartype

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -7,11 +7,12 @@ from collections.abc import Callable, Sequence
 from beartype import beartype
 
 from literalizer._formatters import (
-    ListType,
     MixedNumeric,
     dict_entry_with_separator,
     format_bytes_hex,
     format_string_backslash,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     typed_dict_open,
     typed_sequence_open,
@@ -74,34 +75,20 @@ _GO_SCALAR_TYPES: dict[type, str] = {
     datetime.datetime: "time.Time",
 }
 
+_go_element_to_type = make_element_to_type(
+    scalar_types=_GO_SCALAR_TYPES,
+    list_template="[]{inner}",
+)
 
-@beartype
-def _go_element_to_type(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Go type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _go_element_to_type(element_type=element_type.inner)
-        return f"[]{inner}" if inner is not None else None
-    return _GO_SCALAR_TYPES.get(element_type)
+_go_type_to_opener = make_type_to_opener(
+    element_to_type=_go_element_to_type,
+    opener_template="[]{type_name}{{",
+)
 
-
-@beartype
-def _go_type_to_opener(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Go slice opener."""
-    type_name = _go_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"[]{type_name}{{"
-
-
-@beartype
-def _go_dict_type_to_opener(
-    element_type: type | ListType,
-) -> str | None:
-    """Map a Python element type to a Go map opener."""
-    type_name = _go_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"map[string]{type_name}{{"
+_go_dict_type_to_opener = make_type_to_opener(
+    element_to_type=_go_element_to_type,
+    opener_template="map[string]{type_name}{{",
+)
 
 
 @beartype

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -8,11 +8,12 @@ from typing import Any
 from beartype import beartype
 
 from literalizer._formatters import (
-    ListType,
     MixedNumeric,
     fixed_dict_open,
     format_bytes_hex,
     format_string_backslash,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_sequence_open,
@@ -87,23 +88,15 @@ _JAVA_SCALAR_TYPES: dict[type, str] = {
     datetime.date: "LocalDate",
 }
 
+_java_element_to_type = make_element_to_type(
+    scalar_types=_JAVA_SCALAR_TYPES,
+    list_template="{inner}[]",
+)
 
-@beartype
-def _java_element_to_type(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Java type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _java_element_to_type(element_type=element_type.inner)
-        return f"{inner}[]" if inner is not None else None
-    return _JAVA_SCALAR_TYPES.get(element_type)
-
-
-@beartype
-def _java_type_to_opener(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Java array opener."""
-    type_name = _java_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"new {type_name}[]{{"
+_java_type_to_opener = make_type_to_opener(
+    element_to_type=_java_element_to_type,
+    opener_template="new {type_name}[]{{",
+)
 
 
 @beartype

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -11,6 +11,8 @@ from literalizer._formatters import (
     dict_entry_with_separator,
     format_bytes_hex,
     format_string_backslash_dollar,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_dict_open,
@@ -84,27 +86,15 @@ _KOTLIN_SCALAR_TYPES: dict[type, str] = {
     datetime.datetime: "LocalDateTime",
 }
 
+_kotlin_element_to_type = make_element_to_type(
+    scalar_types=_KOTLIN_SCALAR_TYPES,
+    list_template="Array<{inner}>",
+)
 
-@beartype
-def _kotlin_element_to_type(
-    element_type: type | ListType,
-) -> str | None:
-    """Map a Python element type to a Kotlin type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _kotlin_element_to_type(element_type=element_type.inner)
-        return f"Array<{inner}>" if inner is not None else None
-    return _KOTLIN_SCALAR_TYPES.get(element_type)
-
-
-@beartype
-def _kotlin_dict_type_to_opener(
-    element_type: type | ListType,
-) -> str | None:
-    """Map a Python element type to a Kotlin map opener."""
-    type_name = _kotlin_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"mapOf<String, {type_name}>("
+_kotlin_dict_type_to_opener = make_type_to_opener(
+    element_to_type=_kotlin_element_to_type,
+    opener_template="mapOf<String, {type_name}>(",
+)
 
 
 @beartype

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -7,13 +7,14 @@ from collections.abc import Callable, Sequence
 from beartype import beartype
 
 from literalizer._formatters import (
-    ListType,
     MixedNumeric,
     dict_entry_with_separator,
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
     format_string_backslash,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_dict_open,
@@ -40,34 +41,20 @@ _SCALA_SCALAR_TYPES: dict[type, str] = {
     datetime.datetime: "String",
 }
 
+_scala_element_to_type = make_element_to_type(
+    scalar_types=_SCALA_SCALAR_TYPES,
+    list_template="Array[{inner}]",
+)
 
-@beartype
-def _scala_element_to_type(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Scala type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _scala_element_to_type(element_type=element_type.inner)
-        return f"Array[{inner}]" if inner is not None else None
-    return _SCALA_SCALAR_TYPES.get(element_type)
+_scala_type_to_opener = make_type_to_opener(
+    element_to_type=_scala_element_to_type,
+    opener_template="Array[{type_name}](",
+)
 
-
-@beartype
-def _scala_type_to_opener(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a Scala collection opener."""
-    type_name = _scala_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"Array[{type_name}]("
-
-
-@beartype
-def _scala_dict_type_to_opener(
-    element_type: type | ListType,
-) -> str | None:
-    """Map a Python element type to a Scala map opener."""
-    type_name = _scala_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"Map[String, {type_name}]("
+_scala_dict_type_to_opener = make_type_to_opener(
+    element_to_type=_scala_element_to_type,
+    opener_template="Map[String, {type_name}](",
+)
 
 
 @beartype

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -7,12 +7,13 @@ from collections.abc import Callable, Sequence
 from beartype import beartype
 
 from literalizer._formatters import (
-    ListType,
     MixedNumeric,
     fixed_dict_open,
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
+    make_element_to_type,
+    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_sequence_open,
@@ -106,23 +107,15 @@ _VB_SCALAR_TYPES: dict[type, str] = {
     datetime.datetime: "String",
 }
 
+_vb_element_to_type = make_element_to_type(
+    scalar_types=_VB_SCALAR_TYPES,
+    list_template="{inner}()",
+)
 
-@beartype
-def _vb_element_to_type(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a VB.NET type name, recursively."""
-    if isinstance(element_type, ListType):
-        inner = _vb_element_to_type(element_type=element_type.inner)
-        return f"{inner}()" if inner is not None else None
-    return _VB_SCALAR_TYPES.get(element_type)
-
-
-@beartype
-def _vb_type_to_opener(element_type: type | ListType) -> str | None:
-    """Map a Python element type to a VB.NET array opener."""
-    type_name = _vb_element_to_type(element_type=element_type)
-    if type_name is None:
-        return None
-    return f"New {type_name}() {{"
+_vb_type_to_opener = make_type_to_opener(
+    element_to_type=_vb_element_to_type,
+    opener_template="New {type_name}() {{",
+)
 
 
 @beartype


### PR DESCRIPTION
## Summary

- Adds `make_element_to_type` and `make_type_to_opener` factory functions to `_formatters.py` that replace near-identical recursive type-resolution boilerplate across 8 language files
- Each language (Go, Kotlin, C#, C++, Dart, Java, Scala, VB) now declares its type system with just a scalar types dict and format templates, instead of reimplementing the same recursive algorithm
- Net reduction of ~26 lines despite adding the new factories, with the real win being single-source-of-truth for the resolution logic

## Test plan

- [x] All 6010 existing tests pass
- [x] All pre-commit hooks pass (mypy, pyright, ruff, vulture, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes recursive type resolution for typed collection literals across multiple language backends, so any bug in the new factories could affect code generation in several targets. Changes are mostly mechanical but touch core formatting paths for sequences/maps.
> 
> **Overview**
> **Refactors typed collection type inference/formatting.** Adds `make_element_to_type` and `make_type_to_opener` in `_formatters.py` to standardize recursive resolution of scalar and nested list element types and the corresponding collection opening delimiters.
> 
> Updates the C++, C#, Dart, Go, Java, Kotlin (dict openers), Scala, and VB language specs to use these factories (via per-language scalar-type maps and string templates), removing duplicated per-language resolver/opener functions while preserving existing fallbacks and formatting behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90d9773d01bac557c7f49319b49e36ad6b2b208d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->