### PR TITLE
Remove pinned build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.11.24",
-    # build 1.4.1 breaks in pip-less venvs (uv).
-    # Remove when https://github.com/pypa/build/pull/1003 is released.
-    "build==1.4.0",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
## Summary
- Remove the `build==1.4.0` pin from dev dependencies. The upstream fix (https://github.com/pypa/build/pull/1003) for the pip-less venv (uv) breakage has been released, so the pin is no longer needed.

## Test plan
- [ ] CI passes without the pinned dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates development dependency constraints by dropping the `build==1.4.0` pin; no runtime code or packaging logic changes.
> 
> **Overview**
> Removes the temporary `build==1.4.0` pin from `pyproject.toml`’s `optional-dependencies.dev`, allowing the dev environment to use the current `build` release instead of a fixed version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb2224741d1ecc77fd6f8513f842bf137137a9a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->