### PR TITLE
Remove pyright exclusion for tests/integration/cases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,10 +305,12 @@ project_excludes = [
 enableTypeIgnoreComments = false
 exclude = [
     ".venv",
-    "tests/integration/cases",
 ]
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
+executionEnvironments = [
+    { root = "tests/integration/cases", reportUnusedExpression = false, reportUndefinedVariable = false, reportUnknownVariableType = false },
+]
 
 [tool.ty]
 analysis.respect-type-ignore-comments = false


### PR DESCRIPTION
## Summary
- Removed the blanket `exclude` for `tests/integration/cases` from `[tool.pyright]`
- Added a targeted `executionEnvironments` override that only suppresses the specific diagnostics those generated fixture files trigger (`reportUnusedExpression`, `reportUndefinedVariable`, `reportUnknownVariableType`)

## Test plan
- [x] Verified `pyright` error count is unchanged (154 errors before and after)
- [x] Verified no errors from `tests/integration/cases` remain
- [x] Pre-push hooks (pyright, ty, mypy, etc.) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-only change that narrows how `tests/integration/cases` is handled, without affecting runtime behavior.
> 
> **Overview**
> Removes the blanket Pyright `exclude` for `tests/integration/cases` so those files are included in type checking.
> 
> Adds a Pyright `executionEnvironments` entry for `tests/integration/cases` to disable only `reportUnusedExpression`, `reportUndefinedVariable`, and `reportUnknownVariableType` for that directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b41388bf3fc3dcc87764cb3eb5b8896a2fad6092. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->