### PR TITLE
Inline single-use module-level globals in language specs

### DIFF
--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 from beartype import beartype
 
@@ -27,6 +27,9 @@ from literalizer._language import (
     SetFormatConfig,
 )
 from literalizer._types import Value
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 
 @beartype
@@ -78,28 +81,6 @@ def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
 def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
     """Format a C variable assignment."""
     return f"{name} = {_to_val(value=value)};"
-
-
-_string_format: Callable[[str], str] = format_string_backslash
-
-
-_C_PREAMBLE: tuple[str, ...] = (
-    "#include <stdbool.h>",
-    "#include <stddef.h>",
-    "typedef struct _CVal _CVal;",
-    "typedef struct _CKV _CKV;",
-    "struct _CVal {",
-    "    union {",
-    "        _Bool b;",
-    "        long long i;",
-    "        double f;",
-    "        const char *s;",
-    "        const _CVal *a;",
-    "        const _CKV *m;",
-    "    };",
-    "};",
-    "struct _CKV { const char *k; _CVal v; };",
-)
 
 
 @beartype
@@ -285,7 +266,7 @@ class C(metaclass=LanguageCls):
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self.format_string: Callable[[str], str] = _string_format
+        self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
         self.format_sequence_entry: Callable[[str], str] = _format_c_list_entry
         self.format_set_entry: Callable[[str], str] = _format_c_set_entry
@@ -318,7 +299,23 @@ class C(metaclass=LanguageCls):
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self.static_preamble: Sequence[str] = _C_PREAMBLE
+        self.static_preamble: Sequence[str] = (
+            "#include <stdbool.h>",
+            "#include <stddef.h>",
+            "typedef struct _CVal _CVal;",
+            "typedef struct _CKV _CKV;",
+            "struct _CVal {",
+            "    union {",
+            "        _Bool b;",
+            "        long long i;",
+            "        double f;",
+            "        const char *s;",
+            "        const _CVal *a;",
+            "        const _CKV *m;",
+            "    };",
+            "};",
+            "struct _CKV { const char *k; _CVal v; };",
+        )
         self.static_body_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}
         self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -102,16 +102,6 @@ def _cpp_array_open(items: list[Value]) -> str:
     return f"std::array<{type_name}, {len(items)}>{{"
 
 
-_ANY_INCLUDE: tuple[str, ...] = ("#include <initializer_list>",)
-
-_ANY_STRUCT: tuple[str, ...] = (
-    "struct _Any {",
-    "    template<class T> _Any(T&&) noexcept {}",
-    "    _Any(std::initializer_list<_Any>) noexcept {}",
-    "};",
-)
-
-
 @beartype
 def _format_variable_declaration(
     name: str,
@@ -381,8 +371,13 @@ class Cpp(metaclass=LanguageCls):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.supports_collection_comments = True
-        self.static_preamble: Sequence[str] = _ANY_INCLUDE
-        self.static_body_preamble: Sequence[str] = _ANY_STRUCT
+        self.static_preamble: Sequence[str] = ("#include <initializer_list>",)
+        self.static_body_preamble: Sequence[str] = (
+            "struct _Any {",
+            "    template<class T> _Any(T&&) noexcept {}",
+            "    _Any(std::initializer_list<_Any>) noexcept {}",
+            "};",
+        )
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -3,7 +3,7 @@
 import datetime
 import enum
 import re
-from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 from beartype import beartype
 
@@ -27,6 +27,9 @@ from literalizer._language import (
     SetFormatConfig,
 )
 from literalizer._types import Value
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 
 @beartype
@@ -57,19 +60,6 @@ def _format_string_fortran(value: str) -> str:
     return " // ".join(parts)
 
 
-_FVAL_PREFIXES = (
-    "fnull()",
-    "fbool(",
-    "fint(",
-    "freal(",
-    "fstr(",
-    "flist(",
-    "fmap(",
-    "fset(",
-    "fentry(",
-)
-
-
 @beartype
 def _to_fval(value: str) -> str:
     """Convert a pre-formatted value string to an ``fval_t`` constructor.
@@ -79,7 +69,18 @@ def _to_fval(value: str) -> str:
     that are already ``fval_t`` expressions (``fnull``, ``fbool``,
     ``flist``, ``fmap``, ``fset``, ``fentry``).
     """
-    if any(value.startswith(p) for p in _FVAL_PREFIXES):
+    fval_prefixes = (
+        "fnull()",
+        "fbool(",
+        "fint(",
+        "freal(",
+        "fstr(",
+        "flist(",
+        "fmap(",
+        "fset(",
+        "fentry(",
+    )
+    if any(value.startswith(p) for p in fval_prefixes):
         return value
     if (value.startswith("'") and value.endswith("'")) or (
         value.startswith('"') and value.endswith('"')
@@ -184,46 +185,6 @@ def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
     fval = _to_fval(value=value)
     continued = _add_continuation(value=fval)
     return f"{name} = {continued}"
-
-
-_string_format: Callable[[str], str] = _format_string_fortran
-
-
-_FORTRAN_PREAMBLE: tuple[str, ...] = (
-    "module fval_m",
-    "  implicit none",
-    "  type :: fval_t",
-    "    integer :: t = 0",
-    "  end type fval_t",
-    "contains",
-    "  function fnull() result(v); type(fval_t) :: v; end function",
-    "  function fbool(b) result(v)"
-    "; logical, intent(in) :: b"
-    "; type(fval_t) :: v; end function",
-    "  function fint(n) result(v)"
-    "; integer, intent(in) :: n"
-    "; type(fval_t) :: v; end function",
-    "  function freal(x) result(v)"
-    "; real, intent(in) :: x"
-    "; type(fval_t) :: v; end function",
-    "  function fstr(s) result(v)"
-    "; character(len=*), intent(in) :: s"
-    "; type(fval_t) :: v; end function",
-    "  function flist(a) result(v)"
-    "; type(fval_t), intent(in) :: a(:)"
-    "; type(fval_t) :: v; end function",
-    "  function fmap(a) result(v)"
-    "; type(fval_t), intent(in) :: a(:)"
-    "; type(fval_t) :: v; end function",
-    "  function fset(a) result(v)"
-    "; type(fval_t), intent(in) :: a(:)"
-    "; type(fval_t) :: v; end function",
-    "  function fentry(k, u) result(v)"
-    "; character(len=*), intent(in) :: k"
-    "; type(fval_t), intent(in) :: u"
-    "; type(fval_t) :: v; end function",
-    "end module fval_m",
-)
 
 
 @beartype
@@ -403,7 +364,7 @@ class Fortran(metaclass=LanguageCls):
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self.format_string: Callable[[str], str] = _string_format
+        self.format_string: Callable[[str], str] = _format_string_fortran
         self.format_integer: Callable[[int], str] = str
         self.format_sequence_entry: Callable[[str], str] = _to_fval
         self.format_set_entry: Callable[[str], str] = _to_fval
@@ -436,7 +397,41 @@ class Fortran(metaclass=LanguageCls):
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self.static_preamble: Sequence[str] = _FORTRAN_PREAMBLE
+        self.static_preamble: Sequence[str] = (
+            "module fval_m",
+            "  implicit none",
+            "  type :: fval_t",
+            "    integer :: t = 0",
+            "  end type fval_t",
+            "contains",
+            "  function fnull() result(v); type(fval_t) :: v; end function",
+            "  function fbool(b) result(v)"
+            "; logical, intent(in) :: b"
+            "; type(fval_t) :: v; end function",
+            "  function fint(n) result(v)"
+            "; integer, intent(in) :: n"
+            "; type(fval_t) :: v; end function",
+            "  function freal(x) result(v)"
+            "; real, intent(in) :: x"
+            "; type(fval_t) :: v; end function",
+            "  function fstr(s) result(v)"
+            "; character(len=*), intent(in) :: s"
+            "; type(fval_t) :: v; end function",
+            "  function flist(a) result(v)"
+            "; type(fval_t), intent(in) :: a(:)"
+            "; type(fval_t) :: v; end function",
+            "  function fmap(a) result(v)"
+            "; type(fval_t), intent(in) :: a(:)"
+            "; type(fval_t) :: v; end function",
+            "  function fset(a) result(v)"
+            "; type(fval_t), intent(in) :: a(:)"
+            "; type(fval_t) :: v; end function",
+            "  function fentry(k, u) result(v)"
+            "; character(len=*), intent(in) :: k"
+            "; type(fval_t), intent(in) :: u"
+            "; type(fval_t) :: v; end function",
+            "end module fval_m",
+        )
         self.static_body_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}
         self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 from beartype import beartype
 
@@ -27,6 +27,9 @@ from literalizer._language import (
     SetFormatConfig,
 )
 from literalizer._types import Value
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 
 @beartype
@@ -113,24 +116,6 @@ def _format_string_zig(value: str) -> str:
     )
     escaped = escape_control_chars(value=escaped, fmt="\\x{:02x}")
     return f'"{escaped}"'
-
-
-_string_format: Callable[[str], str] = _format_string_zig
-
-
-_ZIG_PREAMBLE: tuple[str, ...] = (
-    "const ZVal = union(enum) {",
-    "    nil,",
-    "    bool: bool,",
-    "    int: i64,",
-    "    float: f64,",
-    "    str: []const u8,",
-    "    arr: []const ZVal,",
-    "    map: []const ZKV,",
-    "    set: []const ZVal,",
-    "};",
-    "const ZKV = struct { key: []const u8, val: ZVal };",
-)
 
 
 @beartype
@@ -312,7 +297,7 @@ class Zig(metaclass=LanguageCls):
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self.format_string: Callable[[str], str] = _string_format
+        self.format_string: Callable[[str], str] = _format_string_zig
         self.format_integer: Callable[[int], str] = str
         self.format_sequence_entry: Callable[[str], str] = (
             _format_zig_sequence_entry
@@ -347,7 +332,19 @@ class Zig(metaclass=LanguageCls):
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self.static_preamble: Sequence[str] = _ZIG_PREAMBLE
+        self.static_preamble: Sequence[str] = (
+            "const ZVal = union(enum) {",
+            "    nil,",
+            "    bool: bool,",
+            "    int: i64,",
+            "    float: f64,",
+            "    str: []const u8,",
+            "    arr: []const ZVal,",
+            "    map: []const ZKV,",
+            "    set: []const ZVal,",
+            "};",
+            "const ZKV = struct { key: []const u8, val: ZVal };",
+        )
         self.static_body_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}
         self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}


### PR DESCRIPTION
## Summary
- Removed `_string_format` callable aliases in `c.py`, `zig.py`, and `fortran.py`, using the actual function names directly instead
- Inlined preamble tuples (`_C_PREAMBLE`, `_ZIG_PREAMBLE`, `_FORTRAN_PREAMBLE`, `_ANY_INCLUDE`, `_ANY_STRUCT`) at their sole point of use in `__init__`
- Moved `_FVAL_PREFIXES` from module scope into `_to_fval()` as a local variable
- Moved `Callable`/`Sequence` imports into `TYPE_CHECKING` blocks where they were no longer needed at runtime

## Test plan
- [x] All 9269 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, vulture, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to language-spec configuration constants and type-checking imports, with no functional logic changes expected beyond equivalent constant placement.
> 
> **Overview**
> Refactors the C, C++, Fortran, and Zig language specs to **inline previously module-level single-use constants** (string formatter aliases, preamble tuples, and C++ `_Any` include/struct snippets) directly where they’re assigned in `__init__`.
> 
> Also moves `Callable`/`Sequence` imports behind `TYPE_CHECKING` and makes Fortran’s `_to_fval` prefix list a local variable, reducing runtime globals while keeping emitted literals/preambles the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d36e8b39e6b2741bdae99050b7f3d18604907f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->