### PR TITLE
Sort set/frozenset union type hints for deterministic output

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -148,9 +148,10 @@ def _collection_element_union(
     """
     if not elements:
         return "Any"
-    return _element_union(
-        types=[recurse(data=e) for e in elements],
-    )
+    types = [recurse(data=e) for e in elements]
+    if isinstance(elements, frozenset):
+        types.sort()
+    return _element_union(types=types)
 
 
 @beartype


### PR DESCRIPTION
Fixes non-deterministic union ordering for set/frozenset type hints. When a set contains mixed types, iterating a frozenset yields non-deterministic order due to Python hash randomization. This sorts the resolved type hints alphabetically before joining them into a union, but only for frozenset-backed collections, preserving insertion order for lists and dict values.

Addresses review feedback from #528.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes ordering of generated union type hints for `frozenset`-backed collections to be deterministic, without affecting runtime behavior or data handling.
> 
> **Overview**
> Ensures deterministic Python type-hint generation for heterogeneous `set`/`frozenset` values by sorting the resolved element type strings before building the union.
> 
> Sorting is applied only when the collection elements are a `frozenset` (hash-order dependent), preserving existing ordering behavior for list/dict-derived unions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 041d6a88b08be2248e9667469c4ec130edaf2f03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->