### PR TITLE
Mention YAML alongside JSON in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 literalizer
 ===========
 
-``literalizer`` converts JSON data structures to native language literal syntax.
+``literalizer`` converts JSON and YAML data structures to native language literal syntax.
 
 .. contents::
    :local:
@@ -70,9 +70,9 @@ Usage
 Use cases
 ---------
 
-* Generate test fixtures from JSON samples.
-* Generate multi-language request/response examples for JSON API docs (see `guide <https://adamtheturtle.github.io/literalizer/json-api-use-case.html>`__).
-* Create type-safe literal data from JSON config files.
+* Generate test fixtures from JSON or YAML samples.
+* Generate multi-language request/response examples for JSON or YAML API docs (see `guide <https://adamtheturtle.github.io/literalizer/json-api-use-case.html>`__).
+* Create type-safe literal data from JSON or YAML config files.
 
 CLI
 ---


### PR DESCRIPTION
Update the README to mention YAML support wherever JSON is referenced — in the project description and all three use case bullet points.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates with no runtime or API changes, so risk is low.
> 
> **Overview**
> Updates `README.rst` to consistently describe `literalizer` as supporting **YAML in addition to JSON**, including the project tagline and the three *Use cases* bullets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f88b125040c90e250daca5579120864306d8472b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->