### PR TITLE
Add missing @beartype decorator to date_scalar_preamble

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -6,6 +6,8 @@ import enum
 from collections.abc import Callable, Sequence
 from typing import Protocol, runtime_checkable
 
+from beartype import beartype
+
 from literalizer._types import Value
 
 
@@ -41,6 +43,7 @@ class DatetimeFormatConfig:
     type_produced: type = datetime.datetime
 
 
+@beartype
 def date_scalar_preamble(
     *,
     date_format: enum.Enum,


### PR DESCRIPTION
## Summary

- Add `@beartype` decorator to `date_scalar_preamble()` in `_language.py`, which was the only public function in the codebase missing runtime type checking.

## Test plan

- [x] All pre-commit hooks pass (mypy, pyright, ruff, etc.)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a `@beartype` runtime type-checking decorator and its import, which may raise earlier errors on invalid inputs but doesn’t change logic or outputs for valid callers.
> 
> **Overview**
> Adds missing runtime type enforcement to `date_scalar_preamble()` by importing `beartype` and decorating the function with `@beartype`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ed3e4cae3a4c8665a231263a7e08fd1858d28ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->