### PR TITLE
Make indent configurable via language constructor

### DIFF
--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -226,6 +226,7 @@ class Ada(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Ada language specification."""
         self.variable_type_hints = variable_type_hints
@@ -292,7 +293,7 @@ class Ada(metaclass=LanguageCls):
                 format_value=_format_ada_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -239,6 +239,7 @@ class Bash(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Bash language specification."""
         self.variable_type_hints = variable_type_hints
@@ -293,7 +294,7 @@ class Bash(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_bash_dict_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = " "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -234,6 +234,7 @@ class C(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize C language specification."""
         self.variable_type_hints = variable_type_hints
@@ -286,7 +287,7 @@ class C(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=_format_c_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -191,6 +191,7 @@ class Clojure(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Clojure language specification."""
         self.variable_type_hints = variable_type_hints
@@ -251,7 +252,7 @@ class Clojure(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = " "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -365,6 +365,7 @@ class Cobol(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize COBOL language specification."""
         self.variable_type_hints = variable_type_hints
@@ -419,7 +420,7 @@ class Cobol(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_cobol_dict_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = "\n"
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -199,6 +199,7 @@ class CommonLisp(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Common Lisp language specification."""
         self.variable_type_hints = variable_type_hints
@@ -253,7 +254,7 @@ class CommonLisp(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_cons_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = " "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -377,6 +377,7 @@ class Cpp(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Cpp language specification."""
         self.variable_type_hints = variable_type_hints
@@ -428,7 +429,7 @@ class Cpp(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -231,6 +231,7 @@ class Crystal(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Crystal language specification."""
         self.variable_type_hints = variable_type_hints
@@ -293,7 +294,7 @@ class Crystal(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -325,6 +325,7 @@ class CSharp(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize CSharp language specification."""
         self.variable_type_hints = variable_type_hints
@@ -421,7 +422,7 @@ class CSharp(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             csharp_dict_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -249,6 +249,7 @@ class D(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize D language specification."""
         self.variable_type_hints = variable_type_hints
@@ -309,7 +310,7 @@ class D(metaclass=LanguageCls):
                 format_value=_format_d_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -280,6 +280,7 @@ class Dart(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Dart language specification."""
         self.variable_type_hints = variable_type_hints
@@ -369,7 +370,7 @@ class Dart(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -292,6 +292,7 @@ class Elixir(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Elixir language specification."""
         self.variable_type_hints = variable_type_hints
@@ -351,7 +352,7 @@ class Elixir(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -272,6 +272,7 @@ class Erlang(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Erlang language specification."""
         self.variable_type_hints = variable_type_hints
@@ -329,7 +330,7 @@ class Erlang(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -283,6 +283,7 @@ class Fortran(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Fortran language specification."""
         self.variable_type_hints = variable_type_hints
@@ -351,7 +352,7 @@ class Fortran(metaclass=LanguageCls):
                 format_value=_format_fortran_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -300,6 +300,7 @@ class FSharp(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize FSharp language specification."""
         self.variable_type_hints = variable_type_hints
@@ -353,7 +354,7 @@ class FSharp(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=_format_fsharp_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.skip_null_dict_values = False
         self.supports_collection_comments = True

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -348,6 +348,7 @@ class Go(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Go language specification."""
         self.variable_type_hints = variable_type_hints
@@ -452,7 +453,7 @@ class Go(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -196,6 +196,7 @@ class Groovy(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Groovy language specification."""
         self.variable_type_hints = variable_type_hints
@@ -256,7 +257,7 @@ class Groovy(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -403,6 +403,7 @@ class Haskell(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Haskell language specification."""
         self.variable_type_hints = variable_type_hints
@@ -462,7 +463,7 @@ class Haskell(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = "    "
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -195,6 +195,7 @@ class Hcl(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize HCL language specification."""
         self.variable_type_hints = variable_type_hints
@@ -255,7 +256,7 @@ class Hcl(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -373,6 +373,7 @@ class Java(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Java language specification."""
         self.variable_type_hints = variable_type_hints
@@ -456,7 +457,7 @@ class Java(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             java_dict_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = True

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -311,6 +311,7 @@ class JavaScript(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize JavaScript language specification."""
         self.variable_type_hints = variable_type_hints
@@ -365,7 +366,7 @@ class JavaScript(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -313,6 +313,7 @@ class Julia(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Julia language specification."""
         self.variable_type_hints = variable_type_hints
@@ -366,7 +367,7 @@ class Julia(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -384,6 +384,7 @@ class Kotlin(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Kotlin language specification."""
         self.variable_type_hints = variable_type_hints
@@ -477,7 +478,7 @@ class Kotlin(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -247,6 +247,7 @@ class Lua(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Lua language specification."""
         self.variable_type_hints = variable_type_hints
@@ -303,7 +304,7 @@ class Lua(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             lua_dict_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = True

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -312,6 +312,7 @@ class Matlab(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Matlab language specification."""
         self.variable_type_hints = variable_type_hints
@@ -368,7 +369,7 @@ class Matlab(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_matlab_dict_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -222,6 +222,7 @@ class Mojo(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Mojo language specification."""
         self.variable_type_hints = variable_type_hints
@@ -279,7 +280,7 @@ class Mojo(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_mojo_ordered_map_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -355,6 +355,7 @@ class Nim(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Nim language specification."""
         self.variable_type_hints = variable_type_hints
@@ -417,7 +418,7 @@ class Nim(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -202,6 +202,7 @@ class Norg(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Norg language specification."""
         self.variable_type_hints = variable_type_hints
@@ -262,7 +263,7 @@ class Norg(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -289,6 +289,7 @@ class ObjectiveC(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Objective-C language specification."""
         self.variable_type_hints = variable_type_hints
@@ -345,7 +346,7 @@ class ObjectiveC(metaclass=LanguageCls):
                 format_value=_format_objc_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -311,6 +311,7 @@ class OCaml(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize OCaml language specification."""
         self.variable_type_hints = variable_type_hints
@@ -368,7 +369,7 @@ class OCaml(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=_format_ocaml_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.skip_null_dict_values = False
         self.supports_collection_comments = True

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -212,6 +212,7 @@ class Occam(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Occam language specification."""
         self.variable_type_hints = variable_type_hints
@@ -274,7 +275,7 @@ class Occam(metaclass=LanguageCls):
                 format_value=_format_occam_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -290,6 +290,7 @@ class Perl(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Perl language specification."""
         self.variable_type_hints = variable_type_hints
@@ -352,7 +353,7 @@ class Perl(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -256,6 +256,7 @@ class Php(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Php language specification."""
         self.variable_type_hints = variable_type_hints
@@ -318,7 +319,7 @@ class Php(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -220,6 +220,7 @@ class PowerShell(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize PowerShell language specification."""
         self.variable_type_hints = variable_type_hints
@@ -280,7 +281,7 @@ class PowerShell(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = "; "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -531,6 +531,7 @@ class Python(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Python language specification."""
         self.variable_type_hints = variable_type_hints
@@ -592,7 +593,7 @@ class Python(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -282,6 +282,7 @@ class R(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize R language specification."""
         self.variable_type_hints = variable_type_hints
@@ -337,7 +338,7 @@ class R(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -195,6 +195,7 @@ class Racket(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Racket language specification."""
         self.variable_type_hints = variable_type_hints
@@ -255,7 +256,7 @@ class Racket(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = " "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -277,6 +277,7 @@ class Ruby(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Ruby language specification."""
         self.variable_type_hints = variable_type_hints
@@ -340,7 +341,7 @@ class Ruby(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -364,6 +364,7 @@ class Rust(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Rust language specification."""
         self.variable_type_hints = variable_type_hints
@@ -415,7 +416,7 @@ class Rust(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -383,6 +383,7 @@ class Scala(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Scala language specification."""
         self.variable_type_hints = variable_type_hints
@@ -479,7 +480,7 @@ class Scala(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -298,6 +298,7 @@ class Swift(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Swift language specification."""
         self.variable_type_hints = variable_type_hints
@@ -363,7 +364,7 @@ class Swift(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -246,6 +246,7 @@ class Toml(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize TOML language specification."""
         self.variable_type_hints = variable_type_hints
@@ -303,7 +304,7 @@ class Toml(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_toml_dict_entry
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = True

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -342,6 +342,7 @@ class TypeScript(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize TypeScript language specification."""
         self.variable_type_hints = variable_type_hints
@@ -396,7 +397,7 @@ class TypeScript(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -250,6 +250,7 @@ class VisualBasic(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize VisualBasic language specification."""
         self.variable_type_hints = variable_type_hints
@@ -348,7 +349,7 @@ class VisualBasic(metaclass=LanguageCls):
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -221,6 +221,7 @@ class Yaml(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize YAML language specification."""
         self.variable_type_hints = variable_type_hints
@@ -284,7 +285,7 @@ class Yaml(metaclass=LanguageCls):
                 format_value=passthrough_sequence_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -302,6 +302,7 @@ class Zig(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
     ) -> None:
         """Initialize Zig language specification."""
         self.variable_type_hints = variable_type_hints
@@ -365,7 +366,7 @@ class Zig(metaclass=LanguageCls):
                 format_value=_format_zig_entry,
             )
         )
-        self.indent = "    "
+        self.indent = indent
         self.multiline_close_indent = ""
         self.element_separator = ", "
         self.skip_null_dict_values = False

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -298,6 +298,29 @@ def test_include_delimiters_with_line_prefix() -> None:
     assert result.code == expected
 
 
+def test_indent_override() -> None:
+    """User-provided indent overrides the language default."""
+    language = Python(
+        date_format=Python.date_formats.PYTHON,
+        datetime_format=Python.datetime_formats.PYTHON,
+        bytes_format=Python.bytes_formats.HEX,
+        sequence_format=Python.sequence_formats.TUPLE,
+        set_format=Python.set_formats.SET,
+        indent="\t",
+    )
+    result = literalize_json(
+        json_string=json.dumps(obj=[True, False]),
+        language=language,
+        line_prefix="",
+        include_delimiters=True,
+        variable_name=None,
+        new_variable=True,
+        error_on_coercion=False,
+    )
+    expected = "(\n\tTrue,\n\tFalse,\n)"
+    assert result.code == expected
+
+
 @pytest.mark.parametrize(
     argnames="include_delimiters",
     argvalues=[False, True],

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -103,6 +103,30 @@ def test_literalize_yaml_mapping() -> None:
     assert result.code == expected
 
 
+def test_literalize_yaml_indent_override() -> None:
+    """User-provided indent overrides the language default for YAML."""
+    language = Python(
+        date_format=Python.date_formats.PYTHON,
+        datetime_format=Python.datetime_formats.PYTHON,
+        bytes_format=Python.bytes_formats.HEX,
+        sequence_format=Python.sequence_formats.TUPLE,
+        set_format=Python.set_formats.SET,
+        indent="\t",
+    )
+    yaml_string = "a: 1\nb: true\n"
+    result = literalize_yaml(
+        yaml_string=yaml_string,
+        language=language,
+        line_prefix="",
+        include_delimiters=True,
+        variable_name=None,
+        new_variable=True,
+        error_on_coercion=False,
+    )
+    expected = '{\n\t"a": 1,\n\t"b": True,\n}'
+    assert result.code == expected
+
+
 def test_literalize_yaml_invalid() -> None:
     """``literalize_yaml`` raises on invalid YAML."""
     with pytest.raises(expected_exception=YAMLParseError):


### PR DESCRIPTION
## Summary

- Adds `indent` as a constructor parameter (defaulting to `"    "`) on all 46 language classes, consistent with how other formatting options like `trailing_comma` and `string_format` are configured.
- Previously `indent` was hardcoded as `self.indent = "    "` in each language class with no way for users to override it. Now users can pass e.g. `Python(indent="\t")`.
- Includes tests for the indent override in both JSON and YAML paths.

## Test plan

- [x] All 7071 existing tests pass
- [x] New `test_indent_override` tests verify custom indent works for both `literalize_json` and `literalize_yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged by default (still 4-space indent) and the change is a straightforward constructor parameter wiring, with new tests covering the override path.
> 
> **Overview**
> Adds a new `indent` keyword argument (defaulting to four spaces) to each language class constructor and wires it to `self.indent`, replacing the previously hardcoded indentation.
> 
> Extends coverage with new tests ensuring a custom indent (e.g. tab) is respected when rendering via both `literalize_json` and `literalize_yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecb60e29b51d75c575341b44eb77397e05e5cfa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->