### PR TITLE
Document why _wrap_mojo_combined cannot use the generic combiner

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -299,11 +299,12 @@ def _wrap_mojo(content: str) -> str:
 def _wrap_mojo_combined(declaration: str, assignment: str) -> str:
     """Wrap Mojo declaration and assignment in a main function.
 
-    This cannot use ``_newline_combined(wrap=_wrap_mojo)`` because Mojo's
-    ``--Werror`` flags an assignment that is immediately overwritten without
-    being read (``assignment to 'x' was never used``).  A bare
-    ``_ = variable`` must appear *between* the declaration and the
-    reassignment, not only at the end.
+    This cannot use ``_newline_combined(wrap=_wrap_mojo)`` because the
+    Mojo ``--Werror`` flag treats an assignment that is immediately
+    overwritten without being read as an error
+    (``assignment to 'x' was never used``).  A bare ``_ = variable``
+    must appear *between* the declaration and the reassignment, not
+    only at the end.
     """
     use = f"_ = {_VARIABLE_NAME}"
     return _in_mojo_main(


### PR DESCRIPTION
## Summary
- Expands the docstring on `_wrap_mojo_combined` to explain why it exists instead of using `_newline_combined(wrap=_wrap_mojo)`.
- Mojo's `--Werror` flags assignments that are immediately overwritten without being read, so a `_ = variable` use must appear between the declaration and reassignment, not only at the end.

## Test plan
- [ ] Existing integration tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only expands a docstring in test integration helpers and does not change runtime behavior.
> 
> **Overview**
> Clarifies the rationale for the Mojo integration-test helper ` _wrap_mojo_combined`, documenting that Mojo’s `--Werror` treats an immediately-overwritten assignment as an error and therefore requires `_ = variable` to appear *between* the declaration and reassignment (not just at the end).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 692ca58af0cef3a9d4985543a41f2009f3585085. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->