### PR TITLE
Remove duplicate combined-wrap functions for Crystal and Nim

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -519,12 +519,6 @@ def _wrap_nim(content: str) -> str:
 
 
 @beartype
-def _wrap_nim_combined(declaration: str, assignment: str) -> str:
-    """Join Nim declaration and assignment with a newline."""
-    return f"{declaration}\n{assignment}"
-
-
-@beartype
 def _wrap_norg(content: str) -> str:
     """Wrap in a Norg ranged verbatim tag."""
     return f"@code json\n{content}\n@end"
@@ -911,12 +905,6 @@ def _wrap_crystal(content: str) -> str:
 
 
 @beartype
-def _wrap_crystal_combined(declaration: str, assignment: str) -> str:
-    """Join Crystal declaration and assignment with a newline."""
-    return declaration + "\n" + assignment
-
-
-@beartype
 def _wrap_vb(content: str) -> str:
     """Wrap in a VB.NET Module with a Dim declaration.
 
@@ -1275,7 +1263,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         lang_cls=literalizer.languages.Crystal,
         wrap=_wrap_crystal,
         varname_wrap=_wrap_identity,
-        combined_wrap=_wrap_crystal_combined,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.Matlab.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Matlab,
@@ -1293,7 +1281,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
         lang_cls=literalizer.languages.Nim,
         wrap=_wrap_nim,
         varname_wrap=_wrap_identity,
-        combined_wrap=_wrap_nim_combined,
+        combined_wrap=_wrap_combined_newline,
     ),
     literalizer.languages.Norg.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Norg,


### PR DESCRIPTION
## Summary

- Removed `_wrap_crystal_combined` and `_wrap_nim_combined`, which were functionally identical to `_wrap_combined_newline`
- Updated Crystal and Nim language configs to use `_wrap_combined_newline` directly

Follows up on [PR #639 review feedback](https://github.com/adamtheturtle/literalizer/pull/639#discussion_r2978380079).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that removes duplicate helper functions and routes Crystal/Nim combined-output generation through the existing newline joiner.
> 
> **Overview**
> Simplifies integration test wrappers by deleting the Crystal/Nim-specific `*_combined` helpers that only concatenated declaration + assignment with a newline.
> 
> Updates the Crystal and Nim entries in `_LANGUAGES` to use the shared `_wrap_combined_newline` implementation for combined golden-file generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79f52ad4775b331a20bbd51ece80444c2a3822b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->