### PR TITLE
Remove unused _variable_type_hints parameter

### DIFF
--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -218,7 +218,6 @@ class Ada(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_DASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.DECLARE,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -231,7 +231,6 @@ class Bash(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.DECLARE,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -226,7 +226,6 @@ class C(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.TYPED,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -183,7 +183,6 @@ class Clojure(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.SEMICOLON,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.DEF,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -357,7 +357,6 @@ class Cobol(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.STAR_ANGLE,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.TYPED,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -191,7 +191,6 @@ class CommonLisp(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.SEMICOLON,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.DEFPARAMETER,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -374,7 +374,6 @@ class Cpp(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.AUTO,
         dict_format: DictFormats = DictFormats.MAP,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -220,7 +220,6 @@ class Crystal(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -306,7 +306,6 @@ class CSharp(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.HASH_SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.VAR,
         dict_format: DictFormats = DictFormats.DICTIONARY,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -241,7 +241,6 @@ class D(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.AUTO,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -269,7 +269,6 @@ class Dart(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.FINAL,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -284,7 +284,6 @@ class Elixir(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.MAP_SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -264,7 +264,6 @@ class Erlang(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.PERCENT,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -275,7 +275,6 @@ class Fortran(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.EXCLAMATION,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.TYPED,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -292,7 +292,6 @@ class FSharp(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.LET,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -317,7 +317,6 @@ class Go(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.SHORT,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -188,7 +188,6 @@ class Groovy(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.DEF,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -445,7 +445,6 @@ class Haskell(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_DASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -187,7 +187,6 @@ class Hcl(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -364,7 +364,6 @@ class Java(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.VAR,
         dict_format: DictFormats = DictFormats.MAP_OF_ENTRIES,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -303,7 +303,6 @@ class JavaScript(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.CONST,
         dict_format: DictFormats = DictFormats.OBJECT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -305,7 +305,6 @@ class Julia(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DICT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -368,7 +368,6 @@ class Kotlin(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.VAL,
         dict_format: DictFormats = DictFormats.MAP,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -239,7 +239,6 @@ class Lua(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_DASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.LOCAL,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -304,7 +304,6 @@ class Matlab(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.PERCENT,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.STRUCT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -214,7 +214,6 @@ class Mojo(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -347,7 +347,6 @@ class Nim(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.VAR,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -194,7 +194,6 @@ class Norg(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.PERCENT,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.BLOCK,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -281,7 +281,6 @@ class ObjectiveC(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.TYPED,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -303,7 +303,6 @@ class OCaml(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.PAREN_STAR,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.LET,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -204,7 +204,6 @@ class Occam(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_DASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.VAL,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -282,7 +282,6 @@ class Perl(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.MY,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -248,7 +248,6 @@ class Php(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -212,7 +212,6 @@ class PowerShell(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -274,7 +274,6 @@ class R(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -187,7 +187,6 @@ class Racket(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.SEMICOLON,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.DEFINE,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -269,7 +269,6 @@ class Ruby(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -356,7 +356,6 @@ class Rust(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.HASH_SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.LET,
         dict_format: DictFormats = DictFormats.HASH_MAP,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -359,7 +359,6 @@ class Scala(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.VAL,
         dict_format: DictFormats = DictFormats.MAP,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -290,7 +290,6 @@ class Swift(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.LET,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -238,7 +238,6 @@ class Toml(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -334,7 +334,6 @@ class TypeScript(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.CONST,
         dict_format: DictFormats = DictFormats.OBJECT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -242,7 +242,6 @@ class VisualBasic(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.HASH_SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.APOSTROPHE,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.DIM,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -213,7 +213,6 @@ class Yaml(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.HASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -294,7 +294,6 @@ class Zig(metaclass=LanguageCls):
         set_format: SetFormats = SetFormats.SET,
         variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH,
-        _variable_type_hints: VariableTypeHints = VariableTypeHints.NONE,
         declaration_style: DeclarationStyles = DeclarationStyles.CONST,
         dict_format: DictFormats = DictFormats.DEFAULT,
         integer_format: IntegerFormats = IntegerFormats.DECIMAL,


### PR DESCRIPTION
## Summary

- Remove the unused `_variable_type_hints` parameter from `__init__` methods across all 45 non-Python language classes
- Each of these languages already has a `variable_type_hints` parameter (without underscore) that is actually used; the underscore-prefixed duplicate was dead code

## Test plan

- [x] `uv run python -c "import literalizer"` passes
- [x] All pre-commit hooks pass (mypy, pyright, ruff, vulture, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical signature cleanup across many language spec classes; main risk is breaking callers that were passing the now-removed keyword argument.
> 
> **Overview**
> Removes the unused `_variable_type_hints` keyword parameter from `__init__` across all non-Python language specification classes, leaving `variable_type_hints` as the single supported option.
> 
> This is a signature-only cleanup with no intended change to formatting behavior, but it will break any external code still passing `_variable_type_hints`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4664263458af316e32167fae75c43199ffbcb69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->