### PR TITLE
Rename seq_ variable prefixes to full word sequence

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -699,10 +699,10 @@ def _format_list_value(
     spec: Language,
 ) -> str:
     """Format a list as a native language literal."""
-    seq_cfg = spec.sequence_format_config
+    sequence_cfg = spec.sequence_format_config
 
-    if not value and seq_cfg.empty_sequence is not None:
-        return seq_cfg.empty_sequence
+    if not value and sequence_cfg.empty_sequence is not None:
+        return sequence_cfg.empty_sequence
     items = [
         spec.format_sequence_entry(_format_value(value=v, spec=spec))
         for v in value
@@ -710,9 +710,9 @@ def _format_list_value(
     joined = spec.element_separator.join(items)
     # Some languages (e.g. Python) require a trailing comma on
     # single-element sequences to avoid syntactic ambiguity.
-    if len(items) == 1 and seq_cfg.single_element_trailing_comma:
+    if len(items) == 1 and sequence_cfg.single_element_trailing_comma:
         joined += spec.element_separator.strip()
-    return f"{spec.sequence_open(value)}{joined}{seq_cfg.close}"
+    return f"{spec.sequence_open(value)}{joined}{sequence_cfg.close}"
 
 
 @beartype

--- a/src/literalizer/_formatters.py
+++ b/src/literalizer/_formatters.py
@@ -264,7 +264,7 @@ class TypedOpenerConfig:
         date_type: str | None,
         datetime_type: str | None,
         list_template: str,
-        seq_opener_template: str,
+        sequence_opener_template: str,
         dict_opener_template: str,
         set_opener_template: str,
     ) -> None:
@@ -278,7 +278,7 @@ class TypedOpenerConfig:
         self._date_type = date_type
         self._datetime_type = datetime_type
         self._list_template = list_template
-        self._seq_opener_template = seq_opener_template
+        self._sequence_opener_template = sequence_opener_template
         self._dict_opener_template = dict_opener_template
         self._set_opener_template = set_opener_template
 
@@ -353,7 +353,7 @@ class TypedOpenerConfig:
         return TypeOpeners(
             seq=make_type_to_opener(
                 element_to_type=element_type_resolver,
-                opener_template=self._seq_opener_template,
+                opener_template=self._sequence_opener_template,
             ),
             dict=make_type_to_opener(
                 element_to_type=element_type_resolver,

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -52,7 +52,7 @@ _csharp_opener_config = TypedOpenerConfig(
     date_type="DateOnly",
     datetime_type="DateTime",
     list_template="{inner}[]",
-    seq_opener_template="new {type_name}[] {{",
+    sequence_opener_template="new {type_name}[] {{",
     dict_opener_template="new Dictionary<string, {type_name}> {{",
     set_opener_template="new HashSet<{type_name}> {{",
 )

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -283,7 +283,7 @@ class Dart(metaclass=LanguageCls):
             date_type="DateTime",
             datetime_type="DateTime",
             list_template="List<{inner}>",
-            seq_opener_template="<{type_name}>[",
+            sequence_opener_template="<{type_name}>[",
             dict_opener_template="<String, {type_name}>{{",
             set_opener_template="<{type_name}>{{",
         )

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -332,7 +332,7 @@ class Java(metaclass=LanguageCls):
             date_type="LocalDate",
             datetime_type=None,
             list_template="{inner}[]",
-            seq_opener_template="new {type_name}[]{{",
+            sequence_opener_template="new {type_name}[]{{",
             dict_opener_template="new {type_name}[]{{",
             set_opener_template="Set.of(",
         )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -83,7 +83,7 @@ _kotlin_opener_config = TypedOpenerConfig(
     date_type="LocalDate",
     datetime_type="LocalDateTime",
     list_template="Array<{inner}>",
-    seq_opener_template="arrayOf(",
+    sequence_opener_template="arrayOf(",
     dict_opener_template="mapOf<String, {type_name}>(",
     set_opener_template="setOf<{type_name}>(",
 )

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -52,9 +52,9 @@ def _format_datetime_nim(value: datetime.datetime) -> str:
 @beartype
 def _make_variable_declaration(
     *,
-    seq_mode: bool,
+    sequence_mode: bool,
     keyword: str,
-    force_seq: bool,
+    force_sequence: bool,
 ) -> Callable[[str, str, Value], str]:
     """Create a Nim variable declaration formatter."""
 
@@ -63,13 +63,13 @@ def _make_variable_declaration(
         """Format a declaration, using ``@`` for flat sequences of
         simple scalars.
         """
-        use_seq = (
+        use_sequence = (
             isinstance(_data, list)
             and _data
             and (
-                force_seq
+                force_sequence
                 or (
-                    seq_mode
+                    sequence_mode
                     and all(
                         isinstance(item, (str, int, float, bool, bytes))
                         for item in _data
@@ -77,9 +77,9 @@ def _make_variable_declaration(
                 )
             )
         )
-        if use_seq:
+        if use_sequence:
             return f"{keyword} {name} = @{value}"
-        if force_seq:
+        if force_sequence:
             return f"{keyword} {name} = {value}"
         return f"{keyword} {name} = %* {value}"
 
@@ -89,7 +89,7 @@ def _make_variable_declaration(
 @beartype
 def _make_variable_assignment(
     *,
-    seq_mode: bool,
+    sequence_mode: bool,
 ) -> Callable[[str, str, Value], str]:
     """Create a Nim variable assignment formatter."""
 
@@ -99,7 +99,7 @@ def _make_variable_assignment(
         simple scalars.
         """
         if (
-            seq_mode
+            sequence_mode
             and isinstance(_data, list)
             and _data
             and all(
@@ -365,17 +365,17 @@ class Nim(metaclass=LanguageCls):
         self.element_separator = ", "
         self.skip_null_dict_values = False
         self.supports_collection_comments = True
-        _seq = sequence_format is self.sequence_formats.SEQ
+        _is_sequence = sequence_format is self.sequence_formats.SEQ
         _is_const = declaration_style is self.declaration_styles.CONST
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _make_variable_declaration(
-                seq_mode=_seq,
+                sequence_mode=_is_sequence,
                 keyword=declaration_style.value,
-                force_seq=_is_const,
+                force_sequence=_is_const,
             )
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
-            _make_variable_assignment(seq_mode=_seq)
+            _make_variable_assignment(sequence_mode=_is_sequence)
         )
         _json = ("import json",)
         self.static_preamble: Sequence[str] = ()

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -62,7 +62,7 @@ _scala_opener_config = TypedOpenerConfig(
     date_type="LocalDate",
     datetime_type="ZonedDateTime",
     list_template="Array[{inner}]",
-    seq_opener_template="Array[{type_name}](",
+    sequence_opener_template="Array[{type_name}](",
     dict_opener_template="Map[String, {type_name}](",
     set_opener_template="Set[{type_name}](",
 )


### PR DESCRIPTION
## Summary
- Renames all `seq_` variable name prefixes to use the full word `sequence_` across 8 files in the codebase (`_core.py`, `_formatters.py`, and 6 language modules).
- Pure rename refactor with no behavioral changes.

## Test plan
- [x] All pre-commit hooks pass (mypy, pyright, ruff, vulture, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical rename of local variables/parameters and config fields; primary risk is missed references causing runtime errors, but the change appears consistently applied across affected modules.
> 
> **Overview**
> Renames internal `seq_*` naming to the clearer `sequence_*` across the core formatter logic and multiple language specs.
> 
> This includes updating `TypedOpenerConfig`’s constructor argument/storage (`seq_opener_template` → `sequence_opener_template`) and Nim’s helper parameter names (`seq_mode`/`force_seq` → `sequence_mode`/`force_sequence`), with corresponding call-site updates; no functional behavior is intended to change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8aaf6ca242d8a4dc659aab8b58fe5f225865156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->