### PR TITLE
Remove test_format_datetime_epoch unit test

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -9,7 +9,6 @@ from literalizer.languages import (
     Elixir,
     Haskell,
     Perl,
-    Python,
     VisualBasic,
 )
 
@@ -55,14 +54,6 @@ def test_format_datetime_non_utc(
 ) -> None:
     """Non-UTC datetimes are converted to UTC before formatting."""
     assert func(value) == expected
-
-
-def test_format_datetime_epoch() -> None:
-    """``format_datetime_epoch`` returns a numeric timestamp."""
-    result = Python.datetime_formats.EPOCH(_SAMPLE_DATETIME)
-    # The exact value depends on local timezone for naive datetimes,
-    # so just check it parses as a float.
-    float(result)
 
 
 _VB = VisualBasic()


### PR DESCRIPTION
## Summary
- Remove `test_format_datetime_epoch` from `test_formatters.py` — already covered by the `Python_datetime_epoch.py` golden file variant in the `scalar_datetime` integration test case.
- Remove unused `Python` import.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes a redundant unit test and an unused import, with no production code changes.
> 
> **Overview**
> Removes the `test_format_datetime_epoch` unit test from `tests/test_formatters.py` and drops the now-unused `Python` import, relying on existing golden/integration coverage for epoch datetime formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7eccae7e8429063e02bd611edb05b23cd9e0157. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->