### PR TITLE
Link to literalize_yaml and literalize_json from docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,8 @@ Requires Python |minimum-python-version|\+.
 Usage
 -----
 
+Use :func:`literalizer.literalize_yaml` (or :func:`literalizer.literalize_json` for JSON input) to convert data to native language literals:
+
 .. code-block:: python
 
    """Example of using literalizer."""

--- a/docs/source/json-api-use-case.rst
+++ b/docs/source/json-api-use-case.rst
@@ -20,7 +20,7 @@ returns this response:
    // Response
    {"id": 42, "name": "Alice", "email": "alice@example.com", "created": true}
 
-|project| converts these into native literals for each language:
+|project| converts these into native literals for each language using :func:`literalizer.literalize_json`:
 
 .. code-block:: python
 


### PR DESCRIPTION
## Summary

- Add Sphinx `:func:` cross-references to `literalize_yaml` and `literalize_json` from `index.rst` and `json-api-use-case.rst`, so readers can click through to the full API documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds Sphinx `:func:` links; no runtime behavior is affected.
> 
> **Overview**
> Improves documentation navigability by adding Sphinx `:func:` cross-references to `literalizer.literalize_yaml` and `literalizer.literalize_json` in the main usage section and the JSON API use-case guide, so readers can click through to the API reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c89c29b8d5068c6f1e9d425c926af610c85d15d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->