### PR TITLE
Link to literalizer-cli repo in README and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,11 @@ Use cases
 * Generate multi-language request/response examples for JSON API docs (see `guide <https://adamtheturtle.github.io/literalizer/json-api-use-case.html>`__).
 * Create type-safe literal data from JSON config files.
 
+CLI
+---
+
+A command-line interface is available at `literalizer-cli <https://github.com/adamtheturtle/literalizer-cli>`__.
+
 Full documentation
 ------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,11 @@ Use cases
 * Convert API responses to language-native data structures for documentation.
 * Create type-safe literal data from JSON config files.
 
+CLI
+---
+
+A command-line interface is available at `literalizer-cli <https://github.com/adamtheturtle/literalizer-cli>`__.
+
 Reference
 ---------
 


### PR DESCRIPTION
## Summary

- Adds a "CLI" section to both `README.rst` and `docs/source/index.rst` linking to the [literalizer-cli](https://github.com/adamtheturtle/literalizer-cli) repository.

## Test plan

- [ ] Verify the links render correctly in the README on GitHub
- [ ] Build the docs locally and verify the CLI section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a link to an external CLI repo; no runtime/code-path impact.
> 
> **Overview**
> Adds a new **CLI** section to `README.rst` and `docs/source/index.rst` that links to the external `literalizer-cli` repository.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e227a8a71d2b94e4bb0d69bfd1e89af5ab0efb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->