### PR TITLE
Bump doccmd to 2026.3.26.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
-    "doccmd==2026.3.2",
+    "doccmd==2026.3.26.2",
     "furo==2025.12.19",
     "hypothesis>=6.0",
     "interrogate==1.7.0",


### PR DESCRIPTION
Updates the `doccmd` dev dependency to [2026.3.26.2](https://pypi.org/project/doccmd/2026.3.26.2/).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates a pinned development-only documentation tool dependency and does not change runtime code or shipped artifacts.
> 
> **Overview**
> **Updates development tooling** by bumping the `doccmd` dev dependency in `pyproject.toml` from `2026.3.2` to `2026.3.26.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a8fce3c8e3b00e5749df457ac9ce83f6336b794. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->