### PR TITLE
Move JS DictFormatConfig into DictFormats enum values

### DIFF
--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -217,8 +217,20 @@ class JavaScript(metaclass=LanguageCls):
     class DictFormats(enum.Enum):
         """Dict/map format options."""
 
-        OBJECT = "object"
-        MAP = "map"
+        OBJECT = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="{"),
+            close="}",
+            format_entry=dict_entry_with_separator(separator=": "),
+            empty_dict=None,
+            preamble_lines=(),
+        )
+        MAP = DictFormatConfig(
+            open_fn=fixed_dict_open(open_str="new Map(["),
+            close="])",
+            format_entry=_format_map_entry,
+            empty_dict="new Map()",
+            preamble_lines=(),
+        )
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""
@@ -293,22 +305,7 @@ class JavaScript(metaclass=LanguageCls):
         self.set_format = set_format
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        if dict_format.name == "MAP":
-            self.dict_format_config: DictFormatConfig = DictFormatConfig(
-                open_fn=fixed_dict_open(open_str="new Map(["),
-                close="])",
-                format_entry=_format_map_entry,
-                empty_dict="new Map()",
-                preamble_lines=(),
-            )
-        else:
-            self.dict_format_config = DictFormatConfig(
-                open_fn=fixed_dict_open(open_str="{"),
-                close="}",
-                format_entry=dict_entry_with_separator(separator=": "),
-                empty_dict=None,
-                preamble_lines=(),
-            )
+        self.dict_format_config: DictFormatConfig = dict_format.value
         self.multiline_trailing_comma: bool = trailing_comma.name == "YES"
         self.format_bytes: Callable[[bytes], str] = bytes_format
         self.format_date: Callable[[datetime.date], str] = date_format


### PR DESCRIPTION
## Summary
- Moves `DictFormatConfig` instances into the `DictFormats` enum values for JavaScript, matching the pattern used by `SequenceFormats` and `SetFormats`
- Replaces the if/else branch in `__init__` with `self.dict_format_config = dict_format.value`

## Test plan
- [x] All 204 JavaScript tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to JavaScript dict formatting configuration; behavior should remain the same but could affect output if enum values are miswired.
> 
> **Overview**
> Moves JavaScript `DictFormatConfig` definitions into the `DictFormats` enum values (similar to existing `SequenceFormats`/`SetFormats` patterns).
> 
> Simplifies `JavaScript.__init__` by removing the `MAP` vs `OBJECT` conditional and directly assigning `self.dict_format_config = dict_format.value`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c171cd5cd2c8ff6ac6c5bb084a698e55fc4e79c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->