### PR TITLE
Inline module-level globals in javascript, nim, and toml

### DIFF
--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -60,13 +60,6 @@ def _format_datetime_js(value: datetime.datetime) -> str:
     return f'new Date("{value.isoformat()}")'
 
 
-_format_integer_hex = format_integer_hex
-_format_integer_underscore = format_integer_underscore
-
-
-_format_map_entry = dict_entry_with_template(template="[{key}, {value}]")
-
-
 @beartype
 class JavaScript(metaclass=LanguageCls):
     """JavaScript language specification.
@@ -209,7 +202,7 @@ class JavaScript(metaclass=LanguageCls):
         MAP = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="new Map(["),
             close="])",
-            format_entry=_format_map_entry,
+            format_entry=dict_entry_with_template(template="[{key}, {value}]"),
             empty_dict="new Map()",
             preamble_lines=(),
         )
@@ -226,13 +219,13 @@ class JavaScript(metaclass=LanguageCls):
         DECIMAL = MappingProxyType(
             mapping={
                 "NONE": str,
-                "UNDERSCORE": _format_integer_underscore,
+                "UNDERSCORE": format_integer_underscore,
             }
         )
         HEX = MappingProxyType(
             mapping={
-                "NONE": _format_integer_hex,
-                "UNDERSCORE": _format_integer_hex,
+                "NONE": format_integer_hex,
+                "UNDERSCORE": format_integer_hex,
             }
         )
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -49,9 +49,6 @@ def _format_datetime_nim(value: datetime.datetime) -> str:
     )
 
 
-_NIM_SEQ_SAFE_TYPES = (str, int, float, bool, bytes)
-
-
 @beartype
 def _make_variable_declaration(
     *,
@@ -74,7 +71,8 @@ def _make_variable_declaration(
                 or (
                     seq_mode
                     and all(
-                        isinstance(item, _NIM_SEQ_SAFE_TYPES) for item in _data
+                        isinstance(item, (str, int, float, bool, bytes))
+                        for item in _data
                     )
                 )
             )
@@ -104,15 +102,15 @@ def _make_variable_assignment(
             seq_mode
             and isinstance(_data, list)
             and _data
-            and all(isinstance(item, _NIM_SEQ_SAFE_TYPES) for item in _data)
+            and all(
+                isinstance(item, (str, int, float, bool, bytes))
+                for item in _data
+            )
         ):
             return f"{name} = @{value}"
         return f"{name} = %* {value}"
 
     return _format
-
-
-_string_format: Callable[[str], str] = format_string_backslash
 
 
 @beartype
@@ -338,7 +336,7 @@ class Nim(metaclass=LanguageCls):
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self.format_string: Callable[[str], str] = _string_format
+        self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -36,14 +36,6 @@ if TYPE_CHECKING:
 
     from literalizer._types import Value
 
-_BARE_KEY_PATTERN: re.Pattern[str] = re.compile(pattern=r"^[A-Za-z0-9_-]+$")
-
-
-_format_string_toml = functools.partial(
-    format_string_backslash_control,
-    control_char_fmt="\\u{:04x}",
-)
-
 
 @beartype
 def _format_toml_dict_entry(key: str, value: str) -> str:
@@ -60,7 +52,8 @@ def _format_toml_dict_entry(key: str, value: str) -> str:
         and len(key) >= min_quoted_key_length
     ):
         inner = key[1:-1]
-        if _BARE_KEY_PATTERN.match(string=inner):
+        bare_key_pattern = re.compile(pattern=r"^[A-Za-z0-9_-]+$")
+        if bare_key_pattern.match(string=inner):
             return f"{inner} = {value}"
     return f"{key} = {value}"
 
@@ -276,7 +269,10 @@ class Toml(metaclass=LanguageCls):
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self.format_string: Callable[[str], str] = _format_string_toml
+        self.format_string: Callable[[str], str] = functools.partial(
+            format_string_backslash_control,
+            control_char_fmt="\\u{:04x}",
+        )
         self.format_integer: Callable[[int], str] = str
         self.format_sequence_entry: Callable[[str], str] = (
             passthrough_sequence_entry


### PR DESCRIPTION
## Summary
- Inlined 7 module-level globals across 3 language files by replacing aliases with direct references and moving single-use values to their usage sites
- **javascript.py**: Removed `_format_integer_hex`, `_format_integer_underscore` (aliases), and `_format_map_entry` (single-use `dict_entry_with_template` call)
- **toml.py**: Removed `_BARE_KEY_PATTERN` (moved `re.compile` into function) and `_format_string_toml` (inlined `functools.partial` call)
- **nim.py**: Removed `_NIM_SEQ_SAFE_TYPES` (inlined tuple at both usage sites) and `_string_format` (replaced alias with direct `format_string_backslash`)

## Test plan
- [x] All 336 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily removes module-level aliases/single-use constants; behavior should remain the same aside from negligible perf differences (e.g., recompiling a TOML key regex per call).
> 
> **Overview**
> **Refactors language specs to inline module-level globals** in `javascript.py`, `nim.py`, and `toml.py`, removing several private aliases and single-use helpers.
> 
> JavaScript inlines the `Map` entry formatter and uses `format_integer_*` functions directly in `IntegerFormats`. Nim inlines the “seq-safe” type tuple at both call sites and assigns `format_string_backslash` directly. TOML inlines the bare-key regex compilation inside `_format_toml_dict_entry` and inlines the `functools.partial(...)` used for `format_string`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb17795908fd2cb09a93b65f62f2fa5998b84165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->