### PR TITLE
Lint only changed files in PRs

### DIFF
--- a/.github/workflows/lint-ada.yml
+++ b/.github/workflows/lint-ada.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-clojure.yml
+++ b/.github/workflows/lint-clojure.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-cobol.yml
+++ b/.github/workflows/lint-cobol.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-commonlisp.yml
+++ b/.github/workflows/lint-commonlisp.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-crystal.yml
+++ b/.github/workflows/lint-crystal.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-d.yml
+++ b/.github/workflows/lint-d.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-dart.yml
+++ b/.github/workflows/lint-dart.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-erlang.yml
+++ b/.github/workflows/lint-erlang.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-fortran.yml
+++ b/.github/workflows/lint-fortran.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-fsharp.yml
+++ b/.github/workflows/lint-fsharp.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-groovy.yml
+++ b/.github/workflows/lint-groovy.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-haskell.yml
+++ b/.github/workflows/lint-haskell.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-hcl.yml
+++ b/.github/workflows/lint-hcl.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-java.yml
+++ b/.github/workflows/lint-java.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-julia.yml
+++ b/.github/workflows/lint-julia.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-kotlin.yml
+++ b/.github/workflows/lint-kotlin.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-lua.yml
+++ b/.github/workflows/lint-lua.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-matlab.yml
+++ b/.github/workflows/lint-matlab.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-nim.yml
+++ b/.github/workflows/lint-nim.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-norg.yml
+++ b/.github/workflows/lint-norg.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-objectivec.yml
+++ b/.github/workflows/lint-objectivec.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-ocaml.yml
+++ b/.github/workflows/lint-ocaml.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-occam.yml
+++ b/.github/workflows/lint-occam.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-perl.yml
+++ b/.github/workflows/lint-perl.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-racket.yml
+++ b/.github/workflows/lint-racket.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-scala.yml
+++ b/.github/workflows/lint-scala.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-visualbasic.yml
+++ b/.github/workflows/lint-visualbasic.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/lint-zig.yml
+++ b/.github/workflows/lint-zig.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Find files to lint
         id: files
         if: github.event_name != 'pull_request' || steps.changes.outputs.config_any_changed
-          == 'true' || steps.changes.outputs.lang_any_changed == 'true'
+          == 'true' || steps.changes.outputs.lang_any_modified == 'true'
         env:
           CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
-          LANG_FILES: ${{ steps.changes.outputs.lang_all_changed_files }}
+          LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
         run: |-
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
             # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary

- Replace `dorny/paths-filter` with `tj-actions/changed-files` across all 45 lint workflows
- On PRs where only language files changed, lint only those changed files instead of all files
- Config file changes (yml, toml, helper scripts) still trigger a full lint of all files
- Separate file discovery ("Find files to lint" step) from the lint step itself, simplifying conditional logic

## Test plan

- [ ] Verify workflows run correctly on a PR that changes only language files (should lint only changed files)
- [ ] Verify workflows run correctly on a PR that changes config files (should lint all files)
- [ ] Verify workflows run correctly on non-PR events (should lint all files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates many GitHub Actions lint workflows’ change-detection and file-selection logic, which could inadvertently skip linting or change when jobs run if the new `changed-files` outputs/conditions are mis-specified.
> 
> **Overview**
> **Optimizes PR linting in CI.** All language-specific lint workflows switch from `dorny/paths-filter` to `tj-actions/changed-files` and add a dedicated “Find files to lint” step that writes a null-delimited list to `/tmp/files-to-lint`.
> 
> On pull requests, when only language files change, the jobs now lint **only the modified files**; when config files (e.g. `**/*.yml`, `**/*.toml`, and a few helper scripts) change—or on non-PR events—the workflows fall back to linting **all relevant files**. Downstream install/lint steps are gated on `steps.files.outcome == 'success'` and use `xargs -0 ... < /tmp/files-to-lint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5f1bd5813186af40e9247704bdc562e5cbd7962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->