### PR TITLE
Replace _CASES_REL global with cases_dir pytest fixture

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -28,7 +28,13 @@ import literalizer.languages
 from literalizer.exceptions import NullInCollectionError
 from literalizer.languages import ALL_LANGUAGES
 
-_CASES_REL = Path("tests") / "integration" / "cases"
+
+@pytest.fixture(name="cases_dir")
+def fixture_cases_dir(request: pytest.FixtureRequest) -> Path:
+    """Return the absolute path to the integration test cases
+    directory.
+    """
+    return request.config.rootpath / "tests" / "integration" / "cases"
 
 
 @beartype
@@ -1800,11 +1806,10 @@ _CASES = _discover_cases()
 def test_golden_file(
     _case_name: str,
     language: str,
-    request: pytest.FixtureRequest,
+    cases_dir: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
     """Test that literalize_yaml output matches expected golden file."""
-    cases_dir = request.config.rootpath / _CASES_REL
     input_path = cases_dir / _case_name / "input.yaml"
     lang_config = _LANGUAGES[language]
     yaml_string = input_path.read_text()
@@ -1837,13 +1842,12 @@ def test_golden_file(
 def test_golden_file_with_variable_name(
     _case_name: str,
     language: str,
-    request: pytest.FixtureRequest,
+    cases_dir: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
     """Test that literalize_yaml with variable_name matches golden
     file.
     """
-    cases_dir = request.config.rootpath / _CASES_REL
     input_path = cases_dir / _case_name / "input.yaml"
     lang_config = _LANGUAGES[language]
     yaml_string = input_path.read_text()
@@ -1876,14 +1880,13 @@ def test_golden_file_with_variable_name(
 def test_golden_file_combined_variable_forms(
     _case_name: str,
     language: str,
-    request: pytest.FixtureRequest,
+    cases_dir: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
     """Test that literalize_yaml with new_variable=True (declaration) and
     new_variable=False (assignment to existing variable) produce expected
     golden output, combined in one file to show the difference in syntax.
     """
-    cases_dir = request.config.rootpath / _CASES_REL
     input_path = cases_dir / _case_name / "input.yaml"
     lang_config = _LANGUAGES[language]
     yaml_string = input_path.read_text()
@@ -2014,15 +2017,13 @@ _FORMAT_VARIANT_CASES = _build_variant_cases()
 )
 def test_format_variant_golden_file(
     variant_case: _VariantCase,
-    request: pytest.FixtureRequest,
+    cases_dir: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
     """Test format-variant options (dates, sequences, sets, type hints)
     against golden files.
     """
-    case_dir = (
-        request.config.rootpath / _CASES_REL / variant_case.case_dir_name
-    )
+    case_dir = cases_dir / variant_case.case_dir_name
     variant = variant_case.variant
     yaml_string = (case_dir / "input.yaml").read_text()
     try:
@@ -2098,13 +2099,12 @@ _LINE_ENDING_COMBINED_CASES = _build_line_ending_combined_cases()
 )
 def test_line_ending_combined_variable_forms(
     case: _LineEndingCombinedCase,
-    request: pytest.FixtureRequest,
+    cases_dir: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
     """Test that combined (declaration + assignment) output with a
     non-default line ending matches the golden file.
     """
-    cases_dir = request.config.rootpath / _CASES_REL
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
     spec = case.lang_config.lang_cls(line_ending=case.line_ending)


### PR DESCRIPTION
## Summary
- Removes the `_CASES_REL` module-level global from integration tests
- Adds a `fixture_cases_dir` pytest fixture (exposed as `cases_dir`) that resolves the absolute path to the test cases directory
- Updates all 5 test functions to use the fixture instead of manually computing the path

## Test plan
- [x] All integration tests pass (8886 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test plumbing, replacing a module-level path constant with a fixture to resolve the cases directory; no production code or test assertions change.
> 
> **Overview**
> Refactors integration tests to resolve the golden-test cases directory via a new `cases_dir` pytest fixture instead of a module-level `_CASES_REL` constant.
> 
> Updates all affected golden-file tests to accept `cases_dir: Path` and build input/expected paths from it, removing per-test `request.config.rootpath` path construction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12dc4eb582002baf8919a8fbeb793c38748f82c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->