### PR TITLE
Skip install and lint steps when no files are found

### DIFF
--- a/.github/workflows/lint-ada.yml
+++ b/.github/workflows/lint-ada.yml
@@ -37,15 +37,18 @@ jobs:
           else
             find tests/integration/cases -name "*.adb" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install GNAT
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: sudo apt-get install -y gnat
       - name: Install uv
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check Ada syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 uv run python check_ada_golden_syntax.py < /tmp/files-to-lint

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -36,6 +36,9 @@ jobs:
           else
             find tests/integration/cases -name "*.sh" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check Bash syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 bash -n < /tmp/files-to-lint

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -36,6 +36,9 @@ jobs:
           else
             find tests/integration/cases -name "*.c" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check C syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-to-lint

--- a/.github/workflows/lint-clojure.yml
+++ b/.github/workflows/lint-clojure.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.clj" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install clj-kondo
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: DeLaGuardo/setup-clojure@13
         with:
           clj-kondo: latest
       - name: Check Clojure syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 clj-kondo --lint < /tmp/files-to-lint

--- a/.github/workflows/lint-cobol.yml
+++ b/.github/workflows/lint-cobol.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.cob" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install GnuCOBOL
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: sudo apt-get install -y gnucobol
       - name: Check COBOL syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             cobc -free -fsyntax-only "$f" || exit 1

--- a/.github/workflows/lint-commonlisp.yml
+++ b/.github/workflows/lint-commonlisp.yml
@@ -36,9 +36,12 @@ jobs:
           else
             find tests/integration/cases -name "*.lisp" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install SBCL
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: sudo apt-get install -y sbcl
       - name: Check Common Lisp syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 -I{} sbcl --script {} < /tmp/files-to-lint

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -36,6 +36,9 @@ jobs:
           else
             find tests/integration/cases -name "*.cpp" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check C++ syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint

--- a/.github/workflows/lint-crystal.yml
+++ b/.github/workflows/lint-crystal.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.cr" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Crystal
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: crystal-lang/install-crystal@v1
       - name: Check Crystal syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             crystal build --no-codegen "$f" || exit 1

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -37,17 +37,20 @@ jobs:
           else
             find tests/integration/cases -name "*.cs" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Initialize .NET runtime
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |
           mkdir -p /tmp/.dotnet/shm
           dotnet --info
       - name: Install uv
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check C# syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 uv run python check_csharp_golden_syntax.py < /tmp/files-to-lint

--- a/.github/workflows/lint-d.yml
+++ b/.github/workflows/lint-d.yml
@@ -36,13 +36,16 @@ jobs:
           else
             find tests/integration/cases -name "*.d" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install DMD
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: dlang-community/setup-dlang@v2
         with:
           compiler: dmd-latest
       - name: Check D syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             dmd -o- -c "$f" || exit 1

--- a/.github/workflows/lint-dart.yml
+++ b/.github/workflows/lint-dart.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.dart" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Dart
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: dart-lang/setup-dart@v1
       - name: Check Dart syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -36,14 +36,17 @@ jobs:
           else
             find tests/integration/cases -name "*.ex" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Elixir
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.18'
           otp-version: '27'
       - name: Check Elixir syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-erlang.yml
+++ b/.github/workflows/lint-erlang.yml
@@ -36,15 +36,18 @@ jobs:
           else
             find tests/integration/cases -name "*.erl" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Erlang
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: erlef/setup-beam@v1
         with:
           otp-version: '27'
           install-rebar: false
           install-hex: false
       - name: Check Erlang syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-fortran.yml
+++ b/.github/workflows/lint-fortran.yml
@@ -36,10 +36,13 @@ jobs:
           else
             find tests/integration/cases -name "*.f90" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install gfortran
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: sudo apt-get install -y gfortran
       - name: Check Fortran syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 gfortran -std=f2008 -ffree-line-length-none -fsyntax-only <
           /tmp/files-to-lint

--- a/.github/workflows/lint-fsharp.yml
+++ b/.github/workflows/lint-fsharp.yml
@@ -37,13 +37,16 @@ jobs:
           else
             find tests/integration/cases \( -name "*.fs" -o -name "*.fsi" \) -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Initialize .NET runtime
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |
           mkdir -p /tmp/.dotnet/shm
           dotnet --info
       - name: Check F# syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -36,6 +36,9 @@ jobs:
           else
             find tests/integration/cases -name "*.go" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check Go syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 gofmt -e < /tmp/files-to-lint

--- a/.github/workflows/lint-groovy.yml
+++ b/.github/workflows/lint-groovy.yml
@@ -36,13 +36,16 @@ jobs:
           else
             find tests/integration/cases -name "*.groovy" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Groovy
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: wtfjoke/setup-groovy@v3
         with:
           groovy-version: 4.x
       - name: Check Groovy syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-haskell.yml
+++ b/.github/workflows/lint-haskell.yml
@@ -36,12 +36,15 @@ jobs:
           else
             find tests/integration/cases -name "*.hs" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: haskell-actions/setup@v2
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         with:
           ghc-version: latest
       - name: Check Haskell syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           tmpdir=$(mktemp -d)
           while IFS= read -r -d '' f; do

--- a/.github/workflows/lint-hcl.yml
+++ b/.github/workflows/lint-hcl.yml
@@ -36,14 +36,17 @@ jobs:
           else
             find tests/integration/cases -name "*.hcl" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install hcl2json
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: go install github.com/tmccombs/hcl2json@latest
       - name: Add Go bin to PATH
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Check HCL syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             hcl2json "$f" > /dev/null || exit 1

--- a/.github/workflows/lint-java.yml
+++ b/.github/workflows/lint-java.yml
@@ -36,8 +36,11 @@ jobs:
           else
             find tests/integration/cases -name "*.java" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check Java syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           tmpdir=$(mktemp -d)
           while IFS= read -r -d '' f; do

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -36,8 +36,11 @@ jobs:
           else
             find tests/integration/cases -name "*.js" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check JavaScript syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             node --check "$f" || exit 1

--- a/.github/workflows/lint-julia.yml
+++ b/.github/workflows/lint-julia.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.jl" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Julia
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: julia-actions/setup-julia@v2
       - name: Check Julia syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             julia --startup-file=no -e 'Meta.parseall(read(ARGS[1], String))' -- "$f" || exit 1

--- a/.github/workflows/lint-kotlin.yml
+++ b/.github/workflows/lint-kotlin.yml
@@ -36,10 +36,13 @@ jobs:
           else
             find tests/integration/cases -name "*.kts" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Kotlin
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: fwilhe2/setup-kotlin@v1
       - name: Check Kotlin syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           xargs -0 -P "$(nproc)" -n 1 kotlinc -script < /tmp/files-to-lint

--- a/.github/workflows/lint-lua.yml
+++ b/.github/workflows/lint-lua.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.lua" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Lua
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: leafo/gh-actions-lua@v12
         with:
           luaVersion: '5.4'
       - name: Check Lua syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 luac -p < /tmp/files-to-lint

--- a/.github/workflows/lint-matlab.yml
+++ b/.github/workflows/lint-matlab.yml
@@ -36,13 +36,16 @@ jobs:
           else
             find tests/integration/cases -name "matlab*.m" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Octave
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: sudo apt-get update && sudo apt-get install -y octave
       # Octave is a practical CI substitute, but it accepts some
       # double-quoted backslash escapes (e.g. \") that MATLAB rejects.
       - name: Check MATLAB syntax (Octave-compatible files)
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             if grep -q '""' "$f"; then

--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -36,15 +36,18 @@ jobs:
           else
             find tests/integration/cases -name "*.mojo" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install pixi
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: fabasoad/setup-mojo-action@v3
       - name: Install Mojo
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           pixi global install --channel conda-forge --channel https://conda.modular.com/max mojo
       - name: Check Mojo syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             if ! mojo run --Werror "$f"; then

--- a/.github/workflows/lint-nim.yml
+++ b/.github/workflows/lint-nim.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.nim" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Nim
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: jiro4989/setup-nim-action@v2
       - name: Check Nim syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-norg.yml
+++ b/.github/workflows/lint-norg.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.norg" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install tree-sitter CLI
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: npm install tree-sitter-cli
       - name: Build tree-sitter-norg parser
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           git clone --depth=1 https://github.com/nvim-neorg/tree-sitter-norg.git /tmp/tree-sitter-norg
           cc -shared -fPIC -o /tmp/norg.so \
@@ -49,6 +52,6 @@ jobs:
             -x c++ /tmp/tree-sitter-norg/src/scanner.cc \
             -lstdc++
       - name: Check Norg syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 npx tree-sitter parse --lib-path /tmp/norg.so --lang-name norg
           --quiet < /tmp/files-to-lint

--- a/.github/workflows/lint-objectivec.yml
+++ b/.github/workflows/lint-objectivec.yml
@@ -36,8 +36,11 @@ jobs:
           else
             find tests/integration/cases -name "objective_c*.m" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check Objective-C syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             clang -fsyntax-only "$f" || exit 1

--- a/.github/workflows/lint-ocaml.yml
+++ b/.github/workflows/lint-ocaml.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.ml" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install OCaml
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: sudo apt-get install -y ocaml
       - name: Check OCaml syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           tmpdir=$(mktemp -d)
           while IFS= read -r -d '' f; do

--- a/.github/workflows/lint-occam.yml
+++ b/.github/workflows/lint-occam.yml
@@ -37,12 +37,15 @@ jobs:
           else
             find tests/integration/cases -name "*.occ" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install uv
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check Occam-pi syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 uv run python check_occam_golden_syntax.py < /tmp/files-to-lint

--- a/.github/workflows/lint-perl.yml
+++ b/.github/workflows/lint-perl.yml
@@ -36,14 +36,17 @@ jobs:
           else
             find tests/integration/cases -name "*.pl" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Perl dependencies
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           sudo apt-get update
           sudo apt-get install -y cpanminus
           sudo cpanm --notest DateTime
       - name: Check Perl syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             perl -c "$f" || exit 1

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -36,6 +36,9 @@ jobs:
           else
             find tests/integration/cases -name "*.php" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check PHP syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 php -l < /tmp/files-to-lint

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -36,8 +36,11 @@ jobs:
           else
             find tests/integration/cases -name "*.ps1" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check PowerShell syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             pwsh -NoProfile -NonInteractive -Command \

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -36,12 +36,15 @@ jobs:
           else
             find tests/integration/cases -name "*.R" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install R
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: r-lib/actions/setup-r@v2
         with:
           windows-path-include-rtools: false
       - name: Check R syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 Rscript -e 'for (f in commandArgs(trailingOnly=TRUE)) parse(file=f)'
           < /tmp/files-to-lint

--- a/.github/workflows/lint-racket.yml
+++ b/.github/workflows/lint-racket.yml
@@ -36,9 +36,12 @@ jobs:
           else
             find tests/integration/cases -name "*.rkt" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Racket
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: sudo apt-get install -y racket
       - name: Check Racket syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 raco make < /tmp/files-to-lint

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -36,8 +36,11 @@ jobs:
           else
             find tests/integration/cases -name "*.rb" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check Ruby syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             ruby -c "$f" || exit 1

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -36,8 +36,11 @@ jobs:
           else
             find tests/integration/cases -name "*.rs" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check Rust syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT

--- a/.github/workflows/lint-scala.yml
+++ b/.github/workflows/lint-scala.yml
@@ -36,13 +36,16 @@ jobs:
           else
             find tests/integration/cases -name "*.scala" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Scala
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: coursier/setup-action@v3
         with:
           apps: scalac
       - name: Check Scala syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -36,13 +36,16 @@ jobs:
           else
             find tests/integration/cases -name "*.swift" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Swift
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: SwiftyLab/setup-swift@v1
         with:
           cache-snapshot: true
       - name: Check Swift syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -36,14 +36,17 @@ jobs:
           else
             find tests/integration/cases -name "*.toml" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install taplo
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz \
             | gzip -d - \
             | install -m 755 /dev/stdin /usr/local/bin/taplo
       - name: Check TOML syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             # taplo only validates TOML v1.0. Files that use TOML v1.1

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -36,11 +36,14 @@ jobs:
           else
             find tests/integration/cases -name "*.ts" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install TypeScript
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: npm install -g typescript
       - name: Check TypeScript syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tsc --noEmit --noResolve --skipLibCheck --lib es2015 "$f" || exit 1

--- a/.github/workflows/lint-visualbasic.yml
+++ b/.github/workflows/lint-visualbasic.yml
@@ -37,17 +37,20 @@ jobs:
           else
             find tests/integration/cases -name "*.vb" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Initialize .NET runtime
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |
           mkdir -p /tmp/.dotnet/shm
           dotnet --info
       - name: Install uv
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check VB.NET syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: xargs -0 uv run python check_vb_golden_syntax.py < /tmp/files-to-lint

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -37,10 +37,13 @@ jobs:
           else
             find tests/integration/cases -name "*.yaml" ! -name "input.yaml" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install uv
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: astral-sh/setup-uv@v7
       - name: Check YAML syntax
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           xargs -0 uvx yamllint --strict -d '{extends: default, rules: {document-start: disable, line-length: disable}}' -- < /tmp/files-to-lint

--- a/.github/workflows/lint-zig.yml
+++ b/.github/workflows/lint-zig.yml
@@ -36,13 +36,16 @@ jobs:
           else
             find tests/integration/cases -name "*.zig" -print0
           fi > /tmp/files-to-lint
+          if [ -s /tmp/files-to-lint ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Zig
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
       - name: Check Zig
-        if: steps.files.outcome == 'success'
+        if: steps.files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             zig build-obj -fno-emit-bin "$f" || exit 1


### PR DESCRIPTION
## Summary

- In all 45 lint workflows, the "Find files to lint" step could succeed with an empty file list (e.g., no test files of that language exist yet), causing install steps (like `apt-get install octave`) to run needlessly.
- The fix adds `if [ -s /tmp/files-to-lint ]; then echo "found=true" >> "$GITHUB_OUTPUT"; fi` to the file-finding step, and gates all subsequent install/lint steps on `steps.files.outputs.found == 'true'` instead of `steps.files.outcome == 'success'`.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm that lint jobs with matching files still run install + lint steps
- [ ] Confirm that lint jobs with no matching files skip install + lint steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts GitHub Actions workflow conditions to avoid running tool installs and linters when the file list is empty. Main risk is accidentally skipping linting if the new `found` output is not set as expected.
> 
> **Overview**
> Updates all language-specific lint GitHub Actions workflows to **detect when `/tmp/files-to-lint` is empty** and emit a `found=true` step output.
> 
> Subsequent install and lint steps are now gated on `steps.files.outputs.found == 'true'` (instead of the file-finding step merely succeeding), preventing unnecessary dependency installs and checks when no matching files exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2bd797b9f666a1014110aaf96b3c3d725ab8232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->