### PR TITLE
Use snake_case enum aliases in test_formatters to fix pyright

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,10 +1,5 @@
 """Tests for literalizer formatters."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportAttributeAccessIssue=false
-
 import datetime
 from collections.abc import Callable
 
@@ -30,13 +25,13 @@ _NON_UTC_DATETIME = datetime.datetime.fromisoformat(
     argnames=("func", "value", "expected"),
     argvalues=[
         pytest.param(
-            Elixir.DatetimeFormats.ELIXIR,
+            Elixir.datetime_formats.ELIXIR,
             _NON_UTC_DATETIME,
             "~U[2024-01-15 12:30:00+00:00]",
             id="format_datetime_elixir_non_utc",
         ),
         pytest.param(
-            Haskell.DatetimeFormats.HASKELL,
+            Haskell.datetime_formats.HASKELL,
             _NON_UTC_DATETIME,
             "HDatetime (UTCTime "
             "(fromGregorian 2024 1 15) "
@@ -44,7 +39,7 @@ _NON_UTC_DATETIME = datetime.datetime.fromisoformat(
             id="format_datetime_haskell_non_utc",
         ),
         pytest.param(
-            Perl.DatetimeFormats.PERL,
+            Perl.datetime_formats.PERL,
             _NON_UTC_DATETIME,
             "DateTime->new("
             "year => 2024, month => 1, day => 15, "
@@ -65,7 +60,7 @@ def test_format_datetime_non_utc(
 
 def test_format_datetime_epoch() -> None:
     """``format_datetime_epoch`` returns a numeric timestamp."""
-    result = Python.DatetimeFormats.EPOCH(_SAMPLE_DATETIME)
+    result = Python.datetime_formats.EPOCH(_SAMPLE_DATETIME)
     # The exact value depends on local timezone for naive datetimes,
     # so just check it parses as a float.
     float(result)
@@ -73,7 +68,7 @@ def test_format_datetime_epoch() -> None:
 
 def test_format_variable_declaration_let() -> None:
     """``_format_variable_declaration_let`` uses the ``let`` keyword."""
-    js_let = JavaScript(declaration_style=JavaScript.DeclarationStyles.LET)
+    js_let = JavaScript(declaration_style=JavaScript.declaration_styles.LET)
     result = js_let.format_variable_declaration("x", "[1, 2]", [1, 2])
     assert result == "let x = [1, 2];"
 


### PR DESCRIPTION
## Summary
- Removed all four `# pyright: report*=false` suppressions from `tests/test_formatters.py`
- Switched from PascalCase nested enum access (e.g. `Elixir.DatetimeFormats.ELIXIR`) to the snake_case aliases (e.g. `Elixir.datetime_formats.ELIXIR`)
- The PascalCase names are shadowed by the `LanguageCls` metaclass annotations as `type[enum.Enum]`, preventing pyright from resolving specific members. The snake_case aliases avoid this.

## Test plan
- [x] `pyright tests/test_formatters.py` passes with 0 errors
- [x] `pytest tests/test_formatters.py` all 19 tests pass
- [x] Full `pyright .` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test code and type-checker hygiene, with no runtime/library behavior modifications.
> 
> **Overview**
> Updates `tests/test_formatters.py` to remove Pyright suppression directives and to reference language enum options via the snake_case aliases (e.g. `Elixir.datetime_formats.ELIXIR`, `JavaScript.declaration_styles.LET`) instead of the PascalCase nested names.
> 
> This makes the tests type-check cleanly under Pyright while keeping the same test assertions and expected formatting output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f16d93856c7a6546c5615c0e900dc54e779168c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->