### PR TITLE
Remove redundant test_variable_declaration_none_no_wrap

### DIFF
--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -275,28 +275,6 @@ def test_variable_declaration_yaml(
     assert result.code == expected
 
 
-def test_variable_declaration_none_no_wrap() -> None:
-    """Omitting variable_name leaves output unchanged."""
-    result = literalize_json(
-        json_string="[1, 2]",
-        language=PYTHON,
-        line_prefix="",
-        indent="    ",
-        include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        (
-            1,
-            2,
-        )"""
-    )
-    assert result.code == expected
-
-
 @pytest.mark.parametrize(
     argnames=("language", "expected"), argvalues=_ASSIGNMENT_PARAMS
 )


### PR DESCRIPTION
## Summary
- Remove `test_variable_declaration_none_no_wrap` from `tests/test_variables.py` as it is fully covered by the integration suite's `test_golden_file`, which tests `variable_name=None` with `new_variable=True` across all languages and cases.

## Test plan
- [x] All existing tests pass (pre-commit hooks ran successfully on commit and push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single unit test without changing any production logic; potential risk is only reduced coverage if integration tests don’t fully cover the same behavior.
> 
> **Overview**
> Removes `test_variable_declaration_none_no_wrap` from `tests/test_variables.py`, eliminating a redundant case that asserted output is unchanged when `variable_name=None` during new-variable formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14960ac39c6c8d3a01725fe3d8ba387c5476fd2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->