### PR TITLE
Inline module-level globals in _core.py, go.py, and scala.py

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -425,22 +425,6 @@ def _coerce_heterogeneous_scalars(
     return data
 
 
-_TYPE_FAMILY_CHECKS: tuple[tuple[type, str], ...] = (
-    # Check bool before int (bool is a subclass of int), and
-    # datetime before date (datetime is a subclass of date).
-    (bool, "bool"),
-    (int, "int"),
-    (float, "float"),
-    (str, "str"),
-    (bytes, "bytes"),
-    (datetime.datetime, "datetime"),
-    (datetime.date, "date"),
-    (list, "list"),
-    (ordereddict, "dict"),
-    (dict, "dict"),
-)
-
-
 @beartype
 def _value_type_family(*, value: Value) -> str:
     """Return a broad type family label for a value.
@@ -450,7 +434,20 @@ def _value_type_family(*, value: Value) -> str:
     """
     if value is None:
         return "none"
-    for check_type, family in _TYPE_FAMILY_CHECKS:
+    # Check bool before int (bool is a subclass of int), and
+    # datetime before date (datetime is a subclass of date).
+    for check_type, family in (
+        (bool, "bool"),
+        (int, "int"),
+        (float, "float"),
+        (str, "str"),
+        (bytes, "bytes"),
+        (datetime.datetime, "datetime"),
+        (datetime.date, "date"),
+        (list, "list"),
+        (ordereddict, "dict"),
+        (dict, "dict"),
+    ):
         if isinstance(value, check_type):
             return family
     return "set"

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -39,26 +39,32 @@ if TYPE_CHECKING:
 
     from literalizer._types import Value
 
-_GO_MONTHS: dict[int, str] = {
-    1: "time.January",
-    2: "time.February",
-    3: "time.March",
-    4: "time.April",
-    5: "time.May",
-    6: "time.June",
-    7: "time.July",
-    8: "time.August",
-    9: "time.September",
-    10: "time.October",
-    11: "time.November",
-    12: "time.December",
-}
+
+@beartype
+def _go_month_name(month: int) -> str:
+    """Return the Go ``time.Month`` constant for a 1-based month
+    number.
+    """
+    return (
+        "time.January",
+        "time.February",
+        "time.March",
+        "time.April",
+        "time.May",
+        "time.June",
+        "time.July",
+        "time.August",
+        "time.September",
+        "time.October",
+        "time.November",
+        "time.December",
+    )[month - 1]
 
 
 @beartype
 def _format_date_go(value: datetime.date) -> str:
     """Format a date as a Go ``time.Date(...)`` call."""
-    month = _GO_MONTHS[value.month]
+    month = _go_month_name(month=value.month)
     return (
         f"time.Date({value.year}, {month}, {value.day}, 0, 0, 0, 0, time.UTC)"
     )
@@ -67,7 +73,7 @@ def _format_date_go(value: datetime.date) -> str:
 @beartype
 def _format_datetime_go(value: datetime.datetime) -> str:
     """Format a datetime as a Go ``time.Date(...)`` call."""
-    month = _GO_MONTHS[value.month]
+    month = _go_month_name(month=value.month)
     nanos = value.microsecond * 1000
     return (
         f"time.Date({value.year}, {month}, {value.day}, "

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -68,15 +68,6 @@ _scala_opener_config = TypedOpenerConfig(
 )
 
 
-# The LIST format needs List[…] for nested type names, not Array[…].
-_scala_list_type_to_opener = make_type_to_opener(
-    element_to_type=_scala_opener_config.element_to_type(
-        list_template="List[{inner}]",
-    ),
-    opener_template="List[{type_name}](",
-)
-
-
 @beartype
 def _list_sequence_open(
     *,
@@ -176,7 +167,12 @@ class Scala(metaclass=LanguageCls):
 
         LIST = SequenceFormatConfig(
             sequence_open=typed_sequence_open(
-                type_to_opener=_scala_list_type_to_opener,
+                type_to_opener=make_type_to_opener(
+                    element_to_type=_scala_opener_config.element_to_type(
+                        list_template="List[{inner}]",
+                    ),
+                    opener_template="List[{type_name}](",
+                ),
                 fallback="List(",
             ),
             close=")",


### PR DESCRIPTION
## Summary
- Inline `_TYPE_FAMILY_CHECKS` tuple directly into `_value_type_family()` in `_core.py`
- Replace `_GO_MONTHS` dict global with a `_go_month_name()` function using tuple indexing in `go.py`
- Inline `_scala_list_type_to_opener` at its single usage site in `scala.py`

## Test plan
- [x] All 9426 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how a few constant mappings are expressed; main potential issue is an off-by-one/IndexError in the new Go month tuple indexing if an invalid month were ever passed.
> 
> **Overview**
> Refactors a few module-level constants into inline/local implementations to reduce global state.
> 
> In `_core._value_type_family`, the `_TYPE_FAMILY_CHECKS` global is removed and the type-family mapping is inlined in the function. In the Go formatter, the `_GO_MONTHS` dict is replaced with a `_go_month_name()` helper used by date/datetime formatting. In the Scala formatter, the `_scala_list_type_to_opener` global is removed and its `make_type_to_opener(...)` construction is inlined at the `SequenceFormats.LIST` call site.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3462591d5d6513da8034a098fadc75cc952f5dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->