### PR TITLE
Document that trailing commas respect format support

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -119,7 +119,14 @@ class OrderedMapFormatConfig:
 
 @dataclasses.dataclass(frozen=True)
 class TrailingCommaConfig:
-    """Configuration for trailing-comma behavior."""
+    """Configuration for trailing-comma behavior.
+
+    When ``multiline_trailing_comma`` is ``True``, trailing commas are added
+    to multiline collections where the chosen format supports them.
+    Some sequence formats (e.g. Java's ``List.of()``) do not support trailing
+    commas; in those cases the trailing comma is omitted regardless of this
+    setting.
+    """
 
     multiline_trailing_comma: bool
 
@@ -321,7 +328,11 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     """Configuration for dict formatting."""
 
     trailing_comma_config: TrailingCommaConfig
-    """Configuration for trailing-comma behavior."""
+    """Configuration for trailing-comma behavior.
+
+    Trailing commas are only added to collection formats that support them.
+    See :class:`TrailingCommaConfig` for details.
+    """
 
     @property
     def format_bytes(self) -> Callable[[bytes], str]:


### PR DESCRIPTION
## Summary

- Clarifies in `TrailingCommaConfig` and the `Language` protocol that `multiline_trailing_comma=True` only adds trailing commas where the chosen format supports them.
- Some sequence formats (e.g. Java's `List.of()`) do not support trailing commas, and in those cases the comma is silently omitted. The docstrings now make this explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying that `multiline_trailing_comma` only applies when the selected collection format supports trailing commas (e.g., Java `List.of()` omits them).
> 
> **Overview**
> Clarifies the `TrailingCommaConfig` and `Language.trailing_comma_config` docstrings to state that enabling `multiline_trailing_comma` only adds trailing commas for collection formats that explicitly support them, and they are silently omitted for formats that don’t.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f2a7935f92d195d59565184eb354fa686bae7aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->