### PR TITLE
Add type hint variant tests for scalar date, datetime, and binary

### DIFF
--- a/tests/integration/cases/binary/Python_type_hints_inline.py
+++ b/tests/integration/cases/binary/Python_type_hints_inline.py
@@ -1,0 +1,4 @@
+from typing import Any
+my_data: tuple[str, ...] = (
+    "48656c6c6f",
+)

--- a/tests/integration/cases/scalar_date/Python_type_hints_inline.py
+++ b/tests/integration/cases/scalar_date/Python_type_hints_inline.py
@@ -1,0 +1,2 @@
+import datetime
+my_data: datetime.date = datetime.date(year=2024, month=1, day=15)

--- a/tests/integration/cases/scalar_datetime/Python_type_hints_inline.py
+++ b/tests/integration/cases/scalar_datetime/Python_type_hints_inline.py
@@ -1,0 +1,2 @@
+import datetime
+my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1556,7 +1556,7 @@ def _build_type_hint_variants() -> Iterable[_Variant]:
                 _Variant(
                     name=f"{lang_name}_type_hints_{fmt.name.lower()}",
                     spec=lang_config.lang_cls(variable_type_hints=fmt),
-                    wrap=lang_config.wrap,
+                    wrap=lang_config.varname_wrap,
                 )
             )
     return variants
@@ -1964,6 +1964,14 @@ def _build_variant_cases() -> list[_VariantCase]:
         (_build_set_variants(), "set", None, ""),
         (_build_comment_variants(), "comments", None, ""),
         (_build_type_hint_variants(), "type_hints", _VARIABLE_NAME, ""),
+        (_build_type_hint_variants(), "scalar_date", _VARIABLE_NAME, ""),
+        (
+            _build_type_hint_variants(),
+            "scalar_datetime",
+            _VARIABLE_NAME,
+            "",
+        ),
+        (_build_type_hint_variants(), "binary", _VARIABLE_NAME, ""),
         (
             _build_declaration_style_variants(),
             "simple_sequence",


### PR DESCRIPTION
## Summary
- Use `varname_wrap` in `_build_type_hint_variants` since type hints only apply to variable declarations
- Add `scalar_date`, `scalar_datetime`, and `binary` entries to variant sources so the scalar branches in `_python_type_hint` (bytes, datetime.datetime, datetime.date) are exercised by type hint variant tests

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test fixtures and variant selection logic, with no production code or data-handling behavior modified.
> 
> **Overview**
> Improves integration test coverage for *type-hint formatting variants* by ensuring type-hint variants use `varname_wrap` (so tests exercise variable declarations where type hints apply).
> 
> Adds new type-hint variant golden cases for `scalar_date`, `scalar_datetime`, and `binary`, including new Python expected-output files to cover the corresponding scalar type-hint branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d88ea6c8db13e92cbaf548779bba9ca48a65e216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->