### PR TITLE
Remove default on _collection_element_union sort param

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -178,7 +178,7 @@ def _collection_element_union(
     *,
     elements: list[Value],
     recurse: Callable[..., str],
-    sort: bool = False,
+    sort: bool,
 ) -> str:
     """Return the element union for a collection, or ``"Any"`` if
     empty.
@@ -241,6 +241,7 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
             val_union = _collection_element_union(
                 elements=list(data.values()),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
                 recurse=recurse,
+                sort=False,
             )
             return f"{outer}[str, {val_union}]"
         case set():
@@ -254,6 +255,7 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
             elem_union = _collection_element_union(
                 elements=data,
                 recurse=recurse,
+                sort=False,
             )
             if sequence_hint == "tuple":
                 return f"{sequence_hint}[{elem_union}, ...]"


### PR DESCRIPTION
Remove the default value from the `sort` parameter of `_collection_element_union`, making all call sites explicitly pass `sort=True` or `sort=False`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small signature change localized to `src/literalizer/languages/python.py`, with all internal call sites updated to pass `sort=True/False` explicitly.
> 
> **Overview**
> Removes the default value for the `sort` parameter in `_collection_element_union`, making sorting behavior explicit at each call site.
> 
> Updates `_python_type_hint` to pass `sort=False` for `dict` and `list` unions and `sort=True` for `set` unions, preserving existing behavior while tightening the API contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 301f4a80af8e680e1d808f74610a98ff3cb2dbd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->