### PR TITLE
Pin build==1.4.0 to fix check-manifest in uv venvs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.11.24",
+    # build 1.4.1 breaks in pip-less venvs (uv).
+    # Remove when https://github.com/pypa/build/pull/1003 is released.
+    "build==1.4.0",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
## Summary

- Pin `build==1.4.0` as a dev dependency to work around a regression in `build` 1.4.1
- `build` 1.4.1 refactored `_has_valid_outer_pip` and introduced a bug where it returns `True` when pip is not installed, causing `check-manifest` to fail with `No module named pip` in uv-managed venvs
- A fix exists upstream (https://github.com/pypa/build/pull/1003) but has not been released; the pin can be removed once it is

## Test plan

- [x] `uv run --extra=dev -m check_manifest` passes with this pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a dev dependency pin to work around an upstream regression; no runtime/library code changes.
> 
> **Overview**
> Pins dev dependency `build` to `1.4.0` (with explanatory comments) to avoid a `build` `1.4.1` regression that breaks `check-manifest` in pip-less `uv` virtualenvs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a6c4f401747f6afa62ce3712d5ba965df715edb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->