### PR TITLE
Move pytest -n auto from pyproject.toml to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run --extra=dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests .
+          uv run --extra=dev pytest -s -vvv -n auto --cov-fail-under 100 --cov=src/ --cov=tests .
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,7 +276,6 @@ max_supported_python = "3.14"
 [tool.pytest]
 ini_options.xfail_strict = true
 ini_options.log_cli = true
-ini_options.addopts = "-n auto"
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
## Summary

- Removes `-n auto` from `addopts` in `pyproject.toml` so local `pytest` runs default to a single process
- Adds `-n auto` directly to the CI pytest command in `.github/workflows/ci.yml` to keep parallel test execution in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; it only affects how tests are executed (parallel in CI, single-process by default locally) without touching application logic.
> 
> **Overview**
> Moves pytest xdist parallelization from project-wide config to CI execution.
> 
> CI now runs `pytest -n auto` in `.github/workflows/ci.yml`, while `pyproject.toml` no longer sets `addopts`, so local `pytest` runs default to single-process unless explicitly enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7494a2a737127dc9163c0a3833dc78682095857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->