### PR TITLE
Extract hardcoded empty collection type defaults into named variables

### DIFF
--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
     from literalizer._types import Value
 
+_DEFAULT_VALUE_TYPE = "Nil"
+
 
 @beartype
 class Crystal(metaclass=LanguageCls):
@@ -93,7 +95,7 @@ class Crystal(metaclass=LanguageCls):
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_sequence_open(open_str="["),
             close="]",
-            empty_sequence="[] of Nil",
+            empty_sequence=f"[] of {_DEFAULT_VALUE_TYPE}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             supports_trailing_comma=True,
@@ -126,7 +128,7 @@ class Crystal(metaclass=LanguageCls):
         SET = SetFormatConfig(
             set_open=fixed_set_open(open_str="Set{"),
             close="}",
-            empty_set="Set(Nil).new",
+            empty_set=f"Set({_DEFAULT_VALUE_TYPE}).new",
             preamble_lines=('require "set"',),
             set_opener_template="",
         )
@@ -253,7 +255,9 @@ class Crystal(metaclass=LanguageCls):
                 separator=" => ",
                 format_value=passthrough_sequence_entry,
             ),
-            empty_dict="{} of Nil => Nil",
+            empty_dict=(
+                f"{{}} of {_DEFAULT_VALUE_TYPE} => {_DEFAULT_VALUE_TYPE}"
+            ),
             preamble_lines=(),
             narrowed_open=None,
         )

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -59,6 +59,9 @@ class _CSharpDictSpec:
     fallback: str
 
 
+_DEFAULT_VALUE_TYPE = "object"
+
+
 @beartype
 class CSharp(metaclass=LanguageCls):
     """C# language specification.
@@ -96,7 +99,7 @@ class CSharp(metaclass=LanguageCls):
         dict_opener_template="new Dictionary<string, {type_name}> {{",
         set_opener_template="new HashSet<{type_name}> {{",
         dict_type_template="Dictionary<string, {inner}>",
-        fallback_value_type="object",
+        fallback_value_type=_DEFAULT_VALUE_TYPE,
     )
 
     class DateFormats(enum.Enum):
@@ -157,15 +160,17 @@ class CSharp(metaclass=LanguageCls):
             supports_trailing_comma=False,
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="new object[] {"),
+            sequence_open=fixed_sequence_open(
+                open_str=f"new {_DEFAULT_VALUE_TYPE}[] {{",
+            ),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             supports_trailing_comma=True,
-            empty_sequence="Array.Empty<object>()",
+            empty_sequence=f"Array.Empty<{_DEFAULT_VALUE_TYPE}>()",
             preamble_lines=("using System.Collections.Generic;",),
             format_entry=passthrough_sequence_entry,
-            typed_opener_fallback="new object[] {",
+            typed_opener_fallback=f"new {_DEFAULT_VALUE_TYPE}[] {{",
         )
 
         @property
@@ -179,16 +184,20 @@ class CSharp(metaclass=LanguageCls):
         """Set type options for C#."""
 
         HASH_SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="new HashSet<object> {"),
+            set_open=fixed_set_open(
+                open_str=f"new HashSet<{_DEFAULT_VALUE_TYPE}> {{",
+            ),
             close="}",
-            empty_set="new HashSet<object>()",
+            empty_set=f"new HashSet<{_DEFAULT_VALUE_TYPE}>()",
             preamble_lines=("using System.Collections.Generic;",),
             set_opener_template="",
         )
         SORTED_SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="new SortedSet<object> {"),
+            set_open=fixed_set_open(
+                open_str=f"new SortedSet<{_DEFAULT_VALUE_TYPE}> {{",
+            ),
             close="}",
-            empty_set="new SortedSet<object>()",
+            empty_set=f"new SortedSet<{_DEFAULT_VALUE_TYPE}>()",
             preamble_lines=("using System.Collections.Generic;",),
             set_opener_template="new SortedSet<{type_name}> {{",
         )
@@ -215,11 +224,11 @@ class CSharp(metaclass=LanguageCls):
 
         DICTIONARY = _CSharpDictSpec(
             opener_template="new Dictionary<string, {type_name}> {{",
-            fallback="new Dictionary<string, object> {",
+            fallback=f"new Dictionary<string, {_DEFAULT_VALUE_TYPE}> {{",
         )
         SORTED_DICTIONARY = _CSharpDictSpec(
             opener_template="new SortedDictionary<string, {type_name}> {{",
-            fallback="new SortedDictionary<string, object> {",
+            fallback=f"new SortedDictionary<string, {_DEFAULT_VALUE_TYPE}> {{",
         )
 
     class EmptyDictKey(enum.Enum):
@@ -411,7 +420,7 @@ class CSharp(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="new Dictionary<string, object> {",
+                open_str=f"new Dictionary<string, {_DEFAULT_VALUE_TYPE}> {{",
                 close="}",
                 preamble_lines=("using System.Collections.Generic;",),
             )

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
 
     from literalizer._types import Value
 
+_DEFAULT_VALUE_TYPE = "dynamic"
+
 
 @beartype
 class Dart(metaclass=LanguageCls):
@@ -82,7 +84,7 @@ class Dart(metaclass=LanguageCls):
         dict_opener_template="<String, {type_name}>{{",
         set_opener_template="<{type_name}>{{",
         dict_type_template="Map<String, {inner}>",
-        fallback_value_type="dynamic",
+        fallback_value_type=_DEFAULT_VALUE_TYPE,
     )
 
     class DateFormats(enum.Enum):
@@ -164,7 +166,7 @@ class Dart(metaclass=LanguageCls):
         SET = SetFormatConfig(
             set_open=fixed_set_open(open_str="{"),
             close="}",
-            empty_set="<dynamic>{}",
+            empty_set=f"<{_DEFAULT_VALUE_TYPE}>{{}}",
             preamble_lines=(),
             set_opener_template="",
         )

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
     from literalizer._types import Value
 
 
+_DEFAULT_VALUE_TYPE = "Object"
+
+
 @beartype
 class Groovy(metaclass=LanguageCls):
     """Groovy language specification."""
@@ -102,8 +105,8 @@ class Groovy(metaclass=LanguageCls):
 
         SET = SetFormatConfig(
             set_open=fixed_set_open(open_str="["),
-            close="] as Set<Object>",
-            empty_set="[] as Set<Object>",
+            close=f"] as Set<{_DEFAULT_VALUE_TYPE}>",
+            empty_set=f"[] as Set<{_DEFAULT_VALUE_TYPE}>",
             preamble_lines=(),
             set_opener_template="",
         )

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -38,6 +38,8 @@ from literalizer._types import Value
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+_DEFAULT_VALUE_TYPE = "String"
+
 
 @beartype
 def _format_mojo_ordered_map_entry(key: str, _val: Value, value: str) -> str:
@@ -102,7 +104,7 @@ class Mojo(metaclass=LanguageCls):
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
             supports_trailing_comma=True,
-            empty_sequence="List[String]()",
+            empty_sequence=f"List[{_DEFAULT_VALUE_TYPE}]()",
             preamble_lines=(),
             format_entry=passthrough_sequence_entry,
             typed_opener_fallback=None,
@@ -136,10 +138,10 @@ class Mojo(metaclass=LanguageCls):
                     ),
                     opener_template="Set[{type_name}](",
                 ),
-                fallback="Set[String](",
+                fallback=f"Set[{_DEFAULT_VALUE_TYPE}](",
             ),
             close=")",
-            empty_set="Set[String]()",
+            empty_set=f"Set[{_DEFAULT_VALUE_TYPE}]()",
             preamble_lines=("from std.collections import Set",),
             set_opener_template="",
         )
@@ -252,7 +254,7 @@ class Mojo(metaclass=LanguageCls):
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             ),
-            empty_dict="Dict[String, String]()",
+            empty_dict=f"Dict[{_DEFAULT_VALUE_TYPE}, {_DEFAULT_VALUE_TYPE}]()",
             preamble_lines=(),
             narrowed_open=None,
         )

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -45,6 +45,9 @@ if TYPE_CHECKING:
 
     from literalizer._types import Value
 
+_DEFAULT_VALUE_TYPE = "String"
+_DEFAULT_DICT_ENTRY_TYPE = "&str"
+
 
 @beartype
 def _format_date_rust(value: datetime.date) -> str:
@@ -165,7 +168,7 @@ class Rust(metaclass=LanguageCls):
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
             supports_trailing_comma=True,
-            empty_sequence="Vec::<String>::new()",
+            empty_sequence=f"Vec::<{_DEFAULT_VALUE_TYPE}>::new()",
             preamble_lines=(),
             format_entry=passthrough_sequence_entry,
             typed_opener_fallback=None,
@@ -206,14 +209,14 @@ class Rust(metaclass=LanguageCls):
         HASH_SET = SetFormatConfig(
             set_open=fixed_set_open(open_str="HashSet::from(["),
             close="])",
-            empty_set="HashSet::<String>::new()",
+            empty_set=f"HashSet::<{_DEFAULT_VALUE_TYPE}>::new()",
             preamble_lines=("use std::collections::HashSet;",),
             set_opener_template="",
         )
         BTREE_SET = SetFormatConfig(
             set_open=fixed_set_open(open_str="BTreeSet::from(["),
             close="])",
-            empty_set="BTreeSet::<String>::new()",
+            empty_set=f"BTreeSet::<{_DEFAULT_VALUE_TYPE}>::new()",
             preamble_lines=("use std::collections::BTreeSet;",),
             set_opener_template="",
         )
@@ -251,7 +254,10 @@ class Rust(metaclass=LanguageCls):
             format_entry=tuple_dict_entry(
                 format_value=passthrough_sequence_entry
             ),
-            empty_dict="HashMap::<&str, &str>::from([])",
+            empty_dict=(
+                f"HashMap::<{_DEFAULT_DICT_ENTRY_TYPE},"
+                f" {_DEFAULT_DICT_ENTRY_TYPE}>::from([])"
+            ),
             preamble_lines=("use std::collections::HashMap;",),
             narrowed_open=None,
         )
@@ -261,7 +267,10 @@ class Rust(metaclass=LanguageCls):
             format_entry=tuple_dict_entry(
                 format_value=passthrough_sequence_entry
             ),
-            empty_dict="BTreeMap::<&str, &str>::from([])",
+            empty_dict=(
+                f"BTreeMap::<{_DEFAULT_DICT_ENTRY_TYPE},"
+                f" {_DEFAULT_DICT_ENTRY_TYPE}>::from([])"
+            ),
             preamble_lines=("use std::collections::BTreeMap;",),
             narrowed_open=None,
         )

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -80,6 +80,10 @@ def _tuple_sequence_entry(original: Value, entry: str) -> str:
     return entry
 
 
+_DEFAULT_VALUE_TYPE = "Any"
+_DEFAULT_HASHABLE_TYPE = "AnyHashable"
+
+
 @beartype
 class Swift(metaclass=LanguageCls):
     """Swift language specification."""
@@ -134,7 +138,7 @@ class Swift(metaclass=LanguageCls):
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             supports_trailing_comma=True,
-            empty_sequence="[Any]()",
+            empty_sequence=f"[{_DEFAULT_VALUE_TYPE}]()",
             preamble_lines=(),
             format_entry=passthrough_sequence_entry,
             typed_opener_fallback=None,
@@ -162,9 +166,11 @@ class Swift(metaclass=LanguageCls):
         """Set type options for Swift."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="Set<AnyHashable>(["),
+            set_open=fixed_set_open(
+                open_str=f"Set<{_DEFAULT_HASHABLE_TYPE}>(["
+            ),
             close="])",
-            empty_set="Set<AnyHashable>()",
+            empty_set=f"Set<{_DEFAULT_HASHABLE_TYPE}>()",
             preamble_lines=(),
             set_opener_template="",
         )
@@ -323,7 +329,7 @@ class Swift(metaclass=LanguageCls):
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             ),
-            empty_dict="[String: Any]()",
+            empty_dict=f"[String: {_DEFAULT_VALUE_TYPE}]()",
             preamble_lines=(),
             narrowed_open=None,
         )

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -37,6 +37,8 @@ from literalizer._types import Value
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+_DEFAULT_VALUE_TYPE = "Object"
+
 
 @beartype
 def _flush_vb_current(
@@ -283,13 +285,13 @@ class VisualBasic(metaclass=LanguageCls):
         fmt = SequenceFormatConfig(
             sequence_open=typed_sequence_open(
                 type_to_opener=vb_type_to_opener,
-                fallback="New Object() {",
+                fallback=f"New {_DEFAULT_VALUE_TYPE}() {{",
             ),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
             supports_trailing_comma=True,
-            empty_sequence="New Object() {}",
+            empty_sequence=f"New {_DEFAULT_VALUE_TYPE}() {{}}",
             preamble_lines=("Imports System.Collections.Generic",),
             format_entry=passthrough_sequence_entry,
             typed_opener_fallback=None,
@@ -302,17 +304,19 @@ class VisualBasic(metaclass=LanguageCls):
                     element_to_type=element_to_type,
                     opener_template="New HashSet(Of {type_name}) From {{",
                 ),
-                fallback="New HashSet(Of Object) From {",
+                fallback=f"New HashSet(Of {_DEFAULT_VALUE_TYPE}) From {{",
             ),
             close="}",
-            empty_set="New HashSet(Of Object)()",
+            empty_set=f"New HashSet(Of {_DEFAULT_VALUE_TYPE})()",
             preamble_lines=(),
             set_opener_template="",
         )
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(
-                open_str="New Dictionary(Of String, Object) From {",
+                open_str=(
+                    f"New Dictionary(Of String, {_DEFAULT_VALUE_TYPE}) From {{"
+                ),
             ),
             close="}",
             format_entry=braced_dict_entry(
@@ -349,7 +353,9 @@ class VisualBasic(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="New Dictionary(Of String, Object) From {",
+                open_str=(
+                    f"New Dictionary(Of String, {_DEFAULT_VALUE_TYPE}) From {{"
+                ),
                 close="}",
                 preamble_lines=(),
             )


### PR DESCRIPTION
## Summary
- Extract hardcoded type strings (e.g. `"object"`, `"Nil"`, `"String"`) from empty collection expressions into named module-level variables (`_DEFAULT_VALUE_TYPE`, etc.) across 8 language files
- Pure refactoring — no behavior change, all 7281 integration tests pass

Closes #760

## Test plan
- [x] All 339 unit tests pass
- [x] All 7281 integration tests pass (75 skipped)
- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only replaces hardcoded type strings in empty collection literals with module-level constants; potential risk is minor formatting/regression in generated literals if a constant is mistyped.
> 
> **Overview**
> Refactors multiple language backends (Crystal, C#, Dart, Groovy, Mojo, Rust, Swift, VB) to **extract hardcoded default type names** used in empty collection literals (e.g. empty arrays/sets/maps) into module-level constants like `_DEFAULT_VALUE_TYPE` (and Rust/Swift-specific variants).
> 
> Updates the affected `empty_sequence`/`empty_set`/`empty_dict` and fallback opener templates to reference these constants, keeping the emitted literals consistent while making defaults easier to audit and change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15568acca36a0ad516a9caeec37eb42c102555c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->