### PR TITLE
Simplify Dart combined test wrapper to use block scopes

### DIFF
--- a/tests/integration/cases/binary/Dart_combined.dart
+++ b/tests/integration/cases/binary/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = <String>[
-      "48656c6c6f",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "48656c6c6f",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "48656c6c6f",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "48656c6c6f",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/bool_list/Dart_combined.dart
+++ b/tests/integration/cases/bool_list/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <bool>[
-      true,
-      false,
-      true,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <bool>[
-      true,
-      false,
-      true,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <bool>[
+        true,
+        false,
+        true,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <bool>[
+        true,
+        false,
+        true,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments/Dart_combined.dart
+++ b/tests/integration/cases/comments/Dart_combined.dart
@@ -1,25 +1,23 @@
-void _declaration() {
-  final my_data = {
-      // Server configuration
-      "host": "localhost",  // default host
-      "port": 8080,
-      // Enable debug mode
-      "debug": true,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      // Server configuration
-      "host": "localhost",  // default host
-      "port": 8080,
-      // Enable debug mode
-      "debug": true,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        // Server configuration
+        "host": "localhost",  // default host
+        "port": 8080,
+        // Enable debug mode
+        "debug": true,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        // Server configuration
+        "host": "localhost",  // default host
+        "port": 8080,
+        // Enable debug mode
+        "debug": true,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_bang_in_double_quote/Dart_combined.dart
+++ b/tests/integration/cases/comments_bang_in_double_quote/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = <String, String>{
-      "key": "\"bang!\"",  // real
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String, String>{
-      "key": "\"bang!\"",  // real
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String, String>{
+        "key": "\"bang!\"",  // real
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String, String>{
+        "key": "\"bang!\"",  // real
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_double_hash/Dart_combined.dart
+++ b/tests/integration/cases/comments_double_hash/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <String>[
-      // # section
-      "a",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      // # section
-      "a",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        // # section
+        "a",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        // # section
+        "a",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_empty_line/Dart_combined.dart
+++ b/tests/integration/cases/comments_empty_line/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <String>[
-      "a",
-      //
-      "b",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "a",
-      //
-      "b",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "a",
+        //
+        "b",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "a",
+        //
+        "b",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_escaped_quote/Dart_combined.dart
+++ b/tests/integration/cases/comments_escaped_quote/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = <String, String>{
-      "key": "value \" # not a comment",  // real
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String, String>{
-      "key": "value \" # not a comment",  // real
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String, String>{
+        "key": "value \" # not a comment",  // real
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String, String>{
+        "key": "value \" # not a comment",  // real
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_escaped_single_quote/Dart_combined.dart
+++ b/tests/integration/cases/comments_escaped_single_quote/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = <String, String>{
-      "key": "it's here",  // a comment
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String, String>{
-      "key": "it's here",  // a comment
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String, String>{
+        "key": "it's here",  // a comment
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String, String>{
+        "key": "it's here",  // a comment
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_multi_line/Dart_combined.dart
+++ b/tests/integration/cases/comments_multi_line/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <String>[
-      // line 1
-      // line 2
-      "a",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      // line 1
-      // line 2
-      "a",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        // line 1
+        // line 2
+        "a",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        // line 1
+        // line 2
+        "a",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_nested_mapping/Dart_combined.dart
+++ b/tests/integration/cases/comments_nested_mapping/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = {
-      "a": <String, int>{"x": 1},
-      "b": 2,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "a": <String, int>{"x": 1},
-      "b": 2,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "a": <String, int>{"x": 1},
+        "b": 2,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "a": <String, int>{"x": 1},
+        "b": 2,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_sequence_before/Dart_combined.dart
+++ b/tests/integration/cases/comments_sequence_before/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = <String>[
-      // first
-      "a",
-      // second
-      "b",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      // first
-      "a",
-      // second
-      "b",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        // first
+        "a",
+        // second
+        "b",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        // first
+        "a",
+        // second
+        "b",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_sequence_inline/Dart_combined.dart
+++ b/tests/integration/cases/comments_sequence_inline/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <String>[
-      "a",  // note a
-      "b",  // note b
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "a",  // note a
-      "b",  // note b
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "a",  // note a
+        "b",  // note b
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "a",  // note a
+        "b",  // note b
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_trailing/Dart_combined.dart
+++ b/tests/integration/cases/comments_trailing/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <String>[
-      "a",
-      // trailing
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "a",
-      // trailing
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "a",
+        // trailing
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "a",
+        // trailing
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/comments_vb_before_dim/Dart_combined.dart
+++ b/tests/integration/cases/comments_vb_before_dim/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = {
-      // Configuration
-      "name": "app",
-      // Port setting
-      "port": 3000,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      // Configuration
-      "name": "app",
-      // Port setting
-      "port": 3000,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        // Configuration
+        "name": "app",
+        // Port setting
+        "port": 3000,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        // Configuration
+        "name": "app",
+        // Port setting
+        "port": 3000,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/date_list/Dart_combined.dart
+++ b/tests/integration/cases/date_list/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <DateTime>[
-      DateTime.parse("2024-01-15"),
-      DateTime.parse("2024-02-20"),
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <DateTime>[
-      DateTime.parse("2024-01-15"),
-      DateTime.parse("2024-02-20"),
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <DateTime>[
+        DateTime.parse("2024-01-15"),
+        DateTime.parse("2024-02-20"),
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <DateTime>[
+        DateTime.parse("2024-01-15"),
+        DateTime.parse("2024-02-20"),
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/date_set/Dart_combined.dart
+++ b/tests/integration/cases/date_set/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = {
-      DateTime.parse("2024-01-15"),
-      DateTime.parse("2024-06-01"),
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      DateTime.parse("2024-01-15"),
-      DateTime.parse("2024-06-01"),
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        DateTime.parse("2024-01-15"),
+        DateTime.parse("2024-06-01"),
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        DateTime.parse("2024-01-15"),
+        DateTime.parse("2024-06-01"),
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/dates/Dart_combined.dart
+++ b/tests/integration/cases/dates/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = {
-      "date": DateTime.parse("2024-01-15"),
-      "datetime": DateTime.parse("2024-01-15T12:30:00+00:00"),
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "date": DateTime.parse("2024-01-15"),
-      "datetime": DateTime.parse("2024-01-15T12:30:00+00:00"),
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "date": DateTime.parse("2024-01-15"),
+        "datetime": DateTime.parse("2024-01-15T12:30:00+00:00"),
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "date": DateTime.parse("2024-01-15"),
+        "datetime": DateTime.parse("2024-01-15T12:30:00+00:00"),
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/deep_nesting/Dart_combined.dart
+++ b/tests/integration/cases/deep_nesting/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = {
-      "level1": {"level2": {"level3": {"level4": {"value": "deep", "items": <String>["a", "b"]}}, "sibling": 42}, "tags": [{"name": "tag1", "meta": {"priority": 1, "labels": <String>["x", "y"]}}]},
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "level1": {"level2": {"level3": {"level4": {"value": "deep", "items": <String>["a", "b"]}}, "sibling": 42}, "tags": [{"name": "tag1", "meta": {"priority": 1, "labels": <String>["x", "y"]}}]},
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "level1": {"level2": {"level3": {"level4": {"value": "deep", "items": <String>["a", "b"]}}, "sibling": 42}, "tags": [{"name": "tag1", "meta": {"priority": 1, "labels": <String>["x", "y"]}}]},
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "level1": {"level2": {"level3": {"level4": {"value": "deep", "items": <String>["a", "b"]}}, "sibling": 42}, "tags": [{"name": "tag1", "meta": {"priority": 1, "labels": <String>["x", "y"]}}]},
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/dict_with_control_char_keys/Dart_combined.dart
+++ b/tests/integration/cases/dict_with_control_char_keys/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <String, String>{
-      "key\nwith\nnewlines": "value1",
-      "key\twith\ttabs": "value2",
-      "": "value3",
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String, String>{
-      "key\nwith\nnewlines": "value1",
-      "key\twith\ttabs": "value2",
-      "": "value3",
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String, String>{
+        "key\nwith\nnewlines": "value1",
+        "key\twith\ttabs": "value2",
+        "": "value3",
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String, String>{
+        "key\nwith\nnewlines": "value1",
+        "key\twith\ttabs": "value2",
+        "": "value3",
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/dict_with_nulls/Dart_combined.dart
+++ b/tests/integration/cases/dict_with_nulls/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = {
-      "name": "Alice",
-      "score": null,
-      "age": 30,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "name": "Alice",
-      "score": null,
-      "age": 30,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "name": "Alice",
+        "score": null,
+        "age": 30,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "name": "Alice",
+        "score": null,
+        "age": 30,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/empty_dict/Dart_combined.dart
+++ b/tests/integration/cases/empty_dict/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = {};
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {};
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {};
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {};
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/empty_list/Dart_combined.dart
+++ b/tests/integration/cases/empty_list/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = [];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/empty_sequence/Dart_combined.dart
+++ b/tests/integration/cases/empty_sequence/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = [
-      [],
-      {},
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      [],
-      {},
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        [],
+        {},
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        [],
+        {},
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/empty_set/Dart_combined.dart
+++ b/tests/integration/cases/empty_set/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = <dynamic>{};
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <dynamic>{};
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <dynamic>{};
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <dynamic>{};
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/float_list/Dart_combined.dart
+++ b/tests/integration/cases/float_list/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <double>[
-      1.1,
-      2.2,
-      3.3,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <double>[
-      1.1,
-      2.2,
-      3.3,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <double>[
+        1.1,
+        2.2,
+        3.3,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <double>[
+        1.1,
+        2.2,
+        3.3,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/int_list/Dart_combined.dart
+++ b/tests/integration/cases/int_list/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <int>[
-      1,
-      2,
-      3,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <int>[
-      1,
-      2,
-      3,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <int>[
+        1,
+        2,
+        3,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <int>[
+        1,
+        2,
+        3,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/int_list_large/Dart_combined.dart
+++ b/tests/integration/cases/int_list_large/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = <int>[
-      1000000,
-      -1234,
-      255,
-      -10,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <int>[
-      1000000,
-      -1234,
-      255,
-      -10,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <int>[
+        1000000,
+        -1234,
+        255,
+        -10,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <int>[
+        1000000,
+        -1234,
+        255,
+        -10,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/int_set/Dart_combined.dart
+++ b/tests/integration/cases/int_set/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = {
-      1,
-      2,
-      3,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      1,
-      2,
-      3,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        1,
+        2,
+        3,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        1,
+        2,
+        3,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/mixed_number_dict/Dart_combined.dart
+++ b/tests/integration/cases/mixed_number_dict/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <String, double>{
-      "a": 1,
-      "b": 2.5,
-      "c": 3,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String, double>{
-      "a": 1,
-      "b": 2.5,
-      "c": 3,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String, double>{
+        "a": 1,
+        "b": 2.5,
+        "c": 3,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String, double>{
+        "a": 1,
+        "b": 2.5,
+        "c": 3,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/mixed_number_list/Dart_combined.dart
+++ b/tests/integration/cases/mixed_number_list/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <double>[
-      1,
-      2.5,
-      3,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <double>[
-      1,
-      2.5,
-      3,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <double>[
+        1,
+        2.5,
+        3,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <double>[
+        1,
+        2.5,
+        3,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/mixed_set/Dart_combined.dart
+++ b/tests/integration/cases/mixed_set/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = {
-      true,
-      42,
-      "apple",
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      true,
-      42,
-      "apple",
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        true,
+        42,
+        "apple",
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        true,
+        42,
+        "apple",
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested/Dart_combined.dart
+++ b/tests/integration/cases/nested/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = {
-      "users": [{"name": "Bob", "tags": <String>["admin", "user"]}, {"name": "Carol", "tags": <String>["guest"]}],
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "users": [{"name": "Bob", "tags": <String>["admin", "user"]}, {"name": "Carol", "tags": <String>["guest"]}],
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "users": [{"name": "Bob", "tags": <String>["admin", "user"]}, {"name": "Carol", "tags": <String>["guest"]}],
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "users": [{"name": "Bob", "tags": <String>["admin", "user"]}, {"name": "Carol", "tags": <String>["guest"]}],
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_bool_list/Dart_combined.dart
+++ b/tests/integration/cases/nested_bool_list/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <List<bool>>[
-      <bool>[true, false],
-      <bool>[true, true],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <List<bool>>[
-      <bool>[true, false],
-      <bool>[true, true],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <List<bool>>[
+        <bool>[true, false],
+        <bool>[true, true],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <List<bool>>[
+        <bool>[true, false],
+        <bool>[true, true],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/Dart_combined.dart
+++ b/tests/integration/cases/nested_collection_multi_space_string/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = [
-      {"key": "hello   world", "value": 1},
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      {"key": "hello   world", "value": 1},
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        {"key": "hello   world", "value": 1},
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        {"key": "hello   world", "value": 1},
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_deep_empty/Dart_combined.dart
+++ b/tests/integration/cases/nested_deep_empty/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = [
-      [[], []],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      [[], []],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        [[], []],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        [[], []],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_deep_mixed/Dart_combined.dart
+++ b/tests/integration/cases/nested_deep_mixed/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = [
-      [<int>[1, 2], <String>["a", "b"]],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      [<int>[1, 2], <String>["a", "b"]],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        [<int>[1, 2], <String>["a", "b"]],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        [<int>[1, 2], <String>["a", "b"]],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_empty_inner/Dart_combined.dart
+++ b/tests/integration/cases/nested_empty_inner/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = [
-      [],
-      [],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      [],
-      [],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        [],
+        [],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        [],
+        [],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_float_list/Dart_combined.dart
+++ b/tests/integration/cases/nested_float_list/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <List<double>>[
-      <double>[1.5, 2.5],
-      <double>[3.5, 4.5],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <List<double>>[
-      <double>[1.5, 2.5],
-      <double>[3.5, 4.5],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <List<double>>[
+        <double>[1.5, 2.5],
+        <double>[3.5, 4.5],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <List<double>>[
+        <double>[1.5, 2.5],
+        <double>[3.5, 4.5],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_mixed_inner/Dart_combined.dart
+++ b/tests/integration/cases/nested_mixed_inner/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = [
-      [1, "a"],
-      [2, "b"],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      [1, "a"],
-      [2, "b"],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        [1, "a"],
+        [2, "b"],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        [1, "a"],
+        [2, "b"],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_mixed_types/Dart_combined.dart
+++ b/tests/integration/cases/nested_mixed_types/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = [
-      <int>[1, 2],
-      <String>["a", "b"],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      <int>[1, 2],
-      <String>["a", "b"],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        <int>[1, 2],
+        <String>["a", "b"],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        <int>[1, 2],
+        <String>["a", "b"],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_sequence/Dart_combined.dart
+++ b/tests/integration/cases/nested_sequence/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = [
-      true,
-      "hi",
-      <int>[1, 2],
-      null,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      true,
-      "hi",
-      <int>[1, 2],
-      null,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        true,
+        "hi",
+        <int>[1, 2],
+        null,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        true,
+        "hi",
+        <int>[1, 2],
+        null,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/nested_sequences/Dart_combined.dart
+++ b/tests/integration/cases/nested_sequences/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <List<List<int>>>[
-      <List<int>>[<int>[1, 2], <int>[3, 4]],
-      <List<int>>[<int>[5]],
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <List<List<int>>>[
-      <List<int>>[<int>[1, 2], <int>[3, 4]],
-      <List<int>>[<int>[5]],
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <List<List<int>>>[
+        <List<int>>[<int>[1, 2], <int>[3, 4]],
+        <List<int>>[<int>[5]],
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <List<List<int>>>[
+        <List<int>>[<int>[1, 2], <int>[3, 4]],
+        <List<int>>[<int>[5]],
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/no_comment/Dart_combined.dart
+++ b/tests/integration/cases/no_comment/Dart_combined.dart
@@ -1,17 +1,15 @@
-void _declaration() {
-  final my_data = <String, String>{
-      "message": "no comment here",
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String, String>{
-      "message": "no comment here",
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String, String>{
+        "message": "no comment here",
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String, String>{
+        "message": "no comment here",
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/ordered_map/Dart_combined.dart
+++ b/tests/integration/cases/ordered_map/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = {
-      "name": "Alice",
-      "age": 30,
-      "active": true,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "name": "Alice",
-      "age": 30,
-      "active": true,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "name": "Alice",
+        "age": 30,
+        "active": true,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "name": "Alice",
+        "age": 30,
+        "active": true,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/pair_sequence/Dart_combined.dart
+++ b/tests/integration/cases/pair_sequence/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = [
-      1,
-      "hello",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      1,
-      "hello",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        1,
+        "hello",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        1,
+        "hello",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalar_date/Dart_combined.dart
+++ b/tests/integration/cases/scalar_date/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = DateTime.parse("2024-01-15");
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = DateTime.parse("2024-01-15");
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = DateTime.parse("2024-01-15");
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = DateTime.parse("2024-01-15");
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalar_datetime/Dart_combined.dart
+++ b/tests/integration/cases/scalar_datetime/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = DateTime.parse("2024-01-15T12:30:00+00:00");
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = DateTime.parse("2024-01-15T12:30:00+00:00");
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = DateTime.parse("2024-01-15T12:30:00+00:00");
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = DateTime.parse("2024-01-15T12:30:00+00:00");
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalar_datetime_microsecond/Dart_combined.dart
+++ b/tests/integration/cases/scalar_datetime_microsecond/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = DateTime.parse("2024-01-15T12:30:00.123456+00:00");
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = DateTime.parse("2024-01-15T12:30:00.123456+00:00");
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = DateTime.parse("2024-01-15T12:30:00.123456+00:00");
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = DateTime.parse("2024-01-15T12:30:00.123456+00:00");
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalar_datetime_midnight/Dart_combined.dart
+++ b/tests/integration/cases/scalar_datetime_midnight/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = DateTime.parse("2024-01-15T00:00:00");
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = DateTime.parse("2024-01-15T00:00:00");
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = DateTime.parse("2024-01-15T00:00:00");
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = DateTime.parse("2024-01-15T00:00:00");
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalar_datetime_naive/Dart_combined.dart
+++ b/tests/integration/cases/scalar_datetime_naive/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = DateTime.parse("2024-01-15T12:30:00");
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = DateTime.parse("2024-01-15T12:30:00");
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = DateTime.parse("2024-01-15T12:30:00");
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = DateTime.parse("2024-01-15T12:30:00");
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/Dart_combined.dart
+++ b/tests/integration/cases/scalar_datetime_non_utc/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = DateTime.parse("2024-01-15T18:00:00+05:30");
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = DateTime.parse("2024-01-15T18:00:00+05:30");
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = DateTime.parse("2024-01-15T18:00:00+05:30");
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = DateTime.parse("2024-01-15T18:00:00+05:30");
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Dart_combined.dart
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = DateTime.parse("2024-01-15T12:30:45.123456");
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = DateTime.parse("2024-01-15T12:30:45.123456");
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = DateTime.parse("2024-01-15T12:30:45.123456");
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = DateTime.parse("2024-01-15T12:30:45.123456");
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/scalars/Dart_combined.dart
+++ b/tests/integration/cases/scalars/Dart_combined.dart
@@ -1,25 +1,23 @@
-void _declaration() {
-  final my_data = [
-      42,
-      3.14,
-      true,
-      false,
-      "hello \"world\"",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      42,
-      3.14,
-      true,
-      false,
-      "hello \"world\"",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        42,
+        3.14,
+        true,
+        false,
+        "hello \"world\"",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        42,
+        3.14,
+        true,
+        false,
+        "hello \"world\"",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/sequence_of_dicts/Dart_combined.dart
+++ b/tests/integration/cases/sequence_of_dicts/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = [
-      {"name": "Alice", "age": 30},
-      {"name": "Bob", "age": 25},
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      {"name": "Alice", "age": 30},
-      {"name": "Bob", "age": 25},
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        {"name": "Alice", "age": 30},
+        {"name": "Bob", "age": 25},
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        {"name": "Alice", "age": 30},
+        {"name": "Bob", "age": 25},
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/set/Dart_combined.dart
+++ b/tests/integration/cases/set/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = {
-      "apple",
-      "banana",
-      "cherry",
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "apple",
-      "banana",
-      "cherry",
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "apple",
+        "banana",
+        "cherry",
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "apple",
+        "banana",
+        "cherry",
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/set_comments/Dart_combined.dart
+++ b/tests/integration/cases/set_comments/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = {
-      "apple",  // inline comment
-      // before banana
-      "banana",
-      // trailing
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "apple",  // inline comment
-      // before banana
-      "banana",
-      // trailing
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "apple",  // inline comment
+        // before banana
+        "banana",
+        // trailing
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "apple",  // inline comment
+        // before banana
+        "banana",
+        // trailing
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/set_comments_unsorted_order/Dart_combined.dart
+++ b/tests/integration/cases/set_comments_unsorted_order/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = {
-      // before apple
-      "apple",
-      "banana",  // banana inline
-      // trailing
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      // before apple
-      "apple",
-      "banana",  // banana inline
-      // trailing
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        // before apple
+        "apple",
+        "banana",  // banana inline
+        // trailing
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/simple_dict/Dart_combined.dart
+++ b/tests/integration/cases/simple_dict/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = {
-      "name": "Alice",
-      "age": 30,
-      "active": true,
-      "score": null,
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "name": "Alice",
-      "age": 30,
-      "active": true,
-      "score": null,
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "name": "Alice",
+        "age": 30,
+        "active": true,
+        "score": null,
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "name": "Alice",
+        "age": 30,
+        "active": true,
+        "score": null,
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/simple_sequence/Dart_combined.dart
+++ b/tests/integration/cases/simple_sequence/Dart_combined.dart
@@ -1,23 +1,21 @@
-void _declaration() {
-  final my_data = [
-      1,
-      "hello",
-      true,
-      null,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      1,
-      "hello",
-      true,
-      null,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        1,
+        "hello",
+        true,
+        null,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        1,
+        "hello",
+        true,
+        null,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/string_control_chars/Dart_combined.dart
+++ b/tests/integration/cases/string_control_chars/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <String>[
-      "line1\r\nline2",
-      "line1\rline2",
-      "",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "line1\r\nline2",
-      "line1\rline2",
-      "",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "line1\r\nline2",
+        "line1\rline2",
+        "",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "line1\r\nline2",
+        "line1\rline2",
+        "",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Dart_combined.dart
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Dart_combined.dart
@@ -1,13 +1,11 @@
-void _declaration() {
-  final my_data = "hello \"world\" -- not a comment";
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = "hello \"world\" -- not a comment";
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = "hello \"world\" -- not a comment";
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = "hello \"world\" -- not a comment";
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/string_list/Dart_combined.dart
+++ b/tests/integration/cases/string_list/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <String>[
-      "foo",
-      "bar",
-      "baz",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "foo",
-      "bar",
-      "baz",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "foo",
+        "bar",
+        "baz",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "foo",
+        "bar",
+        "baz",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/string_with_backslash/Dart_combined.dart
+++ b/tests/integration/cases/string_with_backslash/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = <String>[
-      "C:\\path\\to\\file",
-      "back\\\\slash",
-      "hello \\\"world\\\"",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "C:\\path\\to\\file",
-      "back\\\\slash",
-      "hello \\\"world\\\"",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "C:\\path\\to\\file",
+        "back\\\\slash",
+        "hello \\\"world\\\"",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "C:\\path\\to\\file",
+        "back\\\\slash",
+        "hello \\\"world\\\"",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/string_with_dollar/Dart_combined.dart
+++ b/tests/integration/cases/string_with_dollar/Dart_combined.dart
@@ -1,19 +1,17 @@
-void _declaration() {
-  final my_data = <String>[
-      "price \$10",
-      "\$HOME",
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = <String>[
-      "price \$10",
-      "\$HOME",
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = <String>[
+        "price \$10",
+        "\$HOME",
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = <String>[
+        "price \$10",
+        "\$HOME",
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/triple_sequence/Dart_combined.dart
+++ b/tests/integration/cases/triple_sequence/Dart_combined.dart
@@ -1,21 +1,19 @@
-void _declaration() {
-  final my_data = [
-      1,
-      "hello",
-      true,
-  ];
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = [
-      1,
-      "hello",
-      true,
-  ];
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = [
+        1,
+        "hello",
+        true,
+    ];
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = [
+        1,
+        "hello",
+        true,
+    ];
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/cases/type_hints/Dart_combined.dart
+++ b/tests/integration/cases/type_hints/Dart_combined.dart
@@ -1,29 +1,27 @@
-void _declaration() {
-  final my_data = {
-      "name": "Alice",
-      "age": 30,
-      "active": true,
-      "score": null,
-      "joined": DateTime.parse("2024-01-15"),
-      "last_login": DateTime.parse("2024-01-15T12:30:00+00:00"),
-      "avatar": "48656c6c6f",
-  };
-  my_data.hashCode;
-}
-void _assignment() {
-  dynamic my_data;
-  my_data = {
-      "name": "Alice",
-      "age": 30,
-      "active": true,
-      "score": null,
-      "joined": DateTime.parse("2024-01-15"),
-      "last_login": DateTime.parse("2024-01-15T12:30:00+00:00"),
-      "avatar": "48656c6c6f",
-  };
-  my_data.hashCode;
-}
 void main() {
-  _declaration();
-  _assignment();
+  {
+    final my_data = {
+        "name": "Alice",
+        "age": 30,
+        "active": true,
+        "score": null,
+        "joined": DateTime.parse("2024-01-15"),
+        "last_login": DateTime.parse("2024-01-15T12:30:00+00:00"),
+        "avatar": "48656c6c6f",
+    };
+    my_data.hashCode;
+  }
+  {
+    dynamic my_data;
+    my_data = {
+        "name": "Alice",
+        "age": 30,
+        "active": true,
+        "score": null,
+        "joined": DateTime.parse("2024-01-15"),
+        "last_login": DateTime.parse("2024-01-15T12:30:00+00:00"),
+        "avatar": "48656c6c6f",
+    };
+    my_data.hashCode;
+  }
 }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -250,24 +250,22 @@ def _wrap_scala_combined(declaration: str, assignment: str) -> str:
 
 @beartype
 def _wrap_dart_combined(declaration: str, assignment: str) -> str:
-    """Dart: final declaration in one function, dynamic + assignment in
-    another, with a main that calls both to avoid unused-element warnings.
+    """Dart: final declaration and dynamic + assignment in block scopes
+    within one function, avoiding unused-element warnings.
     """
-    decl_indented = "  " + declaration.replace("\n", "\n  ")
-    assign_indented = "  " + assignment.replace("\n", "\n  ")
+    decl_indented = "    " + declaration.replace("\n", "\n    ")
+    assign_indented = "    " + assignment.replace("\n", "\n    ")
     return (
-        f"void _declaration() {{\n"
-        f"{decl_indented}\n"
-        f"  {_VARIABLE_NAME}.hashCode;\n"
-        f"}}\n"
-        f"void _assignment() {{\n"
-        f"  dynamic {_VARIABLE_NAME};\n"
-        f"{assign_indented}\n"
-        f"  {_VARIABLE_NAME}.hashCode;\n"
-        f"}}\n"
         f"void main() {{\n"
-        f"  _declaration();\n"
-        f"  _assignment();\n"
+        f"  {{\n"
+        f"{decl_indented}\n"
+        f"    {_VARIABLE_NAME}.hashCode;\n"
+        f"  }}\n"
+        f"  {{\n"
+        f"    dynamic {_VARIABLE_NAME};\n"
+        f"{assign_indented}\n"
+        f"    {_VARIABLE_NAME}.hashCode;\n"
+        f"  }}\n"
         f"}}"
     )
 


### PR DESCRIPTION
## Summary
- Simplifies `_wrap_dart_combined` in the integration tests to use a single `main()` function with block scopes instead of two separate named functions (`_declaration` and `_assignment`) called from `main()`.
- Regenerated all 66 Dart combined golden files to match.

## Test plan
- [x] All 150 Dart integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test wrapping and regenerated Dart golden files, with no impact on library/runtime behavior.
> 
> **Overview**
> Simplifies Dart “combined” integration-test wrapping by generating a single `main()` with two block scopes (one for `final` declaration and one for `dynamic` + assignment) instead of separate `_declaration()`/`_assignment()` functions.
> 
> Regenerates all Dart `*_combined.dart` golden files to match the new structure and updated indentation while preserving the same declaration/assignment semantics and unused-variable suppression (`hashCode`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3c0238fabd88d69a40c32d9061c2fa5483baec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->