### PR TITLE
Use match statement in _coerce_yaml_keys

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -881,18 +881,21 @@ def _coerce_yaml_keys(*, data: object) -> Value:
     key coercion so that ordered-map detection in :func:`_literalize` is
     preserved.
     """
-    if isinstance(data, ordereddict):
-        return cast("Value", data)
-    if isinstance(data, dict):
-        return {
-            f"{k}": _coerce_yaml_keys(data=v)
-            for k, v in cast("dict[object, object]", data).items()
-        }
-    if isinstance(data, list):
-        return [
-            _coerce_yaml_keys(data=item) for item in cast("list[object]", data)
-        ]
-    return cast("Value", data)
+    match data:
+        case ordereddict():
+            return cast("Value", data)
+        case dict():
+            return {
+                f"{k}": _coerce_yaml_keys(data=v)
+                for k, v in cast("dict[object, object]", data).items()
+            }
+        case list():
+            return [
+                _coerce_yaml_keys(data=item)
+                for item in cast("list[object]", data)
+            ]
+        case _:
+            return cast("Value", data)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace sequential `isinstance` if-checks in `_coerce_yaml_keys` with a `match` statement for clearer structural pattern matching over `ordereddict`, `dict`, `list`, and the default case.

## Test plan
- [x] All 7253 existing tests pass
- [x] Pre-commit hooks (mypy, pyright, ruff, etc.) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to YAML key-coercion control flow; behavior should be unchanged aside from any subtle pattern-matching semantics differences.
> 
> **Overview**
> Refactors `_coerce_yaml_keys` in `src/literalizer/_core.py` to use a `match`/`case` statement instead of sequential `isinstance` checks, handling `ordereddict`, `dict`, `list`, and a default case.
> 
> The recursion and key stringification logic is preserved, but expressed via structural pattern matching for clearer branching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b0b664726a27bafa3522d966709c22850efbe3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->