### PR TITLE
Remove duplicate identity wrapper functions in integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -67,12 +67,6 @@ def _wrap_kotlin(content: str) -> str:
 
 
 @beartype
-def _wrap_kotlin_varname(content: str) -> str:
-    """Wrap a Kotlin variable declaration with time imports if needed."""
-    return content
-
-
-@beartype
 def _wrap_cpp(content: str) -> str:
     """Wrap in a C++ struct and function for type-flexible
     initialization.
@@ -335,12 +329,6 @@ def _wrap_java_varname(content: str) -> str:
 
 
 @beartype
-def _wrap_csharp_varname(content: str) -> str:
-    """Wrap a C# top-level variable declaration."""
-    return content
-
-
-@beartype
 def _wrap_ts_varname(content: str) -> str:
     """Wrap a TypeScript variable declaration as a module.
 
@@ -562,12 +550,6 @@ def _wrap_nim(content: str) -> str:
 
 
 @beartype
-def _wrap_nim_varname(content: str) -> str:
-    """Pass through Nim content unchanged."""
-    return content
-
-
-@beartype
 def _wrap_nim_combined(declaration: str, assignment: str) -> str:
     """Join Nim declaration and assignment with a newline."""
     return f"{declaration}\n{assignment}"
@@ -727,12 +709,6 @@ def _wrap_haskell_varname(content: str) -> str:
 
 
 @beartype
-def _wrap_php_varname(content: str) -> str:
-    """Wrap a PHP variable assignment."""
-    return content
-
-
-@beartype
 def _wrap_zig(content: str) -> str:
     """Wrap in a Zig main function."""
     zig = literalizer.languages.Zig()
@@ -772,9 +748,6 @@ def _wrap_zig_combined(declaration: str, assignment: str) -> str:
         f"    _ = _{_VARIABLE_NAME}_read;\n"
         "}"
     )
-
-
-_wrap_swift_varname = _wrap_identity
 
 
 @beartype
@@ -961,18 +934,6 @@ def _wrap_combined_newline(declaration: str, assignment: str) -> str:
 
 
 @beartype
-def _wrap_python(content: str) -> str:
-    """Pass through Python content unchanged."""
-    return content
-
-
-@beartype
-def _wrap_ruby(content: str) -> str:
-    """Pass through Ruby content unchanged."""
-    return content
-
-
-@beartype
 def _wrap_crystal(content: str) -> str:
     """Wrap in a Crystal variable assignment to suppress unused-expression
     warnings.
@@ -981,21 +942,9 @@ def _wrap_crystal(content: str) -> str:
 
 
 @beartype
-def _wrap_crystal_varname(content: str) -> str:
-    """Pass through Crystal content unchanged."""
-    return content
-
-
-@beartype
 def _wrap_crystal_combined(declaration: str, assignment: str) -> str:
     """Join Crystal declaration and assignment with a newline."""
     return declaration + "\n" + assignment
-
-
-@beartype
-def _wrap_julia(content: str) -> str:
-    """Pass through Julia content unchanged."""
-    return content
 
 
 @beartype
@@ -1193,8 +1142,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     literalizer.languages.Python.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Python,
-        wrap=_wrap_python,
-        varname_wrap=_wrap_python,
+        wrap=_wrap_identity,
+        varname_wrap=_wrap_identity,
         combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.JavaScript.__name__: _LanguageConfig(
@@ -1212,14 +1161,14 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Kotlin.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Kotlin,
         wrap=_wrap_kotlin,
-        varname_wrap=_wrap_kotlin_varname,
+        varname_wrap=_wrap_identity,
         combined_wrap=_wrap_kotlin_combined,
     ),
     literalizer.languages.Ruby.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Ruby,
-        wrap=_wrap_ruby,
-        varname_wrap=_wrap_ruby,
-        combined_wrap=lambda d, a: _wrap_ruby(content=d + "\n" + a),
+        wrap=_wrap_identity,
+        varname_wrap=_wrap_identity,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.Go.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Go,
@@ -1236,8 +1185,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.CSharp.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.CSharp,
         wrap=_wrap_csharp,
-        varname_wrap=_wrap_csharp_varname,
-        combined_wrap=lambda d, a: _wrap_csharp_varname(content=d + "\n" + a),
+        varname_wrap=_wrap_identity,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.Dart.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Dart,
@@ -1248,7 +1197,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Swift.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Swift,
         wrap=_wrap_swift,
-        varname_wrap=_wrap_swift_varname,
+        varname_wrap=_wrap_identity,
         combined_wrap=_wrap_swift_combined,
     ),
     literalizer.languages.Cpp.__name__: _LanguageConfig(
@@ -1277,9 +1226,9 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     ),
     literalizer.languages.Julia.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Julia,
-        wrap=_wrap_julia,
-        varname_wrap=_wrap_julia,
-        combined_wrap=lambda d, a: _wrap_julia(content=d + "\n" + a),
+        wrap=_wrap_identity,
+        varname_wrap=_wrap_identity,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.Lua.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Lua,
@@ -1296,8 +1245,8 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Php.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Php,
         wrap=_wrap_php,
-        varname_wrap=_wrap_php_varname,
-        combined_wrap=lambda d, a: _wrap_php_varname(content=d + "\n" + a),
+        varname_wrap=_wrap_identity,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.Elixir.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Elixir,
@@ -1356,7 +1305,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Crystal.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Crystal,
         wrap=_wrap_crystal,
-        varname_wrap=_wrap_crystal_varname,
+        varname_wrap=_wrap_identity,
         combined_wrap=_wrap_crystal_combined,
     ),
     literalizer.languages.Matlab.__name__: _LanguageConfig(
@@ -1374,7 +1323,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Nim.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Nim,
         wrap=_wrap_nim,
-        varname_wrap=_wrap_nim_varname,
+        varname_wrap=_wrap_identity,
         combined_wrap=_wrap_nim_combined,
     ),
     literalizer.languages.Norg.__name__: _LanguageConfig(


### PR DESCRIPTION
## Summary
- Removed 8 passthrough wrapper functions (`_wrap_python`, `_wrap_ruby`, `_wrap_julia`, `_wrap_kotlin_varname`, `_wrap_csharp_varname`, `_wrap_nim_varname`, `_wrap_php_varname`, `_wrap_crystal_varname`) and 1 alias (`_wrap_swift_varname`) that were identical to `_wrap_identity`
- Updated all references to use `_wrap_identity` directly
- Replaced equivalent `combined_wrap` lambdas (e.g. `lambda d, a: _wrap_ruby(content=d + "\n" + a)`) with the existing `_wrap_combined_newline` helper

## Test plan
- [x] All 8933 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only refactor that removes redundant wrapper helpers; main risk is subtle changes in how combined golden outputs are concatenated for a few languages.
> 
> **Overview**
> Simplifies the integration-test golden-file wrapping logic by deleting several language-specific pass-through wrappers/aliases and using the shared `_wrap_identity` instead.
> 
> Also standardizes some `combined_wrap` implementations by replacing equivalent inline lambdas with the existing `_wrap_combined_newline` helper (notably for Ruby/Python/Julia/PHP/C#/Swift/Kotlin/Nim varname handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df20309a8b72bba2d21e5a72cb99835dd9c15a79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->