### PR TITLE
Use formatter templates instead of custom date/datetime functions

### DIFF
--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_ymd_formatter,
+    datetime_ymdhms_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -46,21 +48,6 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_date_julia(value: datetime.date) -> str:
-    """Format a date as a Julia ``Date(...)`` constructor call."""
-    return f"Date({value.year}, {value.month}, {value.day})"
-
-
-@beartype
-def _format_datetime_julia(value: datetime.datetime) -> str:
-    """Format a datetime as a Julia ``DateTime(...)`` constructor call."""
-    return (
-        f"DateTime({value.year}, {value.month}, {value.day}, "
-        f"{value.hour}, {value.minute}, {value.second})"
-    )
-
-
-@beartype
 class Julia(metaclass=LanguageCls):
     """Julia language specification.
 
@@ -94,7 +81,9 @@ class Julia(metaclass=LanguageCls):
         """Date formatting options for Julia."""
 
         JULIA = DateFormatConfig(
-            formatter=_format_date_julia,
+            formatter=date_ymd_formatter(
+                template="Date({year}, {month}, {day})",
+            ),
             preamble_lines=("using Dates",),
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
@@ -107,7 +96,10 @@ class Julia(metaclass=LanguageCls):
         """Datetime formatting options for Julia."""
 
         JULIA = DatetimeFormatConfig(
-            formatter=_format_datetime_julia,
+            formatter=datetime_ymdhms_formatter(
+                template="DateTime({year}, {month}, {day}, "
+                "{hour}, {minute}, {second})",
+            ),
             preamble_lines=("using Dates",),
         )
         ISO = DatetimeFormatConfig(

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_ymd_formatter,
     fixed_dict_open,
     fixed_sequence_open,
     fixed_set_open,
@@ -107,12 +108,6 @@ def _format_matlab_dict_entry(key: str, _val: Value, value: str) -> str:
 
 
 @beartype
-def _format_date_matlab(value: datetime.date) -> str:
-    """Format a date as a MATLAB ``datetime`` expression."""
-    return f"datetime({value.year}, {value.month}, {value.day})"
-
-
-@beartype
 def _format_datetime_matlab(value: datetime.datetime) -> str:
     """Format a datetime as a MATLAB ``datetime`` expression."""
     parts = (
@@ -150,7 +145,11 @@ class Matlab(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date format options for Matlab."""
 
-        MATLAB = DateFormatConfig(formatter=_format_date_matlab)
+        MATLAB = DateFormatConfig(
+            formatter=date_ymd_formatter(
+                template="datetime({year}, {month}, {day})",
+            ),
+        )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
         def __call__(self, date_value: datetime.date, /) -> str:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -8,6 +8,8 @@ from types import MappingProxyType
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_ymd_formatter,
+    datetime_ymdhms_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -36,24 +38,6 @@ from literalizer._language import (
     body_preamble_from_scalars,
 )
 from literalizer._types import Value
-
-
-@beartype
-def _format_date_nim(value: datetime.date) -> str:
-    """Format a date as a Nim table literal."""
-    return (
-        f'{{"year": {value.year}, "month": {value.month}, "day": {value.day}}}'
-    )
-
-
-@beartype
-def _format_datetime_nim(value: datetime.datetime) -> str:
-    """Format a datetime as a Nim table literal."""
-    return (
-        f'{{"year": {value.year}, "month": {value.month}, '
-        f'"day": {value.day}, "hour": {value.hour}, '
-        f'"minute": {value.minute}, "second": {value.second}}}'
-    )
 
 
 @beartype
@@ -148,7 +132,9 @@ class Nim(metaclass=LanguageCls):
         """Date format options for Nim."""
 
         NIM = DateFormatConfig(
-            formatter=_format_date_nim,
+            formatter=date_ymd_formatter(
+                template='{{"year": {year}, "month": {month}, "day": {day}}}',
+            ),
             preamble_lines=("import json",),
         )
         ISO = DateFormatConfig(
@@ -165,7 +151,11 @@ class Nim(metaclass=LanguageCls):
         """Datetime format options for Nim."""
 
         NIM = DatetimeFormatConfig(
-            formatter=_format_datetime_nim,
+            formatter=datetime_ymdhms_formatter(
+                template='{{"year": {year}, "month": {month}, '
+                '"day": {day}, "hour": {hour}, '
+                '"minute": {minute}, "second": {second}}}',
+            ),
             preamble_lines=("import json",),
         )
         ISO = DatetimeFormatConfig(

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_iso_formatter,
+    datetime_iso_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -75,51 +77,6 @@ def _format_objc_bytes(value: bytes) -> str:
 
 
 @beartype
-def _format_objc_date(value: datetime.date) -> str:
-    """Format a date as an Objective-C ``NSString`` ISO 8601 literal.
-
-    Example: ``datetime.date(2024, 1, 15)`` → ``@"2024-01-15"``.
-    """
-    return f'@"{value.isoformat()}"'
-
-
-@beartype
-def _format_objc_date_iso(value: datetime.date) -> str:
-    """Format a date as an Objective-C ``NSString`` ISO 8601 literal.
-
-    This is the ISO format variant, producing the same ``@"..."``
-    ``NSString`` output as the native format.
-
-    Example: ``datetime.date(2024, 1, 15)`` → ``@"2024-01-15"``.
-    """
-    return f'@"{value.isoformat()}"'
-
-
-@beartype
-def _format_objc_datetime(value: datetime.datetime) -> str:
-    """Format a datetime as an Objective-C ``NSString`` ISO 8601
-    literal.
-
-    Example: ``datetime.datetime(2024, 1, 15, 12, 30)`` →
-    ``@"2024-01-15T12:30:00"``.
-    """
-    return f'@"{value.isoformat()}"'
-
-
-@beartype
-def _format_objc_datetime_iso(value: datetime.datetime) -> str:
-    """Format a datetime as an Objective-C ``NSString`` ISO 8601 literal.
-
-    This is the ISO format variant, producing the same ``@"..."``
-    ``NSString`` output as the native format.
-
-    Example: ``datetime.datetime(2024, 1, 15, 12, 30)`` →
-    ``@"2024-01-15T12:30:00"``.
-    """
-    return f'@"{value.isoformat()}"'
-
-
-@beartype
 class ObjectiveC(metaclass=LanguageCls):
     """Objective-C language specification."""
 
@@ -129,9 +86,11 @@ class ObjectiveC(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""
 
-        OBJC = DateFormatConfig(formatter=_format_objc_date)
+        OBJC = DateFormatConfig(
+            formatter=date_iso_formatter(template='@"{iso}"'),
+        )
         ISO = DateFormatConfig(
-            formatter=_format_objc_date_iso,
+            formatter=date_iso_formatter(template='@"{iso}"'),
             type_produced=str,
         )
 
@@ -142,9 +101,11 @@ class ObjectiveC(metaclass=LanguageCls):
     class DatetimeFormats(enum.Enum):
         """Datetime format options for ObjectiveC."""
 
-        OBJC = DatetimeFormatConfig(formatter=_format_objc_datetime)
+        OBJC = DatetimeFormatConfig(
+            formatter=datetime_iso_formatter(template='@"{iso}"'),
+        )
         ISO = DatetimeFormatConfig(
-            formatter=_format_objc_datetime_iso,
+            formatter=datetime_iso_formatter(template='@"{iso}"'),
             type_produced=str,
         )
 

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -10,6 +10,8 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters import (
+    date_ymd_formatter,
+    datetime_ymdhms_formatter,
     fixed_dict_open,
     fixed_sequence_open,
     fixed_set_open,
@@ -40,21 +42,6 @@ from literalizer._types import Value
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-
-@beartype
-def _format_date_ocaml(value: datetime.date) -> str:
-    """Format a date as an OCaml ``ODate`` constructor."""
-    return f"ODate ({value.year}, {value.month}, {value.day})"
-
-
-@beartype
-def _format_datetime_ocaml(value: datetime.datetime) -> str:
-    """Format a datetime as an OCaml ``ODatetime`` constructor."""
-    return (
-        f"ODatetime (({value.year}, {value.month}, {value.day}), "
-        f"({value.hour}, {value.minute}, {value.second}))"
-    )
 
 
 @beartype
@@ -121,7 +108,11 @@ class OCaml(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""
 
-        OCAML = DateFormatConfig(formatter=_format_date_ocaml)
+        OCAML = DateFormatConfig(
+            formatter=date_ymd_formatter(
+                template="ODate ({year}, {month}, {day})",
+            ),
+        )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
         def __call__(self, date_value: datetime.date, /) -> str:
@@ -131,7 +122,12 @@ class OCaml(metaclass=LanguageCls):
     class DatetimeFormats(enum.Enum):
         """Datetime format options for OCaml."""
 
-        OCAML = DatetimeFormatConfig(formatter=_format_datetime_ocaml)
+        OCAML = DatetimeFormatConfig(
+            formatter=datetime_ymdhms_formatter(
+                template="ODatetime (({year}, {month}, {day}), "
+                "({hour}, {minute}, {second}))",
+            ),
+        )
         ISO = DatetimeFormatConfig(
             formatter=format_datetime_iso,
             type_produced=str,

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_ymd_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -44,15 +45,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from literalizer._types import Value
-
-
-@beartype
-def _format_date_perl(value: datetime.date) -> str:
-    """Format a date as a Perl ``DateTime`` constructor."""
-    return (
-        f"DateTime->new(year => {value.year}, "
-        f"month => {value.month}, day => {value.day})"
-    )
 
 
 @beartype
@@ -100,7 +92,10 @@ class Perl(metaclass=LanguageCls):
         """Date format options for Perl."""
 
         PERL = DateFormatConfig(
-            formatter=_format_date_perl,
+            formatter=date_ymd_formatter(
+                template="DateTime->new("
+                "year => {year}, month => {month}, day => {day})",
+            ),
             preamble_lines=("use DateTime;",),
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_iso_formatter,
+    datetime_iso_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -46,18 +48,6 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_date(value: datetime.date) -> str:
-    """Format a date as a PHP DateTime object."""
-    return f'new DateTime("{value.isoformat()}")'
-
-
-@beartype
-def _format_datetime(value: datetime.datetime) -> str:
-    """Format a datetime as a PHP DateTime object."""
-    return f'new DateTime("{value.isoformat()}")'
-
-
-@beartype
 class Php(metaclass=LanguageCls):
     """PHP language specification."""
 
@@ -67,7 +57,9 @@ class Php(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date format options for Php."""
 
-        PHP = DateFormatConfig(formatter=_format_date)
+        PHP = DateFormatConfig(
+            formatter=date_iso_formatter(template='new DateTime("{iso}")'),
+        )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
         def __call__(self, date_value: datetime.date, /) -> str:
@@ -77,7 +69,11 @@ class Php(metaclass=LanguageCls):
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Php."""
 
-        PHP = DatetimeFormatConfig(formatter=_format_datetime)
+        PHP = DatetimeFormatConfig(
+            formatter=datetime_iso_formatter(
+                template='new DateTime("{iso}")',
+            ),
+        )
         ISO = DatetimeFormatConfig(
             formatter=format_datetime_iso,
             type_produced=str,

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -12,6 +12,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters import (
+    date_ymd_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -43,17 +44,6 @@ from literalizer._language import (
     date_scalar_preamble,
 )
 from literalizer._types import Value
-
-
-@beartype
-def _format_date_python(value: datetime.date) -> str:
-    """Format a date as a Python ``datetime.date(...)`` constructor
-    call.
-    """
-    return (
-        f"datetime.date("
-        f"year={value.year}, month={value.month}, day={value.day})"
-    )
 
 
 @beartype
@@ -325,7 +315,10 @@ class Python(metaclass=LanguageCls):
         """Date formatting options for Python."""
 
         PYTHON = DateFormatConfig(
-            formatter=_format_date_python,
+            formatter=date_ymd_formatter(
+                template="datetime.date("
+                "year={year}, month={month}, day={day})",
+            ),
             preamble_lines=("import datetime",),
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_iso_formatter,
+    datetime_iso_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -37,18 +39,6 @@ from literalizer.exceptions import EmptyDictKeyError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-
-@beartype
-def _format_date_r(value: datetime.date) -> str:
-    """Format a date as an R ``as.Date(...)`` call."""
-    return f'as.Date("{value.isoformat()}")'
-
-
-@beartype
-def _format_datetime_r(value: datetime.datetime) -> str:
-    """Format a datetime as an R ``as.POSIXct(...)`` call."""
-    return f'as.POSIXct("{value.isoformat()}")'
 
 
 @beartype
@@ -115,7 +105,9 @@ class R(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date formatting options for R."""
 
-        R = DateFormatConfig(formatter=_format_date_r)
+        R = DateFormatConfig(
+            formatter=date_iso_formatter(template='as.Date("{iso}")'),
+        )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
         def __call__(self, date_value: datetime.date, /) -> str:
@@ -125,7 +117,11 @@ class R(metaclass=LanguageCls):
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for R."""
 
-        R = DatetimeFormatConfig(formatter=_format_datetime_r)
+        R = DatetimeFormatConfig(
+            formatter=datetime_iso_formatter(
+                template='as.POSIXct("{iso}")',
+            ),
+        )
         ISO = DatetimeFormatConfig(
             formatter=format_datetime_iso,
             type_produced=str,

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_ymd_formatter,
+    datetime_ymdhms_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -47,21 +49,6 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_date_ruby(value: datetime.date) -> str:
-    """Format a date as a Ruby ``Date.new(...)`` call."""
-    return f"Date.new({value.year}, {value.month}, {value.day})"
-
-
-@beartype
-def _format_datetime_ruby(value: datetime.datetime) -> str:
-    """Format a datetime as a Ruby ``Time.new(...)`` call."""
-    return (
-        f"Time.new({value.year}, {value.month}, {value.day}, "
-        f"{value.hour}, {value.minute}, {value.second})"
-    )
-
-
-@beartype
 class Ruby(metaclass=LanguageCls):
     """Ruby language specification.
 
@@ -88,7 +75,9 @@ class Ruby(metaclass=LanguageCls):
         """Date format options for Ruby."""
 
         RUBY = DateFormatConfig(
-            formatter=_format_date_ruby,
+            formatter=date_ymd_formatter(
+                template="Date.new({year}, {month}, {day})",
+            ),
             preamble_lines=("require 'date'",),
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
@@ -101,7 +90,10 @@ class Ruby(metaclass=LanguageCls):
         """Datetime format options for Ruby."""
 
         RUBY = DatetimeFormatConfig(
-            formatter=_format_datetime_ruby,
+            formatter=datetime_ymdhms_formatter(
+                template="Time.new({year}, {month}, {day}, "
+                "{hour}, {minute}, {second})",
+            ),
         )
         ISO = DatetimeFormatConfig(
             formatter=format_datetime_iso,

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_iso_formatter,
+    datetime_iso_formatter,
     fixed_dict_open,
     fixed_sequence_open,
     fixed_set_open,
@@ -60,26 +62,6 @@ def _format_toml_dict_entry(key: str, _val: Value, value: str) -> str:
 
 
 @beartype
-def _format_toml_date(value: datetime.date) -> str:
-    """Format a date as a TOML local date literal (unquoted).
-
-    Example: ``datetime.date(2024, 1, 15)`` → ``2024-01-15``.
-    """
-    return value.isoformat()
-
-
-@beartype
-def _format_toml_datetime(value: datetime.datetime) -> str:
-    """Format a datetime as a TOML offset or local datetime literal
-    (unquoted).
-
-    Example: ``datetime.datetime(2024, 1, 15, 12, 30, tzinfo=UTC)`` →
-    ``2024-01-15T12:30:00+00:00``.
-    """
-    return value.isoformat()
-
-
-@beartype
 class Toml(metaclass=LanguageCls):
     """TOML language specification.
 
@@ -101,7 +83,9 @@ class Toml(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date format options for Toml."""
 
-        TOML = DateFormatConfig(formatter=_format_toml_date)
+        TOML = DateFormatConfig(
+            formatter=date_iso_formatter(template="{iso}"),
+        )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
         def __call__(self, date_value: datetime.date, /) -> str:
@@ -111,7 +95,9 @@ class Toml(metaclass=LanguageCls):
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Toml."""
 
-        TOML = DatetimeFormatConfig(formatter=_format_toml_datetime)
+        TOML = DatetimeFormatConfig(
+            formatter=datetime_iso_formatter(template="{iso}"),
+        )
         ISO = DatetimeFormatConfig(
             formatter=format_datetime_iso,
             type_produced=str,

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_iso_formatter,
+    datetime_iso_formatter,
     dict_entry_with_separator,
     dict_entry_with_template,
     fixed_dict_open,
@@ -47,24 +49,6 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_date_ts(value: datetime.date) -> str:
-    """Format a date as a TypeScript ``new Date(...)`` call.
-
-    Example: ``new Date("2024-01-15")``.
-    """
-    return f'new Date("{value.isoformat()}")'
-
-
-@beartype
-def _format_datetime_ts(value: datetime.datetime) -> str:
-    """Format a datetime as a TypeScript ``new Date(...)`` call.
-
-    Example: ``new Date("2024-01-15T12:30:00")``.
-    """
-    return f'new Date("{value.isoformat()}")'
-
-
-@beartype
 class TypeScript(metaclass=LanguageCls):
     """TypeScript language specification.
 
@@ -98,7 +82,9 @@ class TypeScript(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date formatting options for TypeScript."""
 
-        JS = DateFormatConfig(formatter=_format_date_ts)
+        JS = DateFormatConfig(
+            formatter=date_iso_formatter(template='new Date("{iso}")'),
+        )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
         def __call__(self, date_value: datetime.date, /) -> str:
@@ -108,7 +94,11 @@ class TypeScript(metaclass=LanguageCls):
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for TypeScript."""
 
-        JS = DatetimeFormatConfig(formatter=_format_datetime_ts)
+        JS = DatetimeFormatConfig(
+            formatter=datetime_iso_formatter(
+                template='new Date("{iso}")',
+            ),
+        )
         ISO = DatetimeFormatConfig(
             formatter=format_datetime_iso,
             type_produced=str,

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters import (
+    date_iso_formatter,
+    datetime_iso_formatter,
     dict_entry_with_separator,
     fixed_dict_open,
     fixed_sequence_open,
@@ -40,25 +42,6 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_yaml_date(value: datetime.date) -> str:
-    """Format a date as a YAML native date literal (unquoted).
-
-    Example: ``datetime.date(2024, 1, 15)`` → ``2024-01-15``.
-    """
-    return value.isoformat()
-
-
-@beartype
-def _format_yaml_datetime(value: datetime.datetime) -> str:
-    """Format a datetime as a YAML native datetime literal (unquoted).
-
-    Example: ``datetime.datetime(2024, 1, 15, 12, 30, tzinfo=UTC)`` →
-    ``2024-01-15T12:30:00+00:00``.
-    """
-    return value.isoformat()
-
-
-@beartype
 class Yaml(metaclass=LanguageCls):
     """YAML language specification.
 
@@ -76,7 +59,9 @@ class Yaml(metaclass=LanguageCls):
     class DateFormats(enum.Enum):
         """Date format options for Yaml."""
 
-        YAML = DateFormatConfig(formatter=_format_yaml_date)
+        YAML = DateFormatConfig(
+            formatter=date_iso_formatter(template="{iso}"),
+        )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
         def __call__(self, date_value: datetime.date, /) -> str:
@@ -86,7 +71,9 @@ class Yaml(metaclass=LanguageCls):
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Yaml."""
 
-        YAML = DatetimeFormatConfig(formatter=_format_yaml_datetime)
+        YAML = DatetimeFormatConfig(
+            formatter=datetime_iso_formatter(template="{iso}"),
+        )
         ISO = DatetimeFormatConfig(
             formatter=format_datetime_iso,
             type_produced=str,


### PR DESCRIPTION
## Summary
- Replace hand-written date/datetime formatting functions across 13 language files with inline calls to the existing template-based formatters (`date_iso_formatter`, `datetime_iso_formatter`, `date_ymd_formatter`, `datetime_ymdhms_formatter`) from `_formatters.py`.
- Removes ~130 lines of boilerplate while preserving identical behavior.
- Languages with complex formatting (microsecond/timezone handling) keep their custom functions; only simple template-compatible cases were converted.

## Test plan
- [x] All 7253 existing tests pass with no changes to test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor across many language backends that could subtly change emitted date/datetime literals if any template differs from prior output, though logic is largely a direct substitution and complex cases were left untouched.
> 
> **Overview**
> Refactors multiple language specs to **remove bespoke date/datetime formatting functions** and instead use shared template-based helpers (`date_ymd_formatter`, `datetime_ymdhms_formatter`, `date_iso_formatter`, `datetime_iso_formatter`) for their native date/datetime variants.
> 
> This reduces repeated boilerplate while keeping per-language behavior the same, and leaves more complex datetime handling (e.g., timezone/microsecond logic) on existing custom formatters where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 077a8f1b64905ab0a87047f41525fcff586e5a9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->