### PR TITLE
Gate mixed dict/list coercions on error_on_coercion

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -511,6 +511,42 @@ def _coerce_mixed_list_values(*, data: Value) -> Value:
 
 
 @beartype
+def _has_mixed_dict_values(*, data: Value) -> bool:
+    """Recursively check whether data contains any dict whose values span
+    multiple type families.
+    """
+    if isinstance(data, (ordereddict, dict)):
+        values: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        if _dict_values_mixed_types(values=values):
+            return True
+        return any(_has_mixed_dict_values(data=v) for v in values)
+
+    if isinstance(data, list):
+        return any(_has_mixed_dict_values(data=v) for v in data)
+
+    return False
+
+
+@beartype
+def _has_mixed_list_values(*, data: Value) -> bool:
+    """Recursively check whether data contains any list whose elements span
+    multiple type families.
+    """
+    if isinstance(data, (ordereddict, dict)):
+        return any(
+            _has_mixed_list_values(data=v)  # pyright: ignore[reportUnknownArgumentType]
+            for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        )
+
+    if isinstance(data, list):
+        if _dict_values_mixed_types(values=data):
+            return True
+        return any(_has_mixed_list_values(data=v) for v in data)
+
+    return False
+
+
+@beartype
 def _format_scalar(*, value: Scalar, spec: Language) -> str:
     """Format a scalar JSON value as a native language literal."""
     if value is None:
@@ -729,11 +765,23 @@ def _apply_coercions(
                     "that would be coerced to strings"
                 )
                 raise HeterogeneousCoercionError(msg)
+            if _has_mixed_dict_values(data=data):
+                msg = (
+                    "Dict contains values of mixed types "
+                    "that would be coerced to strings"
+                )
+                raise HeterogeneousCoercionError(msg)
+            if _has_mixed_list_values(data=data):
+                msg = (
+                    "List contains elements of mixed types "
+                    "that would be coerced to strings"
+                )
+                raise HeterogeneousCoercionError(msg)
         else:
             data = _coerce_heterogeneous_scalars(data=data)
             data = _coerce_heterogeneous_sibling_lists(data=data)
-        data = _coerce_mixed_dict_values(data=data)
-        data = _coerce_mixed_list_values(data=data)
+            data = _coerce_mixed_dict_values(data=data)
+            data = _coerce_mixed_list_values(data=data)
     return data
 
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -978,3 +978,70 @@ def test_error_on_coercion_no_raise_for_homogeneous_set() -> None:
         ]"""
     )
     assert result.code == expected
+
+
+def test_error_on_coercion_raises_for_mixed_dict_values() -> None:
+    """Error_on_coercion raises when a dict has values of mixed types."""
+    yaml_string = textwrap.dedent(
+        text="""\
+        name: Bob
+        tags:
+          - admin
+          - user
+    """,
+    )
+    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+        literalize_yaml(
+            yaml_string=yaml_string,
+            language=MOJO,
+            line_prefix="",
+            indent="    ",
+            include_delimiters=True,
+            variable_name=None,
+            new_variable=True,
+            error_on_coercion=True,
+        )
+
+
+def test_error_on_coercion_raises_for_mixed_list_values() -> None:
+    """Error_on_coercion raises when a list has mixed element types."""
+    yaml_string = textwrap.dedent(
+        text="""\
+        - hello
+        -
+          - nested
+    """,
+    )
+    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+        literalize_yaml(
+            yaml_string=yaml_string,
+            language=MOJO,
+            line_prefix="",
+            indent="    ",
+            include_delimiters=True,
+            variable_name=None,
+            new_variable=True,
+            error_on_coercion=True,
+        )
+
+
+def test_error_on_coercion_raises_for_mixed_dict_none_list() -> None:
+    """Error_on_coercion raises when a dict has None alongside a list."""
+    yaml_string = textwrap.dedent(
+        text="""\
+        tags:
+          - admin
+        extra:
+    """,
+    )
+    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+        literalize_yaml(
+            yaml_string=yaml_string,
+            language=MOJO,
+            line_prefix="",
+            indent="    ",
+            include_delimiters=True,
+            variable_name=None,
+            new_variable=True,
+            error_on_coercion=True,
+        )


### PR DESCRIPTION
## Summary
- Move `_coerce_mixed_dict_values` and `_coerce_mixed_list_values` into the `else` branch so they only run when `error_on_coercion=False`
- Add `_has_mixed_dict_values` and `_has_mixed_list_values` check functions that raise `HeterogeneousCoercionError` when `error_on_coercion=True`
- Add tests for the new error paths

Closes #566

## Test plan
- [x] Existing tests pass (7147 passed)
- [x] New tests verify `error_on_coercion=True` raises for mixed dict values, mixed list values, and None-with-list cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coercion/validation behavior for heterogeneous collections, which can alter output or introduce new `HeterogeneousCoercionError` failures for existing inputs when `error_on_coercion=True`. Scope is limited to literalization coercion logic and covered by new tests.
> 
> **Overview**
> When a language does not support heterogeneous sequences, `error_on_coercion=True` now also **rejects mixed-type dict values and mixed-type list elements** (e.g. dicts mixing scalars and lists, or lists mixing scalars and nested lists) by raising `HeterogeneousCoercionError`.
> 
> The mixed-type coercions (`_coerce_mixed_dict_values` / `_coerce_mixed_list_values`) are now **only applied when `error_on_coercion=False`**, and new recursive predicates (`_has_mixed_dict_values` / `_has_mixed_list_values`) drive the error paths; YAML tests were added for these new failure cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fec04c52a599f5d8bc0f8888d45c19055565011. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->