### PR TITLE
Add go vet compilation check to Go lint workflow

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -41,3 +41,6 @@ jobs:
       - name: Check Go syntax
         if: steps.files.outputs.found == 'true'
         run: xargs -0 gofmt -e < /tmp/files-to-lint
+      - name: Check Go compilation
+        if: steps.files.outputs.found == 'true'
+        run: xargs -0 -n1 go vet < /tmp/files-to-lint


### PR DESCRIPTION
The existing Go lint workflow only ran `gofmt -e`, which checks formatting and syntax but not type correctness or compilation. This adds a `go vet` step to catch compilation errors and static analysis issues in the generated Go test case files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, though it may start failing PRs due to new `go vet` findings in generated/changed Go test files.
> 
> **Overview**
> The Go lint workflow now runs an additional **compilation/static analysis** pass by invoking `go vet` (one file at a time via `xargs -n1`) on the same set of Go files already checked by `gofmt -e`.
> 
> This increases CI strictness by catching type/compile issues (and vet warnings) in `tests/integration/cases/**/*.go` when relevant files are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7bfda2bd0c1e27e71e883bdc33e019df77664df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->