### PR TITLE
Remove trailing-whitespace workaround from Racket test wrappers

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -397,18 +397,6 @@ def _wrap_dart_combined(declaration: str, assignment: str) -> str:
 
 
 @beartype
-def _wrap_racket(content: str) -> str:
-    """Return Racket content unchanged."""
-    return content
-
-
-@beartype
-def _wrap_racket_combined(declaration: str, assignment: str) -> str:
-    """Wrap Racket declaration and assignment."""
-    return f"{declaration}\n{assignment}"
-
-
-@beartype
 def _wrap_perl(content: str) -> str:
     """Wrap in a Perl variable assignment."""
     return f"my $x = {content};"
@@ -1353,9 +1341,9 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     literalizer.languages.Racket.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Racket,
-        wrap=_wrap_racket,
-        varname_wrap=_wrap_racket,
-        combined_wrap=_wrap_racket_combined,
+        wrap=_wrap_identity,
+        varname_wrap=_wrap_identity,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.Crystal.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Crystal,


### PR DESCRIPTION
## Summary
- Remove `line.rstrip()` post-processing from `_wrap_racket` and `_wrap_racket_combined` test helpers
- The multiline formatting in `_core.py` already strips trailing whitespace from opening delimiters via `opening.rstrip()`, making the test workaround unnecessary

Closes #610

## Test plan
- [x] All 188 Racket integration tests pass without the workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts integration test wrapping for the `Racket` language, with no changes to production literalization logic.
> 
> **Overview**
> Removes the custom Racket integration-test wrappers that `rstrip()` trailing whitespace on every line.
> 
> Updates the `Racket` entry in `_LANGUAGES` to use the standard `_wrap_identity` and `_wrap_combined_newline` helpers for normal, variable-name, and combined golden-file generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b874497c84c945fe17c955c6cdd0e6fa756865a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->