### PR TITLE
Only emit `from typing import Any` when empty collections exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,18 @@ lint.per-file-ignores."doccmd_*.py" = [
     # Allow asserts in docs.
     "S101",
 ]
-lint.per-file-ignores."tests/integration/cases/**/*.py" = [ "ALL" ]
+lint.per-file-ignores."tests/integration/cases/**/*.py" = [
+    # These are generated fixture files; suppress everything except
+    # unused-import checks (F401) so we catch stale imports.
+    "B",
+    "D",
+    "DTZ",
+    "E",
+    "I",
+    "INP",
+    "PLR",
+    "Q",
+]
 lint.per-file-ignores."tests/integration/test_*.py" = [
     # Allow 'assert' as we use it for tests.
     "S101",

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -78,6 +78,25 @@ def _collect_value_types(*, data: Value) -> frozenset[type]:
 
 
 @beartype
+def _has_empty_collection(*, data: Value) -> bool:
+    """Return whether *data* contains any empty collection."""
+    if isinstance(data, (ordereddict, dict)):
+        if not data:
+            return True
+        return any(
+            _has_empty_collection(data=v)  # pyright: ignore[reportUnknownArgumentType]
+            for v in data.values()  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
+        )
+    if isinstance(data, (set, frozenset)):
+        return len(data) == 0
+    if isinstance(data, list):
+        if not data:
+            return True
+        return any(_has_empty_collection(data=v) for v in data)
+    return False
+
+
+@beartype
 def _preamble_scalar_type(*, value: Value) -> type | None:
     """Return the preamble-relevant type for a scalar.
 
@@ -152,6 +171,7 @@ def _compute_preamble(
     type_hint = (
         language.type_hint_collection_preamble_lines
         if types & {dict, list, set, ordereddict}
+        and _has_empty_collection(data=data)
         else ()
     )
     body = _deduplicate(

--- a/tests/integration/cases/binary/Python_type_hints_inline.py
+++ b/tests/integration/cases/binary/Python_type_hints_inline.py
@@ -1,4 +1,3 @@
-from typing import Any
 my_data: tuple[str, ...] = (
     "48656c6c6f",
 )

--- a/tests/integration/cases/binary/Python_type_hints_inline_binary.py
+++ b/tests/integration/cases/binary/Python_type_hints_inline_binary.py
@@ -1,4 +1,3 @@
-from typing import Any
 my_data: tuple[str, ...] = (
     "48656c6c6f",
 )

--- a/tests/integration/cases/type_hints/Python_type_hints_inline.py
+++ b/tests/integration/cases/type_hints/Python_type_hints_inline.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Any
 my_data: dict[str, str | int | bool | None | datetime.date | datetime.datetime] = {
     "name": "Alice",
     "age": 30,


### PR DESCRIPTION
## Summary

- Added `_has_empty_collection()` helper to `_core.py` that recursively checks whether data contains any empty collections, and updated `_compute_preamble()` to only include the `from typing import Any` import when `Any` will actually appear in the generated type hints.
- Replaced the `"ALL"` ruff ignore for `tests/integration/cases/**/*.py` with specific rule prefixes so that F401 (unused imports) is now checked on generated fixture files.
- Regenerated affected fixtures and fixed an orphaned fixture file that no test regenerates.

## Test plan

- [x] All 9507 integration tests pass
- [x] `ruff check --select F401` passes on test case fixtures
- [x] Full `ruff check` passes on test case fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes core preamble/type-hint generation logic, which can alter emitted code and fixtures for some nested/empty-collection inputs, but the change is small and well-scoped.
> 
> **Overview**
> Updates Python type-hint preamble generation so `from typing import Any` is emitted **only when the input contains empty collections** (via a new recursive `_has_empty_collection()` check) rather than for any collection.
> 
> Tightens Ruff config for generated integration fixtures to re-enable unused-import detection, and regenerates affected fixture outputs to drop now-unneeded `Any` imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 286d9d081098bb8cb8780a6b0d6182c9ec7c258c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->