### PR TITLE
Use Mojo's native Set type for set formatting

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -124,7 +124,7 @@ class Mojo(metaclass=LanguageCls):
             open_str="Set[String](",
             close=")",
             empty_set="Set[String]()",
-            preamble_lines=(),
+            preamble_lines=("from std.collections import Set",),
         )
 
     class CommentFormats(enum.Enum):

--- a/tests/integration/cases/empty_set/Mojo.mojo
+++ b/tests/integration/cases/empty_set/Mojo.mojo
@@ -1,2 +1,3 @@
+from std.collections import Set
 def main():
     _ = Set[String]()

--- a/tests/integration/cases/empty_set/Mojo_combined.mojo
+++ b/tests/integration/cases/empty_set/Mojo_combined.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String]()
     _ = my_data

--- a/tests/integration/cases/empty_set/Mojo_varname.mojo
+++ b/tests/integration/cases/empty_set/Mojo_varname.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String]()
     _ = my_data

--- a/tests/integration/cases/mixed_set/Mojo.mojo
+++ b/tests/integration/cases/mixed_set/Mojo.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     _ = Set[String](
         "42",

--- a/tests/integration/cases/mixed_set/Mojo_combined.mojo
+++ b/tests/integration/cases/mixed_set/Mojo_combined.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         "42",

--- a/tests/integration/cases/mixed_set/Mojo_varname.mojo
+++ b/tests/integration/cases/mixed_set/Mojo_varname.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         "42",

--- a/tests/integration/cases/set/Mojo.mojo
+++ b/tests/integration/cases/set/Mojo.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     _ = Set[String](
         "apple",

--- a/tests/integration/cases/set/Mojo_combined.mojo
+++ b/tests/integration/cases/set/Mojo_combined.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         "apple",

--- a/tests/integration/cases/set/Mojo_varname.mojo
+++ b/tests/integration/cases/set/Mojo_varname.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         "apple",

--- a/tests/integration/cases/set_comments/Mojo.mojo
+++ b/tests/integration/cases/set_comments/Mojo.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     _ = Set[String](
         "apple",  # inline comment

--- a/tests/integration/cases/set_comments/Mojo_combined.mojo
+++ b/tests/integration/cases/set_comments/Mojo_combined.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         "apple",  # inline comment

--- a/tests/integration/cases/set_comments/Mojo_varname.mojo
+++ b/tests/integration/cases/set_comments/Mojo_varname.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         "apple",  # inline comment

--- a/tests/integration/cases/set_comments_unsorted_order/Mojo.mojo
+++ b/tests/integration/cases/set_comments_unsorted_order/Mojo.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     _ = Set[String](
         # before apple

--- a/tests/integration/cases/set_comments_unsorted_order/Mojo_combined.mojo
+++ b/tests/integration/cases/set_comments_unsorted_order/Mojo_combined.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         # before apple

--- a/tests/integration/cases/set_comments_unsorted_order/Mojo_varname.mojo
+++ b/tests/integration/cases/set_comments_unsorted_order/Mojo_varname.mojo
@@ -1,3 +1,4 @@
+from std.collections import Set
 def main():
     var my_data = Set[String](
         # before apple

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -354,10 +354,10 @@ def test_coerce_heterogeneous_set() -> None:
     )
     expected = textwrap.dedent(
         text="""\
-        [
+        Set[String](
             "1",
             "hello",
-        ]"""
+        )"""
     )
     assert result.code == expected
 
@@ -972,10 +972,10 @@ def test_error_on_coercion_no_raise_for_homogeneous_set() -> None:
     )
     expected = textwrap.dedent(
         text="""\
-        [
+        Set[String](
             1,
             2,
-        ]"""
+        )"""
     )
     assert result.code == expected
 


### PR DESCRIPTION
## Summary
- Update Mojo `SetFormatConfig` to emit `Set[String](...)` with variadic constructor syntax instead of incorrectly using `List[String]()` / `[...]`
- Mojo has a native `Set[T]` type in `std.collections.set` — sets should use it rather than falling back to list syntax
- Update all Mojo set-related golden test fixtures to match

## Test plan
- [x] All 148 Mojo integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mojo code generation for YAML `!!set` values (including adding a `from std.collections import Set` preamble), which can affect downstream consumers expecting the prior list-style output.
> 
> **Overview**
> **Mojo set literal output is corrected to use the native `Set[String]` type.** The Mojo `SetFormatConfig` now emits `Set[String](...)` / `Set[String]()` and adds a `from std.collections import Set` preamble, replacing the previous list-style delimiters/empty-set literal.
> 
> Integration fixtures and YAML tests are updated to expect the new set formatting (including empty sets, mixed/coerced sets, and comment-preserving cases).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e7b3b4cfdf72415bd0a37078d669ace2284a961. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->