### PR TITLE
Swift: handle nil in tuples and add :Any to declarations

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -19,6 +19,7 @@ class SequenceFormatConfig:
     single_element_trailing_comma: bool
     empty_sequence: str | None
     preamble_lines: tuple[str, ...]
+    format_entry: Callable[[str], str]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -174,6 +175,7 @@ class Ada(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="AList'(1 .. 0 => ANull)",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_date_iso,
     format_datetime_iso,
     format_string_backslash,
+    passthrough_sequence_entry,
     passthrough_set_entry,
 )
 from literalizer._language import (
@@ -127,6 +128,7 @@ class Bash(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_date_iso,
     format_datetime_iso,
     format_string_backslash,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -150,6 +151,7 @@ class C(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -93,6 +93,7 @@ class Clojure(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -264,6 +265,7 @@ class Cobol(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="05 FILLER PIC X(1) VALUE SPACES.",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -98,6 +98,7 @@ class CommonLisp(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="nil",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -199,6 +199,7 @@ class Cpp(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=("#include <vector>",),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=_cpp_array_open,
@@ -207,6 +208,7 @@ class Cpp(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=("#include <array>",),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -102,6 +102,7 @@ class Crystal(metaclass=LanguageCls):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="{"),
@@ -110,6 +111,7 @@ class Crystal(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -161,6 +161,7 @@ class CSharp(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="ValueTuple.Create()",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=typed_sequence_open(
@@ -174,6 +175,7 @@ class CSharp(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="Array.Empty<object>()",
             preamble_lines=("using System.Collections.Generic;",),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_date_iso,
     format_datetime_iso,
     format_string_backslash,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -147,6 +148,7 @@ class D(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence='parseJSON("[]")',
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -157,6 +157,7 @@ class Dart(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="("),
@@ -165,6 +166,7 @@ class Dart(metaclass=LanguageCls):
             single_element_trailing_comma=True,
             empty_sequence="()",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -150,6 +150,7 @@ class Elixir(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="{"),
@@ -158,6 +159,7 @@ class Elixir(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -149,6 +149,7 @@ class Erlang(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="{"),
@@ -157,6 +158,7 @@ class Erlang(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -272,6 +273,7 @@ class Fortran(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_date_iso,
     format_datetime_iso,
     format_string_backslash,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -178,6 +179,7 @@ class FSharp(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="[|"),
@@ -186,6 +188,7 @@ class FSharp(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -197,6 +197,7 @@ class Go(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -93,6 +93,7 @@ class Groovy(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -232,6 +232,7 @@ class Haskell(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="("),
@@ -240,6 +241,7 @@ class Haskell(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -95,6 +95,7 @@ class Hcl(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -208,9 +208,11 @@ class Java(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         LIST = SequenceFormatConfig(
             sequence_open=_list_of_open,
+            format_entry=passthrough_sequence_entry,
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -177,6 +177,7 @@ class JavaScript(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -139,6 +139,7 @@ class Julia(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="("),
@@ -147,6 +148,7 @@ class Julia(metaclass=LanguageCls):
             single_element_trailing_comma=True,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -206,6 +206,7 @@ class Kotlin(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="arrayOf<Any?>("),
@@ -214,9 +215,11 @@ class Kotlin(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=_kotlin_tuple_open,
+            format_entry=passthrough_sequence_entry,
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -140,6 +140,7 @@ class Lua(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -212,6 +212,7 @@ class Matlab(metaclass=LanguageCls):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -133,6 +133,7 @@ class Mojo(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="List[String]()",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -180,6 +180,7 @@ class Nim(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=("import json",),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="["),
@@ -188,6 +189,7 @@ class Nim(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=("import json",),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -113,6 +113,7 @@ class Norg(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -10,6 +10,7 @@ from literalizer._formatters import (
     fixed_dict_open,
     fixed_sequence_open,
     fixed_set_open,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -196,6 +197,7 @@ class ObjectiveC(metaclass=LanguageCls):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_date_iso,
     format_datetime_iso,
     format_string_backslash,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -186,6 +187,7 @@ class OCaml(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="[|"),
@@ -194,6 +196,7 @@ class OCaml(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_date_iso,
     format_datetime_iso,
     format_string_backslash,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -140,6 +141,7 @@ class Occam(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -144,6 +144,7 @@ class Perl(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -113,6 +113,7 @@ class Php(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
+    passthrough_sequence_entry,
     passthrough_set_entry,
 )
 from literalizer._language import (
@@ -120,6 +121,7 @@ class PowerShell(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -334,6 +334,7 @@ class Python(metaclass=LanguageCls):
             single_element_trailing_comma=True,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         LIST = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="["),
@@ -342,6 +343,7 @@ class Python(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -181,6 +181,7 @@ class R(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -93,6 +93,7 @@ class Racket(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="(list)",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -137,6 +137,7 @@ class Ruby(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -177,6 +177,7 @@ class Rust(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="Vec::<String>::new()",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="["),
@@ -185,6 +186,7 @@ class Rust(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="("),
@@ -193,6 +195,7 @@ class Rust(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -191,6 +191,7 @@ class Scala(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         SEQ = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="Seq("),
@@ -199,6 +200,7 @@ class Scala(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=typed_sequence_open(
@@ -212,6 +214,7 @@ class Scala(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -66,7 +66,7 @@ def _format_swift_ordered_map_entry(key: str, value: str) -> str:
 @beartype
 def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
     """Format a Swift variable declaration."""
-    return f"let {name} = {value}"
+    return f"let {name}: Any = {value}"
 
 
 @beartype
@@ -87,6 +87,14 @@ def _format_string_swift(value: str) -> str:
     )
     escaped = escape_control_chars(value=escaped, fmt="\\u{{{:x}}}")
     return f'"{escaped}"'
+
+
+@beartype
+def _tuple_sequence_entry(entry: str) -> str:
+    """Format a tuple sequence entry, casting nil to Any? for Swift."""
+    if entry == "nil":
+        return "nil as Any?"
+    return entry
 
 
 _string_format: Callable[[str], str] = _format_string_swift
@@ -147,6 +155,7 @@ class Swift(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="[Any]()",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="("),
@@ -155,6 +164,7 @@ class Swift(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=_tuple_sequence_entry,
         )
 
         @property
@@ -280,9 +290,7 @@ class Swift(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = _string_format
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
-            passthrough_sequence_entry
-        )
+        self.format_sequence_entry: Callable[[str], str] = fmt.format_entry
         self.format_set_entry: Callable[[str], str] = passthrough_set_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -173,6 +173,7 @@ class Toml(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -143,6 +143,7 @@ class TypeScript(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="["),
@@ -151,6 +152,7 @@ class TypeScript(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="[] as const",
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -205,6 +205,7 @@ class VisualBasic(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence="New Object() {}",
             preamble_lines=("Imports System.Collections.Generic",),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -141,6 +141,7 @@ class Yaml(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
+    passthrough_sequence_entry,
 )
 from literalizer._language import (
     CommentConfig,
@@ -181,6 +182,7 @@ class Zig(metaclass=LanguageCls):
             single_element_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
         )
 
         @property

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -14,7 +14,6 @@ To regenerate all golden files after changing output::
 
 import dataclasses
 import enum
-import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -92,12 +91,6 @@ def _wrap_cpp(content: str) -> str:
 @beartype
 def _wrap_swift(content: str) -> str:
     """Wrap in a Swift variable assignment."""
-    if content.lstrip().startswith("("):
-        content = re.sub(
-            pattern=r"\bnil\b",
-            repl="nil as Any?",
-            string=content,
-        )
     return f"let x: Any? = {content}"
 
 
@@ -747,17 +740,7 @@ def _wrap_zig_combined(declaration: str, assignment: str) -> str:
     )
 
 
-@beartype
-def _wrap_swift_varname(content: str) -> str:
-    """Add type annotation to Swift let declaration for mixed-type
-    collections.
-
-    The content from format_variable_declaration_swift is like
-    "let my_data = [...]", and we need to add a type annotation for Swift
-    to accept heterogeneous collections.
-    """
-    prefix = f"let {_VARIABLE_NAME}"
-    return prefix + ": Any =" + content[len(prefix) + 2 :]
+_wrap_swift_varname = _wrap_identity
 
 
 @beartype
@@ -801,11 +784,10 @@ def _wrap_kotlin_combined(declaration: str, assignment: str) -> str:
 
 @beartype
 def _wrap_swift_combined(declaration: str, assignment: str) -> str:
-    """Swift: let declaration (with type annotation) in a do block,
+    """Swift: let declaration in a do block,
     then var + assignment in the outer scope.
     """
-    annotated = _wrap_swift_varname(content=declaration)
-    decl_indented = "    " + annotated.replace("\n", "\n    ")
+    decl_indented = "    " + declaration.replace("\n", "\n    ")
     return (
         f"do {{\n{decl_indented}\n}}\nvar {_VARIABLE_NAME}: Any\n{assignment}"
     )

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -191,7 +191,7 @@ _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {  # pyrefly: ignore[bad-ass
         declaration="val my_var = 42", assignment="my_var = 42"
     ),
     SWIFT: _VariableSyntax(
-        declaration="let my_var = 42", assignment="my_var = 42"
+        declaration="let my_var: Any = 42", assignment="my_var = 42"
     ),
     RUST: _VariableSyntax(
         declaration="let my_var = 42;", assignment="my_var = 42;"


### PR DESCRIPTION
## Summary

Closes #612.

- Emit `nil as Any?` instead of bare `nil` for tuple sequence entries, so Swift can infer the type
- Add `: Any` type annotation to `_format_variable_declaration` (`let {name}: Any = {value}`) so heterogeneous collections compile
- Simplify test wrappers (`_wrap_swift`, `_wrap_swift_varname`, `_wrap_swift_combined`) that previously patched these issues from the test side

## Test plan

- [x] All 9215 tests pass (197 Swift-specific tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated Swift output (variable declarations and tuple literals) and introduces a new required `SequenceFormatConfig.format_entry` field, which may break custom language/format implementations until updated.
> 
> **Overview**
> Fixes Swift output so heterogeneous literals compile: variable declarations are now emitted as `let <name>: Any = ...`, and tuple entries emit `nil as Any?` instead of bare `nil`.
> 
> Extends `SequenceFormatConfig` with a required `format_entry` hook and updates all built-in languages to provide it (mostly passthrough), with Swift now sourcing `format_sequence_entry` from the selected sequence format. Integration/unit tests are simplified to stop patching Swift output in wrappers and to expect the new Swift declaration syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed04dfa6eb1440a3c742bf5fc27a3b1ede8e3d57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->