### PR TITLE
Use match statement for collection type dispatch

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -913,6 +913,8 @@ def _format_collection_lines(
                 add_sep = i < last_idx or trailing_comma
                 sep = spec.element_separator.strip() if add_sep else ""
                 lines.append(f"{body_prefix}{formatted}{sep}")
+        case _:  # pragma: no cover
+            pass
     return lines
 
 


### PR DESCRIPTION
## Summary
- Replace the `if/elif/else` isinstance chain in `_literalize` with a `match` statement for clearer collection type dispatch
- Extract `_format_collection_lines` helper to keep both functions under the C901 complexity limit
- The `case list()` branch makes the intent explicit, removing the need for the `# data must be a list` comment

## Test plan
- [x] All 7132 existing tests pass
- [x] All pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in literal formatting that should be behavior-preserving, but it touches core output formatting paths for dict/set/list multiline rendering.
> 
> **Overview**
> Refactors `_literalize` to delegate multiline dict/set/list element formatting to a new helper, `_format_collection_lines`, using a `match` statement for collection-type dispatch.
> 
> Behavior is intended to be unchanged, including handling of skipped null dict values, ordered-map formatting, and multiline trailing-comma/separator logic, while reducing complexity in `_literalize`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 345ce3e91a600e4cdca095dce803623bfb2d0875. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->