### PR TITLE
Move opener configs to class attributes, inline Haskell constants

### DIFF
--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -15,6 +15,7 @@ from literalizer._formatters import (
     datetime_ymdhms_formatter,
     dict_entry_with_template,
     fixed_sequence_open,
+    fixed_set_open,
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
@@ -50,22 +51,6 @@ if TYPE_CHECKING:
     from literalizer._types import Value
 
 
-_csharp_opener_config = TypedOpenerConfig(
-    str_type="string",
-    bool_type="bool",
-    int_type="int",
-    float_type="double",
-    mixed_numeric_type="double",
-    bytes_type="string",
-    date_type="DateOnly",
-    datetime_type="DateTime",
-    list_template="{inner}[]",
-    sequence_opener_template="new {type_name}[] {{",
-    dict_opener_template="new Dictionary<string, {type_name}> {{",
-    set_opener_template="new HashSet<{type_name}> {{",
-)
-
-
 @dataclasses.dataclass(frozen=True)
 class _CSharpDictSpec:
     """Per-format dict config pieces resolved at init time."""
@@ -96,6 +81,21 @@ class CSharp(metaclass=LanguageCls):
 
     extension = ".cs"
     pygments_name = "csharp"
+
+    _opener_config = TypedOpenerConfig(
+        str_type="string",
+        bool_type="bool",
+        int_type="int",
+        float_type="double",
+        mixed_numeric_type="double",
+        bytes_type="string",
+        date_type="DateOnly",
+        datetime_type="DateTime",
+        list_template="{inner}[]",
+        sequence_opener_template="new {type_name}[] {{",
+        dict_opener_template="new Dictionary<string, {type_name}> {{",
+        set_opener_template="new HashSet<{type_name}> {{",
+    )
 
     class DateFormats(enum.Enum):
         """Date format options for C#."""
@@ -155,10 +155,7 @@ class CSharp(metaclass=LanguageCls):
             supports_trailing_comma=False,
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
-                type_to_opener=_csharp_opener_config.build().seq,
-                fallback="new object[] {",
-            ),
+            sequence_open=fixed_sequence_open(open_str="new object[] {"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -180,22 +177,14 @@ class CSharp(metaclass=LanguageCls):
         """Set type options for C#."""
 
         HASH_SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=_csharp_opener_config.build().set,
-                fallback="new HashSet<object> {",
-            ),
+            set_open=fixed_set_open(open_str="new HashSet<object> {"),
             close="}",
             empty_set="new HashSet<object>()",
             preamble_lines=("using System.Collections.Generic;",),
             set_opener_template="",
         )
         SORTED_SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=_csharp_opener_config.build(
-                    set_opener_template="new SortedSet<{type_name}> {{",
-                ).set,
-                fallback="new SortedSet<object> {",
-            ),
+            set_open=fixed_set_open(open_str="new SortedSet<object> {"),
             close="}",
             empty_set="new SortedSet<object>()",
             preamble_lines=("using System.Collections.Generic;",),
@@ -343,9 +332,10 @@ class CSharp(metaclass=LanguageCls):
 
         date_tp = date_format.value.type_produced
         dt_tp = datetime_format.value.type_produced
-        openers = _csharp_opener_config.build(
-            date_type=_csharp_opener_config.type_name(py_type=date_tp),
-            datetime_type=_csharp_opener_config.type_name(py_type=dt_tp),
+        cfg = self._opener_config
+        openers = cfg.build(
+            date_type=cfg.type_name(py_type=date_tp),
+            datetime_type=cfg.type_name(py_type=dt_tp),
             set_opener_template=set_format.value.set_opener_template or None,
         )
         self.set_format_config: SetFormatConfig = dataclasses.replace(
@@ -367,13 +357,9 @@ class CSharp(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=make_type_to_opener(
-                    element_to_type=_csharp_opener_config.element_to_type(
-                        date_type=_csharp_opener_config.type_name(
-                            py_type=date_tp
-                        ),
-                        datetime_type=_csharp_opener_config.type_name(
-                            py_type=dt_tp
-                        ),
+                    element_to_type=cfg.element_to_type(
+                        date_type=cfg.type_name(py_type=date_tp),
+                        datetime_type=cfg.type_name(py_type=dt_tp),
                     ),
                     opener_template=dict_spec.opener_template,
                 ),

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -66,13 +66,6 @@ def _format_datetime_haskell(value: datetime.datetime) -> str:
     )
 
 
-_FRACTIONAL_INSTANCE = (
-    "instance Fractional Val where\n"
-    "    fromRational r = HFloat (realToFrac r)\n"
-    '    a / b = error "not implemented"'
-)
-
-
 def _num_instance(*, has_int: bool, has_float: bool) -> str:
     """Build the ``Num Val`` instance with only relevant constructors."""
     if has_int:
@@ -112,18 +105,6 @@ def _has_microsecond_datetime(*, data: Value) -> bool:
     if isinstance(data, (list, set)):
         return any(_has_microsecond_datetime(data=v) for v in data)
     return False
-
-
-_VAL_CONSTRUCTORS: tuple[tuple[frozenset[type], str], ...] = (
-    (frozenset({type(None)}), "HNull"),
-    (frozenset({bool}), "HBool Bool"),
-    (frozenset({int}), "HInt Integer"),
-    (frozenset({float}), "HFloat Double"),
-    (frozenset({str, bytes}), "HStr String"),
-    (frozenset({list}), "HList [Val]"),
-    (frozenset({dict, ordereddict}), "HMap [(String, Val)]"),
-    (frozenset({set}), "HSet [Val]"),
-)
 
 
 def _datetime_import_items(
@@ -169,7 +150,16 @@ def _build_scalar_body_preamble(
         """Return body-preamble lines for the given *types*."""
         data_val_parts = [
             constructor
-            for type_set, constructor in _VAL_CONSTRUCTORS
+            for type_set, constructor in (
+                (frozenset({type(None)}), "HNull"),
+                (frozenset({bool}), "HBool Bool"),
+                (frozenset({int}), "HInt Integer"),
+                (frozenset({float}), "HFloat Double"),
+                (frozenset({str, bytes}), "HStr String"),
+                (frozenset({list}), "HList [Val]"),
+                (frozenset({dict, ordereddict}), "HMap [(String, Val)]"),
+                (frozenset({set}), "HSet [Val]"),
+            )
             if types & type_set
         ]
         import_items: list[str] = []
@@ -208,7 +198,11 @@ def _build_scalar_body_preamble(
                 _num_instance(has_int=has_int, has_float=has_float),
             )
         if has_float:
-            lines.append(_FRACTIONAL_INSTANCE)
+            lines.append(
+                "instance Fractional Val where\n"
+                "    fromRational r = HFloat (realToFrac r)\n"
+                '    a / b = error "not implemented"'
+            )
 
         return tuple(lines)
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -16,6 +16,7 @@ from literalizer._formatters import (
     datetime_ymdhms_formatter,
     dict_entry_with_separator,
     fixed_sequence_open,
+    fixed_set_open,
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
@@ -81,22 +82,6 @@ def _kotlin_type_to_opener(
     return scalar_openers.get(element_type)
 
 
-_kotlin_opener_config = TypedOpenerConfig(
-    str_type="String",
-    bool_type="Boolean",
-    int_type="Int",
-    float_type="Double",
-    bytes_type="String",
-    mixed_numeric_type=None,
-    date_type="LocalDate",
-    datetime_type="LocalDateTime",
-    list_template="Array<{inner}>",
-    sequence_opener_template="arrayOf(",
-    dict_opener_template="mapOf<String, {type_name}>(",
-    set_opener_template="setOf<{type_name}>(",
-)
-
-
 @dataclasses.dataclass(frozen=True)
 class _KotlinDictSpec:
     """Per-format dict config pieces resolved at init time."""
@@ -137,6 +122,21 @@ class Kotlin(metaclass=LanguageCls):
 
     extension = ".kts"
     pygments_name = "kotlin"
+
+    _opener_config = TypedOpenerConfig(
+        str_type="String",
+        bool_type="Boolean",
+        int_type="Int",
+        float_type="Double",
+        bytes_type="String",
+        mixed_numeric_type=None,
+        date_type="LocalDate",
+        datetime_type="LocalDateTime",
+        list_template="Array<{inner}>",
+        sequence_opener_template="arrayOf(",
+        dict_opener_template="mapOf<String, {type_name}>(",
+        set_opener_template="setOf<{type_name}>(",
+    )
 
     class DateFormats(enum.Enum):
         """Date format options for Kotlin."""
@@ -232,22 +232,14 @@ class Kotlin(metaclass=LanguageCls):
         """Set type options for Kotlin."""
 
         SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=_kotlin_opener_config.build().set,
-                fallback="setOf<Any?>(",
-            ),
+            set_open=fixed_set_open(open_str="setOf<Any?>("),
             close=")",
             empty_set=None,
             preamble_lines=(),
             set_opener_template="",
         )
         SORTED_SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=_kotlin_opener_config.build(
-                    set_opener_template="sortedSetOf<{type_name}>(",
-                ).set,
-                fallback="sortedSetOf<Any?>(",
-            ),
+            set_open=fixed_set_open(open_str="sortedSetOf<Any?>("),
             close=")",
             empty_set=None,
             preamble_lines=(),
@@ -399,9 +391,10 @@ class Kotlin(metaclass=LanguageCls):
 
         date_tp = date_format.value.type_produced
         dt_tp = datetime_format.value.type_produced
-        openers = _kotlin_opener_config.build(
-            date_type=_kotlin_opener_config.type_name(py_type=date_tp),
-            datetime_type=_kotlin_opener_config.type_name(py_type=dt_tp),
+        cfg = self._opener_config
+        openers = cfg.build(
+            date_type=cfg.type_name(py_type=date_tp),
+            datetime_type=cfg.type_name(py_type=dt_tp),
             set_opener_template=set_format.value.set_opener_template or None,
         )
         self.set_format_config: SetFormatConfig = dataclasses.replace(
@@ -415,13 +408,9 @@ class Kotlin(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=make_type_to_opener(
-                    element_to_type=_kotlin_opener_config.element_to_type(
-                        date_type=_kotlin_opener_config.type_name(
-                            py_type=date_tp
-                        ),
-                        datetime_type=_kotlin_opener_config.type_name(
-                            py_type=dt_tp
-                        ),
+                    element_to_type=cfg.element_to_type(
+                        date_type=cfg.type_name(py_type=date_tp),
+                        datetime_type=cfg.type_name(py_type=dt_tp),
                     ),
                     opener_template=dict_spec.opener_template,
                 ),

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     date_ymd_formatter,
     dict_entry_with_separator,
     fixed_sequence_open,
+    fixed_set_open,
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
@@ -57,32 +58,17 @@ def _format_datetime_scala(value: datetime.datetime) -> str:
     )
 
 
-_scala_opener_config = TypedOpenerConfig(
-    str_type="String",
-    bool_type="Boolean",
-    int_type="Int",
-    float_type="Double",
-    mixed_numeric_type="Double",
-    bytes_type="String",
-    date_type="LocalDate",
-    datetime_type="ZonedDateTime",
-    list_template="Array[{inner}]",
-    sequence_opener_template="Array[{type_name}](",
-    dict_opener_template="Map[String, {type_name}](",
-    set_opener_template="Set[{type_name}](",
-)
-
-
 @beartype
 def _list_sequence_open(
     *,
+    cfg: TypedOpenerConfig,
     date_type: str | None,
     datetime_type: str | None,
 ) -> Callable[[list[Value]], str]:
     """Build a typed sequence opener for the List format."""
     return typed_sequence_open(
         type_to_opener=make_type_to_opener(
-            element_to_type=_scala_opener_config.element_to_type(
+            element_to_type=cfg.element_to_type(
                 list_template="List[{inner}]",
                 date_type=date_type,
                 datetime_type=datetime_type,
@@ -96,6 +82,7 @@ def _list_sequence_open(
 @beartype
 def _resolve_sequence_open(
     *,
+    cfg: TypedOpenerConfig,
     sequence_format: enum.Enum,
     list_member: enum.Enum,
     fmt: SequenceFormatConfig,
@@ -106,6 +93,7 @@ def _resolve_sequence_open(
     """Resolve the sequence opener for a Scala sequence format."""
     if sequence_format is list_member:
         return _list_sequence_open(
+            cfg=cfg,
             date_type=date_type,
             datetime_type=datetime_type,
         )
@@ -132,6 +120,21 @@ class Scala(metaclass=LanguageCls):
 
     extension = ".scala"
     pygments_name = "scala"
+
+    _opener_config = TypedOpenerConfig(
+        str_type="String",
+        bool_type="Boolean",
+        int_type="Int",
+        float_type="Double",
+        mixed_numeric_type="Double",
+        bytes_type="String",
+        date_type="LocalDate",
+        datetime_type="ZonedDateTime",
+        list_template="Array[{inner}]",
+        sequence_opener_template="Array[{type_name}](",
+        dict_opener_template="Map[String, {type_name}](",
+        set_opener_template="Set[{type_name}](",
+    )
 
     class DateFormats(enum.Enum):
         """Date format options for Scala."""
@@ -180,15 +183,7 @@ class Scala(metaclass=LanguageCls):
         """Sequence type options for Scala."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=_scala_opener_config.element_to_type(
-                        list_template="List[{inner}]",
-                    ),
-                    opener_template="List[{type_name}](",
-                ),
-                fallback="List(",
-            ),
+            sequence_open=fixed_sequence_open(open_str="List("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -210,10 +205,7 @@ class Scala(metaclass=LanguageCls):
             typed_opener_fallback=None,
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
-                type_to_opener=_scala_opener_config.build().seq,
-                fallback="Array(",
-            ),
+            sequence_open=fixed_sequence_open(open_str="Array("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -235,22 +227,14 @@ class Scala(metaclass=LanguageCls):
         """Set type options for Scala."""
 
         SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=_scala_opener_config.build().set,
-                fallback="Set(",
-            ),
+            set_open=fixed_set_open(open_str="Set("),
             close=")",
             empty_set=None,
             preamble_lines=(),
             set_opener_template="",
         )
         TREE_SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=_scala_opener_config.build(
-                    set_opener_template="TreeSet[{type_name}](",
-                ).set,
-                fallback="TreeSet(",
-            ),
+            set_open=fixed_set_open(open_str="TreeSet("),
             close=")",
             empty_set=None,
             preamble_lines=("import scala.collection.immutable.TreeSet",),
@@ -396,9 +380,9 @@ class Scala(metaclass=LanguageCls):
         self.set_format = set_format
         date_tp = date_format.value.type_produced
         dt_tp = datetime_format.value.type_produced
-        date_type_name = _scala_opener_config.type_name(py_type=date_tp)
-        datetime_type_name = _scala_opener_config.type_name(py_type=dt_tp)
-        openers = _scala_opener_config.build(
+        date_type_name = self._opener_config.type_name(py_type=date_tp)
+        datetime_type_name = self._opener_config.type_name(py_type=dt_tp)
+        openers = self._opener_config.build(
             date_type=date_type_name,
             datetime_type=datetime_type_name,
             set_opener_template=set_format.value.set_opener_template or None,
@@ -412,6 +396,7 @@ class Scala(metaclass=LanguageCls):
         )
         self.sequence_open: Callable[[list[Value]], str] = (
             _resolve_sequence_open(
+                cfg=self._opener_config,
                 sequence_format=sequence_format,
                 list_member=self.sequence_formats.LIST,
                 fmt=fmt,
@@ -424,7 +409,7 @@ class Scala(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=make_type_to_opener(
-                    element_to_type=_scala_opener_config.element_to_type(
+                    element_to_type=self._opener_config.element_to_type(
                         date_type=date_type_name,
                         datetime_type=datetime_type_name,
                     ),


### PR DESCRIPTION
## Summary
- Move `_csharp_opener_config`, `_kotlin_opener_config`, and `_scala_opener_config` from module-level variables to `_opener_config` class attributes on the one class that uses each.
- Simplify enum members to use `fixed_sequence_open`/`fixed_set_open` with fallback strings, since `__init__` always replaces them with typed openers anyway.
- Inline `_FRACTIONAL_INSTANCE` and `_VAL_CONSTRUCTORS` at their single usage sites in Haskell.
- Net reduction of 46 lines.

## Test plan
- [x] All 7253 tests pass
- [x] Pre-commit hooks (ruff, mypy, pyright, ty, pyrefly) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on configuration plumbing for C#/Kotlin/Scala literal generation; main risk is subtle changes in inferred collection opener strings for some formats.
> 
> **Overview**
> Refactors the C#, Kotlin, and Scala language specs to store `TypedOpenerConfig` as a `_opener_config` class attribute (instead of module-level globals) and updates `__init__` to consistently build openers from that shared config.
> 
> Simplifies several enum `SequenceFormatConfig`/`SetFormatConfig` members to use fixed openers via `fixed_sequence_open`/`fixed_set_open`, since typed openers are resolved/replaced during initialization.
> 
> In Haskell, inlines previously module-level constants used for body-preamble generation (the `Val` constructor list and `Fractional` instance snippet) at their single call sites to reduce indirection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c629e8256a78c726ec28479e7995fa78d771621. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->