### PR TITLE
Inline module-level globals in cobol.py and vb.py

### DIFF
--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -31,14 +31,6 @@ from literalizer._types import Value
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-_COBOL_CONTROL_CHAR_REPLACEMENTS: dict[str, str] = {
-    "\n": " ",
-    "\r": " ",
-    "\t": " ",
-}
-
-_MAX_COBOL_LEVEL: int = 49
-
 
 @beartype
 def _format_string_cobol(value: str) -> str:
@@ -52,7 +44,7 @@ def _format_string_cobol(value: str) -> str:
     Example: ``say "hi" loud`` becomes ``"say ""hi"" loud"``.
     """
     cleaned = value
-    for char, replacement in _COBOL_CONTROL_CHAR_REPLACEMENTS.items():
+    for char, replacement in {"\n": " ", "\r": " ", "\t": " "}.items():
         cleaned = cleaned.replace(char, replacement)
     escaped = cleaned.replace('"', '""')
     return f'"{escaped}"'
@@ -112,7 +104,7 @@ def _bump_levels(content: str) -> str:
         if not m:
             msg = f"Expected COBOL level-number line, got: {line!r}"
             raise ValueError(msg)
-        new_level = min(int(m.group(2)) + 5, _MAX_COBOL_LEVEL)
+        new_level = min(int(m.group(2)) + 5, 49)
         result.append(
             f"{m.group(1)}{new_level:02d}{m.group(3)}{line[m.end() :]}"
         )

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -35,12 +35,6 @@ from literalizer._types import Value
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-_VB_CHAR_REPLACEMENTS: dict[str, str] = {
-    "\n": "Chr(10)",
-    "\r": "Chr(13)",
-    "\t": "vbTab",
-}
-
 
 @beartype
 def _flush_vb_current(
@@ -61,6 +55,7 @@ def _vb_string_parts(value: str) -> list[str]:
     parts: list[str] = []
     current = ""
     i = 0
+    char_replacements = {"\n": "Chr(10)", "\r": "Chr(13)", "\t": "vbTab"}
     while i < len(value):
         c = value[i]
         if c == '"':
@@ -70,9 +65,9 @@ def _vb_string_parts(value: str) -> list[str]:
             current = _flush_vb_current(parts=parts, current=current)
             parts.append("vbCrLf")
             i += 2
-        elif c in _VB_CHAR_REPLACEMENTS:
+        elif c in char_replacements:
             current = _flush_vb_current(parts=parts, current=current)
-            parts.append(_VB_CHAR_REPLACEMENTS[c])
+            parts.append(char_replacements[c])
             i += 1
         elif ord(c) < control_char_threshold:
             current = _flush_vb_current(parts=parts, current=current)
@@ -100,19 +95,6 @@ def _format_string_vb(value: str) -> str:
     if len(parts) == 1:
         return parts[0]
     return " & ".join(parts)
-
-
-_vb_element_to_type = make_element_to_type(
-    str_type="String",
-    bool_type="Boolean",
-    int_type="Integer",
-    float_type="Double",
-    mixed_numeric_type="Double",
-    bytes_type="String",
-    date_type="String",
-    datetime_type="String",
-    list_template="{inner}()",
-)
 
 
 @beartype
@@ -182,46 +164,19 @@ class VisualBasic(metaclass=LanguageCls):
     class SequenceFormats(enum.Enum):
         """Sequence type options for Visual Basic."""
 
-        ARRAY = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=_vb_element_to_type,
-                    opener_template="New {type_name}() {{",
-                ),
-                fallback="New Object() {",
-            ),
-            close="}",
-            supports_heterogeneity=True,
-            single_element_trailing_comma=False,
-            empty_sequence="New Object() {}",
-            preamble_lines=("Imports System.Collections.Generic",),
-            format_entry=passthrough_sequence_entry,
-            typed_opener_fallback=None,
-        )
+        ARRAY = "array"
 
         @property
         def supports_heterogeneity(self) -> bool:
             """Whether this sequence format supports mixed-type
             elements.
             """
-            return self.value.supports_heterogeneity
+            return True
 
     class SetFormats(enum.Enum):
         """Set type options for Visual Basic."""
 
-        HASH_SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=_vb_element_to_type,
-                    opener_template="New HashSet(Of {type_name}) From {{",
-                ),
-                fallback="New HashSet(Of Object) From {",
-            ),
-            close="}",
-            empty_set="New HashSet(Of Object)()",
-            preamble_lines=(),
-            set_opener_template="",
-        )
+        HASH_SET = "hash_set"
 
     class CommentFormats(enum.Enum):
         """Comment style options."""
@@ -313,10 +268,49 @@ class VisualBasic(metaclass=LanguageCls):
         self.null_literal = "Nothing"
         self.true_literal = "True"
         self.false_literal = "False"
-        fmt = sequence_format.value
+        element_to_type = make_element_to_type(
+            str_type="String",
+            bool_type="Boolean",
+            int_type="Integer",
+            float_type="Double",
+            mixed_numeric_type="Double",
+            bytes_type="String",
+            date_type="String",
+            datetime_type="String",
+            list_template="{inner}()",
+        )
+        vb_type_to_opener = make_type_to_opener(
+            element_to_type=element_to_type,
+            opener_template="New {type_name}() {{",
+        )
+        fmt = SequenceFormatConfig(
+            sequence_open=typed_sequence_open(
+                type_to_opener=vb_type_to_opener,
+                fallback="New Object() {",
+            ),
+            close="}",
+            supports_heterogeneity=True,
+            single_element_trailing_comma=False,
+            empty_sequence="New Object() {}",
+            preamble_lines=("Imports System.Collections.Generic",),
+            format_entry=passthrough_sequence_entry,
+            typed_opener_fallback=None,
+        )
         self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self.set_format_config: SetFormatConfig = set_format.value
+        self.set_format_config: SetFormatConfig = SetFormatConfig(
+            set_open=typed_set_open(
+                type_to_opener=make_type_to_opener(
+                    element_to_type=element_to_type,
+                    opener_template="New HashSet(Of {type_name}) From {{",
+                ),
+                fallback="New HashSet(Of Object) From {",
+            ),
+            close="}",
+            empty_set="New HashSet(Of Object)()",
+            preamble_lines=(),
+            set_opener_template="",
+        )
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(


### PR DESCRIPTION
## Summary
- Inline `_COBOL_CONTROL_CHAR_REPLACEMENTS` dict and `_MAX_COBOL_LEVEL` constant in cobol.py
- Inline `_VB_CHAR_REPLACEMENTS` dict in vb.py
- Move `_vb_element_to_type` from module-level into `__init__` in vb.py, constructing sequence and set format configs there instead of in enum member definitions

## Test plan
- [x] All 9269 tests pass
- [x] Pre-commit hooks (ruff, mypy, pyright, ty, vulture) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor, but it changes `VisualBasic.SequenceFormats`/`SetFormats` enum `.value` from config objects to strings and rebuilds `SequenceFormatConfig`/`SetFormatConfig` at init time, which could break any callers relying on the previous enum values or identity semantics.
> 
> **Overview**
> Refactors `cobol.py` and `vb.py` to inline previously module-level constants (control-character replacement maps and the COBOL max level `49`) directly at their usage sites.
> 
> In `vb.py`, moves VB type-mapping and collection initializer configuration out of module-level/enum member definitions: `SequenceFormats.ARRAY` and `SetFormats.HASH_SET` are now string-valued, while `VisualBasic.__init__` constructs the `SequenceFormatConfig` and `SetFormatConfig` (and the `make_element_to_type` mapping) at runtime and makes `supports_heterogeneity` unconditionally `True`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cd0ac082acdcb758315c59c46e401af3226a20c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->