### PR TITLE
Fix missing preamble for C# SORTED_SET

### DIFF
--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -213,7 +213,7 @@ class CSharp(metaclass=LanguageCls):
             ),
             close="}",
             empty_set="new SortedSet<object>()",
-            preamble_lines=(),
+            preamble_lines=("using System.Collections.Generic;",),
             set_opener_template="new SortedSet<{type_name}> {{",
         )
 

--- a/tests/integration/cases/set/CSharp_set_sorted_set.cs
+++ b/tests/integration/cases/set/CSharp_set_sorted_set.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 var x = new SortedSet<string> {
     "apple",
     "banana",


### PR DESCRIPTION
## Summary
- Restores the `using System.Collections.Generic;` preamble for the C# `SORTED_SET` format, which was accidentally removed in #623
- Updates the golden test file to match

## Test plan
- [x] `sorted_set` integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a missing `using System.Collections.Generic;` preamble for C# `SORTED_SET` output and updates the corresponding golden integration test.
> 
> **Overview**
> Restores emission of the `using System.Collections.Generic;` preamble when generating C# `SortedSet` literals (`SetFormats.SORTED_SET`).
> 
> Updates the `CSharp_set_sorted_set` integration golden file to include the restored preamble.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58ee0667f1460e82d0615d0e8246b0b29dbc045a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->