### PR TITLE
Replace _no_semi_decl dict with LineEndings.wrap_formatter

### DIFF
--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -408,10 +408,10 @@ class JavaScript(metaclass=LanguageCls):
             declaration_style.value.formatter
         )
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            line_ending.wrap_formatter(_base_decl)
+            line_ending.wrap_formatter(formatter=_base_decl)
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
-            line_ending.wrap_formatter(_format_variable_assignment)
+            line_ending.wrap_formatter(formatter=_format_variable_assignment)
         )
         self.static_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -365,10 +365,10 @@ class TypeScript(metaclass=LanguageCls):
             declaration_style.value.formatter
         )
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            line_ending.wrap_formatter(_base_decl)
+            line_ending.wrap_formatter(formatter=_base_decl)
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
-            line_ending.wrap_formatter(_format_variable_assignment)
+            line_ending.wrap_formatter(formatter=_format_variable_assignment)
         )
         self.static_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}


### PR DESCRIPTION
## Summary
- Removes duplicate `_no_semi` formatter functions and the fragile `_no_semi_decl` dict lookup in JS and TS
- Adds a `wrap_formatter` method to `LineEndings` that strips trailing semicolons for `NONE`, passes through for `SEMICOLON`
- New declaration styles no longer risk `KeyError` from a missing dict entry

## Test plan
- [x] All 422 JS/TS tests pass, including `line_ending_none` variants
- [x] All pre-commit hooks pass (ruff, mypy, pyright, ty, interrogate, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to JS/TS code generation line-ending formatting; behavior should be equivalent aside from relying on semicolon stripping via `removesuffix`, which could affect edge cases if formatters ever emit nonstandard trailing characters.
> 
> **Overview**
> Refactors JS/TS variable declaration/assignment formatting to **remove duplicated `*_no_semi` helper functions** and the `_no_semi_decl` lookup logic.
> 
> Adds `LineEndings.wrap_formatter(...)` in both `javascript.py` and `typescript.py`, and wires `format_variable_declaration`/`format_variable_assignment` through it so `LineEndings.NONE` simply strips a trailing `;` while `SEMICOLON` passes through unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f142d3ef993e20da79cc40f223a382f0f918df3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->