### PR TITLE
Simplify enum openers to fixed_*_open in dart, java, go

### DIFF
--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -19,8 +19,6 @@ from literalizer._formatters import (
     format_integer_hex,
     format_string_backslash_dollar,
     format_string_backslash_dollar_single,
-    make_element_to_type,
-    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_dict_open,
@@ -70,6 +68,21 @@ class Dart(metaclass=LanguageCls):
     extension = ".dart"
     pygments_name = "dart"
 
+    _opener_config = TypedOpenerConfig(
+        str_type="String",
+        bool_type="bool",
+        int_type="int",
+        float_type="double",
+        mixed_numeric_type="double",
+        bytes_type="String",
+        date_type="DateTime",
+        datetime_type="DateTime",
+        list_template="List<{inner}>",
+        sequence_opener_template="<{type_name}>[",
+        dict_opener_template="<String, {type_name}>{{",
+        set_opener_template="<{type_name}>{{",
+    )
+
     class DateFormats(enum.Enum):
         """Date formatting options for Dart."""
 
@@ -114,23 +127,7 @@ class Dart(metaclass=LanguageCls):
         """Sequence type options for Dart."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=make_element_to_type(
-                        str_type="String",
-                        bool_type="bool",
-                        int_type="int",
-                        float_type="double",
-                        mixed_numeric_type="double",
-                        bytes_type="String",
-                        date_type="DateTime",
-                        datetime_type="DateTime",
-                        list_template="List<{inner}>",
-                    ),
-                    opener_template="<{type_name}>[",
-                ),
-                fallback="[",
-            ),
+            sequence_open=fixed_sequence_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -295,23 +292,10 @@ class Dart(metaclass=LanguageCls):
 
         date_tp = date_format.value.type_produced
         dt_tp = datetime_format.value.type_produced
-        opener_config = TypedOpenerConfig(
-            str_type="String",
-            bool_type="bool",
-            int_type="int",
-            float_type="double",
-            mixed_numeric_type="double",
-            bytes_type="String",
-            date_type="DateTime",
-            datetime_type="DateTime",
-            list_template="List<{inner}>",
-            sequence_opener_template="<{type_name}>[",
-            dict_opener_template="<String, {type_name}>{{",
-            set_opener_template="<{type_name}>{{",
-        )
-        openers = opener_config.build(
-            date_type=opener_config.type_name(py_type=date_tp),
-            datetime_type=opener_config.type_name(py_type=dt_tp),
+        cfg = self._opener_config
+        openers = cfg.build(
+            date_type=cfg.type_name(py_type=date_tp),
+            datetime_type=cfg.type_name(py_type=dt_tp),
         )
         self.sequence_open: Callable[[list[Value]], str] = (
             typed_sequence_open(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -12,6 +12,8 @@ from beartype import beartype
 from literalizer._formatters import (
     braced_dict_entry,
     dict_entry_with_separator,
+    fixed_sequence_open,
+    fixed_set_open,
     format_bytes_hex,
     format_date_iso,
     format_datetime_iso,
@@ -166,23 +168,7 @@ class Go(metaclass=LanguageCls):
         """Sequence type options for Go."""
 
         SLICE = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=make_element_to_type(
-                        str_type="string",
-                        bool_type="bool",
-                        int_type="int",
-                        float_type="float64",
-                        mixed_numeric_type="float64",
-                        bytes_type="string",
-                        date_type="time.Time",
-                        datetime_type="time.Time",
-                        list_template="[]{inner}",
-                    ),
-                    opener_template="[]{type_name}{{",
-                ),
-                fallback="[]any{",
-            ),
+            sequence_open=fixed_sequence_open(open_str="[]any{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -204,23 +190,7 @@ class Go(metaclass=LanguageCls):
         """Set type options for Go."""
 
         SET = SetFormatConfig(
-            set_open=typed_set_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=make_element_to_type(
-                        str_type="string",
-                        bool_type="bool",
-                        int_type="int",
-                        float_type="float64",
-                        mixed_numeric_type="float64",
-                        bytes_type="string",
-                        date_type="time.Time",
-                        datetime_type="time.Time",
-                        list_template="[]{inner}",
-                    ),
-                    opener_template="map[{type_name}]struct{{}}{{",
-                ),
-                fallback="map[any]struct{}{",
-            ),
+            set_open=fixed_set_open(open_str="map[any]struct{}{"),
             close="}",
             empty_set=None,
             preamble_lines=(),

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -14,6 +14,7 @@ from literalizer._formatters import (
     datetime_iso_formatter,
     dict_entry_with_template,
     fixed_dict_open,
+    fixed_sequence_open,
     fixed_set_open,
     format_bytes_hex,
     format_date_iso,
@@ -23,8 +24,6 @@ from literalizer._formatters import (
     format_integer_octal_c_style,
     format_integer_underscore,
     format_string_backslash,
-    make_element_to_type,
-    make_type_to_opener,
     passthrough_sequence_entry,
     passthrough_set_entry,
     typed_sequence_open,
@@ -111,6 +110,21 @@ class Java(metaclass=LanguageCls):
     extension = ".java"
     pygments_name = "java"
 
+    _opener_config = TypedOpenerConfig(
+        str_type="String",
+        bool_type="boolean",
+        int_type="int",
+        float_type="double",
+        mixed_numeric_type="double",
+        bytes_type="String",
+        date_type="LocalDate",
+        datetime_type=None,
+        list_template="{inner}[]",
+        sequence_opener_template="new {type_name}[]{{",
+        dict_opener_template="new {type_name}[]{{",
+        set_opener_template="Set.of(",
+    )
+
     class DateFormats(enum.Enum):
         """Date formatting options for Java."""
 
@@ -164,22 +178,7 @@ class Java(metaclass=LanguageCls):
         """Sequence type options for Java."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=make_element_to_type(
-                        str_type="String",
-                        bool_type="boolean",
-                        int_type="int",
-                        float_type="double",
-                        mixed_numeric_type="double",
-                        bytes_type="String",
-                        date_type="LocalDate",
-                        list_template="{inner}[]",
-                    ),
-                    opener_template="new {type_name}[]{{",
-                ),
-                fallback="new Object[]{",
-            ),
+            sequence_open=fixed_sequence_open(open_str="new Object[]{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -391,23 +390,10 @@ class Java(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
 
         date_tp = date_format.value.type_produced
-        opener_config = TypedOpenerConfig(
-            str_type="String",
-            bool_type="boolean",
-            int_type="int",
-            float_type="double",
-            mixed_numeric_type="double",
-            bytes_type="String",
-            date_type="LocalDate",
-            datetime_type=None,
-            list_template="{inner}[]",
-            sequence_opener_template="new {type_name}[]{{",
-            dict_opener_template="new {type_name}[]{{",
-            set_opener_template="Set.of(",
-        )
-        openers = opener_config.build(
-            date_type=opener_config.type_name(py_type=date_tp),
-            datetime_type=opener_config.type_name(
+        cfg = self._opener_config
+        openers = cfg.build(
+            date_type=cfg.type_name(py_type=date_tp),
+            datetime_type=cfg.type_name(
                 py_type=datetime_format.value.type_produced,
             ),
         )


### PR DESCRIPTION
## Summary

- Replace complex `typed_sequence_open(make_type_to_opener(make_element_to_type(...)))` calls in enum definitions with simple `fixed_sequence_open`/`fixed_set_open` fallback strings in dart, java, and go — the enum values are throwaway since `__init__` always rebuilds typed openers.
- Move `opener_config` from local variables in `__init__` to class attributes `_opener_config` in dart and java (matching the pattern from csharp, kotlin, scala in #732).
- Remove now-unused `make_element_to_type` and `make_type_to_opener` imports from dart and java.

## Test plan

- [x] All 7253 tests pass
- [x] Ruff lint clean
- [x] Pre-commit hooks pass (mypy, pyright, ty, pyrefly all clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly refactors how sequence/set opener callables are defined for Dart/Java/Go, with minimal behavioral change expected since typed openers are still built in `__init__`. Risk is limited to potential differences in fallback opener strings for empty/heterogeneous collections.
> 
> **Overview**
> Simplifies Dart/Java/Go language specs by replacing enum-level `typed_*_open` constructions with `fixed_sequence_open`/`fixed_set_open` openers that just return the fallback delimiter/string.
> 
> For Dart and Java, moves the repeated `TypedOpenerConfig` construction into a class-level `_opener_config` and reuses it in `__init__` when building typed openers; also drops now-unused `make_element_to_type`/`make_type_to_opener` imports in those modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd748c3fc446e57beb7dfbd8e29b7924928fa176. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->