### PR TITLE
Remove type: ignore[assignment] in Crystal

### DIFF
--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -154,7 +154,7 @@ class Crystal(metaclass=LanguageCls):
 
         DECIMAL = MappingProxyType(
             mapping={
-                "NONE": str,
+                "NONE": lambda value: str(object=value),
                 "UNDERSCORE": format_integer_underscore,
             }
         )
@@ -164,10 +164,7 @@ class Crystal(metaclass=LanguageCls):
             numeric_separator: enum.Enum,
         ) -> Callable[[int], str]:
             """Return the integer formatter for the given separator."""
-            formatter: Callable[[int], str] = self.value[  # type: ignore[assignment]
-                numeric_separator.name
-            ]
-            return formatter
+            return self.value[numeric_separator.name]
 
     class NumericSeparators(enum.Enum):
         """Numeric separator options."""


### PR DESCRIPTION
## Summary
- Wrap `str` in a lambda in Crystal's `IntegerFormats.DECIMAL` mapping so mypy can verify the type without a `# type: ignore[assignment]`
- Simplify `get_formatter` to return directly instead of using an intermediate annotated variable

## Test plan
- [x] mypy passes cleanly
- [x] Manual verification that formatting still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small refactor confined to Crystal integer formatting, intended to satisfy mypy; runtime behavior should be unchanged aside from the `str` call being wrapped in a lambda.
> 
> **Overview**
> Adjusts Crystal integer formatting to remove a mypy suppression by replacing the `IntegerFormats.DECIMAL` `NONE` formatter from `str` to an explicit `lambda` wrapper.
> 
> Also simplifies `IntegerFormats.get_formatter` to return the mapping entry directly instead of using an intermediate annotated variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9227d9f11b96c7a1c918fdc78b16e6f873a5c887. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->