### PR TITLE
Retry Mojo lint step to work around runtime crash

### DIFF
--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -46,11 +46,18 @@ jobs:
         if: steps.files.outputs.found == 'true'
         run: |-
           pixi global install --channel conda-forge --channel https://conda.modular.com/max mojo
+      # The Mojo runtime has a known bug where it randomly crashes
+      # with "mojo: error: execution crashed" (see #558).
+      # This is not caused by our code. Retrying works around it.
       - name: Check Mojo syntax
         if: steps.files.outputs.found == 'true'
-        run: |-
-          while IFS= read -r -d '' f; do
-            if ! mojo run --Werror "$f"; then
-              exit 1
-            fi
-          done < /tmp/files-to-lint
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          command: |-
+            while IFS= read -r -d '' f; do
+              if ! mojo run --Werror "$f"; then
+                exit 1
+              fi
+            done < /tmp/files-to-lint


### PR DESCRIPTION
## Summary
- Wraps the Mojo syntax check step with `nick-fields/retry@v4` (up to 3 attempts) to work around a known Mojo runtime bug that randomly crashes with "execution crashed"
- This is an upstream issue in the Mojo runtime, not in our code

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the CI workflow by retrying a flaky `mojo run` step; main impact is slightly longer CI time when the upstream crash occurs.
> 
> **Overview**
> Wraps the Mojo syntax-check step in `.github/workflows/lint-mojo.yml` with `nick-fields/retry@v4` to retry up to 3 times (10 min timeout) when the Mojo runtime intermittently crashes.
> 
> Adds inline comments documenting the upstream crash (`execution crashed`) and the rationale for retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5a93a333518766545625478ec14872357cb70df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->