### PR TITLE
Remove last pragma: no cover from python.py

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -211,8 +211,8 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
             if sequence_hint == "tuple":
                 return f"{sequence_hint}[{elem_union}, ...]"
             return f"{sequence_hint}[{elem_union}]"
-        case _:  # pragma: no cover
-            assert_never(data)
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 @beartype


### PR DESCRIPTION
Remove the remaining `pragma: no cover` inline comment from `python.py` by switching to the `case _ as unreachable:` / `assert_never(unreachable)` pattern. This matches the existing `coverage.py` `exclude_also` rule in `pyproject.toml`, so no inline pragma is needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, behavior-preserving change limited to the `match` default case in Python type-hint derivation; it mainly affects coverage reporting rather than runtime logic.
> 
> **Overview**
> Removes the last inline `# pragma: no cover` in `languages/python.py` by replacing the wildcard `match` arm with `case _ as unreachable: assert_never(unreachable)`.
> 
> This aligns the unreachable-path marking with the project’s existing `coverage.py` exclusion rules while keeping the type-hint logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b158ccbc8c7991d0ca1aa3e48f9c3e23e643f099. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->