### PR TITLE
Use syntax highlighting and textwrap.dedent in API doc

### DIFF
--- a/docs/source/json-api-use-case.rst
+++ b/docs/source/json-api-use-case.rst
@@ -54,11 +54,11 @@ returns this response:
        new_variable=True,
    )
    assert request_literal.code == textwrap.dedent(
-       """\
+       text="""\
        request_body = {
            "name": "Alice",
            "email": "alice@example.com",
-       }"""
+       }""",
    )
 
    response_literal = literalize_json(
@@ -78,13 +78,13 @@ returns this response:
        new_variable=True,
    )
    assert response_literal.code == textwrap.dedent(
-       """\
+       text="""\
        response = {
            "id": 42,
            "name": "Alice",
            "email": "alice@example.com",
            "created": True,
-       }"""
+       }""",
    )
 
 Pass a different language to get the same data as JavaScript, Go, Ruby, etc.


### PR DESCRIPTION
## Summary
- Replace `.. code-block:: text` with language-specific syntax highlighting (`python`, `javascript`, `go`, `ruby`) for output examples
- Use `textwrap.dedent` instead of string concatenation for multiline assertions in the sample code
- Add `skip doccmd[all]: next` marker for the Python output block to avoid vulture false positives

## Test plan
- [ ] Verify docs build without warnings
- [ ] Confirm syntax highlighting renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that adjust formatting/syntax highlighting and example assertions without affecting runtime code.
> 
> **Overview**
> Improves the `json-api-use-case.rst` documentation examples by switching output snippets from generic `text` blocks to language-specific code blocks (Python/JavaScript/Go/Ruby) for proper syntax highlighting.
> 
> Refactors the embedded Python example assertions to use `textwrap.dedent` multi-line strings instead of manual string concatenation, and adds `.. skip doccmd[all]: next` before the Python output block to avoid doc tooling false positives.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70953fdca859f2c354184f639f57823146a1be86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->