### PR TITLE
Remove ty exclusion for tests/integration/cases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,9 +311,6 @@ typeCheckingMode = "strict"
 [tool.ty]
 analysis.respect-type-ignore-comments = false
 terminal.error-on-warning = true
-src.exclude = [
-    "tests/integration/cases",
-]
 
 [tool.pytest]
 ini_options.xfail_strict = true


### PR DESCRIPTION
## Summary
- Removes the `src.exclude` entry for `tests/integration/cases` from the `[tool.ty]` section in `pyproject.toml`, so ty no longer skips that directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that just expands `ty`'s analysis scope to include `tests/integration/cases`, which may surface new type-checking warnings in CI.
> 
> **Overview**
> Removes the `[tool.ty]` `src.exclude` configuration for `tests/integration/cases`, so `ty` now type-checks those integration case files instead of skipping them.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12b84e96bbff95fd398959be07918313a7e718bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->