### PR TITLE
Fix Nim CONST declaration style for non-list data

### DIFF
--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -66,7 +66,7 @@ def _make_variable_declaration(
         """Format a declaration, using ``@`` for flat sequences of
         simple scalars.
         """
-        if (
+        use_seq = (
             isinstance(_data, list)
             and _data
             and (
@@ -78,8 +78,11 @@ def _make_variable_declaration(
                     )
                 )
             )
-        ):
+        )
+        if use_seq:
             return f"{keyword} {name} = @{value}"
+        if force_seq:
+            return f"{keyword} {name} = {value}"
         return f"{keyword} {name} = %* {value}"
 
     return _format

--- a/tests/integration/cases/empty_list/Dart_declaration_style_const.dart
+++ b/tests/integration/cases/empty_list/Dart_declaration_style_const.dart
@@ -1,0 +1,1 @@
+const my_data = [];

--- a/tests/integration/cases/empty_list/Dart_declaration_style_var.dart
+++ b/tests/integration/cases/empty_list/Dart_declaration_style_var.dart
@@ -1,0 +1,1 @@
+var my_data = [];

--- a/tests/integration/cases/empty_list/FSharp_declaration_style_let_mutable.fs
+++ b/tests/integration/cases/empty_list/FSharp_declaration_style_let_mutable.fs
@@ -1,0 +1,15 @@
+module Check
+
+type Val =
+    | FNull
+    | FBool of bool
+    | FInt of int64
+    | FFloat of float
+    | FStr of string
+    | FList of Val list
+    | FMap of (string * Val) list
+    | FSet of Val list
+    | FDate of System.DateTime
+    | FDatetime of System.DateTime
+
+let mutable my_data: Val = FList []

--- a/tests/integration/cases/empty_list/Go_declaration_style_var.go
+++ b/tests/integration/cases/empty_list/Go_declaration_style_var.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+var my_data = []any{}
+_ = my_data
+}

--- a/tests/integration/cases/empty_list/JavaScript_declaration_style_let.js
+++ b/tests/integration/cases/empty_list/JavaScript_declaration_style_let.js
@@ -1,0 +1,1 @@
+let my_data = [];

--- a/tests/integration/cases/empty_list/Kotlin_declaration_style_var.kts
+++ b/tests/integration/cases/empty_list/Kotlin_declaration_style_var.kts
@@ -1,0 +1,1 @@
+var my_data = listOf<Any?>()

--- a/tests/integration/cases/empty_list/Nim_declaration_style_const.nim
+++ b/tests/integration/cases/empty_list/Nim_declaration_style_const.nim
@@ -1,0 +1,2 @@
+import json
+const my_data = []

--- a/tests/integration/cases/empty_list/Nim_declaration_style_let.nim
+++ b/tests/integration/cases/empty_list/Nim_declaration_style_let.nim
@@ -1,0 +1,2 @@
+import json
+let my_data = %* []

--- a/tests/integration/cases/empty_list/Rust_declaration_style_let_mut.rs
+++ b/tests/integration/cases/empty_list/Rust_declaration_style_let_mut.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let mut my_data = Vec::<String>::new();
+    let _ = my_data;
+}

--- a/tests/integration/cases/empty_list/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/empty_list/Scala_declaration_style_var.scala
@@ -1,0 +1,3 @@
+object Check {
+var my_data = List()
+}

--- a/tests/integration/cases/empty_list/Swift_declaration_style_var.swift
+++ b/tests/integration/cases/empty_list/Swift_declaration_style_var.swift
@@ -1,0 +1,1 @@
+var my_data: Any = [Any]()

--- a/tests/integration/cases/empty_list/TypeScript_declaration_style_let.ts
+++ b/tests/integration/cases/empty_list/TypeScript_declaration_style_let.ts
@@ -1,0 +1,2 @@
+let my_data = [];
+export {};

--- a/tests/integration/cases/empty_list/TypeScript_declaration_style_var.ts
+++ b/tests/integration/cases/empty_list/TypeScript_declaration_style_var.ts
@@ -1,0 +1,2 @@
+var my_data = [];
+export {};

--- a/tests/integration/cases/simple_dict/Dart_declaration_style_const.dart
+++ b/tests/integration/cases/simple_dict/Dart_declaration_style_const.dart
@@ -1,0 +1,6 @@
+const my_data = {
+    "name": "Alice",
+    "age": 30,
+    "active": true,
+    "score": null,
+};

--- a/tests/integration/cases/simple_dict/Dart_declaration_style_var.dart
+++ b/tests/integration/cases/simple_dict/Dart_declaration_style_var.dart
@@ -1,0 +1,6 @@
+var my_data = {
+    "name": "Alice",
+    "age": 30,
+    "active": true,
+    "score": null,
+};

--- a/tests/integration/cases/simple_dict/FSharp_declaration_style_let_mutable.fs
+++ b/tests/integration/cases/simple_dict/FSharp_declaration_style_let_mutable.fs
@@ -1,0 +1,20 @@
+module Check
+
+type Val =
+    | FNull
+    | FBool of bool
+    | FInt of int64
+    | FFloat of float
+    | FStr of string
+    | FList of Val list
+    | FMap of (string * Val) list
+    | FSet of Val list
+    | FDate of System.DateTime
+    | FDatetime of System.DateTime
+
+let mutable my_data: Val = FMap [
+    ("name", FStr "Alice");
+    ("age", FInt 30L);
+    ("active", FBool true);
+    ("score", FNull)
+]

--- a/tests/integration/cases/simple_dict/Go_declaration_style_var.go
+++ b/tests/integration/cases/simple_dict/Go_declaration_style_var.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+var my_data = map[string]any{
+    "name": "Alice",
+    "age": 30,
+    "active": true,
+    "score": nil,
+}
+_ = my_data
+}

--- a/tests/integration/cases/simple_dict/JavaScript_declaration_style_let.js
+++ b/tests/integration/cases/simple_dict/JavaScript_declaration_style_let.js
@@ -1,0 +1,6 @@
+let my_data = {
+    "name": "Alice",
+    "age": 30,
+    "active": true,
+    "score": null,
+};

--- a/tests/integration/cases/simple_dict/Kotlin_declaration_style_var.kts
+++ b/tests/integration/cases/simple_dict/Kotlin_declaration_style_var.kts
@@ -1,0 +1,6 @@
+var my_data = mapOf<String, Any?>(
+    "name" to "Alice",
+    "age" to 30,
+    "active" to true,
+    "score" to null,
+)

--- a/tests/integration/cases/simple_dict/Nim_declaration_style_const.nim
+++ b/tests/integration/cases/simple_dict/Nim_declaration_style_const.nim
@@ -1,0 +1,7 @@
+import json
+const my_data = {
+    "name": "Alice",
+    "age": "30",
+    "active": "True",
+    "score": "None"
+}

--- a/tests/integration/cases/simple_dict/Nim_declaration_style_let.nim
+++ b/tests/integration/cases/simple_dict/Nim_declaration_style_let.nim
@@ -1,0 +1,7 @@
+import json
+let my_data = %* {
+    "name": "Alice",
+    "age": "30",
+    "active": "True",
+    "score": "None"
+}

--- a/tests/integration/cases/simple_dict/Rust_declaration_style_let_mut.rs
+++ b/tests/integration/cases/simple_dict/Rust_declaration_style_let_mut.rs
@@ -1,0 +1,10 @@
+use std::collections::HashMap;
+fn main() {
+    let mut my_data = HashMap::from([
+        ("name", "Alice"),
+        ("age", "30"),
+        ("active", "True"),
+        ("score", "None"),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/simple_dict/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/simple_dict/Scala_declaration_style_var.scala
@@ -1,0 +1,8 @@
+object Check {
+var my_data = Map(
+    "name" -> "Alice",
+    "age" -> 30,
+    "active" -> true,
+    "score" -> null,
+)
+}

--- a/tests/integration/cases/simple_dict/Swift_declaration_style_var.swift
+++ b/tests/integration/cases/simple_dict/Swift_declaration_style_var.swift
@@ -1,0 +1,6 @@
+var my_data: Any = [
+    "name": "Alice",
+    "age": 30,
+    "active": true,
+    "score": nil,
+]

--- a/tests/integration/cases/simple_dict/TypeScript_declaration_style_let.ts
+++ b/tests/integration/cases/simple_dict/TypeScript_declaration_style_let.ts
@@ -1,0 +1,7 @@
+let my_data = {
+    "name": "Alice",
+    "age": 30,
+    "active": true,
+    "score": null,
+};
+export {};

--- a/tests/integration/cases/simple_dict/TypeScript_declaration_style_var.ts
+++ b/tests/integration/cases/simple_dict/TypeScript_declaration_style_var.ts
@@ -1,0 +1,7 @@
+var my_data = {
+    "name": "Alice",
+    "age": 30,
+    "active": true,
+    "score": null,
+};
+export {};

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1907,6 +1907,18 @@ def _build_variant_cases() -> list[_VariantCase]:
             _VARIABLE_NAME,
             "",
         ),
+        (
+            _build_declaration_style_variants(),
+            "simple_dict",
+            _VARIABLE_NAME,
+            "",
+        ),
+        (
+            _build_declaration_style_variants(),
+            "empty_list",
+            _VARIABLE_NAME,
+            "",
+        ),
         (_build_dict_format_variants(), "simple_dict", None, ""),
         (_build_integer_format_variants(), "int_list", None, ""),
         (_build_integer_format_variants(), "int_list_large", None, "_large"),


### PR DESCRIPTION
## Summary
- Nim's `const` cannot hold `%*` values (heap-allocated `JsonNode`), but the CONST declaration style was emitting `%*` for non-list data (dicts, empty lists, scalars). Now emits plain literals without `%*` for const declarations.
- Adds declaration style test coverage for `simple_dict` and `empty_list` cases across all languages.

Addresses https://github.com/adamtheturtle/literalizer/pull/615#discussion_r2977241583

## Test plan
- [x] All 9253 existing tests pass
- [x] New golden files verify `const` uses plain syntax while `let`/`var` keep `%*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Nim code generation semantics for `const` declarations and adds many golden fixtures, which can expose additional cross-language expectation mismatches.
> 
> **Overview**
> Fixes Nim `const` declaration output to **avoid heap-allocated `%*` JsonNode literals** for non-sequence values: only non-empty flat scalar lists use `@...`, while all other `const` declarations now emit plain literals without `%*`.
> 
> Expands integration coverage by adding new declaration-style golden cases for `simple_dict` and `empty_list` across languages, and updates the integration variant matrix to run declaration-style variants for those cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8be88955f3a1b7cb608f36997fe2fbad93430117. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->