### PR TITLE
Use `--no-project` for standalone lint scripts

### DIFF
--- a/.github/workflows/lint-ada.yml
+++ b/.github/workflows/lint-ada.yml
@@ -51,4 +51,4 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check Ada syntax
         if: steps.files.outputs.found == 'true'
-        run: xargs -0 uv run python check_ada_golden_syntax.py < /tmp/files-to-lint
+        run: xargs -0 uv run --no-project python check_ada_golden_syntax.py < /tmp/files-to-lint

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -53,4 +53,4 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check C# syntax
         if: steps.files.outputs.found == 'true'
-        run: xargs -0 uv run python check_csharp_golden_syntax.py < /tmp/files-to-lint
+        run: xargs -0 uv run --no-project python check_csharp_golden_syntax.py < /tmp/files-to-lint

--- a/.github/workflows/lint-occam.yml
+++ b/.github/workflows/lint-occam.yml
@@ -48,4 +48,4 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check Occam-pi syntax
         if: steps.files.outputs.found == 'true'
-        run: xargs -0 uv run python check_occam_golden_syntax.py < /tmp/files-to-lint
+        run: xargs -0 uv run --no-project python check_occam_golden_syntax.py < /tmp/files-to-lint

--- a/.github/workflows/lint-visualbasic.yml
+++ b/.github/workflows/lint-visualbasic.yml
@@ -53,4 +53,4 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check VB.NET syntax
         if: steps.files.outputs.found == 'true'
-        run: xargs -0 uv run python check_vb_golden_syntax.py < /tmp/files-to-lint
+        run: xargs -0 uv run --no-project python check_vb_golden_syntax.py < /tmp/files-to-lint


### PR DESCRIPTION
## Summary

- Add `--no-project` to `uv run` in lint workflows for Ada, C#, Occam-pi, and VB.NET
- These golden-file syntax check scripts only use stdlib modules, so syncing the full project environment is unnecessary overhead

## Test plan

- [ ] Verify CI lint jobs still pass for Ada, C#, Occam-pi, and VB.NET workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tweaks how the lint jobs invoke `uv run`; main risk is the workflows failing if the scripts implicitly relied on project dependencies or configuration.
> 
> **Overview**
> Updates the Ada, C#, Occam-pi, and VB.NET lint GitHub Actions workflows to run the golden-file syntax check scripts via `uv run --no-project`, avoiding syncing/using the repository’s Python project environment for these standalone checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27e074a08e44d17733fe18ccaafc9275a380a900. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->