### PR TITLE
Use find_lexer_class_by_name to avoid pyright ignore

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -4,9 +4,7 @@ import json
 import textwrap
 
 import pytest
-from pygments.lexers import (
-    get_lexer_by_name,  # pyright: ignore[reportUnknownVariableType]
-)
+from pygments.lexers import find_lexer_class_by_name
 
 import literalizer.languages
 from literalizer import (
@@ -717,7 +715,8 @@ def test_pygments_name_is_valid(
     language_cls: LanguageCls,
 ) -> None:
     """Every language's ``pygments_name`` is recognized by Pygments."""
-    get_lexer_by_name(_alias=language_cls.pygments_name)
+    # Raises ClassNotFound if the name is not a valid Pygments alias.
+    find_lexer_class_by_name(_alias=language_cls.pygments_name)
 
 
 def test_cobol_bump_levels_rejects_non_level_line() -> None:


### PR DESCRIPTION
## Summary

Replace `get_lexer_by_name` with `find_lexer_class_by_name` in the Pygments name validation test. The latter is properly typed in the Pygments stubs, removing the need for a `# pyright: ignore[reportUnknownVariableType]` comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes a unit test helper call and import, with no runtime or data-handling behavior changes.
> 
> **Overview**
> Simplifies the `test_pygments_name_is_valid` check by switching from `get_lexer_by_name` (and its Pyright typing ignore) to the typed `find_lexer_class_by_name`, while preserving the same failure behavior when a `pygments_name` alias is invalid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69094e5982964d6b024a9bd08373bdd660e925cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->