### PR TITLE
Fix Obj-C ISO date/datetime to produce NSString literals

### DIFF
--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -9,8 +9,6 @@ from beartype import beartype
 from literalizer._formatters import (
     fixed_dict_open,
     fixed_sequence_open,
-    format_date_iso,
-    format_datetime_iso,
 )
 from literalizer._language import (
     CommentConfig,
@@ -88,9 +86,34 @@ def _format_objc_date(value: datetime.date) -> str:
 
 
 @beartype
+def _format_objc_date_iso(value: datetime.date) -> str:
+    """Format a date as an Objective-C ``NSString`` ISO 8601 literal.
+
+    This is the ISO format variant, producing the same ``@"..."``
+    ``NSString`` output as the native format.
+
+    Example: ``datetime.date(2024, 1, 15)`` → ``@"2024-01-15"``.
+    """
+    return f'@"{value.isoformat()}"'
+
+
+@beartype
 def _format_objc_datetime(value: datetime.datetime) -> str:
     """Format a datetime as an Objective-C ``NSString`` ISO 8601
     literal.
+
+    Example: ``datetime.datetime(2024, 1, 15, 12, 30)`` →
+    ``@"2024-01-15T12:30:00"``.
+    """
+    return f'@"{value.isoformat()}"'
+
+
+@beartype
+def _format_objc_datetime_iso(value: datetime.datetime) -> str:
+    """Format a datetime as an Objective-C ``NSString`` ISO 8601 literal.
+
+    This is the ISO format variant, producing the same ``@"..."``
+    ``NSString`` output as the native format.
 
     Example: ``datetime.datetime(2024, 1, 15, 12, 30)`` →
     ``@"2024-01-15T12:30:00"``.
@@ -131,7 +154,7 @@ class ObjectiveC(metaclass=LanguageCls):
         """Date format options for ObjectiveC."""
 
         OBJC = DateFormatConfig(formatter=_format_objc_date)
-        ISO = DateFormatConfig(formatter=format_date_iso)
+        ISO = DateFormatConfig(formatter=_format_objc_date_iso)
 
         def __call__(self, date_value: datetime.date, /) -> str:
             """Format a date."""
@@ -141,7 +164,7 @@ class ObjectiveC(metaclass=LanguageCls):
         """Datetime format options for ObjectiveC."""
 
         OBJC = DatetimeFormatConfig(formatter=_format_objc_datetime)
-        ISO = DatetimeFormatConfig(formatter=format_datetime_iso)
+        ISO = DatetimeFormatConfig(formatter=_format_objc_datetime_iso)
 
         def __call__(self, dt_value: datetime.datetime, /) -> str:
             """Format a datetime."""

--- a/tests/integration/cases/scalar_date/ObjectiveC_date_iso.m
+++ b/tests/integration/cases/scalar_date/ObjectiveC_date_iso.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 void _check(void) {
-    id _v = "2024-01-15";
+    id _v = @"2024-01-15";
     (void)_v;
 }

--- a/tests/integration/cases/scalar_datetime/ObjectiveC_datetime_iso.m
+++ b/tests/integration/cases/scalar_datetime/ObjectiveC_datetime_iso.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 void _check(void) {
-    id _v = "2024-01-15T12:30:00+00:00";
+    id _v = @"2024-01-15T12:30:00+00:00";
     (void)_v;
 }

--- a/tests/integration/cases/scalar_datetime_naive/ObjectiveC_datetime_iso_naive.m
+++ b/tests/integration/cases/scalar_datetime_naive/ObjectiveC_datetime_iso_naive.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 void _check(void) {
-    id _v = "2024-01-15T12:30:00";
+    id _v = @"2024-01-15T12:30:00";
     (void)_v;
 }


### PR DESCRIPTION
## Summary
- The Obj-C ISO date/datetime formats were using generic `format_date_iso`/`format_datetime_iso` formatters that produce C string literals (`"2024-01-15"`) instead of NSString literals (`@"2024-01-15"`)
- Added Obj-C-specific ISO formatter functions that produce the correct `@"..."` NSString syntax
- Updated golden test files to expect `@"..."` output

## Test plan
- [x] Verified `format_date` with `ISO` format produces `@"2024-01-15"`
- [x] Verified `format_datetime` with `ISO` format produces `@"2024-01-15T12:30:00"`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Objective-C date/datetime ISO formatter wiring and updates corresponding golden integration outputs.
> 
> **Overview**
> Fixes Objective-C `ISO` date/datetime formatting to emit `NSString` literals (`@"..."`) instead of plain C string literals (`"..."`) by introducing Obj-C-specific ISO formatter functions and wiring them into `ObjectiveC.DateFormats.ISO`/`DatetimeFormats.ISO`.
> 
> Updates the Objective-C integration golden files for ISO date and datetime cases (including naive/offset datetimes) to expect the `@"..."` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fddabcfa0aa04ef8c46b67d04498ef1c943cad32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->