### PR TITLE
Emit only used Val constructors in F# output

### DIFF
--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -5,6 +5,7 @@ import enum
 from typing import TYPE_CHECKING
 
 from beartype import beartype
+from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters import (
     date_ymd_formatter,
@@ -363,33 +364,31 @@ class FSharp(metaclass=LanguageCls):
         self.static_preamble: Sequence[str] = ()
         self.static_body_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}
-        _type_val: tuple[str, ...] = (
-            "type Val =\n"
-            "    | FNull\n"
-            "    | FBool of bool\n"
-            "    | FInt of int64\n"
-            "    | FFloat of float\n"
-            "    | FStr of string\n"
-            "    | FList of Val list\n"
-            "    | FMap of (string * Val) list\n"
-            "    | FSet of Val list\n"
-            "    | FDate of System.DateTime\n"
-            "    | FDatetime of System.DateTime",
-        )
-        _all_types = (
-            type(None),
-            bool,
-            int,
-            float,
-            str,
-            bytes,
-            datetime.date,
-            datetime.datetime,
-            list,
-            set,
-        )
+        _header = "type Val ="
+        _f_str = "    | FStr of string"
         self.scalar_body_preamble: dict[
             type,
             tuple[str, ...],
-        ] = dict.fromkeys(_all_types, _type_val)
+        ] = {
+            type(None): (_header, "    | FNull"),
+            bool: (_header, "    | FBool of bool"),
+            int: (_header, "    | FInt of int64"),
+            float: (_header, "    | FFloat of float"),
+            str: (_header, _f_str),
+            bytes: (_header, _f_str),
+            list: (_header, "    | FList of Val list"),
+            dict: (_header, "    | FMap of (string * Val) list"),
+            ordereddict: (_header, "    | FMap of (string * Val) list"),
+            set: (_header, "    | FSet of Val list"),
+            datetime.date: (
+                _header,
+                _f_str,
+                "    | FDate of System.DateTime",
+            ),
+            datetime.datetime: (
+                _header,
+                _f_str,
+                "    | FDatetime of System.DateTime",
+            ),
+        }
         self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/tests/integration/cases/binary/FSharp.fs
+++ b/tests/integration/cases/binary/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "48656c6c6f"
 ]

--- a/tests/integration/cases/binary/FSharp_combined.fs
+++ b/tests/integration/cases/binary/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "48656c6c6f"
 ]

--- a/tests/integration/cases/bool_list/FSharp.fs
+++ b/tests/integration/cases/bool_list/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FBool true;
     FBool false;

--- a/tests/integration/cases/bool_list/FSharp_combined.fs
+++ b/tests/integration/cases/bool_list/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FBool true;
     FBool false;

--- a/tests/integration/cases/comments/FSharp.fs
+++ b/tests/integration/cases/comments/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     // Server configuration
     ("host", FStr "localhost");  // default host

--- a/tests/integration/cases/comments/FSharp_combined.fs
+++ b/tests/integration/cases/comments/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     // Server configuration
     ("host", FStr "localhost");  // default host

--- a/tests/integration/cases/comments/FSharp_comment_block.fs
+++ b/tests/integration/cases/comments/FSharp_comment_block.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     (* Server configuration *)
     ("host", FStr "localhost");  (* default host *)

--- a/tests/integration/cases/comments_bang_in_double_quote/FSharp.fs
+++ b/tests/integration/cases/comments_bang_in_double_quote/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key", FStr "\"bang!\"")  // real
 ]

--- a/tests/integration/cases/comments_bang_in_double_quote/FSharp_combined.fs
+++ b/tests/integration/cases/comments_bang_in_double_quote/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key", FStr "\"bang!\"")  // real
 ]

--- a/tests/integration/cases/comments_double_hash/FSharp.fs
+++ b/tests/integration/cases/comments_double_hash/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     // # section
     FStr "a"

--- a/tests/integration/cases/comments_double_hash/FSharp_combined.fs
+++ b/tests/integration/cases/comments_double_hash/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     // # section
     FStr "a"

--- a/tests/integration/cases/comments_empty_line/FSharp.fs
+++ b/tests/integration/cases/comments_empty_line/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "a";
     //

--- a/tests/integration/cases/comments_empty_line/FSharp_combined.fs
+++ b/tests/integration/cases/comments_empty_line/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "a";
     //

--- a/tests/integration/cases/comments_escaped_quote/FSharp.fs
+++ b/tests/integration/cases/comments_escaped_quote/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key", FStr "value \" # not a comment")  // real
 ]

--- a/tests/integration/cases/comments_escaped_quote/FSharp_combined.fs
+++ b/tests/integration/cases/comments_escaped_quote/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key", FStr "value \" # not a comment")  // real
 ]

--- a/tests/integration/cases/comments_escaped_single_quote/FSharp.fs
+++ b/tests/integration/cases/comments_escaped_single_quote/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key", FStr "it's here")  // a comment
 ]

--- a/tests/integration/cases/comments_escaped_single_quote/FSharp_combined.fs
+++ b/tests/integration/cases/comments_escaped_single_quote/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key", FStr "it's here")  // a comment
 ]

--- a/tests/integration/cases/comments_multi_line/FSharp.fs
+++ b/tests/integration/cases/comments_multi_line/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     // line 1
     // line 2

--- a/tests/integration/cases/comments_multi_line/FSharp_combined.fs
+++ b/tests/integration/cases/comments_multi_line/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     // line 1
     // line 2

--- a/tests/integration/cases/comments_nested_mapping/FSharp.fs
+++ b/tests/integration/cases/comments_nested_mapping/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("a", FMap [("x", FInt 1L)]);
     ("b", FInt 2L)

--- a/tests/integration/cases/comments_nested_mapping/FSharp_combined.fs
+++ b/tests/integration/cases/comments_nested_mapping/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("a", FMap [("x", FInt 1L)]);
     ("b", FInt 2L)

--- a/tests/integration/cases/comments_sequence_before/FSharp.fs
+++ b/tests/integration/cases/comments_sequence_before/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     // first
     FStr "a";

--- a/tests/integration/cases/comments_sequence_before/FSharp_combined.fs
+++ b/tests/integration/cases/comments_sequence_before/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     // first
     FStr "a";

--- a/tests/integration/cases/comments_sequence_inline/FSharp.fs
+++ b/tests/integration/cases/comments_sequence_inline/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "a";  // note a
     FStr "b"  // note b

--- a/tests/integration/cases/comments_sequence_inline/FSharp_combined.fs
+++ b/tests/integration/cases/comments_sequence_inline/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "a";  // note a
     FStr "b"  // note b

--- a/tests/integration/cases/comments_trailing/FSharp.fs
+++ b/tests/integration/cases/comments_trailing/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "a"
     // trailing

--- a/tests/integration/cases/comments_trailing/FSharp_combined.fs
+++ b/tests/integration/cases/comments_trailing/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "a"
     // trailing

--- a/tests/integration/cases/comments_vb_before_dim/FSharp.fs
+++ b/tests/integration/cases/comments_vb_before_dim/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     // Configuration
     ("name", FStr "app");

--- a/tests/integration/cases/comments_vb_before_dim/FSharp_combined.fs
+++ b/tests/integration/cases/comments_vb_before_dim/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     // Configuration
     ("name", FStr "app");

--- a/tests/integration/cases/date_list/FSharp.fs
+++ b/tests/integration/cases/date_list/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
+    | FStr of string
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr (string (System.DateOnly(2024, 1, 15)));
     FStr (string (System.DateOnly(2024, 2, 20)))

--- a/tests/integration/cases/date_list/FSharp_combined.fs
+++ b/tests/integration/cases/date_list/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
+    | FStr of string
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr (string (System.DateOnly(2024, 1, 15)));
     FStr (string (System.DateOnly(2024, 2, 20)))

--- a/tests/integration/cases/date_list/FSharp_date_iso.fs
+++ b/tests/integration/cases/date_list/FSharp_date_iso.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
+    | FStr of string
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "2024-01-15";
     FStr "2024-02-20"

--- a/tests/integration/cases/date_set/FSharp.fs
+++ b/tests/integration/cases/date_set/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
+    | FStr of string
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FStr (string (System.DateOnly(2024, 1, 15)));
     FStr (string (System.DateOnly(2024, 6, 1)))

--- a/tests/integration/cases/date_set/FSharp_combined.fs
+++ b/tests/integration/cases/date_set/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
+    | FStr of string
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FStr (string (System.DateOnly(2024, 1, 15)));
     FStr (string (System.DateOnly(2024, 6, 1)))

--- a/tests/integration/cases/date_set/FSharp_date_iso.fs
+++ b/tests/integration/cases/date_set/FSharp_date_iso.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
+    | FStr of string
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FStr "2024-01-15";
     FStr "2024-06-01"

--- a/tests/integration/cases/dates/FSharp.fs
+++ b/tests/integration/cases/dates/FSharp.fs
@@ -1,14 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
     | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FMap [

--- a/tests/integration/cases/dates/FSharp_combined.fs
+++ b/tests/integration/cases/dates/FSharp_combined.fs
@@ -1,14 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
     | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FMap [

--- a/tests/integration/cases/deep_nesting/FSharp.fs
+++ b/tests/integration/cases/deep_nesting/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("level1", FMap [("level2", FMap [("level3", FMap [("level4", FMap [("value", FStr "deep"); ("items", FList [FStr "a"; FStr "b"])])]); ("sibling", FInt 42L)]); ("tags", FList [FMap [("name", FStr "tag1"); ("meta", FMap [("priority", FInt 1L); ("labels", FList [FStr "x"; FStr "y"])])]])])
 ]

--- a/tests/integration/cases/deep_nesting/FSharp_combined.fs
+++ b/tests/integration/cases/deep_nesting/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("level1", FMap [("level2", FMap [("level3", FMap [("level4", FMap [("value", FStr "deep"); ("items", FList [FStr "a"; FStr "b"])])]); ("sibling", FInt 42L)]); ("tags", FList [FMap [("name", FStr "tag1"); ("meta", FMap [("priority", FInt 1L); ("labels", FList [FStr "x"; FStr "y"])])]])])
 ]

--- a/tests/integration/cases/dict_with_control_char_keys/FSharp.fs
+++ b/tests/integration/cases/dict_with_control_char_keys/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key\nwith\nnewlines", FStr "value1");
     ("key\twith\ttabs", FStr "value2");

--- a/tests/integration/cases/dict_with_control_char_keys/FSharp_combined.fs
+++ b/tests/integration/cases/dict_with_control_char_keys/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("key\nwith\nnewlines", FStr "value1");
     ("key\twith\ttabs", FStr "value2");

--- a/tests/integration/cases/dict_with_list_value/FSharp.fs
+++ b/tests/integration/cases/dict_with_list_value/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("scores", FList [FInt 10L; FInt 20L; FInt 30L])

--- a/tests/integration/cases/dict_with_list_value/FSharp_combined.fs
+++ b/tests/integration/cases/dict_with_list_value/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("scores", FList [FInt 10L; FInt 20L; FInt 30L])

--- a/tests/integration/cases/dict_with_nulls/FSharp.fs
+++ b/tests/integration/cases/dict_with_nulls/FSharp.fs
@@ -2,15 +2,9 @@ module Check
 
 type Val =
     | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("score", FNull);

--- a/tests/integration/cases/dict_with_nulls/FSharp_combined.fs
+++ b/tests/integration/cases/dict_with_nulls/FSharp_combined.fs
@@ -2,15 +2,9 @@ module Check
 
 type Val =
     | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("score", FNull);

--- a/tests/integration/cases/empty_dict/FSharp.fs
+++ b/tests/integration/cases/empty_dict/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap []

--- a/tests/integration/cases/empty_dict/FSharp_combined.fs
+++ b/tests/integration/cases/empty_dict/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap []

--- a/tests/integration/cases/empty_list/FSharp.fs
+++ b/tests/integration/cases/empty_list/FSharp.fs
@@ -1,14 +1,5 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList []

--- a/tests/integration/cases/empty_list/FSharp_combined.fs
+++ b/tests/integration/cases/empty_list/FSharp_combined.fs
@@ -1,14 +1,5 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList []

--- a/tests/integration/cases/empty_list/FSharp_declaration_style_let_mutable.fs
+++ b/tests/integration/cases/empty_list/FSharp_declaration_style_let_mutable.fs
@@ -1,14 +1,5 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let mutable my_data: Val = FList []

--- a/tests/integration/cases/empty_sequence/FSharp.fs
+++ b/tests/integration/cases/empty_sequence/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [];
     FMap []

--- a/tests/integration/cases/empty_sequence/FSharp_combined.fs
+++ b/tests/integration/cases/empty_sequence/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [];
     FMap []

--- a/tests/integration/cases/empty_set/FSharp.fs
+++ b/tests/integration/cases/empty_set/FSharp.fs
@@ -1,14 +1,5 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet []

--- a/tests/integration/cases/empty_set/FSharp_combined.fs
+++ b/tests/integration/cases/empty_set/FSharp_combined.fs
@@ -1,14 +1,5 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet []

--- a/tests/integration/cases/float_list/FSharp.fs
+++ b/tests/integration/cases/float_list/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
     | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FFloat 1.1;
     FFloat 2.2;

--- a/tests/integration/cases/float_list/FSharp_combined.fs
+++ b/tests/integration/cases/float_list/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
     | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FFloat 1.1;
     FFloat 2.2;

--- a/tests/integration/cases/int_list/FSharp.fs
+++ b/tests/integration/cases/int_list/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FInt 2L;

--- a/tests/integration/cases/int_list/FSharp_combined.fs
+++ b/tests/integration/cases/int_list/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FInt 2L;

--- a/tests/integration/cases/int_list/FSharp_integer_format_binary.fs
+++ b/tests/integration/cases/int_list/FSharp_integer_format_binary.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 0b1L;
     FInt 0b10L;

--- a/tests/integration/cases/int_list/FSharp_integer_format_hex.fs
+++ b/tests/integration/cases/int_list/FSharp_integer_format_hex.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 0x1L;
     FInt 0x2L;

--- a/tests/integration/cases/int_list/FSharp_integer_format_octal.fs
+++ b/tests/integration/cases/int_list/FSharp_integer_format_octal.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 0o1L;
     FInt 0o2L;

--- a/tests/integration/cases/int_list_large/FSharp.fs
+++ b/tests/integration/cases/int_list_large/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1000000L;
     FInt(-1234L);

--- a/tests/integration/cases/int_list_large/FSharp_combined.fs
+++ b/tests/integration/cases/int_list_large/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1000000L;
     FInt(-1234L);

--- a/tests/integration/cases/int_list_large/FSharp_integer_format_binary_large.fs
+++ b/tests/integration/cases/int_list_large/FSharp_integer_format_binary_large.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 0b11110100001001000000L;
     FInt(-0b10011010010L);

--- a/tests/integration/cases/int_list_large/FSharp_integer_format_hex_large.fs
+++ b/tests/integration/cases/int_list_large/FSharp_integer_format_hex_large.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 0xf4240L;
     FInt(-0x4d2L);

--- a/tests/integration/cases/int_list_large/FSharp_integer_format_octal_large.fs
+++ b/tests/integration/cases/int_list_large/FSharp_integer_format_octal_large.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 0o3641100L;
     FInt(-0o2322L);

--- a/tests/integration/cases/int_set/FSharp.fs
+++ b/tests/integration/cases/int_set/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FInt 1L;
     FInt 2L;

--- a/tests/integration/cases/int_set/FSharp_combined.fs
+++ b/tests/integration/cases/int_set/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FInt 1L;
     FInt 2L;

--- a/tests/integration/cases/mixed_number_dict/FSharp.fs
+++ b/tests/integration/cases/mixed_number_dict/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
     | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("a", FInt 1L);
     ("b", FFloat 2.5);

--- a/tests/integration/cases/mixed_number_dict/FSharp_combined.fs
+++ b/tests/integration/cases/mixed_number_dict/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
     | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("a", FInt 1L);
     ("b", FFloat 2.5);

--- a/tests/integration/cases/mixed_number_list/FSharp.fs
+++ b/tests/integration/cases/mixed_number_list/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
     | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FFloat 2.5;

--- a/tests/integration/cases/mixed_number_list/FSharp_combined.fs
+++ b/tests/integration/cases/mixed_number_list/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
     | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FFloat 2.5;

--- a/tests/integration/cases/mixed_set/FSharp.fs
+++ b/tests/integration/cases/mixed_set/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FBool true;
     FInt 42L;

--- a/tests/integration/cases/mixed_set/FSharp_combined.fs
+++ b/tests/integration/cases/mixed_set/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FBool true;
     FInt 42L;

--- a/tests/integration/cases/nested/FSharp.fs
+++ b/tests/integration/cases/nested/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("users", FList [FMap [("name", FStr "Bob"); ("tags", FList [FStr "admin"; FStr "user"])]; FMap [("name", FStr "Carol"); ("tags", FList [FStr "guest"])]])
 ]

--- a/tests/integration/cases/nested/FSharp_combined.fs
+++ b/tests/integration/cases/nested/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("users", FList [FMap [("name", FStr "Bob"); ("tags", FList [FStr "admin"; FStr "user"])]; FMap [("name", FStr "Carol"); ("tags", FList [FStr "guest"])]])
 ]

--- a/tests/integration/cases/nested_bool_list/FSharp.fs
+++ b/tests/integration/cases/nested_bool_list/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FBool true; FBool false];
     FList [FBool true; FBool true]

--- a/tests/integration/cases/nested_bool_list/FSharp_combined.fs
+++ b/tests/integration/cases/nested_bool_list/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FBool true; FBool false];
     FList [FBool true; FBool true]

--- a/tests/integration/cases/nested_collection_multi_space_string/FSharp.fs
+++ b/tests/integration/cases/nested_collection_multi_space_string/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FMap [("key", FStr "hello   world"); ("value", FInt 1L)]
 ]

--- a/tests/integration/cases/nested_collection_multi_space_string/FSharp_combined.fs
+++ b/tests/integration/cases/nested_collection_multi_space_string/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FMap [("key", FStr "hello   world"); ("value", FInt 1L)]
 ]

--- a/tests/integration/cases/nested_deep_empty/FSharp.fs
+++ b/tests/integration/cases/nested_deep_empty/FSharp.fs
@@ -1,16 +1,7 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FList []; FList []]
 ]

--- a/tests/integration/cases/nested_deep_empty/FSharp_combined.fs
+++ b/tests/integration/cases/nested_deep_empty/FSharp_combined.fs
@@ -1,16 +1,7 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FList []; FList []]
 ]

--- a/tests/integration/cases/nested_deep_mixed/FSharp.fs
+++ b/tests/integration/cases/nested_deep_mixed/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FList [FInt 1L; FInt 2L]; FList [FStr "a"; FStr "b"]]
 ]

--- a/tests/integration/cases/nested_deep_mixed/FSharp_combined.fs
+++ b/tests/integration/cases/nested_deep_mixed/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FList [FInt 1L; FInt 2L]; FList [FStr "a"; FStr "b"]]
 ]

--- a/tests/integration/cases/nested_empty_inner/FSharp.fs
+++ b/tests/integration/cases/nested_empty_inner/FSharp.fs
@@ -1,16 +1,7 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [];
     FList []

--- a/tests/integration/cases/nested_empty_inner/FSharp_combined.fs
+++ b/tests/integration/cases/nested_empty_inner/FSharp_combined.fs
@@ -1,16 +1,7 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [];
     FList []

--- a/tests/integration/cases/nested_float_list/FSharp.fs
+++ b/tests/integration/cases/nested_float_list/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
     | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FFloat 1.5; FFloat 2.5];
     FList [FFloat 3.5; FFloat 4.5]

--- a/tests/integration/cases/nested_float_list/FSharp_combined.fs
+++ b/tests/integration/cases/nested_float_list/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
     | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FFloat 1.5; FFloat 2.5];
     FList [FFloat 3.5; FFloat 4.5]

--- a/tests/integration/cases/nested_mixed_inner/FSharp.fs
+++ b/tests/integration/cases/nested_mixed_inner/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FInt 1L; FStr "a"];
     FList [FInt 2L; FStr "b"]

--- a/tests/integration/cases/nested_mixed_inner/FSharp_combined.fs
+++ b/tests/integration/cases/nested_mixed_inner/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FInt 1L; FStr "a"];
     FList [FInt 2L; FStr "b"]

--- a/tests/integration/cases/nested_mixed_types/FSharp.fs
+++ b/tests/integration/cases/nested_mixed_types/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FInt 1L; FInt 2L];
     FList [FStr "a"; FStr "b"]

--- a/tests/integration/cases/nested_mixed_types/FSharp_combined.fs
+++ b/tests/integration/cases/nested_mixed_types/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FInt 1L; FInt 2L];
     FList [FStr "a"; FStr "b"]

--- a/tests/integration/cases/nested_sequence/FSharp.fs
+++ b/tests/integration/cases/nested_sequence/FSharp.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FBool true;
     FStr "hi";

--- a/tests/integration/cases/nested_sequence/FSharp_combined.fs
+++ b/tests/integration/cases/nested_sequence/FSharp_combined.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FBool true;
     FStr "hi";

--- a/tests/integration/cases/nested_sequences/FSharp.fs
+++ b/tests/integration/cases/nested_sequences/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FList [FInt 1L; FInt 2L]; FList [FInt 3L; FInt 4L]];
     FList [FList [FInt 5L]]

--- a/tests/integration/cases/nested_sequences/FSharp_combined.fs
+++ b/tests/integration/cases/nested_sequences/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
-    | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FList [FList [FInt 1L; FInt 2L]; FList [FInt 3L; FInt 4L]];
     FList [FList [FInt 5L]]

--- a/tests/integration/cases/no_comment/FSharp.fs
+++ b/tests/integration/cases/no_comment/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("message", FStr "no comment here")
 ]

--- a/tests/integration/cases/no_comment/FSharp_combined.fs
+++ b/tests/integration/cases/no_comment/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("message", FStr "no comment here")
 ]

--- a/tests/integration/cases/ordered_map/FSharp.fs
+++ b/tests/integration/cases/ordered_map/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("age", FInt 30L);

--- a/tests/integration/cases/ordered_map/FSharp_combined.fs
+++ b/tests/integration/cases/ordered_map/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("age", FInt 30L);

--- a/tests/integration/cases/pair_sequence/FSharp.fs
+++ b/tests/integration/cases/pair_sequence/FSharp.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FStr "hello"

--- a/tests/integration/cases/pair_sequence/FSharp_combined.fs
+++ b/tests/integration/cases/pair_sequence/FSharp_combined.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FStr "hello"

--- a/tests/integration/cases/pair_sequence/FSharp_sequence_array_pair.fs
+++ b/tests/integration/cases/pair_sequence/FSharp_sequence_array_pair.fs
@@ -1,16 +1,9 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val array = [|
     FInt 1L;
     FStr "hello"

--- a/tests/integration/cases/scalar_date/FSharp.fs
+++ b/tests/integration/cases/scalar_date/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateOnly(2024, 1, 15)))

--- a/tests/integration/cases/scalar_date/FSharp_combined.fs
+++ b/tests/integration/cases/scalar_date/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateOnly(2024, 1, 15)))

--- a/tests/integration/cases/scalar_date/FSharp_date_iso.fs
+++ b/tests/integration/cases/scalar_date/FSharp_date_iso.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
     | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FStr "2024-01-15"

--- a/tests/integration/cases/scalar_datetime/FSharp.fs
+++ b/tests/integration/cases/scalar_datetime/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 0)))

--- a/tests/integration/cases/scalar_datetime/FSharp_combined.fs
+++ b/tests/integration/cases/scalar_datetime/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 0)))

--- a/tests/integration/cases/scalar_datetime/FSharp_datetime_iso.fs
+++ b/tests/integration/cases/scalar_datetime/FSharp_datetime_iso.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr "2024-01-15T12:30:00+00:00"

--- a/tests/integration/cases/scalar_datetime_microsecond/FSharp.fs
+++ b/tests/integration/cases/scalar_datetime_microsecond/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 0)))

--- a/tests/integration/cases/scalar_datetime_microsecond/FSharp_combined.fs
+++ b/tests/integration/cases/scalar_datetime_microsecond/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 0)))

--- a/tests/integration/cases/scalar_datetime_midnight/FSharp.fs
+++ b/tests/integration/cases/scalar_datetime_midnight/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 0, 0, 0)))

--- a/tests/integration/cases/scalar_datetime_midnight/FSharp_combined.fs
+++ b/tests/integration/cases/scalar_datetime_midnight/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 0, 0, 0)))

--- a/tests/integration/cases/scalar_datetime_naive/FSharp.fs
+++ b/tests/integration/cases/scalar_datetime_naive/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 0)))

--- a/tests/integration/cases/scalar_datetime_naive/FSharp_combined.fs
+++ b/tests/integration/cases/scalar_datetime_naive/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 0)))

--- a/tests/integration/cases/scalar_datetime_naive/FSharp_datetime_iso_naive.fs
+++ b/tests/integration/cases/scalar_datetime_naive/FSharp_datetime_iso_naive.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr "2024-01-15T12:30:00"

--- a/tests/integration/cases/scalar_datetime_non_utc/FSharp.fs
+++ b/tests/integration/cases/scalar_datetime_non_utc/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 18, 0, 0)))

--- a/tests/integration/cases/scalar_datetime_non_utc/FSharp_combined.fs
+++ b/tests/integration/cases/scalar_datetime_non_utc/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 18, 0, 0)))

--- a/tests/integration/cases/scalar_datetime_non_utc/FSharp_datetime_iso_non_utc.fs
+++ b/tests/integration/cases/scalar_datetime_non_utc/FSharp_datetime_iso_non_utc.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr "2024-01-15T18:00:00+05:30"

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/FSharp.fs
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/FSharp.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 45)))

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/FSharp_combined.fs
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/FSharp_combined.fs
@@ -1,14 +1,6 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 45)))

--- a/tests/integration/cases/scalars/FSharp.fs
+++ b/tests/integration/cases/scalars/FSharp.fs
@@ -1,16 +1,11 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
     | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 42L;
     FFloat 3.14;

--- a/tests/integration/cases/scalars/FSharp_combined.fs
+++ b/tests/integration/cases/scalars/FSharp_combined.fs
@@ -1,16 +1,11 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
     | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 42L;
     FFloat 3.14;

--- a/tests/integration/cases/sequence_of_dicts/FSharp.fs
+++ b/tests/integration/cases/sequence_of_dicts/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FMap [("name", FStr "Alice"); ("age", FInt 30L)];
     FMap [("name", FStr "Bob"); ("age", FInt 25L)]

--- a/tests/integration/cases/sequence_of_dicts/FSharp_combined.fs
+++ b/tests/integration/cases/sequence_of_dicts/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FMap [("name", FStr "Alice"); ("age", FInt 30L)];
     FMap [("name", FStr "Bob"); ("age", FInt 25L)]

--- a/tests/integration/cases/set/FSharp.fs
+++ b/tests/integration/cases/set/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FStr "apple";
     FStr "banana";

--- a/tests/integration/cases/set/FSharp_combined.fs
+++ b/tests/integration/cases/set/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FStr "apple";
     FStr "banana";

--- a/tests/integration/cases/set_comments/FSharp.fs
+++ b/tests/integration/cases/set_comments/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FStr "apple";  // inline comment
     // before banana

--- a/tests/integration/cases/set_comments/FSharp_combined.fs
+++ b/tests/integration/cases/set_comments/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     FStr "apple";  // inline comment
     // before banana

--- a/tests/integration/cases/set_comments_unsorted_order/FSharp.fs
+++ b/tests/integration/cases/set_comments_unsorted_order/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     // before apple
     FStr "apple";

--- a/tests/integration/cases/set_comments_unsorted_order/FSharp_combined.fs
+++ b/tests/integration/cases/set_comments_unsorted_order/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
     | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FSet [
     // before apple
     FStr "apple";

--- a/tests/integration/cases/simple_dict/FSharp.fs
+++ b/tests/integration/cases/simple_dict/FSharp.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("age", FInt 30L);

--- a/tests/integration/cases/simple_dict/FSharp_combined.fs
+++ b/tests/integration/cases/simple_dict/FSharp_combined.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FMap [
     ("name", FStr "Alice");
     ("age", FInt 30L);

--- a/tests/integration/cases/simple_dict/FSharp_declaration_style_let_mutable.fs
+++ b/tests/integration/cases/simple_dict/FSharp_declaration_style_let_mutable.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let mutable my_data: Val = FMap [
     ("name", FStr "Alice");
     ("age", FInt 30L);

--- a/tests/integration/cases/simple_sequence/FSharp.fs
+++ b/tests/integration/cases/simple_sequence/FSharp.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/simple_sequence/FSharp_combined.fs
+++ b/tests/integration/cases/simple_sequence/FSharp_combined.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/simple_sequence/FSharp_declaration_style_let_mutable.fs
+++ b/tests/integration/cases/simple_sequence/FSharp_declaration_style_let_mutable.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let mutable my_data: Val = FList [
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/simple_sequence/FSharp_sequence_array.fs
+++ b/tests/integration/cases/simple_sequence/FSharp_sequence_array.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val array = [|
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/simple_sequence/FSharp_sequence_array_varname.fs
+++ b/tests/integration/cases/simple_sequence/FSharp_sequence_array_varname.fs
@@ -4,13 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val array = [|
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/string_control_chars/FSharp.fs
+++ b/tests/integration/cases/string_control_chars/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "line1\r\nline2";
     FStr "line1\rline2";

--- a/tests/integration/cases/string_control_chars/FSharp_combined.fs
+++ b/tests/integration/cases/string_control_chars/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "line1\r\nline2";
     FStr "line1\rline2";

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/FSharp.fs
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/FSharp.fs
@@ -1,14 +1,5 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FStr "hello \"world\" -- not a comment"

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/FSharp_combined.fs
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/FSharp_combined.fs
@@ -1,14 +1,5 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FStr "hello \"world\" -- not a comment"

--- a/tests/integration/cases/string_list/FSharp.fs
+++ b/tests/integration/cases/string_list/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "foo";
     FStr "bar";

--- a/tests/integration/cases/string_list/FSharp_combined.fs
+++ b/tests/integration/cases/string_list/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "foo";
     FStr "bar";

--- a/tests/integration/cases/string_with_backslash/FSharp.fs
+++ b/tests/integration/cases/string_with_backslash/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "C:\\path\\to\\file";
     FStr "back\\\\slash";

--- a/tests/integration/cases/string_with_backslash/FSharp_combined.fs
+++ b/tests/integration/cases/string_with_backslash/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "C:\\path\\to\\file";
     FStr "back\\\\slash";

--- a/tests/integration/cases/string_with_dollar/FSharp.fs
+++ b/tests/integration/cases/string_with_dollar/FSharp.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "price $10";
     FStr "$HOME"

--- a/tests/integration/cases/string_with_dollar/FSharp_combined.fs
+++ b/tests/integration/cases/string_with_dollar/FSharp_combined.fs
@@ -1,16 +1,8 @@
 module Check
 
 type Val =
-    | FNull
-    | FBool of bool
-    | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FStr "price $10";
     FStr "$HOME"

--- a/tests/integration/cases/triple_sequence/FSharp.fs
+++ b/tests/integration/cases/triple_sequence/FSharp.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/triple_sequence/FSharp_combined.fs
+++ b/tests/integration/cases/triple_sequence/FSharp_combined.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val = FList [
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/triple_sequence/FSharp_sequence_array_triple.fs
+++ b/tests/integration/cases/triple_sequence/FSharp_sequence_array_triple.fs
@@ -1,16 +1,10 @@
 module Check
 
 type Val =
-    | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
     | FList of Val list
-    | FMap of (string * Val) list
-    | FSet of Val list
-    | FDate of System.DateTime
-    | FDatetime of System.DateTime
 let my_data: Val array = [|
     FInt 1L;
     FStr "hello";

--- a/tests/integration/cases/type_hints/FSharp.fs
+++ b/tests/integration/cases/type_hints/FSharp.fs
@@ -4,11 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
     | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FMap [

--- a/tests/integration/cases/type_hints/FSharp_combined.fs
+++ b/tests/integration/cases/type_hints/FSharp_combined.fs
@@ -4,11 +4,8 @@ type Val =
     | FNull
     | FBool of bool
     | FInt of int64
-    | FFloat of float
     | FStr of string
-    | FList of Val list
     | FMap of (string * Val) list
-    | FSet of Val list
     | FDate of System.DateTime
     | FDatetime of System.DateTime
 let my_data: Val = FMap [

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -239,32 +239,10 @@ _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {  # pyrefly: ignore[bad-ass
     ),
     FSHARP: _VariableSyntax(
         declaration=(
-            "type Val =\n"
-            "    | FNull\n"
-            "    | FBool of bool\n"
-            "    | FInt of int64\n"
-            "    | FFloat of float\n"
-            "    | FStr of string\n"
-            "    | FList of Val list\n"
-            "    | FMap of (string * Val) list\n"
-            "    | FSet of Val list\n"
-            "    | FDate of System.DateTime\n"
-            "    | FDatetime of System.DateTime\n"
-            "let my_var: Val = FInt 42L"
+            "type Val =\n    | FInt of int64\nlet my_var: Val = FInt 42L"
         ),
         assignment=(
-            "type Val =\n"
-            "    | FNull\n"
-            "    | FBool of bool\n"
-            "    | FInt of int64\n"
-            "    | FFloat of float\n"
-            "    | FStr of string\n"
-            "    | FList of Val list\n"
-            "    | FMap of (string * Val) list\n"
-            "    | FSet of Val list\n"
-            "    | FDate of System.DateTime\n"
-            "    | FDatetime of System.DateTime\n"
-            "let my_var: Val = FInt 42L"
+            "type Val =\n    | FInt of int64\nlet my_var: Val = FInt 42L"
         ),
     ),
     CLOJURE: _VariableSyntax(


### PR DESCRIPTION
## Summary
- F# output now only includes `Val` discriminated union constructors for types actually present in the data, instead of always emitting the full type definition with all constructors
- Each type maps to its own constructor line(s) in `scalar_body_preamble`, leveraging the existing deduplication logic to assemble the minimal `type Val` block
- Added `dict` and `ordereddict` mappings so `FMap` is properly included when maps are present

Closes #697

## Test plan
- [x] All 7132 tests pass (155 F# integration tests regenerated)
- [x] Verified fixture output: `bool_list` now has only `FBool` and `FList` constructors
- [x] Verified dates, dicts, nested structures all produce correct minimal constructor sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes F# code generation output structure by emitting only the `Val` union cases required by the input data, which could affect downstream consumers that relied on the full union definition. Risk is mitigated by broad integration fixture updates but still impacts generated code format.
> 
> **Overview**
> F# output generation now **emits only the `Val` discriminated union constructors actually used** in the input data, instead of always outputting the full union definition.
> 
> This refactors `FSharp.scalar_body_preamble` to map each Python type to its own `type Val =` header plus relevant constructor line(s), relying on existing preamble deduplication to assemble a minimal union; it also adds explicit support for `dict` and `ruamel.yaml` `ordereddict` to ensure `FMap` is included when maps are present.
> 
> Integration fixtures and variable declaration/assignment expectations were regenerated/updated to match the new minimal `Val` definitions across many F# test cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02d9859ed02e1e7ec04f4b81f24f649a40f4666e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->