### PR TITLE
Use match statements for type dispatch and remove frozenset from Value

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -61,7 +61,7 @@ def _collect_value_types(*, data: Value) -> frozenset[type]:
         for v in data.values():
             child_types = child_types | _collect_value_types(data=v)
         return frozenset({dict, str}) | child_types
-    if isinstance(data, (set, frozenset)):
+    if isinstance(data, set):
         scalar_types: frozenset[type] = frozenset(
             t
             for v in data
@@ -87,7 +87,7 @@ def _has_empty_collection(*, data: Value) -> bool:
             _has_empty_collection(data=v)  # pyright: ignore[reportUnknownArgumentType]
             for v in data.values()  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
         )
-    if isinstance(data, (set, frozenset)):
+    if isinstance(data, set):
         return len(data) == 0
     if isinstance(data, list):
         if not data:
@@ -307,14 +307,15 @@ def _has_heterogeneous(*, data: Value) -> bool:
     """Recursively check whether data contains any heterogeneous
     all-scalar collections.
     """
-    if isinstance(data, (ordereddict, dict)):
-        children: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-    elif isinstance(data, list):
-        children = data
-    elif isinstance(data, (set, frozenset)):
-        return _all_scalars_heterogeneous(values=list(data))
-    else:
-        return False
+    match data:
+        case ordereddict() | dict():
+            children: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        case list():
+            children = data
+        case set():
+            return _all_scalars_heterogeneous(values=list(data))
+        case _:
+            return False
 
     return any(
         _has_heterogeneous(data=v) for v in children
@@ -432,17 +433,17 @@ def _coerce_heterogeneous_scalars(
     """Recursively coerce heterogeneous all-scalar collections to
     strings.
     """
-    if isinstance(data, ordereddict):
-        return _coerce_heterogeneous_ordereddict(data=data)
-    if isinstance(data, dict):
-        return _coerce_heterogeneous_dict(data=data)
-    if isinstance(data, set):
-        return _coerce_heterogeneous_set(data=data)
-    if isinstance(data, frozenset):
-        return data  # pragma: no cover
-    if isinstance(data, list):
-        return _coerce_heterogeneous_list(data=data)
-    return data
+    match data:
+        case ordereddict():
+            return _coerce_heterogeneous_ordereddict(data=data)
+        case dict():
+            return _coerce_heterogeneous_dict(data=data)
+        case set():
+            return _coerce_heterogeneous_set(data=data)
+        case list():
+            return _coerce_heterogeneous_list(data=data)
+        case _:
+            return data
 
 
 @beartype
@@ -597,22 +598,23 @@ def _has_mixed_list_values(*, data: Value) -> bool:
 @beartype
 def _format_scalar(*, value: Scalar, spec: Language) -> str:
     """Format a scalar JSON value as a native language literal."""
-    if value is None:
-        result = spec.null_literal
-    elif isinstance(value, bool):
-        result = spec.true_literal if value else spec.false_literal
-    elif isinstance(value, int):
-        result = spec.format_integer(value)
-    elif isinstance(value, float):
-        result = repr(value)
-    elif isinstance(value, str):
-        result = spec.format_string(value)
-    elif isinstance(value, bytes):
-        result = spec.format_bytes(value)
-    elif isinstance(value, datetime.datetime):
-        result = spec.format_datetime(value)
-    else:
-        result = spec.format_date(value)
+    match value:
+        case None:
+            result = spec.null_literal
+        case bool():
+            result = spec.true_literal if value else spec.false_literal
+        case int():
+            result = spec.format_integer(value)
+        case float():
+            result = repr(value)
+        case str():
+            result = spec.format_string(value)
+        case bytes():
+            result = spec.format_bytes(value)
+        case datetime.datetime():
+            result = spec.format_datetime(value)
+        case _:
+            result = spec.format_date(value)
     return result
 
 
@@ -625,9 +627,7 @@ def _build_dict_entry(
 
 
 @beartype
-def _format_set_value(
-    *, value: set[Scalar] | frozenset[Scalar], spec: Language
-) -> str:
+def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
     """Format a set value as a native language literal."""
     set_cfg = spec.set_format_config
 
@@ -732,19 +732,17 @@ def _format_value(
 
     Handles scalars, lists (recursively), dicts, and sets.
     """
-    if isinstance(value, ordereddict):
-        return _format_ordered_map_value(value=value, spec=spec)
-
-    if isinstance(value, dict):
-        return _format_dict_value(value=value, spec=spec)
-
-    if isinstance(value, (set, frozenset)):
-        return _format_set_value(value=value, spec=spec)
-
-    if isinstance(value, list):
-        return _format_list_value(value=value, spec=spec)
-
-    return _format_scalar(value=value, spec=spec)
+    match value:
+        case ordereddict():
+            return _format_ordered_map_value(value=value, spec=spec)
+        case dict():
+            return _format_dict_value(value=value, spec=spec)
+        case set():
+            return _format_set_value(value=value, spec=spec)
+        case list():
+            return _format_list_value(value=value, spec=spec)
+        case _:
+            return _format_scalar(value=value, spec=spec)
 
 
 @beartype
@@ -752,7 +750,7 @@ def _wrap_body(
     *,
     body: str,
     is_ordered_map: bool,
-    data: list[Value] | dict[str, Value] | set[Scalar] | frozenset[Scalar],
+    data: list[Value] | dict[str, Value] | set[Scalar],
     spec: Language,
     line_prefix: str,
 ) -> str:
@@ -769,7 +767,7 @@ def _wrap_body(
 
         opening = f"{line_prefix}{dict_cfg.open_fn(data)}"
         closing = f"{close_prefix}{dict_cfg.close}"
-    elif isinstance(data, (set, frozenset)):
+    elif isinstance(data, set):
         sorted_set: list[Value] = sorted(
             data,
             key=lambda v: (type(v).__name__, repr(v)),
@@ -950,7 +948,7 @@ def _literalize(
             add_sep = i < last_idx or spec.multiline_trailing_comma
             sep = spec.element_separator.strip() if add_sep else ""
             lines.append(f"{body_prefix}{entry}{sep}")
-    elif isinstance(data, (set, frozenset)):
+    elif isinstance(data, set):
         sorted_items = sorted(data, key=lambda v: (type(v).__name__, repr(v)))
         last_idx = len(sorted_items) - 1
         for i, item in enumerate(iterable=sorted_items):
@@ -1221,7 +1219,7 @@ def _resolve_yaml_comments(
     include_delimiters: bool,
 ) -> _ResolvedComments:
     """Parse YAML for comment metadata and resolve comments."""
-    if isinstance(data, (set, frozenset)):
+    if isinstance(data, set):
         # https://sourceforge.net/p/ruamel-yaml/tickets/328/
         ruamel_set: CommentedSet = YAML().load(  # pyright: ignore[reportUnknownMemberType]
             stream=StringIO(initial_value=yaml_string),

--- a/src/literalizer/_types.py
+++ b/src/literalizer/_types.py
@@ -5,6 +5,4 @@ import datetime
 type Scalar = (
     str | int | float | bool | None | datetime.date | datetime.datetime | bytes
 )
-type Value = (
-    Scalar | list[Value] | dict[str, Value] | set[Scalar] | frozenset[Scalar]
-)
+type Value = Scalar | list[Value] | dict[str, Value] | set[Scalar]

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -35,15 +35,17 @@ if TYPE_CHECKING:
 @beartype
 def _format_ada_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate Ada ``A_Val`` constructor."""
-    if isinstance(original, bool):
-        return formatted
-    if isinstance(original, int):
-        return f"AInt ({formatted})"
-    if isinstance(original, float):
-        return f"AFloat ({formatted})"
-    if isinstance(original, (str, bytes, datetime.date)):
-        return f"AStr ({formatted})"
-    return formatted
+    match original:
+        case bool():
+            return formatted
+        case int():
+            return f"AInt ({formatted})"
+        case float():
+            return f"AFloat ({formatted})"
+        case str() | bytes() | datetime.date():
+            return f"AStr ({formatted})"
+        case _:
+            return formatted
 
 
 @beartype

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -56,7 +56,7 @@ def _to_bash_value(item: str) -> str:
 @beartype
 def _format_bash_sequence_entry(original: Value, item: str) -> str:
     """Format a Bash indexed-array element, quoting nested collections."""
-    if isinstance(original, (list, dict, set, frozenset)):
+    if isinstance(original, (list, dict, set)):
         escaped = (
             item.replace("\\", "\\\\")
             .replace('"', '\\"')

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -37,15 +37,17 @@ def _format_c_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate ``_CVal`` union
     literal.
     """
-    if isinstance(original, (str, bytes, datetime.date)):
-        return f"((_CVal){{.s = {formatted}}})"
-    if isinstance(original, bool):
-        return formatted
-    if isinstance(original, int):
-        return f"((_CVal){{.i = {formatted}}})"
-    if isinstance(original, float):
-        return f"((_CVal){{.f = {formatted}}})"
-    return formatted
+    match original:
+        case str() | bytes() | datetime.date():
+            return f"((_CVal){{.s = {formatted}}})"
+        case bool():
+            return formatted
+        case int():
+            return f"((_CVal){{.i = {formatted}}})"
+        case float():
+            return f"((_CVal){{.f = {formatted}}})"
+        case _:
+            return formatted
 
 
 @beartype

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 @beartype
 def _format_d_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in ``JSONValue(...)``."""
-    if isinstance(original, (list, dict, set, frozenset)):
+    if isinstance(original, (list, dict, set)):
         return formatted
     return f"JSONValue({formatted})"
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -37,15 +37,17 @@ def _format_fortran_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate ``fval_t``
     constructor.
     """
-    if isinstance(original, bool):
-        return formatted
-    if isinstance(original, int):
-        return f"fint({formatted})"
-    if isinstance(original, float):
-        return f"freal({formatted})"
-    if isinstance(original, (str, bytes, datetime.date)):
-        return f"fstr({formatted})"
-    return formatted
+    match original:
+        case bool():
+            return formatted
+        case int():
+            return f"fint({formatted})"
+        case float():
+            return f"freal({formatted})"
+        case str() | bytes() | datetime.date():
+            return f"fstr({formatted})"
+        case _:
+            return formatted
 
 
 @beartype

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -40,19 +40,23 @@ def _format_fsharp_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate F# ``Val``
     constructor.
     """
-    if isinstance(original, bool):
-        return formatted
-    if isinstance(original, int):
-        negative = formatted.startswith("-")
-        return f"FInt({formatted}L)" if negative else f"FInt {formatted}L"
-    if isinstance(original, float):
-        negative = formatted.startswith("-")
-        return f"FFloat({formatted})" if negative else f"FFloat {formatted}"
-    if isinstance(original, (str, bytes, datetime.date)):
-        if formatted.startswith("System."):
-            return f"FStr (string ({formatted}))"
-        return f"FStr {formatted}"
-    return formatted
+    match original:
+        case bool():
+            return formatted
+        case int():
+            negative = formatted.startswith("-")
+            return f"FInt({formatted}L)" if negative else f"FInt {formatted}L"
+        case float():
+            negative = formatted.startswith("-")
+            return (
+                f"FFloat({formatted})" if negative else f"FFloat {formatted}"
+            )
+        case str() | bytes() | datetime.date():
+            if formatted.startswith("System."):
+                return f"FStr (string ({formatted}))"
+            return f"FStr {formatted}"
+        case _:
+            return formatted
 
 
 @beartype

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -52,19 +52,23 @@ def _format_ocaml_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate OCaml ``val_t``
     constructor.
     """
-    if isinstance(original, bool):
-        return formatted
-    if isinstance(original, int):
-        negative = formatted.startswith("-")
-        return f"OInt ({formatted})" if negative else f"OInt {formatted}"
-    if isinstance(original, float):
-        negative = formatted.startswith("-")
-        return f"OFloat ({formatted})" if negative else f"OFloat {formatted}"
-    if isinstance(original, (str, bytes)):
-        return f"OStr {formatted}"
-    if isinstance(original, datetime.date) and formatted.startswith('"'):
-        return f"OStr {formatted}"
-    return formatted
+    match original:
+        case bool():
+            return formatted
+        case int():
+            negative = formatted.startswith("-")
+            return f"OInt ({formatted})" if negative else f"OInt {formatted}"
+        case float():
+            negative = formatted.startswith("-")
+            return (
+                f"OFloat ({formatted})" if negative else f"OFloat {formatted}"
+            )
+        case str() | bytes():
+            return f"OStr {formatted}"
+        case datetime.date() if formatted.startswith('"'):
+            return f"OStr {formatted}"
+        case _:
+            return formatted
 
 
 @beartype

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -38,15 +38,17 @@ def _format_occam_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate occam-pi ``LIT``
     constructor.
     """
-    if isinstance(original, bool):
-        return formatted
-    if isinstance(original, int):
-        return f"MOBILE LIT(lit.int; {formatted})"
-    if isinstance(original, float):
-        return f"MOBILE LIT(lit.float; {formatted}(REAL32))"
-    if isinstance(original, (str, bytes, datetime.date)):
-        return f"MOBILE LIT(lit.str; MOBILE []BYTE {formatted})"
-    return formatted
+    match original:
+        case bool():
+            return formatted
+        case int():
+            return f"MOBILE LIT(lit.int; {formatted})"
+        case float():
+            return f"MOBILE LIT(lit.float; {formatted}(REAL32))"
+        case str() | bytes() | datetime.date():
+            return f"MOBILE LIT(lit.str; MOBILE []BYTE {formatted})"
+        case _:
+            return formatted
 
 
 @beartype

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -121,8 +121,9 @@ def _element_union(*, types: list[str]) -> str:
 @beartype
 def _collection_element_union(
     *,
-    elements: frozenset[Value] | list[Value],
+    elements: list[Value],
     recurse: Callable[..., str],
+    sort: bool = False,
 ) -> str:
     """Return the element union for a collection, or ``"Any"`` if
     empty.
@@ -130,7 +131,7 @@ def _collection_element_union(
     if not elements:
         return "Any"
     types = [recurse(data=e) for e in elements]
-    if isinstance(elements, frozenset):
+    if sort:
         types.sort()
     return _element_union(types=types)
 
@@ -187,10 +188,11 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
                 recurse=recurse,
             )
             return f"{outer}[str, {val_union}]"
-        case set() | frozenset():
+        case set():
             elem_union = _collection_element_union(
-                elements=frozenset(data),
+                elements=list(data),
                 recurse=recurse,
+                sort=True,
             )
             return f"{set_hint}[{elem_union}]"
         case list():

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -58,18 +58,20 @@ def _format_zig_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate Zig ``ZVal`` union
     tag.
     """
-    if isinstance(original, bool):
-        return formatted
-    if isinstance(original, int):
-        return f".{{ .int = {formatted} }}"
-    if isinstance(original, float):
-        return f".{{ .float = {formatted} }}"
-    if isinstance(original, (str, bytes)):
-        return f".{{ .str = {formatted} }}"
-    if isinstance(original, datetime.date):
-        tag = "str" if formatted.startswith('"') else "int"
-        return f".{{ .{tag} = {formatted} }}"
-    return formatted
+    match original:
+        case bool():
+            return formatted
+        case int():
+            return f".{{ .int = {formatted} }}"
+        case float():
+            return f".{{ .float = {formatted} }}"
+        case str() | bytes():
+            return f".{{ .str = {formatted} }}"
+        case datetime.date():
+            tag = "str" if formatted.startswith('"') else "int"
+            return f".{{ .{tag} = {formatted} }}"
+        case _:
+            return formatted
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace isinstance check chains with match/case statements in `_core.py` (4 functions: `_has_heterogeneous`, `_coerce_heterogeneous_scalars`, `_format_scalar`, `_format_value`) and 7 language files (`ada`, `c`, `fortran`, `fsharp`, `ocaml`, `occam`, `zig`)
- Remove `frozenset[Scalar]` from the `Value` type alias — frozensets are never produced by YAML or JSON parsing, so the branches handling them were dead code (including a `# pragma: no cover` workaround)
- Clean up all resulting dead `frozenset` branches across `_core.py`, `bash.py`, `d.py`, and `python.py`

## Test plan
- [x] All 275 tests pass
- [x] pyrefly type checker passes with 0 errors
- [x] All pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes `frozenset` support from the public `Value` type and several runtime dispatch paths, which could break callers that previously passed `frozenset` inputs. Logic is mostly refactoring to `match/case`, but it touches core formatting/coercion code paths across multiple languages.
> 
> **Overview**
> Refactors core type-dispatch logic to use Python `match/case` instead of `isinstance` chains for heterogeneous checks/coercions and value formatting (e.g. `_has_heterogeneous`, `_coerce_heterogeneous_scalars`, `_format_scalar`, `_format_value`).
> 
> Simplifies the data model by removing `frozenset` from the `Value` alias and deletes the now-dead `frozenset` branches throughout core formatting/wrapping/comment-resolution and several language backends; Python type-hint generation for sets is adjusted to explicitly sort element unions for stable output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd337df4c01e0bbc7b8fffb7090afe4adbb5c2f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->