### PR TITLE
Pass original Value through dict/map entry formatters

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -597,9 +597,11 @@ def _format_scalar(*, value: Scalar, spec: Language) -> str:
 
 
 @beartype
-def _build_dict_entry(*, key_str: str, val_str: str, spec: Language) -> str:
+def _build_dict_entry(
+    *, key_str: str, val: Value, val_str: str, spec: Language
+) -> str:
     """Format a single dict key-value entry using the language spec."""
-    return spec.dict_format_config.format_entry(key_str, val_str)
+    return spec.dict_format_config.format_entry(key_str, val, val_str)
 
 
 @beartype
@@ -614,7 +616,10 @@ def _format_set_value(
     sorted_items = sorted(value, key=lambda v: (type(v).__name__, repr(v)))
     items_as_values: list[Value] = list(sorted_items)
     formatted = [_format_scalar(value=v, spec=spec) for v in sorted_items]
-    entries = [spec.format_set_entry(item) for item in formatted]
+    entries = [
+        spec.format_set_entry(v, item)
+        for v, item in zip(sorted_items, formatted, strict=True)
+    ]
     joined = spec.element_separator.join(entries)
     return set_cfg.set_open(items_as_values) + joined + set_cfg.close
 
@@ -636,6 +641,7 @@ def _format_ordered_map_value(
     pairs = [
         spec.format_ordered_map_entry(
             _format_value(value=k, spec=spec),
+            v,
             _format_value(value=v, spec=spec),
         )
         for k, v in ordered_map_items
@@ -663,6 +669,7 @@ def _format_dict_value(
     pairs = [
         _build_dict_entry(
             key_str=_format_value(value=k, spec=spec),
+            val=v,
             val_str=_format_value(value=v, spec=spec),
             spec=spec,
         )
@@ -684,7 +691,7 @@ def _format_list_value(
     if not value and seq_cfg.empty_sequence is not None:
         return seq_cfg.empty_sequence
     items = [
-        spec.format_sequence_entry(_format_value(value=v, spec=spec))
+        spec.format_sequence_entry(v, _format_value(value=v, spec=spec))
         for v in value
     ]
     joined = spec.element_separator.join(items)
@@ -911,10 +918,13 @@ def _literalize(
             formatted_key = _format_value(value=k, spec=spec)
             formatted_val = _format_value(value=v, spec=spec)
             entry = (
-                spec.format_ordered_map_entry(formatted_key, formatted_val)
+                spec.format_ordered_map_entry(formatted_key, v, formatted_val)
                 if is_ordered_map
                 else _build_dict_entry(
-                    key_str=formatted_key, val_str=formatted_val, spec=spec
+                    key_str=formatted_key,
+                    val=v,
+                    val_str=formatted_val,
+                    spec=spec,
                 )
             )
             add_sep = i < last_idx or spec.multiline_trailing_comma
@@ -925,7 +935,7 @@ def _literalize(
         last_idx = len(sorted_items) - 1
         for i, item in enumerate(iterable=sorted_items):
             formatted = _format_value(value=item, spec=spec)
-            entry = spec.format_set_entry(formatted)
+            entry = spec.format_set_entry(item, formatted)
             add_sep = i < last_idx or spec.multiline_trailing_comma
             sep = spec.element_separator.strip() if add_sep else ""
             lines.append(f"{body_prefix}{entry}{sep}")
@@ -935,7 +945,7 @@ def _literalize(
         last_idx = len(items) - 1
         for i, element in enumerate(iterable=items):
             formatted = spec.format_sequence_entry(
-                _format_value(value=element, spec=spec)
+                element, _format_value(value=element, spec=spec)
             )
             add_sep = i < last_idx or spec.multiline_trailing_comma
             sep = spec.element_separator.strip() if add_sep else ""

--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -81,19 +81,19 @@ def variable_formatter(*, template: str) -> Callable[[str, str, Value], str]:
 
 
 @beartype
-def tuple_dict_entry(key: str, value: str) -> str:
+def tuple_dict_entry(key: str, _val: Value, value: str) -> str:
     """Format a dict/map entry as a tuple ``(key, value)``.
 
-    Example: ``tuple_dict_entry("k", "v")`` → ``"(k, v)"``.
+    Example: ``tuple_dict_entry("k", ..., "v")`` → ``"(k, v)"``.
     """
     return f"({key}, {value})"
 
 
 @beartype
-def braced_dict_entry(key: str, value: str) -> str:
+def braced_dict_entry(key: str, _val: Value, value: str) -> str:
     r"""Format a dict/map entry as ``{key, value}``.
 
-    Example: ``braced_dict_entry("k", "v")`` → ``"{k, v}"``.
+    Example: ``braced_dict_entry("k", ..., "v")`` → ``"{k, v}"``.
     """
     return f"{{{key}, {value}}}"
 
@@ -436,7 +436,7 @@ def format_bytes_hex(value: bytes) -> str:
 
 
 @beartype
-def passthrough_sequence_entry(item: str) -> str:
+def passthrough_sequence_entry(_value: Value, item: str) -> str:
     """Return *item* unchanged.
 
     Use this as ``format_sequence_entry`` for languages where sequence entries
@@ -446,7 +446,7 @@ def passthrough_sequence_entry(item: str) -> str:
 
 
 @beartype
-def passthrough_set_entry(item: str) -> str:
+def passthrough_set_entry(_value: Value, item: str) -> str:
     """Return *item* unchanged.
 
     Use this as ``format_set_entry`` for languages where set entries
@@ -456,15 +456,17 @@ def passthrough_set_entry(item: str) -> str:
 
 
 @beartype
-def dict_entry_with_separator(separator: str) -> Callable[[str, str], str]:
+def dict_entry_with_separator(
+    separator: str,
+) -> Callable[[str, Value, str], str]:
     """Return a ``format_dict_entry`` callable that joins key and value
     with *separator*.
 
-    Example: ``dict_entry_with_separator(": ")("k", "v")`` → ``"k: v"``.
+    Example: ``dict_entry_with_separator(": ")("k", ..., "v")`` → ``"k: v"``.
     """
 
     @beartype
-    def _format(key: str, value: str) -> str:
+    def _format(key: str, _val: Value, value: str) -> str:
         """Format a dict entry by joining key and value with separator."""
         return f"{key}{separator}{value}"
 
@@ -877,7 +879,7 @@ def typed_dict_open(
 def dict_entry_with_template(
     *,
     template: str,
-) -> Callable[[str, str], str]:
+) -> Callable[[str, Value, str], str]:
     """Return a ``format_dict_entry`` callable from a template string.
 
     The *template* must contain ``{key}`` and ``{value}`` placeholders.
@@ -887,7 +889,7 @@ def dict_entry_with_template(
     """
 
     @beartype
-    def _format(key: str, value: str) -> str:
+    def _format(key: str, _val: Value, value: str) -> str:
         """Format a dict entry using the template."""
         return template.format(key=key, value=value)
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -21,7 +21,7 @@ class SequenceFormatConfig:
     single_element_trailing_comma: bool
     empty_sequence: str | None
     preamble_lines: tuple[str, ...]
-    format_entry: Callable[[str], str]
+    format_entry: Callable[[Value, str], str]
     typed_opener_fallback: str | None
 
 
@@ -102,7 +102,7 @@ class DictFormatConfig:
 
     open_fn: Callable[[dict[str, Value]], str]
     close: str
-    format_entry: Callable[[str, str], str]
+    format_entry: Callable[[str, Value, str], str]
     empty_dict: str | None
     preamble_lines: tuple[str, ...]
 
@@ -339,12 +339,12 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     """Configuration for the chosen set format."""
 
     @property
-    def format_sequence_entry(self) -> Callable[[str], str]:
+    def format_sequence_entry(self) -> Callable[[Value, str], str]:
         """Callable that formats a sequence entry."""
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def format_set_entry(self) -> Callable[[str], str]:
+    def format_set_entry(self) -> Callable[[Value, str], str]:
         """Callable that formats a set entry."""
         ...  # pylint: disable=unnecessary-ellipsis
 
@@ -355,7 +355,7 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     """Configuration for ordered-map formatting."""
 
     @property
-    def format_ordered_map_entry(self) -> Callable[[str, str], str]:
+    def format_ordered_map_entry(self) -> Callable[[str, Value, str], str]:
         """Callable that formats one ordered-map entry."""
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -33,71 +33,48 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _to_ada_val(value: str) -> str:
-    """Wrap a pre-formatted value string in an Ada ``A_Val`` constructor.
-
-    Inspects the string representation to determine the appropriate
-    constructor: ``AStr``, ``AInt``, ``AFloat``, or passes through
-    values that are already ``A_Val`` expressions
-    (``ANull``, ``ABool``, ``AList``, ``AMap``, ``ASet``, ``AEntry``).
-    """
-    _val_prefixes = (
-        "ANull",
-        "ABool",
-        "AInt",
-        "AFloat",
-        "AStr",
-        "AList",
-        "AMap",
-        "ASet",
-        "AEntry",
-    )
-    if any(value.startswith(p) for p in _val_prefixes):
-        return value
-    if value.startswith('"') and value.endswith('"'):
-        return f"AStr ({value})"
-    if "Character'Val(" in value:
-        return f"AStr ({value})"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    int_result = None
-    try:
-        int(rest)
-        int_result = f"AInt ({value})"
-    except ValueError:
-        pass
-    if int_result is not None:
-        return int_result
-    float(rest)
-    return f"AFloat ({value})"
+def _format_ada_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in the appropriate Ada ``A_Val`` constructor."""
+    if isinstance(original, bool):
+        return formatted
+    if isinstance(original, int):
+        return f"AInt ({formatted})"
+    if isinstance(original, float):
+        return f"AFloat ({formatted})"
+    if isinstance(original, (str, bytes, datetime.date)):
+        return f"AStr ({formatted})"
+    return formatted
 
 
 @beartype
-def _format_ada_dict_entry(key: str, value: str) -> str:
+def _format_ada_dict_entry(key: str, val: Value, value: str) -> str:
     """Format an Ada dict/map entry as an ``AEntry (key, AVal value)``
     call.
     """
-    return f"AEntry ({key}, {_to_ada_val(value=value)})"
+    wrapped = _format_ada_entry(original=val, formatted=value)
+    return f"AEntry ({key}, {wrapped})"
 
 
 @beartype
-def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
+def _format_variable_declaration(name: str, value: str, data: Value) -> str:
     """Format an Ada object declaration.
 
     Example: ``"x"`` and ``"AList'(AInt (1))"`` →
     ``"x : A_Val := AList'(AInt (1));"``
     """
-    return f"{name} : A_Val := {_to_ada_val(value=value)};"
+    wrapped = _format_ada_entry(original=data, formatted=value)
+    return f"{name} : A_Val := {wrapped};"
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
+def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format an Ada assignment statement to an existing variable.
 
     Example: ``"x"`` and ``"AList'(AInt (1))"`` →
     ``"x := AList'(AInt (1));"``
     """
-    return f"{name} := {_to_ada_val(value=value)};"
+    wrapped = _format_ada_entry(original=data, formatted=value)
+    return f"{name} := {wrapped};"
 
 
 @beartype
@@ -287,8 +264,10 @@ class Ada(metaclass=LanguageCls):
             )
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = _to_ada_val
-        self.format_set_entry: Callable[[str], str] = _to_ada_val
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_ada_entry
+        )
+        self.format_set_entry: Callable[[Value, str], str] = _format_ada_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -305,7 +284,7 @@ class Ada(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_ada_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -54,13 +54,21 @@ def _to_bash_value(item: str) -> str:
 
 
 @beartype
-def _format_bash_sequence_entry(item: str) -> str:
+def _format_bash_sequence_entry(original: Value, item: str) -> str:
     """Format a Bash indexed-array element, quoting nested collections."""
-    return _to_bash_value(item=item)
+    if isinstance(original, (list, dict, set, frozenset)):
+        escaped = (
+            item.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("$", "\\$")
+            .replace("`", "\\`")
+        )
+        return f'"{escaped}"'
+    return item
 
 
 @beartype
-def _format_bash_dict_entry(key: str, value: str) -> str:
+def _format_bash_dict_entry(key: str, _val: Value, value: str) -> str:
     """Format a Bash associative-array entry as ``[key]=value``."""
     return f"[{key}]={_to_bash_value(item=value)}"
 
@@ -255,10 +263,12 @@ class Bash(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_bash_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -275,7 +285,7 @@ class Bash(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_bash_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -33,54 +33,39 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _to_val(value: str) -> str:
-    """Convert a value to a C union cast expression."""
-    if value.startswith("((_CVal)"):
-        return value
-    if value.startswith('"') and value.endswith('"'):
-        return f"((_CVal){{.s = {value}}})"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    int_result = None
-    try:
-        int(rest)
-        int_result = f"((_CVal){{.i = {value}}})"
-    except ValueError:
-        pass
-    if int_result is not None:
-        return int_result
-    float(rest)
-    return f"((_CVal){{.f = {value}}})"
+def _format_c_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in the appropriate ``_CVal`` union
+    literal.
+    """
+    if isinstance(original, (str, bytes, datetime.date)):
+        return f"((_CVal){{.s = {formatted}}})"
+    if isinstance(original, bool):
+        return formatted
+    if isinstance(original, int):
+        return f"((_CVal){{.i = {formatted}}})"
+    if isinstance(original, float):
+        return f"((_CVal){{.f = {formatted}}})"
+    return formatted
 
 
 @beartype
-def _format_c_dict_entry(key: str, value: str) -> str:
+def _format_c_dict_entry(key: str, val: Value, value: str) -> str:
     """Format a C dict entry as a ``_CKV`` compound literal."""
-    return f"{{{key}, {_to_val(value=value)}}}"
+    return f"{{{key}, {_format_c_entry(original=val, formatted=value)}}}"
 
 
 @beartype
-def _format_c_list_entry(item: str) -> str:
-    """Format a C list entry as a ``_CVal`` compound literal."""
-    return _to_val(value=item)
-
-
-@beartype
-def _format_c_set_entry(item: str) -> str:
-    """Format a C set entry as a ``_CVal`` compound literal."""
-    return _to_val(value=item)
-
-
-@beartype
-def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
+def _format_variable_declaration(name: str, value: str, data: Value) -> str:
     """Format a C variable declaration."""
-    return f"_CVal {name} = {_to_val(value=value)};"
+    wrapped = _format_c_entry(original=data, formatted=value)
+    return f"_CVal {name} = {wrapped};"
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
+def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format a C variable assignment."""
-    return f"{name} = {_to_val(value=value)};"
+    wrapped = _format_c_entry(original=data, formatted=value)
+    return f"{name} = {wrapped};"
 
 
 @beartype
@@ -268,8 +253,10 @@ class C(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = _format_c_list_entry
-        self.format_set_entry: Callable[[str], str] = _format_c_set_entry
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_c_entry
+        )
+        self.format_set_entry: Callable[[Value, str], str] = _format_c_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -286,7 +273,7 @@ class C(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_c_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -215,10 +215,12 @@ class Clojure(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -235,7 +237,7 @@ class Clojure(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -112,12 +112,12 @@ def _bump_levels(content: str) -> str:
 
 
 @beartype
-def _format_cobol_sequence_entry(item: str) -> str:
+def _format_cobol_sequence_entry(_original: Value, item: str) -> str:
     """Format a sequence item as a COBOL DATA DIVISION entry.
 
     Scalar values become ``05 FILLER PIC … VALUE …`` items.
-    Nested collections (detected by an embedded newline) are wrapped in
-    a ``05 FILLER.`` group with inner level numbers bumped by 5.
+    Nested collections are wrapped in a ``05 FILLER.`` group with
+    inner level numbers bumped by 5.
     """
     if "\n" in item:
         bumped = _bump_levels(content=item)
@@ -146,7 +146,7 @@ def _key_to_cobol_name(key_str: str) -> str:
 
 
 @beartype
-def _format_cobol_dict_entry(key: str, value: str) -> str:
+def _format_cobol_dict_entry(key: str, _val: Value, value: str) -> str:
     """Format a COBOL DATA DIVISION entry for a dict key-value pair.
 
     The key string is converted to a valid COBOL data name.  Scalar
@@ -389,10 +389,10 @@ class Cobol(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = _format_string_cobol
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_cobol_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_cobol_sequence_entry
         )
         self.comment_format = comment_format
@@ -411,7 +411,7 @@ class Cobol(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_cobol_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -28,15 +28,14 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from literalizer._types import Value
-
 
 @beartype
-def _format_cons_entry(key: str, value: str) -> str:
+def _format_cons_entry(key: str, _val: Value, value: str) -> str:
     """Format a Common Lisp association-list entry as a ``cons`` pair."""
     return f"(cons {key} {value})"
 
@@ -224,10 +223,12 @@ class CommonLisp(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -244,7 +245,7 @@ class CommonLisp(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_cons_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -335,10 +335,12 @@ class Cpp(metaclass=LanguageCls):
 
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -355,7 +357,7 @@ class Cpp(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -234,10 +234,12 @@ class Crystal(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -254,7 +256,7 @@ class Crystal(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" => ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -326,10 +326,12 @@ class CSharp(metaclass=LanguageCls):
 
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -346,7 +348,7 @@ class CSharp(metaclass=LanguageCls):
                 preamble_lines=("using System.Collections.Generic;",),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             csharp_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -33,72 +33,40 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _to_val(value: str) -> str:
-    """Wrap a pre-formatted value string in a D ``JSONValue(...)`` call.
-
-    Inspects the string representation to determine whether wrapping is
-    needed.  Values that are already ``JSONValue(...)`` or ``parseJSON(...)``
-    expressions are returned unchanged; ``null``, ``true``, and ``false``
-    literals and numeric and string literals are all wrapped.
-    """
-    if value.startswith(("JSONValue(", 'parseJSON("')):
-        return value
-    if value in {"null", "true", "false"}:
-        return f"JSONValue({value})"
-    if value.startswith('"') and value.endswith('"'):
-        return f"JSONValue({value})"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    int_result = None
-    try:
-        int(rest)
-        int_result = f"JSONValue({value})"
-    except ValueError:
-        pass
-    if int_result is not None:
-        return int_result
-    float(rest)
-    return f"JSONValue({value})"
+def _format_d_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in ``JSONValue(...)``."""
+    if isinstance(original, (list, dict, set, frozenset)):
+        return formatted
+    return f"JSONValue({formatted})"
 
 
 @beartype
-def _format_d_dict_entry(key: str, value: str) -> str:
+def _format_d_dict_entry(key: str, val: Value, value: str) -> str:
     """Format a D associative-array entry as ``key: JSONValue(value)``."""
-    return f"{key}: {_to_val(value=value)}"
+    return f"{key}: {_format_d_entry(original=val, formatted=value)}"
 
 
 @beartype
-def _format_d_sequence_entry(item: str) -> str:
-    """Format a D array entry as a ``JSONValue(item)`` call."""
-    return _to_val(value=item)
-
-
-@beartype
-def _format_d_set_entry(item: str) -> str:
-    """Format a D set entry (represented as array) as
-    ``JSONValue(item)``.
-    """
-    return _to_val(value=item)
-
-
-@beartype
-def _format_d_ordered_map_entry(key: str, value: str) -> str:
+def _format_d_ordered_map_entry(key: str, val: Value, value: str) -> str:
     """Format a D ordered-map entry as a two-element ``JSONValue``
     array.
     """
-    return f"JSONValue([JSONValue({key}), {_to_val(value=value)}])"
+    wrapped = _format_d_entry(original=val, formatted=value)
+    return f"JSONValue([JSONValue({key}), {wrapped}])"
 
 
 @beartype
-def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
+def _format_variable_declaration(name: str, value: str, data: Value) -> str:
     """Format a D ``auto`` variable declaration using ``JSONValue``."""
-    return f"auto {name} = {_to_val(value=value)};"
+    wrapped = _format_d_entry(original=data, formatted=value)
+    return f"auto {name} = {wrapped};"
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
+def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format a D assignment to an existing variable."""
-    return f"{name} = {_to_val(value=value)};"
+    wrapped = _format_d_entry(original=data, formatted=value)
+    return f"{name} = {wrapped};"
 
 
 @beartype
@@ -284,10 +252,10 @@ class D(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
-            _format_d_sequence_entry
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_d_entry
         )
-        self.format_set_entry: Callable[[str], str] = _format_d_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = _format_d_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -304,7 +272,7 @@ class D(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_d_ordered_map_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -319,10 +319,12 @@ class Dart(metaclass=LanguageCls):
             format_string_backslash_dollar
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -339,7 +341,7 @@ class Dart(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -274,10 +274,12 @@ class Elixir(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -294,7 +296,7 @@ class Elixir(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -286,10 +286,12 @@ class Erlang(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -306,7 +308,7 @@ class Erlang(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -33,45 +33,19 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _to_fval(value: str) -> str:
-    """Convert a pre-formatted value string to an ``fval_t`` constructor.
-
-    Inspects the string representation to determine the appropriate
-    constructor: ``fstr``, ``fint``, ``freal``, or passes through values
-    that are already ``fval_t`` expressions (``fnull``, ``fbool``,
-    ``flist``, ``fmap``, ``fset``, ``fentry``).
+def _format_fortran_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in the appropriate ``fval_t``
+    constructor.
     """
-    fval_prefixes = (
-        "fnull()",
-        "fbool(",
-        "fint(",
-        "freal(",
-        "fstr(",
-        "flist(",
-        "fmap(",
-        "fset(",
-        "fentry(",
-    )
-    if any(value.startswith(p) for p in fval_prefixes):
-        return value
-    if (value.startswith("'") and value.endswith("'")) or (
-        value.startswith('"') and value.endswith('"')
-    ):
-        return f"fstr({value})"
-    if "achar(" in value:
-        return f"fstr({value})"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    int_result = None
-    try:
-        int(rest)
-        int_result = f"fint({value})"
-    except ValueError:
-        pass
-    if int_result is not None:
-        return int_result
-    float(rest)
-    return f"freal({value})"
+    if isinstance(original, bool):
+        return formatted
+    if isinstance(original, int):
+        return f"fint({formatted})"
+    if isinstance(original, float):
+        return f"freal({formatted})"
+    if isinstance(original, (str, bytes, datetime.date)):
+        return f"fstr({formatted})"
+    return formatted
 
 
 @beartype
@@ -128,33 +102,34 @@ def _add_continuation(value: str) -> str:
 
 
 @beartype
-def _format_fortran_dict_entry(key: str, value: str) -> str:
+def _format_fortran_dict_entry(key: str, val: Value, value: str) -> str:
     """Format a Fortran dict entry as an ``fentry(key, fval_t value)``
     call.
     """
-    return f"fentry({key}, {_to_fval(value=value)})"
+    wrapped = _format_fortran_entry(original=val, formatted=value)
+    return f"fentry({key}, {wrapped})"
 
 
 @beartype
-def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
+def _format_variable_declaration(name: str, value: str, data: Value) -> str:
     r"""Format a Fortran variable declaration and initialisation.
 
     Example: ``"x"`` and ``"flist([fval_t :: fint(1)])"`` →
     ``"type(fval_t) :: x\nx = flist([fval_t :: fint(1)])"``
     """
-    fval = _to_fval(value=value)
+    fval = _format_fortran_entry(original=data, formatted=value)
     continued = _add_continuation(value=fval)
     return f"type(fval_t) :: {name}\n{name} = {continued}"
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
+def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format a Fortran assignment to an existing ``fval_t`` variable.
 
     Example: ``"x"`` and ``"flist([fval_t :: fint(1)])"`` →
     ``"x = flist([fval_t :: fint(1)])"``
     """
-    fval = _to_fval(value=value)
+    fval = _format_fortran_entry(original=data, formatted=value)
     continued = _add_continuation(value=fval)
     return f"{name} = {continued}"
 
@@ -346,8 +321,12 @@ class Fortran(metaclass=LanguageCls):
             )
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = _to_fval
-        self.format_set_entry: Callable[[str], str] = _to_fval
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_fortran_entry
+        )
+        self.format_set_entry: Callable[[Value, str], str] = (
+            _format_fortran_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -364,7 +343,7 @@ class Fortran(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_fortran_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -36,89 +36,63 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _to_val(value: str) -> str:
-    """Convert a value to an F# union type expression."""
-    _val_prefixes = (
-        "FNull",
-        "FBool",
-        "FList",
-        "FMap",
-        "FSet",
-        "FStr",
-        "FInt",
-        "FFloat",
-    )
-    if any(value.startswith(p) for p in _val_prefixes):
-        return value
-    if value.lstrip().startswith("[|"):
-        return value
-    if value.startswith("System."):
-        return f"FStr (string ({value}))"
-    if value.startswith('"') and value.endswith('"'):
-        return f"FStr {value}"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    int_result = None
-    try:
-        int(rest)
-        int_result = f"FInt({value}L)" if negative else f"FInt {value}L"
-    except ValueError:
-        pass
-    if int_result is not None:
-        return int_result
-    float(rest)
-    return f"FFloat({value})" if negative else f"FFloat {value}"
-
-
-@beartype
-def _format_fsharp_dict_entry(key: str, value: str) -> str:
-    """Format an F# dict entry as a ``(key, FVal value)`` tuple."""
-    return f"({key}, {_to_val(value=value)})"
-
-
-@beartype
-def _format_fsharp_ordered_map_entry(key: str, value: str) -> str:
-    """Format an F# ordered-map entry as a ``(key, FVal value)`` tuple."""
-    return f"({key}, {_to_val(value=value)})"
-
-
-@beartype
-def _format_fsharp_set_entry(item: str) -> str:
-    """Format an F# set entry with the appropriate ``Val`` constructor."""
-    return _to_val(value=item)
-
-
-@beartype
-def _format_fsharp_sequence_entry(item: str) -> str:
-    """Format an F# sequence entry with the appropriate ``Val``
+def _format_fsharp_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in the appropriate F# ``Val``
     constructor.
     """
-    return _to_val(value=item)
+    if isinstance(original, bool):
+        return formatted
+    if isinstance(original, int):
+        negative = formatted.startswith("-")
+        return f"FInt({formatted}L)" if negative else f"FInt {formatted}L"
+    if isinstance(original, float):
+        negative = formatted.startswith("-")
+        return f"FFloat({formatted})" if negative else f"FFloat {formatted}"
+    if isinstance(original, (str, bytes, datetime.date)):
+        if formatted.startswith("System."):
+            return f"FStr (string ({formatted}))"
+        return f"FStr {formatted}"
+    return formatted
+
+
+@beartype
+def _format_fsharp_dict_entry(key: str, val: Value, value: str) -> str:
+    """Format an F# dict entry as a ``(key, FVal value)`` tuple."""
+    return f"({key}, {_format_fsharp_entry(original=val, formatted=value)})"
+
+
+@beartype
+def _format_fsharp_ordered_map_entry(key: str, val: Value, value: str) -> str:
+    """Format an F# ordered-map entry as a ``(key, FVal value)`` tuple."""
+    return f"({key}, {_format_fsharp_entry(original=val, formatted=value)})"
 
 
 @beartype
 def _format_variable_declaration_let(
-    name: str, value: str, _data: Value
+    name: str, value: str, data: Value
 ) -> str:
     """Format an F# ``let`` variable declaration."""
     val_type = "Val array" if value.lstrip().startswith("[|") else "Val"
-    return f"let {name}: {val_type} = {_to_val(value=value)}"
+    wrapped = _format_fsharp_entry(original=data, formatted=value)
+    return f"let {name}: {val_type} = {wrapped}"
 
 
 @beartype
 def _format_variable_declaration_let_mutable(
-    name: str, value: str, _data: Value
+    name: str, value: str, data: Value
 ) -> str:
     """Format an F# ``let mutable`` variable declaration."""
     val_type = "Val array" if value.lstrip().startswith("[|") else "Val"
-    return f"let mutable {name}: {val_type} = {_to_val(value=value)}"
+    wrapped = _format_fsharp_entry(original=data, formatted=value)
+    return f"let mutable {name}: {val_type} = {wrapped}"
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
+def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format an F# variable assignment."""
     val_type = "Val array" if value.lstrip().startswith("[|") else "Val"
-    return f"let {name}: {val_type} = {_to_val(value=value)}"
+    wrapped = _format_fsharp_entry(original=data, formatted=value)
+    return f"let {name}: {val_type} = {wrapped}"
 
 
 @beartype
@@ -342,7 +316,9 @@ class FSharp(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_set_entry: Callable[[str], str] = _format_fsharp_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            _format_fsharp_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -359,7 +335,7 @@ class FSharp(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_fsharp_ordered_map_entry
         )
         self.multiline_close_indent = ""
@@ -372,8 +348,8 @@ class FSharp(metaclass=LanguageCls):
             _format_variable_assignment
         )
         self.element_separator = "; "
-        self.format_sequence_entry: Callable[[str], str] = (
-            _format_fsharp_sequence_entry
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_fsharp_entry
         )
         self.static_preamble: Sequence[str] = ()
         self.static_body_preamble: Sequence[str] = ()

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -34,11 +34,10 @@ from literalizer._language import (
     SetFormatConfig,
     date_scalar_preamble,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-    from literalizer._types import Value
 
 
 @beartype
@@ -97,7 +96,7 @@ _go_element_to_type = make_element_to_type(
 
 
 @beartype
-def _format_go_set_entry(item: str) -> str:
+def _format_go_set_entry(_original: Value, item: str) -> str:
     """Format a Go set entry as a map entry with empty struct value.
 
     Example: ``"apple"`` → ``"apple": struct{}{}``.
@@ -374,10 +373,12 @@ class Go(metaclass=LanguageCls):
 
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = _format_go_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            _format_go_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -394,7 +395,7 @@ class Go(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -221,10 +221,12 @@ class Groovy(metaclass=LanguageCls):
             format_string_backslash_dollar
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -241,7 +243,7 @@ class Groovy(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -325,10 +325,12 @@ class Haskell(metaclass=LanguageCls):
             control_char_fmt="\\x{:02x}",
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -345,7 +347,7 @@ class Haskell(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry
         )
         self.multiline_close_indent = "    "

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -219,10 +219,12 @@ class Hcl(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -239,7 +241,7 @@ class Hcl(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" = ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -365,10 +365,12 @@ class Java(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -385,7 +387,7 @@ class Java(metaclass=LanguageCls):
                 preamble_lines=("import java.util.Map;",),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             java_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -307,10 +307,12 @@ class JavaScript(metaclass=LanguageCls):
         )
 
         self.format_string: Callable[[str], str] = string_format
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
@@ -332,7 +334,7 @@ class JavaScript(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -276,10 +276,12 @@ class Julia(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -296,7 +298,7 @@ class Julia(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" => ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -374,10 +374,12 @@ class Kotlin(metaclass=LanguageCls):
             format_string_backslash_dollar
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -394,7 +396,7 @@ class Kotlin(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" to ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -28,11 +28,10 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-    from literalizer._types import Value
 
 
 @beartype
@@ -65,7 +64,7 @@ def _format_datetime_lua(value: datetime.datetime) -> str:
 
 
 @beartype
-def _format_lua_set_entry(item: str) -> str:
+def _format_lua_set_entry(_original: Value, item: str) -> str:
     """Format a Lua set entry as a table key with a ``true`` value.
 
     Example: ``'"apple"'`` → ``'["apple"] = true'``.
@@ -261,10 +260,12 @@ class Lua(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = _format_lua_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            _format_lua_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -281,7 +282,7 @@ class Lua(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             lua_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -29,11 +29,10 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-    from literalizer._types import Value
 
 
 @beartype
@@ -84,7 +83,7 @@ def _matlab_char_key(s: str) -> str:
 
 
 @beartype
-def _format_matlab_dict_entry(key: str, value: str) -> str:
+def _format_matlab_dict_entry(key: str, _val: Value, value: str) -> str:
     """Format a MATLAB ``struct`` field as a ``'key', value`` pair.
 
     MATLAB ``struct`` accepts alternating character-vector keys and values.
@@ -317,10 +316,12 @@ class Matlab(metaclass=LanguageCls):
             )
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -337,7 +338,7 @@ class Matlab(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_matlab_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -31,15 +31,14 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from literalizer._types import Value
-
 
 @beartype
-def _format_mojo_ordered_map_entry(key: str, value: str) -> str:
+def _format_mojo_ordered_map_entry(key: str, _val: Value, value: str) -> str:
     """Format one Mojo ordered-map entry as a ``Tuple(key, value)``."""
     return f"Tuple({key}, {value})"
 
@@ -247,10 +246,12 @@ class Mojo(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -267,7 +268,7 @@ class Mojo(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_mojo_ordered_map_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -338,10 +338,12 @@ class Nim(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -358,7 +360,7 @@ class Nim(metaclass=LanguageCls):
                 preamble_lines=("import json",),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -226,10 +226,12 @@ class Norg(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -246,7 +248,7 @@ class Norg(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -23,32 +23,29 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from literalizer._types import Value
-
 
 @beartype
-def _to_objc_val(value: str) -> str:
-    """Convert a pre-formatted value string to an Objective-C NSObject
-    expression.
+def _format_objc_entry(_original: Value, formatted: str) -> str:
+    """Wrap a formatted entry for use inside an Objective-C collection.
 
-    Strings, booleans, null, and nested collections already start with
-    ``@`` or ``[`` and are returned unchanged.  Bare numeric strings are
-    wrapped in ``@(...)`` to produce an ``NSNumber`` literal.
+    Only bare numeric values (``int`` / ``float``, but not ``bool``)
+    need ``@(...)`` wrapping; everything else is already a valid
+    Objective-C object expression.
     """
-    prefixes = ("@", "[NSNull null]", "[NSSet setWithArray:")
-    if any(value.startswith(p) for p in prefixes):
-        return value
-    return f"@({value})"
+    if isinstance(_original, (int, float)) and not isinstance(_original, bool):
+        return f"@({formatted})"
+    return formatted
 
 
 @beartype
-def _format_objc_dict_entry(key: str, value: str) -> str:
+def _format_objc_dict_entry(key: str, val: Value, value: str) -> str:
     """Format an Objective-C NSDictionary literal entry."""
-    return f"{key}: {_to_objc_val(value=value)}"
+    return f"{key}: {_format_objc_entry(_original=val, formatted=value)}"
 
 
 @beartype
@@ -311,8 +308,10 @@ class ObjectiveC(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = _format_objc_string
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = _to_objc_val
-        self.format_set_entry: Callable[[str], str] = _to_objc_val
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_objc_entry
+        )
+        self.format_set_entry: Callable[[Value, str], str] = _format_objc_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -329,7 +328,7 @@ class ObjectiveC(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_objc_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -48,81 +48,51 @@ def _format_datetime_ocaml(value: datetime.datetime) -> str:
 
 
 @beartype
-def _to_val(value: str) -> str:
-    """Convert a value to an OCaml union type expression."""
-    _val_prefixes = (
-        "ONull",
-        "OBool",
-        "OList",
-        "OMap",
-        "OSet",
-        "OStr",
-        "OInt",
-        "OFloat",
-        "ODate",
-        "ODatetime",
-    )
-    if any(value.startswith(p) for p in _val_prefixes):
-        return value
-    if value.lstrip().startswith("[|"):
-        return value
-    if value.startswith('"') and value.endswith('"'):
-        return f"OStr {value}"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    int_result = None
-    try:
-        int(rest)
-        int_result = f"OInt ({value})" if negative else f"OInt {value}"
-    except ValueError:
-        pass
-    if int_result is not None:
-        return int_result
-    float(rest)
-    return f"OFloat ({value})" if negative else f"OFloat {value}"
+def _format_ocaml_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in the appropriate OCaml ``val_t``
+    constructor.
+    """
+    if isinstance(original, bool):
+        return formatted
+    if isinstance(original, int):
+        negative = formatted.startswith("-")
+        return f"OInt ({formatted})" if negative else f"OInt {formatted}"
+    if isinstance(original, float):
+        negative = formatted.startswith("-")
+        return f"OFloat ({formatted})" if negative else f"OFloat {formatted}"
+    if isinstance(original, (str, bytes)):
+        return f"OStr {formatted}"
+    if isinstance(original, datetime.date) and formatted.startswith('"'):
+        return f"OStr {formatted}"
+    return formatted
 
 
 @beartype
-def _format_ocaml_dict_entry(key: str, value: str) -> str:
+def _format_ocaml_dict_entry(key: str, val: Value, value: str) -> str:
     """Format an OCaml dict entry as a ``(key, OXxx value)`` tuple."""
-    return f"({key}, {_to_val(value=value)})"
+    return f"({key}, {_format_ocaml_entry(original=val, formatted=value)})"
 
 
 @beartype
-def _format_ocaml_ordered_map_entry(key: str, value: str) -> str:
+def _format_ocaml_ordered_map_entry(key: str, val: Value, value: str) -> str:
     """Format an OCaml ordered-map entry as a ``(key, OXxx value)``
     tuple.
     """
-    return f"({key}, {_to_val(value=value)})"
+    return f"({key}, {_format_ocaml_entry(original=val, formatted=value)})"
 
 
 @beartype
-def _format_ocaml_set_entry(item: str) -> str:
-    """Format an OCaml set entry with the appropriate ``val_t``
-    constructor.
-    """
-    return _to_val(value=item)
-
-
-@beartype
-def _format_ocaml_sequence_entry(item: str) -> str:
-    """Format an OCaml list entry with the appropriate ``val_t``
-    constructor.
-    """
-    return _to_val(value=item)
-
-
-@beartype
-def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
+def _format_variable_declaration(name: str, value: str, data: Value) -> str:
     """Format an OCaml variable declaration."""
     val_type = "val_t array" if value.lstrip().startswith("[|") else "val_t"
-    return f"let {name} : {val_type} = {_to_val(value=value)}"
+    wrapped = _format_ocaml_entry(original=data, formatted=value)
+    return f"let {name} : {val_type} = {wrapped}"
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
+def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format an OCaml variable assignment."""
-    return _format_variable_declaration(name=name, value=value, _data=_data)
+    return _format_variable_declaration(name=name, value=value, data=data)
 
 
 @beartype
@@ -332,7 +302,9 @@ class OCaml(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_set_entry: Callable[[str], str] = _format_ocaml_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            _format_ocaml_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -349,7 +321,7 @@ class OCaml(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_ocaml_ordered_map_entry
         )
         self.multiline_close_indent = ""
@@ -362,8 +334,8 @@ class OCaml(metaclass=LanguageCls):
             _format_variable_assignment
         )
         self.element_separator = "; "
-        self.format_sequence_entry: Callable[[str], str] = (
-            _format_ocaml_sequence_entry
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_ocaml_entry
         )
         self.static_preamble: Sequence[str] = ()
         self.static_body_preamble: Sequence[str] = ()

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -27,58 +27,36 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from literalizer._types import Value
+
+@beartype
+def _format_occam_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in the appropriate occam-pi ``LIT``
+    constructor.
+    """
+    if isinstance(original, bool):
+        return formatted
+    if isinstance(original, int):
+        return f"MOBILE LIT(lit.int; {formatted})"
+    if isinstance(original, float):
+        return f"MOBILE LIT(lit.float; {formatted}(REAL32))"
+    if isinstance(original, (str, bytes, datetime.date)):
+        return f"MOBILE LIT(lit.str; MOBILE []BYTE {formatted})"
+    return formatted
 
 
 @beartype
-def _to_val(value: str) -> str:
-    """Convert a value to an occam-pi MOBILE LIT expression."""
-    if value.startswith("MOBILE LIT("):
-        return value
-    if value.startswith('"') and value.endswith('"'):
-        return f"MOBILE LIT(lit.str; MOBILE []BYTE {value})"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    int_result = None
-    try:
-        int(rest)
-        int_result = f"MOBILE LIT(lit.int; {value})"
-    except ValueError:
-        pass
-    if int_result is not None:
-        return int_result
-    float(rest)
-    return f"MOBILE LIT(lit.float; {value}(REAL32))"
-
-
-@beartype
-def _format_occam_dict_entry(key: str, value: str) -> str:
+def _format_occam_dict_entry(key: str, val: Value, value: str) -> str:
     """Format an occam-pi dict or ordered-map entry as a ``MOBILE
     LIT(lit.pair;
     ...)`` constructor.
     """
-    val = _to_val(value=value)
-    return f"MOBILE LIT(lit.pair; MOBILE []BYTE {key}; {val})"
-
-
-@beartype
-def _format_occam_list_entry(item: str) -> str:
-    """Format an occam-pi list entry with the appropriate ``LIT``
-    constructor.
-    """
-    return _to_val(value=item)
-
-
-@beartype
-def _format_occam_set_entry(item: str) -> str:
-    """Format an occam-pi set entry with the appropriate ``LIT``
-    constructor.
-    """
-    return _to_val(value=item)
+    wrapped = _format_occam_entry(original=val, formatted=value)
+    return f"MOBILE LIT(lit.pair; MOBILE []BYTE {key}; {wrapped})"
 
 
 @beartype
@@ -267,10 +245,12 @@ class Occam(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
-            _format_occam_list_entry
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_occam_entry
         )
-        self.format_set_entry: Callable[[str], str] = _format_occam_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            _format_occam_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -287,7 +267,7 @@ class Occam(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_occam_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -267,10 +267,12 @@ class Perl(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -287,7 +289,7 @@ class Perl(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" => ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -233,10 +233,12 @@ class Php(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -253,7 +255,7 @@ class Php(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" => ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -28,24 +28,21 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from literalizer._types import Value
-
 
 @beartype
-def _format_sequence_entry(item: str) -> str:
+def _format_sequence_entry(original: Value, item: str) -> str:
     """Prevent nested array flattening with a unary comma prefix.
 
     In PowerShell ``@()`` collects pipeline output and arrays written to the
     pipeline are automatically unrolled.  Prefixing a nested ``@(…)`` with
     the unary comma operator keeps it as a single array element.
-
-    Example: ``"@(1; 2)"`` → ``",@(1; 2)"``; ``"42"`` → ``"42"``.
     """
-    if item.startswith("@("):
+    if isinstance(original, list):
         return f",{item}"
     return item
 
@@ -247,10 +244,12 @@ class PowerShell(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = _format_string
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -267,7 +266,7 @@ class PowerShell(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" = ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -508,10 +508,12 @@ class Python(metaclass=LanguageCls):
 
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -528,7 +530,7 @@ class Python(metaclass=LanguageCls):
                 preamble_lines=("from collections import OrderedDict",),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -29,12 +29,11 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 from literalizer.exceptions import EmptyDictKeyError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-    from literalizer._types import Value
 
 
 @beartype
@@ -50,7 +49,7 @@ def _format_datetime_r(value: datetime.datetime) -> str:
 
 
 @beartype
-def _format_r_dict_entry_positional(key: str, value: str) -> str:
+def _format_r_dict_entry_positional(key: str, _val: Value, value: str) -> str:
     """Format an R named list entry.
 
     R list syntax does not allow zero-length names (``"" = value`` is a
@@ -63,7 +62,7 @@ def _format_r_dict_entry_positional(key: str, value: str) -> str:
 
 
 @beartype
-def _format_r_dict_entry_error(key: str, value: str) -> str:
+def _format_r_dict_entry_error(key: str, _val: Value, value: str) -> str:
     """Format an R named list entry, raising on empty-string keys."""
     if key == '""':
         msg = (
@@ -143,9 +142,9 @@ class R(metaclass=LanguageCls):
         POSITIONAL = enum.member(value=_format_r_dict_entry_positional)
         ERROR = enum.member(value=_format_r_dict_entry_error)
 
-        def __call__(self, key: str, value: str, /) -> str:
+        def __call__(self, key: str, val: Value, value: str, /) -> str:
             """Format a dict entry."""
-            return self.value(key=key, value=value)
+            return self.value(key=key, _val=val, value=value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -299,10 +298,12 @@ class R(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -319,7 +320,7 @@ class R(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" = ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -219,10 +219,12 @@ class Racket(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -239,7 +241,7 @@ class Racket(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -255,10 +255,12 @@ class Ruby(metaclass=LanguageCls):
 
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -275,7 +277,7 @@ class Ruby(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" => ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -327,10 +327,12 @@ class Rust(metaclass=LanguageCls):
 
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -347,7 +349,7 @@ class Rust(metaclass=LanguageCls):
                 preamble_lines=("use std::collections::HashMap;",),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -386,10 +386,12 @@ class Scala(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -406,7 +408,7 @@ class Scala(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=" -> ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -32,11 +32,10 @@ from literalizer._language import (
     SetFormatConfig,
     date_scalar_preamble,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-    from literalizer._types import Value
 
 
 @beartype
@@ -66,9 +65,9 @@ def _format_datetime_swift(value: datetime.datetime) -> str:
 
 
 @beartype
-def _tuple_sequence_entry(entry: str) -> str:
+def _tuple_sequence_entry(original: Value, entry: str) -> str:
     """Format a tuple sequence entry, casting nil to Any? for Swift."""
-    if entry == "nil":
+    if original is None:
         return "nil as Any?"
     return entry
 
@@ -282,8 +281,12 @@ class Swift(metaclass=LanguageCls):
             control_char_fmt="\\u{{{:x}}}",
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = fmt.format_entry
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            fmt.format_entry
+        )
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -300,7 +303,7 @@ class Swift(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -30,15 +30,14 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
 )
+from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from literalizer._types import Value
-
 
 @beartype
-def _format_toml_dict_entry(key: str, value: str) -> str:
+def _format_toml_dict_entry(key: str, _val: Value, value: str) -> str:
     """Format a TOML dict entry as ``key = value``.
 
     If the key is a double-quoted string that is also a valid bare key
@@ -274,10 +273,12 @@ class Toml(metaclass=LanguageCls):
             control_char_fmt="\\u{:04x}",
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -294,7 +295,7 @@ class Toml(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_toml_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -297,10 +297,12 @@ class TypeScript(metaclass=LanguageCls):
 
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -317,7 +319,7 @@ class TypeScript(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -316,10 +316,12 @@ class VisualBasic(metaclass=LanguageCls):
         )
         self.format_string: Callable[[str], str] = _format_string_vb
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -336,7 +338,7 @@ class VisualBasic(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -248,10 +248,12 @@ class Yaml(metaclass=LanguageCls):
             control_char_fmt="\\x{:02x}",
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self.format_set_entry: Callable[[str], str] = passthrough_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = (
+            passthrough_set_entry
+        )
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -268,7 +270,7 @@ class Yaml(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(separator=": ")
         )
         self.multiline_close_indent = ""

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -54,55 +54,43 @@ def _format_datetime_zig(value: datetime.datetime) -> str:
 
 
 @beartype
-def _to_val(value: str) -> str:
-    """Wrap a pre-formatted value string in a Zig ``ZVal`` union literal.
-
-    Inspects the string representation to determine the appropriate union
-    tag: ``.int`` for integers, ``.float`` for floats, ``.str`` for
-    strings.  Values that are already tagged (starting with ``.``) are
-    returned unchanged.
+def _format_zig_entry(original: Value, formatted: str) -> str:
+    """Wrap a formatted entry in the appropriate Zig ``ZVal`` union
+    tag.
     """
-    if value.startswith("."):
-        return value
-    if value.startswith('"') and value.endswith('"'):
-        return f".{{ .str = {value} }}"
-    negative = value.startswith("-")
-    rest = value[1:] if negative else value
-    try:
-        int(rest)
-    except ValueError:
-        return f".{{ .float = {value} }}"
-    return f".{{ .int = {value} }}"
+    if isinstance(original, bool):
+        return formatted
+    if isinstance(original, int):
+        return f".{{ .int = {formatted} }}"
+    if isinstance(original, float):
+        return f".{{ .float = {formatted} }}"
+    if isinstance(original, (str, bytes)):
+        return f".{{ .str = {formatted} }}"
+    if isinstance(original, datetime.date):
+        tag = "str" if formatted.startswith('"') else "int"
+        return f".{{ .{tag} = {formatted} }}"
+    return formatted
 
 
 @beartype
-def _format_zig_dict_entry(key: str, value: str) -> str:
+def _format_zig_dict_entry(key: str, val: Value, value: str) -> str:
     """Format a Zig dict entry as a ``ZKV`` anonymous struct literal."""
-    return f".{{ .key = {key}, .val = {_to_val(value=value)} }}"
+    wrapped = _format_zig_entry(original=val, formatted=value)
+    return f".{{ .key = {key}, .val = {wrapped} }}"
 
 
 @beartype
-def _format_zig_sequence_entry(item: str) -> str:
-    """Format a Zig sequence entry as a ``ZVal`` union literal."""
-    return _to_val(value=item)
-
-
-@beartype
-def _format_zig_set_entry(item: str) -> str:
-    """Format a Zig set entry as a ``ZVal`` union literal."""
-    return _to_val(value=item)
-
-
-@beartype
-def _format_variable_declaration(name: str, value: str, _data: Value) -> str:
+def _format_variable_declaration(name: str, value: str, data: Value) -> str:
     """Format a Zig ``const`` declaration with explicit ``ZVal`` type."""
-    return f"const {name}: ZVal = {_to_val(value=value)};"
+    wrapped = _format_zig_entry(original=data, formatted=value)
+    return f"const {name}: ZVal = {wrapped};"
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, _data: Value) -> str:
+def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format a Zig assignment to an existing ``ZVal`` variable."""
-    return f"{name} = {_to_val(value=value)};"
+    wrapped = _format_zig_entry(original=data, formatted=value)
+    return f"{name} = {wrapped};"
 
 
 @beartype
@@ -289,10 +277,10 @@ class Zig(metaclass=LanguageCls):
             control_char_fmt="\\x{:02x}",
         )
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[str], str] = (
-            _format_zig_sequence_entry
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _format_zig_entry
         )
-        self.format_set_entry: Callable[[str], str] = _format_zig_set_entry
+        self.format_set_entry: Callable[[Value, str], str] = _format_zig_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -309,7 +297,7 @@ class Zig(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self.format_ordered_map_entry: Callable[[str, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_zig_dict_entry
         )
         self.multiline_close_indent = ""

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -540,7 +540,9 @@ def test_toml_non_quoted_dict_key() -> None:
     When the key does not start with a double-quote character the
     bare-key optimization is skipped and the key is used verbatim.
     """
-    result = TOML.dict_format_config.format_entry("plain_key", '"value"')
+    result = TOML.dict_format_config.format_entry(
+        "plain_key", "value", '"value"'
+    )
     assert result == 'plain_key = "value"'
 
 


### PR DESCRIPTION
## Summary
- Thread the original `Value` through `DictFormatConfig.format_entry`, `format_ordered_map_entry`, `format_set_entry`, and `format_sequence_entry` so type-wrapping decisions use `isinstance` checks on structured data instead of fragile string inspection.
- Removes all nine `_to_*_from_str` helper functions (`_to_val_from_str` in F#/OCaml/occam/C/D/Zig, `_to_ada_val_from_str`, `_to_fval_from_str`, `_to_objc_val_from_str`) that inferred types by parsing formatted output strings.
- Net reduction of ~87 lines across 50 files.

## Test plan
- [x] All 9843 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the callable signatures and call sites for dict/ordered-map/set/sequence entry formatting across many language specs, which could subtly alter literal output formatting for edge cases.
> 
> **Overview**
> Updates the literalization pipeline to pass the *original* Python `Value` into `format_sequence_entry`, `format_set_entry`, `DictFormatConfig.format_entry`, and `format_ordered_map_entry`, enabling entry wrappers to make type-based decisions without inspecting formatted strings.
> 
> Refactors multiple language implementations (notably `ada`, `c`, `d`, `fortran`, `fsharp`, `ocaml`, `occam`, `objective_c`, `zig`, plus small tweaks like `bash`, `powershell`, `swift`) to replace string-parsing `_to_*` helpers with `isinstance`-driven wrappers, and adjusts the TOML unit test to the new `format_entry` signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5a22ce2e9e6c89331cd09a5797aab09b143e52f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->