### PR TITLE
Remove formatter tests redundant with integration cases

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -13,6 +13,7 @@ import pytest
 from literalizer.languages import (
     Elixir,
     Haskell,
+    JavaScript,
     Perl,
     Python,
     VisualBasic,
@@ -106,6 +107,13 @@ def test_format_bytes(
 ) -> None:
     """Each bytes format function returns the expected string."""
     assert func(value) == expected
+
+
+def test_format_variable_declaration_let() -> None:
+    """``_format_variable_declaration_let`` uses the ``let`` keyword."""
+    js_let = JavaScript(declaration_style=JavaScript.DeclarationStyles.LET)
+    result = js_let.format_variable_declaration("x", "[1, 2]", [1, 2])
+    assert result == "let x = [1, 2];"
 
 
 _VB = VisualBasic()


### PR DESCRIPTION
## Summary
- Remove 22 date/datetime parametrized test cases and 4 standalone JS formatter tests (`let` declaration, hex negative, underscore large/negative) that are already covered by integration golden file cases (`scalar_date`, `scalar_datetime`, `int_list_large`, `simple_sequence` variants).
- Keep the 3 non-UTC timezone conversion tests (Elixir, Haskell, Perl) since no `scalar_datetime_non_utc` integration case exists yet.
- Keep `test_format_datetime_epoch`, `test_format_bytes`, and `test_format_string_vb` which aren't covered by integration cases.

## Test plan
- [x] `pytest tests/test_formatters.py` passes (22 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that mainly delete redundant unit coverage; low risk aside from potentially missing regressions if integration golden cases don’t fully match removed assertions.
> 
> **Overview**
> Removes most per-language date/datetime formatter unit cases (and several JavaScript integer-format tests) that are already covered by integration golden-file variants (e.g. `scalar_date`, `scalar_datetime`, `int_list_large`, `simple_sequence`).
> 
> Keeps a small focused set of unit tests: non-UTC datetime-to-UTC normalization for Elixir/Haskell/Perl, `Python.DatetimeFormats.EPOCH` parsing, byte formatting, VB string escaping, and a `let` variable-declaration check (now using a per-test `JavaScript(...)` instance).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ce1b0980c39bda1b6067f0cb9ca21092dbd473f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->