### PR TITLE
Remove unused module-level aliases in javascript.py

### DIFF
--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -44,13 +44,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-_format_integer_hex = format_integer_hex
-_format_integer_underscore = format_integer_underscore
-
-
-_format_map_entry = dict_entry_with_template(template="[{key}, {value}]")
-
-
 @beartype
 class JavaScript(metaclass=LanguageCls):
     """JavaScript language specification.


### PR DESCRIPTION
## Summary
- Removes three unused module-level aliases (`_format_integer_hex`, `_format_integer_underscore`, `_format_map_entry`) from `javascript.py` that were left over from the formatter refactoring in #649. The original imports are used directly in the class body.

## Test plan
- [x] All 9269 tests pass
- [x] Pre-commit hooks pass (vulture, ruff, mypy, pyright, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only deletes unused module-level variables in `javascript.py` without changing runtime behavior.
> 
> **Overview**
> Removes leftover module-level formatter aliases in `src/literalizer/languages/javascript.py` (`_format_integer_hex`, `_format_integer_underscore`, `_format_map_entry`) and relies on the existing imported formatter functions directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d69502c83aef016794d7b46e958896345d201cac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->