### PR TITLE
Fix lint-toml config pattern to enable incremental linting

### DIFF
--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -19,7 +19,7 @@ jobs:
           files_yaml: |
             config:
               - '**/*.yml'
-              - '**/*.toml'
+              - 'pyproject.toml'
             lang:
               - 'tests/integration/cases/**/*.toml'
       - name: Find files to lint


### PR DESCRIPTION
## Summary

- Narrows the `config` pattern in `lint-toml.yml` from `**/*.toml` to `pyproject.toml`
- The broad pattern overlapped with the `lang` pattern (`tests/integration/cases/**/*.toml`), causing `config_any_changed` to always be true when TOML test files changed
- This made the incremental lint path (lint only changed files) dead code — every run fell through to `find` all files

Addresses https://github.com/adamtheturtle/literalizer/pull/550#discussion_r2973550405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just adjusts the file-change detection patterns; main impact is which TOML files are linted on PRs.
> 
> **Overview**
> Fixes incremental TOML linting in `.github/workflows/lint-toml.yml` by narrowing the `config` changed-files glob from `**/*.toml` to `pyproject.toml`.
> 
> This avoids overlapping with the `lang` TOML test-case patterns so PRs that only touch `tests/integration/cases/**/*.toml` lint just the modified files instead of falling back to linting all TOML files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffe4f71235307d0faea40caf1cbd7859488c99da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->