### PR TITLE
Disable Hypothesis deadline on flaky roundtrip tests

### DIFF
--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -75,6 +75,7 @@ json_arrays = st.lists(elements=json_values, max_size=10)
 json_objects = st.dictionaries(keys=json_text, values=json_values, max_size=10)
 
 
+@settings(deadline=None)
 @given(data=json_arrays)
 def test_roundtrip_array(data: list[_JSONValue]) -> None:
     """JSON array -> Python literal -> ast.literal_eval round-trips."""
@@ -114,7 +115,7 @@ def test_roundtrip_scalar(data: _JSONScalar) -> None:
 # health check on unlucky seeds.  The filtering is expected behavior here,
 # so we suppress the check rather than change the strategy.
 @given(data=json_objects)
-@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
 def test_roundtrip_dict(data: dict[str, _JSONValue]) -> None:
     """JSON object -> Python literal -> ast.literal_eval round-trips."""
     result = literalize_json(


### PR DESCRIPTION
## Summary
- Disable the Hypothesis deadline (`deadline=None`) on `test_roundtrip_array` and `test_roundtrip_dict` to fix intermittent `DeadlineExceeded` failures

Fixes #593

## Test plan
- [x] Both affected tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that relaxes Hypothesis timing constraints to avoid intermittent `DeadlineExceeded` failures; no production code paths are affected.
> 
> **Overview**
> Disables Hypothesis timeouts by setting `deadline=None` for `test_roundtrip_array` and `test_roundtrip_dict` in `tests/test_roundtrip.py`, keeping the existing health-check suppression for dictionary key filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f36e953af1fa77f35cd98d691751ca64507c9c1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->