### PR TITLE
Convert isinstance check chains to match/case

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 from collections.abc import Iterable
-from typing import Any, assert_never
+from typing import Any
 
 from beartype import beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
@@ -121,15 +121,12 @@ def extract_yaml_comments(
     # mappings at index 2.
     token_idx = 2 if isinstance(ruamel_data, CommentedMap) else 0
 
-    match ruamel_data:
-        case CommentedSeq():
-            keys: list[object] = list(range(len(ruamel_data)))
-        case CommentedSet():
-            keys = list(ruamel_data)
-        case CommentedMap():  # pyright: ignore[reportUnnecessaryComparison]
-            keys = list(ruamel_data.keys())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-        case _ as unreachable:  # pragma: no cover
-            assert_never(unreachable)
+    if isinstance(ruamel_data, CommentedSeq):
+        keys: list[object] = list(range(len(ruamel_data)))
+    elif isinstance(ruamel_data, CommentedSet):
+        keys = list(ruamel_data)
+    else:
+        keys = list(ruamel_data.keys())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 
     # Iterate in insertion order so that pending_before propagation is
     # correct (a "before element N" comment is stored in the after-token


### PR DESCRIPTION
## Summary
- Convert 10 isinstance check chains to match/case statements in `_comments.py` and `_core.py`, consistent with existing match/case usage elsewhere in the codebase
- Add assert_never catch-all to the `_comments.py` match to satisfy pyrefly's unbound-name check
- Fix line-length violations from the extra indentation level

## Test plan
- [x] All 7069 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical refactors of type-dispatch logic to `match/case`, so functional risk is low; main concern is subtle behavior differences in pattern matching edge cases (e.g., subclass handling) across coercion paths.
> 
> **Overview**
> Refactors multiple helper functions in `src/literalizer/_core.py` to replace chained `isinstance` conditionals with `match/case` pattern matching for collection/scalar handling (e.g., type collection, empty-collection detection, scalar-to-string coercion, and mixed/heterogeneous collection coercions).
> 
> No new behavior is intended; changes primarily improve consistency/readability of type dispatch while preserving existing recursion and coercion rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad4b953e0c5af23734746f7ff18ee461d687f3ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->