### PR TITLE
Remove assert_never branch from _python_type_hint

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -211,6 +211,8 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
                 return f"{sequence_hint}[{elem_union}, ...]"
             return f"{sequence_hint}[{elem_union}]"
 
+    raise AssertionError  # pragma: no cover
+
 
 @beartype
 class Python(metaclass=LanguageCls):


### PR DESCRIPTION
## Summary
- Removed the `case _: assert_never(data)` branch from `_python_type_hint` in `python.py`
- Removed the unused `assert_never` import
- Added an unreachable `raise AssertionError` after the match block to satisfy pyrefly's return-path analysis

## Test plan
- [ ] CI passes (all type checkers: mypy, pyright, pyrefly, ty)
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts an unreachable exhaustiveness/return-path guard in `_python_type_hint` and removes an unused import, with no change to supported value-to-hint mappings.
> 
> **Overview**
> Removes the `typing.assert_never` import and drops the `case _`/`assert_never(data)` branch from `src/literalizer/languages/python.py`.
> 
> Adds an explicit unreachable `raise AssertionError` after the `match` in `_python_type_hint` to satisfy static return-path analysis, and updates the pylint suppression comment accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2316379fec958372d3daa7a008074051beca8058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->