### PR TITLE
Add pytest-xdist for parallel test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ optional-dependencies.dev = [
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "pytest-regressions==2.10.0",
+    "pytest-xdist==3.5.0",
     "ruff==0.15.7",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
     # but also because having it installed means that ``actionlint-py`` will
@@ -275,6 +276,7 @@ max_supported_python = "3.14"
 [tool.pytest]
 ini_options.xfail_strict = true
 ini_options.log_cli = true
+ini_options.addopts = "-n auto"
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
## Summary
- Adds `pytest-xdist==3.5.0` as a dev dependency
- Configures `addopts = "-n auto"` in pytest settings to automatically use all available CPU cores
- Local test suite runtime drops from **~38s to ~16s** (2.4x speedup)

## Test plan
- [x] All 6329 tests pass with parallel execution
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling `-n auto` makes all pytest runs execute in parallel by default, which can surface hidden test order/concurrency issues and cause CI variability across platforms.
> 
> **Overview**
> Adds `pytest-xdist` as a dev dependency and configures pytest `addopts = "-n auto"` in `pyproject.toml` so the test suite runs in parallel by default using available CPU cores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4dce66561155dff4ba53e8dd5929e3eb4381675. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->