### PR TITLE
Use keyword argument in VB string parts call

### DIFF
--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -91,7 +91,7 @@ def _format_string_vb(value: str) -> str:
     tabs are expressed via ``vbCrLf``, ``vbTab``, or ``Chr(N)`` string
     concatenation.
     """
-    parts = _vb_string_parts(value)  # type: ignore[misc]
+    parts = _vb_string_parts(value=value)
     if not parts:
         return '""'
     if len(parts) == 1:


### PR DESCRIPTION
Use an explicit keyword argument for `_vb_string_parts(value=value)` instead of a positional call with `# type: ignore[misc]`. This satisfies mypy-strict-kwargs without suppressing the error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a no-op refactor that only changes `_vb_string_parts` invocation style to satisfy type checking, without altering string formatting logic.
> 
> **Overview**
> Updates VB string formatting to call `_vb_string_parts(value=value)` with an explicit keyword argument and removes the associated `# type: ignore[misc]` suppression to satisfy `mypy` strict-kwargs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8efc0a2d6d8070b411295e6c6d2cb2d285f6db81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->