### PR TITLE
Remove defaults from TypedOpenerConfig.__init__ and rename eto

### DIFF
--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -255,14 +255,14 @@ class TypedOpenerConfig:
     def __init__(
         self,
         *,
-        str_type: str | None = None,
-        bool_type: str | None = None,
-        int_type: str | None = None,
-        float_type: str | None = None,
-        bytes_type: str | None = None,
-        mixed_numeric_type: str | None = None,
-        date_type: str | None = None,
-        datetime_type: str | None = None,
+        str_type: str | None,
+        bool_type: str | None,
+        int_type: str | None,
+        float_type: str | None,
+        bytes_type: str | None,
+        mixed_numeric_type: str | None,
+        date_type: str | None,
+        datetime_type: str | None,
         list_template: str,
         seq_opener_template: str,
         dict_opener_template: str,
@@ -346,21 +346,21 @@ class TypedOpenerConfig:
         the template used for ``set`` openers, allowing a single
         ``TypedOpenerConfig`` to serve multiple set formats.
         """
-        eto = self.element_to_type(
+        element_type_resolver = self.element_to_type(
             date_type=date_type,
             datetime_type=datetime_type,
         )
         return TypeOpeners(
             seq=make_type_to_opener(
-                element_to_type=eto,
+                element_to_type=element_type_resolver,
                 opener_template=self._seq_opener_template,
             ),
             dict=make_type_to_opener(
-                element_to_type=eto,
+                element_to_type=element_type_resolver,
                 opener_template=self._dict_opener_template,
             ),
             set=make_type_to_opener(
-                element_to_type=eto,
+                element_to_type=element_type_resolver,
                 opener_template=(
                     set_opener_template or self._set_opener_template
                 ),

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -81,6 +81,7 @@ _java_opener_config = TypedOpenerConfig(
     mixed_numeric_type="double",
     bytes_type="String",
     date_type="LocalDate",
+    datetime_type=None,
     list_template="{inner}[]",
     seq_opener_template="new {type_name}[]{{",
     dict_opener_template="new {type_name}[]{{",

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -79,6 +79,7 @@ _kotlin_opener_config = TypedOpenerConfig(
     int_type="Int",
     float_type="Double",
     bytes_type="String",
+    mixed_numeric_type=None,
     date_type="LocalDate",
     datetime_type="LocalDateTime",
     list_template="Array<{inner}>",


### PR DESCRIPTION
Remove `= None` defaults from all type parameters in `TypedOpenerConfig.__init__`, making callers explicit about which types they support. Update Java and Kotlin configs to pass explicit `None` for unsupported types. Rename the unclear `eto` variable to `element_type_resolver` in the `build` method.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `TypedOpenerConfig` constructor signature (removing defaults), which can break any existing callers/language configs not updated. Behavioral logic is effectively unchanged aside from requiring explicit `None` for unsupported scalar types.
> 
> **Overview**
> **Makes typed-opener configuration explicit.** `TypedOpenerConfig.__init__` no longer provides `= None` defaults for scalar type mappings, forcing callers to pass explicit `None` when a language doesn’t support a type.
> 
> **Minor readability tweak.** Renames `eto` to `element_type_resolver` in `TypedOpenerConfig.build()`, and updates Java/Kotlin opener configs to include explicit `None` for unsupported types (Java `datetime_type`, Kotlin `mixed_numeric_type`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e155cf72cfc85b25d0a91026a77e06d5b42f56d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->