### PR TITLE
Revert "Prefix internal Language protocol attributes with underscore"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,11 +124,6 @@ lint.per-file-ignores."doccmd_*.py" = [
     # Allow asserts in docs.
     "S101",
 ]
-lint.per-file-ignores."src/literalizer/_core.py" = [
-    # _core.py is the internal engine that consumes the Language protocol's
-    # private attributes (e.g. _indent, _format_string).
-    "SLF001",
-]
 lint.per-file-ignores."tests/integration/cases/**/*.py" = [
     # These are generated fixture files; suppress everything except
     # unused-import checks (F401) so we catch stale imports.
@@ -144,16 +139,12 @@ lint.per-file-ignores."tests/integration/cases/**/*.py" = [
 lint.per-file-ignores."tests/integration/test_*.py" = [
     # Allow 'assert' as we use it for tests.
     "S101",
-    # Tests may access private Language attributes for verification.
-    "SLF001",
     # FileRegressionFixture must be imported at runtime for beartype.
     "TC002",
 ]
 lint.per-file-ignores."tests/test_*.py" = [
     # Allow 'assert' as we use it for tests.
     "S101",
-    # Tests may access private Language attributes for verification.
-    "SLF001",
 ]
 # Do not automatically remove commented out code.
 # We comment out code during development, and with VSCode auto-save, this code
@@ -248,9 +239,6 @@ MESSAGES-CONTROL.per-file-ignores = [
     "docs/source/conf.py:invalid-name",
     "docs/source/doccmd_*.py:invalid-name",
     "doccmd_README_rst_*.py:invalid-name",
-    "src/literalizer/_core.py:protected-access",
-    "tests/test_*.py:protected-access",
-    "tests/integration/test_*.py:protected-access",
 ]
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 """Core conversion logic: formatting values and parsing JSON/YAML."""
 
 import dataclasses
@@ -126,13 +125,13 @@ def _collection_preamble(
     """Return collection-config preamble lines for present types."""
     lines: list[str] = []
     if dict in types:
-        lines.extend(language._dict_format_config.preamble_lines)
+        lines.extend(language.dict_format_config.preamble_lines)
     if set in types:
-        lines.extend(language._set_format_config.preamble_lines)
+        lines.extend(language.set_format_config.preamble_lines)
     if list in types:
-        lines.extend(language._sequence_format_config.preamble_lines)
+        lines.extend(language.sequence_format_config.preamble_lines)
     if ordereddict in types:
-        lines.extend(language._ordered_map_format_config.preamble_lines)
+        lines.extend(language.ordered_map_format_config.preamble_lines)
     return tuple(lines)
 
 
@@ -170,24 +169,24 @@ def _compute_preamble(
 
     scalar = tuple(
         line
-        for scalar_type, preamble in language._scalar_preamble.items()
+        for scalar_type, preamble in language.scalar_preamble.items()
         if scalar_type in types
         for line in preamble
     )
     collection = _collection_preamble(types=types, language=language)
     type_hint = (
-        language._type_hint_collection_preamble_lines
+        language.type_hint_collection_preamble_lines
         if has_variable_declaration
         and types & {dict, list, set, ordereddict}
         and _has_empty_collection(data=data)
         else ()
     )
-    body = language._compute_body_preamble(types, data)
+    body = language.compute_body_preamble(types, data)
     return _PreambleResult(
         header=_deduplicate(
             lines=scalar + collection + type_hint,
         )
-        + tuple(language._static_body_preamble),
+        + tuple(language.static_body_preamble),
         body=body,
     )
 
@@ -606,21 +605,21 @@ def _format_scalar(*, value: Scalar, spec: Language) -> str:
     """Format a scalar JSON value as a native language literal."""
     match value:
         case None:
-            result = spec._null_literal
+            result = spec.null_literal
         case bool():
-            result = spec._true_literal if value else spec._false_literal
+            result = spec.true_literal if value else spec.false_literal
         case int():
-            result = spec._format_integer(value)
+            result = spec.format_integer(value)
         case float():
             result = repr(value)
         case str():
-            result = spec._format_string(value)
+            result = spec.format_string(value)
         case bytes():
-            result = spec._format_bytes(value)
+            result = spec.format_bytes(value)
         case datetime.datetime():
-            result = spec._format_datetime(value)
+            result = spec.format_datetime(value)
         case _:
-            result = spec._format_date(value)
+            result = spec.format_date(value)
     return result
 
 
@@ -629,13 +628,13 @@ def _build_dict_entry(
     *, key_str: str, val: Value, val_str: str, spec: Language
 ) -> str:
     """Format a single dict key-value entry using the language spec."""
-    return spec._dict_format_config.format_entry(key_str, val, val_str)
+    return spec.dict_format_config.format_entry(key_str, val, val_str)
 
 
 @beartype
 def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
     """Format a set value as a native language literal."""
-    set_cfg = spec._set_format_config
+    set_cfg = spec.set_format_config
 
     if not value and set_cfg.empty_set is not None:
         return set_cfg.empty_set
@@ -643,10 +642,10 @@ def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
     items_as_values: list[Value] = list(sorted_items)
     formatted = [_format_scalar(value=v, spec=spec) for v in sorted_items]
     entries = [
-        spec._format_set_entry(v, item)
+        spec.format_set_entry(v, item)
         for v, item in zip(sorted_items, formatted, strict=True)
     ]
-    joined = spec._element_separator.join(entries)
+    joined = spec.element_separator.join(entries)
     return set_cfg.set_open(items_as_values) + joined + set_cfg.close
 
 
@@ -657,15 +656,15 @@ def _format_ordered_map_value(
     spec: Language,
 ) -> str:
     """Format an ordered map as a native language literal."""
-    ordered_map_cfg = spec._ordered_map_format_config
+    ordered_map_cfg = spec.ordered_map_format_config
 
     ordered_map_items: list[tuple[str, Value]] = [
         (k, v)
         for k, v in value.items()  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-        if not (spec._skip_null_dict_values and v is None)
+        if not (spec.skip_null_dict_values and v is None)
     ]
     pairs = [
-        spec._format_ordered_map_entry(
+        spec.format_ordered_map_entry(
             _format_value(
                 value=k,
                 spec=spec,
@@ -680,7 +679,7 @@ def _format_ordered_map_value(
         )
         for k, v in ordered_map_items
     ]
-    joined = spec._element_separator.join(pairs)
+    joined = spec.element_separator.join(pairs)
     return ordered_map_cfg.open_str + joined + ordered_map_cfg.close
 
 
@@ -692,12 +691,12 @@ def _format_dict_value(
     open_override: str | None,
 ) -> str:
     """Format a dict as a native language literal."""
-    dict_cfg = spec._dict_format_config
+    dict_cfg = spec.dict_format_config
 
     dict_items: dict[str, Value] = {
         k: v
         for k, v in value.items()
-        if not (spec._skip_null_dict_values and v is None)
+        if not (spec.skip_null_dict_values and v is None)
     }
     if not dict_items and dict_cfg.empty_dict is not None:
         return dict_cfg.empty_dict
@@ -718,7 +717,7 @@ def _format_dict_value(
         )
         for k, v in dict_items.items()
     ]
-    joined = spec._element_separator.join(pairs)
+    joined = spec.element_separator.join(pairs)
     opener = (
         open_override
         if open_override is not None
@@ -736,7 +735,7 @@ def _compute_dict_open_override(
     """Return a widened dict opener when dicts in a list infer
     different value types, or ``None`` when no widening is needed.
     """
-    open_fn = spec._dict_format_config.open_fn
+    open_fn = spec.dict_format_config.open_fn
     dicts: list[dict[str, Value]] = [
         item
         for item in items
@@ -750,7 +749,7 @@ def _compute_dict_open_override(
         {
             k: v
             for k, v in d.items()
-            if not (spec._skip_null_dict_values and v is None)
+            if not (spec.skip_null_dict_values and v is None)
         }
         for d in dicts
     ]
@@ -783,7 +782,7 @@ def _compute_sequence_dict_override(
     Otherwise falls back to the widening logic of
     :func:`_compute_dict_open_override`.
     """
-    narrowed_open = spec._dict_format_config.narrowed_open
+    narrowed_open = spec.dict_format_config.narrowed_open
     if narrowed_open is not None:
         element_type = infer_element_type(items=items)
         if isinstance(element_type, DictType):
@@ -798,7 +797,7 @@ def _format_list_value(
     spec: Language,
 ) -> str:
     """Format a list as a native language literal."""
-    sequence_cfg = spec._sequence_format_config
+    sequence_cfg = spec.sequence_format_config
 
     if not value and sequence_cfg.empty_sequence is not None:
         return sequence_cfg.empty_sequence
@@ -807,7 +806,7 @@ def _format_list_value(
         spec=spec,
     )
     items = [
-        spec._format_sequence_entry(
+        spec.format_sequence_entry(
             v,
             _format_value(
                 value=v,
@@ -817,12 +816,12 @@ def _format_list_value(
         )
         for v in value
     ]
-    joined = spec._element_separator.join(items)
+    joined = spec.element_separator.join(items)
     # Some languages (e.g. Python) require a trailing comma on
     # single-element sequences to avoid syntactic ambiguity.
     if len(items) == 1 and sequence_cfg.single_element_trailing_comma:
-        joined += spec._element_separator.strip()
-    return f"{spec._sequence_open(value)}{joined}{sequence_cfg.close}"
+        joined += spec.element_separator.strip()
+    return f"{spec.sequence_open(value)}{joined}{sequence_cfg.close}"
 
 
 @beartype
@@ -868,15 +867,15 @@ def _wrap_body(
     line_prefix: str,
 ) -> str:
     """Wrap ``body`` in the language's open/close delimiters."""
-    ci = spec._indent if spec._indent_closing_delimiter else ""
+    ci = spec.indent if spec.indent_closing_delimiter else ""
     close_prefix = f"{line_prefix}{ci}"
     if is_ordered_map:
-        ordered_map_cfg = spec._ordered_map_format_config
+        ordered_map_cfg = spec.ordered_map_format_config
 
         opening = f"{line_prefix}{ordered_map_cfg.open_str}"
         closing = f"{close_prefix}{ordered_map_cfg.close}"
     elif isinstance(data, dict):
-        dict_cfg = spec._dict_format_config
+        dict_cfg = spec.dict_format_config
 
         opening = f"{line_prefix}{dict_cfg.open_fn(data)}"
         closing = f"{close_prefix}{dict_cfg.close}"
@@ -885,12 +884,11 @@ def _wrap_body(
             data,
             key=lambda v: (type(v).__name__, repr(v)),
         )
-        set_open = spec._set_format_config.set_open(sorted_set)
-        opening = f"{line_prefix}{set_open}"
-        closing = f"{close_prefix}{spec._set_format_config.close}"
+        opening = f"{line_prefix}{spec.set_format_config.set_open(sorted_set)}"
+        closing = f"{close_prefix}{spec.set_format_config.close}"
     else:
-        opening = f"{line_prefix}{spec._sequence_open(data)}"
-        closing = f"{close_prefix}{spec._sequence_format_config.close}"
+        opening = f"{line_prefix}{spec.sequence_open(data)}"
+        closing = f"{close_prefix}{spec.sequence_format_config.close}"
     return f"{opening.rstrip()}\n{body}\n{closing}"
 
 
@@ -983,7 +981,7 @@ def _format_collection_lines(
             entries = [
                 (k, v)
                 for k, v in dict_data.items()
-                if not (spec._skip_null_dict_values and v is None)
+                if not (spec.skip_null_dict_values and v is None)
             ]
             if not entries and include_delimiters and dict_data:
                 empty_value: ordereddict | dict[str, Value] = (
@@ -1007,7 +1005,7 @@ def _format_collection_lines(
                     dict_open_override=None,
                 )
                 entry = (
-                    spec._format_ordered_map_entry(
+                    spec.format_ordered_map_entry(
                         formatted_key, v, formatted_val
                     )
                     if is_ordered_map
@@ -1019,7 +1017,7 @@ def _format_collection_lines(
                     )
                 )
                 add_sep = i < last_idx or trailing_comma
-                sep = spec._element_separator.strip() if add_sep else ""
+                sep = spec.element_separator.strip() if add_sep else ""
                 lines.append(f"{body_prefix}{entry}{sep}")
         case set() as set_data:
             sorted_items = sorted(
@@ -1033,14 +1031,14 @@ def _format_collection_lines(
                     spec=spec,
                     dict_open_override=None,
                 )
-                entry = spec._format_set_entry(item, formatted)
+                entry = spec.format_set_entry(item, formatted)
                 add_sep = i < last_idx or trailing_comma
-                sep = spec._element_separator.strip() if add_sep else ""
+                sep = spec.element_separator.strip() if add_sep else ""
                 lines.append(f"{body_prefix}{entry}{sep}")
         case list() as list_data:
             seq_trailing = (
                 trailing_comma
-                and spec._sequence_format_config.supports_trailing_comma
+                and spec.sequence_format_config.supports_trailing_comma
             )
             dict_open_override = _compute_sequence_dict_override(
                 items=list_data,
@@ -1048,7 +1046,7 @@ def _format_collection_lines(
             )
             last_idx = len(list_data) - 1
             for i, element in enumerate(iterable=list_data):
-                formatted = spec._format_sequence_entry(
+                formatted = spec.format_sequence_entry(
                     element,
                     _format_value(
                         value=element,
@@ -1057,7 +1055,7 @@ def _format_collection_lines(
                     ),
                 )
                 add_sep = i < last_idx or seq_trailing
-                sep = spec._element_separator.strip() if add_sep else ""
+                sep = spec.element_separator.strip() if add_sep else ""
                 lines.append(f"{body_prefix}{formatted}{sep}")
         case _ as unreachable:
             assert_never(unreachable)
@@ -1136,11 +1134,11 @@ def _literalize(
         return f"{line_prefix}{formatted}"
 
     body_prefix = (
-        line_prefix + language._indent if include_delimiters else line_prefix
+        line_prefix + language.indent if include_delimiters else line_prefix
     )
 
     is_ordered_map = isinstance(data, ordereddict)
-    trailing_comma = spec._trailing_comma_config.multiline_trailing_comma
+    trailing_comma = spec.trailing_comma_config.multiline_trailing_comma
     lines_or_early = _format_collection_lines(
         data=data,
         spec=spec,
@@ -1182,9 +1180,9 @@ def _apply_variable_wrapper(
     if variable_name is None:
         return result
     formatter = (
-        language._format_variable_declaration
+        language.format_variable_declaration
         if new_variable
-        else language._format_variable_assignment
+        else language.format_variable_assignment
     )
     return formatter(variable_name, result, data)
 
@@ -1237,7 +1235,7 @@ def literalize_json(
             and the data contains heterogeneous scalar collections
             that would be coerced.
     """
-    line_prefix = language._indent * pre_indent_level
+    line_prefix = language.indent * pre_indent_level
     try:
         data = json.loads(s=json_string)
     except json.JSONDecodeError as exc:
@@ -1254,9 +1252,9 @@ def literalize_json(
     )
     if variable_name is not None:
         formatter = (
-            language._format_variable_declaration
+            language.format_variable_declaration
             if new_variable
-            else language._format_variable_assignment
+            else language.format_variable_assignment
         )
         result = formatter(variable_name, result, data)
     computed = _compute_preamble(
@@ -1264,7 +1262,7 @@ def literalize_json(
         language=language,
         has_variable_declaration=variable_name is not None and new_variable,
     )
-    preamble = tuple(language._static_preamble) + computed.header
+    preamble = tuple(language.static_preamble) + computed.header
     if computed.body:
         result = "\n".join(computed.body) + "\n" + result
     return LiteralizeResult(
@@ -1330,7 +1328,7 @@ def _resolve_yaml_set_comments(
 ) -> _ResolvedComments:
     """Resolve comments for a YAML set."""
     set_comments = extract_yaml_comments(ruamel_data=ruamel_set)
-    if not language._supports_collection_comments:
+    if not language.supports_collection_comments:
         return _ResolvedComments(result=base, pending=set_comments)
     result = apply_collection_comments(
         collection_comments=set_comments,
@@ -1361,7 +1359,7 @@ def _resolve_yaml_collection_comments(
     )
 
     if (
-        language._skip_null_dict_values
+        language.skip_null_dict_values
         and isinstance(ruamel_data, CommentedMap)
         and isinstance(data, dict)
     ):
@@ -1371,7 +1369,7 @@ def _resolve_yaml_collection_comments(
             collection_comments=collection_comments,
         )
 
-    if not language._supports_collection_comments:
+    if not language.supports_collection_comments:
         return _ResolvedComments(
             result=base,
             pending=collection_comments,
@@ -1496,7 +1494,7 @@ def literalize_yaml(
             and the data contains heterogeneous scalar collections
             that would be coerced.
     """
-    line_prefix = language._indent * pre_indent_level
+    line_prefix = language.indent * pre_indent_level
     ruamel_yaml = YAML(typ="safe")
     try:
         # https://sourceforge.net/p/ruamel-yaml/tickets/564/
@@ -1513,11 +1511,11 @@ def literalize_yaml(
         error_on_coercion=error_on_coercion,
     )
 
-    comment_cfg = language._comment_config
+    comment_cfg = language.comment_config
     cp = comment_cfg.prefix
     cs = comment_cfg.suffix
     comment_line_prefix = (
-        line_prefix + language._indent if include_delimiters else line_prefix
+        line_prefix + language.indent if include_delimiters else line_prefix
     )
 
     resolved = _resolve_yaml_comments(
@@ -1555,7 +1553,7 @@ def literalize_yaml(
         language=language,
         has_variable_declaration=variable_name is not None and new_variable,
     )
-    preamble = tuple(language._static_preamble) + computed.header
+    preamble = tuple(language.static_preamble) + computed.header
     if computed.body:
         result = "\n".join(computed.body) + "\n" + result
     return LiteralizeResult(

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -304,17 +304,17 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     pygments_name: str
     """The Pygments lexer short name for syntax highlighting."""
 
-    _null_literal: str
+    null_literal: str
     """The literal representing null/None."""
 
-    _true_literal: str
+    true_literal: str
     """The literal representing true/True."""
 
-    _false_literal: str
+    false_literal: str
     """The literal representing false/False."""
 
     @property
-    def _sequence_open(self) -> Callable[[list[Value]], str]:
+    def sequence_open(self) -> Callable[[list[Value]], str]:
         """Callable that returns the opening delimiter for a sequence.
 
         Receives the list of items about to be formatted, so the delimiter
@@ -323,13 +323,13 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
-    _sequence_format_config: SequenceFormatConfig
+    sequence_format_config: SequenceFormatConfig
     """Configuration for the chosen sequence format."""
 
-    _dict_format_config: DictFormatConfig
+    dict_format_config: DictFormatConfig
     """Configuration for dict formatting."""
 
-    _trailing_comma_config: TrailingCommaConfig
+    trailing_comma_config: TrailingCommaConfig
     """Configuration for trailing-comma behavior.
 
     Trailing commas are only added to collection formats that support them.
@@ -337,67 +337,67 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     """
 
     @property
-    def _format_bytes(self) -> Callable[[bytes], str]:
+    def format_bytes(self) -> Callable[[bytes], str]:
         """Callable that formats a :class:`bytes` value as a string
         literal.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def _format_date(self) -> Callable[[datetime.date], str]:
+    def format_date(self) -> Callable[[datetime.date], str]:
         """Callable that formats a :class:`datetime.date` as a string
         literal.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def _format_datetime(self) -> Callable[[datetime.datetime], str]:
+    def format_datetime(self) -> Callable[[datetime.datetime], str]:
         """Callable that formats a :class:`datetime.datetime` as a string
         literal.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
-    _set_format_config: SetFormatConfig
+    set_format_config: SetFormatConfig
     """Configuration for the chosen set format."""
 
     @property
-    def _format_sequence_entry(self) -> Callable[[Value, str], str]:
+    def format_sequence_entry(self) -> Callable[[Value, str], str]:
         """Callable that formats a sequence entry."""
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def _format_set_entry(self) -> Callable[[Value, str], str]:
+    def format_set_entry(self) -> Callable[[Value, str], str]:
         """Callable that formats a set entry."""
         ...  # pylint: disable=unnecessary-ellipsis
 
-    _comment_config: CommentConfig
+    comment_config: CommentConfig
     """Configuration for the language's comment syntax."""
 
-    _ordered_map_format_config: OrderedMapFormatConfig
+    ordered_map_format_config: OrderedMapFormatConfig
     """Configuration for ordered-map formatting."""
 
     @property
-    def _format_ordered_map_entry(self) -> Callable[[str, Value, str], str]:
+    def format_ordered_map_entry(self) -> Callable[[str, Value, str], str]:
         """Callable that formats one ordered-map entry."""
         ...  # pylint: disable=unnecessary-ellipsis
 
-    _indent: str
+    indent: str
     """The indentation step for elements inside delimiters in multi-line
     structures (e.g. ``"    "`` for 4-space indent).
     """
 
-    _indent_closing_delimiter: bool
+    indent_closing_delimiter: bool
     """Whether to indent the closing delimiter of multi-line structures
     by one ``indent`` step.
     """
 
-    _element_separator: str
+    element_separator: str
     """The separator placed between elements in inline sequences."""
 
-    _skip_null_dict_values: bool
+    skip_null_dict_values: bool
     """Whether to omit dict entries whose value is ``None``."""
 
-    _supports_collection_comments: bool
+    supports_collection_comments: bool
     """Whether the language supports comments inside collection
     initializers.
 
@@ -408,7 +408,7 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     """
 
     @property
-    def _format_variable_declaration(self) -> Callable[[str, str, Value], str]:
+    def format_variable_declaration(self) -> Callable[[str, str, Value], str]:
         """Callable that formats a new variable declaration.
 
         Called as ``format_variable_declaration(name, value, data)`` where
@@ -418,7 +418,7 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def _format_variable_assignment(self) -> Callable[[str, str, Value], str]:
+    def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
         """Callable that formats an assignment to an existing variable.
 
         Called as ``format_variable_assignment(name, value, data)`` where
@@ -428,12 +428,12 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def _format_string(self) -> Callable[[str], str]:
+    def format_string(self) -> Callable[[str], str]:
         """Callable that formats a string value as a quoted literal."""
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def _format_integer(self) -> Callable[[int], str]:
+    def format_integer(self) -> Callable[[int], str]:
         """Callable that formats an int value as a literal."""
         ...  # pylint: disable=unnecessary-ellipsis
 
@@ -494,27 +494,27 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
         """The line ending option chosen for this language instance."""
         ...  # pylint: disable=unnecessary-ellipsis
 
-    _static_preamble: Sequence[str]
+    static_preamble: Sequence[str]
     """Lines (imports, package declarations, etc.) that are always
     emitted before the generated code, regardless of what types appear
     in the data.  Use an empty sequence when none are needed.
     """
 
-    _scalar_preamble: dict[type, tuple[str, ...]]
+    scalar_preamble: dict[type, tuple[str, ...]]
     """Maps Python scalar types to the preamble lines required when
     that type appears in the data.  For example, a language that needs
     ``import datetime`` when dates are present would include
     ``{datetime.date: ("import datetime",)}``.
     """
 
-    _static_body_preamble: Sequence[str]
+    static_body_preamble: Sequence[str]
     """Lines that are always prepended to the generated code,
     regardless of what types appear in the data.  Appears after the
     header preamble but before the code body.  Use an empty sequence
     when none are needed.
     """
 
-    _scalar_body_preamble: dict[type, tuple[str, ...]]
+    scalar_body_preamble: dict[type, tuple[str, ...]]
     """Maps Python scalar types to body-preamble lines that are
     prepended to the generated code.
 
@@ -522,7 +522,7 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     instance definitions.
     """
 
-    _compute_body_preamble: Callable[[frozenset[type], Value], tuple[str, ...]]
+    compute_body_preamble: Callable[[frozenset[type], Value], tuple[str, ...]]
     """Computes body-preamble lines based on which types are present in
     the data.  Most languages build this from
     :attr:`scalar_body_preamble`; Haskell overrides it to compose the
@@ -534,7 +534,7 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
     required).
     """
 
-    _type_hint_collection_preamble_lines: tuple[str, ...]
+    type_hint_collection_preamble_lines: tuple[str, ...]
     """Preamble lines required when the language produces type-hinted
     variable declarations *and* the data contains collections.
     Empty for most languages; Python sets this to

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -236,15 +236,15 @@ class Ada(metaclass=LanguageCls):
         """Initialize Ada language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "ANull"
-        self._true_literal = "ABool (True)"
-        self._false_literal = "ABool (False)"
+        self.null_literal = "ANull"
+        self.true_literal = "ABool (True)"
+        self.false_literal = "ABool (False)"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="AMap'("),
             close=")",
             format_entry=dict_entry_with_template(
@@ -255,15 +255,15 @@ class Ada(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = (
+        self.format_string: Callable[[str], str] = (
             format_string_concat_control(
                 quote_char='"',
                 quote_escape='""',
@@ -272,11 +272,11 @@ class Ada(metaclass=LanguageCls):
                 escape_backslash=False,
             )
         )
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_ada_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = _format_ada_entry
+        self.format_set_entry: Callable[[Value, str], str] = _format_ada_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -285,39 +285,39 @@ class Ada(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="AMap'(",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_template(
                 template="AEntry ({key}, {value})",
                 format_value=_format_ada_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -250,14 +250,14 @@ class Bash(metaclass=LanguageCls):
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._null_literal = '""'
-        self._true_literal = "true"
-        self._false_literal = "false"
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.null_literal = '""'
+        self.true_literal = "true"
+        self.false_literal = "false"
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="("),
             close=")",
             format_entry=_format_bash_dict_entry,
@@ -265,20 +265,20 @@ class Bash(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_bash_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -289,36 +289,36 @@ class Bash(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="(",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_bash_dict_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = " "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = " "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name}={value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -244,15 +244,15 @@ class C(metaclass=LanguageCls):
         """Initialize C language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "((_CVal){.s = NULL})"
-        self._true_literal = "((_CVal){.b = true})"
-        self._false_literal = "((_CVal){.b = false})"
+        self.null_literal = "((_CVal){.s = NULL})"
+        self.true_literal = "((_CVal){.b = true})"
+        self.false_literal = "((_CVal){.b = false})"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="((_CVal){.m = (_CKV[]){"),
             close="}})",
             format_entry=braced_dict_entry(
@@ -262,18 +262,18 @@ class C(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_c_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = _format_c_entry
+        self.format_set_entry: Callable[[Value, str], str] = _format_c_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -282,29 +282,29 @@ class C(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="((_CVal){.m = (_CKV[]){",
                 close="}})",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=_format_c_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._static_preamble: Sequence[str] = (
+        self.static_preamble: Sequence[str] = (
             "#include <stdbool.h>",
             "#include <stddef.h>",
             "typedef struct _CVal _CVal;",
@@ -321,13 +321,13 @@ class C(metaclass=LanguageCls):
             "};",
             "struct _CKV { const char *k; _CVal v; };",
         )
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -201,15 +201,15 @@ class Clojure(metaclass=LanguageCls):
         """Initialize Clojure language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -220,20 +220,20 @@ class Clojure(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -244,39 +244,39 @@ class Clojure(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = " "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = " "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="(def {name} {value})")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="(def {name} {value})")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -375,15 +375,15 @@ class Cobol(metaclass=LanguageCls):
         """Initialize COBOL language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "SPACES"
+        self.null_literal = "SPACES"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._true_literal = '"TRUE"'
-        self._false_literal = '"FALSE"'
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.true_literal = '"TRUE"'
+        self.false_literal = '"FALSE"'
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str=""),
             close="",
             format_entry=_format_cobol_dict_entry,
@@ -391,20 +391,20 @@ class Cobol(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = _format_string_cobol
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = _format_string_cobol
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_cobol_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_cobol_sequence_entry
         )
         self.comment_format = comment_format
@@ -415,36 +415,36 @@ class Cobol(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="",
                 close="",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_cobol_dict_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = "\n"
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = "\n"
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -209,15 +209,15 @@ class CommonLisp(metaclass=LanguageCls):
         """Initialize Common Lisp language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "t"
-        self._false_literal = "nil"
+        self.null_literal = "nil"
+        self.true_literal = "t"
+        self.false_literal = "nil"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="(list "),
             close=")",
             format_entry=_format_cons_entry,
@@ -225,20 +225,20 @@ class CommonLisp(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -249,36 +249,36 @@ class CommonLisp(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="(list ",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_cons_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = " "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = " "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="(defparameter *{name}* {value})")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="(setf *{name}* {value})")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -401,32 +401,32 @@ class Cpp(metaclass=LanguageCls):
         """Initialize Cpp language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nullptr"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nullptr"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = dict_format.value
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = dict_format.value
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -437,36 +437,36 @@ class Cpp(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._static_preamble: Sequence[str] = ("#include <initializer_list>",)
-        self._static_body_preamble: Sequence[str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.static_preamble: Sequence[str] = ("#include <initializer_list>",)
+        self.static_body_preamble: Sequence[str] = (
             "struct _Any {",
             "    template<class T> _Any(T&&) noexcept {}",
             "    _Any(std::initializer_list<_Any>) noexcept {}",
             "};",
         )
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
@@ -477,11 +477,11 @@ class Cpp(metaclass=LanguageCls):
                 },
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -240,15 +240,15 @@ class Crystal(metaclass=LanguageCls):
         """Initialize Crystal language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -261,22 +261,22 @@ class Crystal(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -287,39 +287,39 @@ class Crystal(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" => ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -335,11 +335,11 @@ class CSharp(metaclass=LanguageCls):
         """Initialize CSharp language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "(object?)null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "(object?)null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
         csharp_dict_entry = dict_entry_with_template(
             template="[{key}] = {value}",
@@ -355,14 +355,14 @@ class CSharp(metaclass=LanguageCls):
             set_opener_template=set_format.value.set_opener_template or None,
             narrow_dict_values=False,
         )
-        self._set_format_config: SetFormatConfig = dataclasses.replace(
+        self.set_format_config: SetFormatConfig = dataclasses.replace(
             set_format.value,
             set_open=typed_set_open(
                 type_to_opener=openers.set,
                 fallback=set_format.value.set_open([]),
             ),
         )
-        self._sequence_open: Callable[[list[Value]], str] = (
+        self.sequence_open: Callable[[list[Value]], str] = (
             typed_sequence_open(
                 type_to_opener=openers.seq,
                 fallback=fmt.typed_opener_fallback,
@@ -371,7 +371,7 @@ class CSharp(metaclass=LanguageCls):
             else fmt.sequence_open
         )
         dict_spec: _CSharpDictSpec = dict_format.value
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=cfg.element_to_type(
@@ -390,23 +390,23 @@ class CSharp(metaclass=LanguageCls):
             preamble_lines=("using System.Collections.Generic;",),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -417,41 +417,41 @@ class CSharp(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str=f"new Dictionary<string, {_DEFAULT_VALUE_TYPE}> {{",
                 close="}",
                 preamble_lines=("using System.Collections.Generic;",),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             csharp_dict_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="var {name} = {value};")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -259,15 +259,15 @@ class D(metaclass=LanguageCls):
         """Initialize D language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="JSONValue(["),
             close="])",
             format_entry=dict_entry_with_separator(
@@ -278,22 +278,22 @@ class D(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_d_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = _format_d_entry
+        self.format_set_entry: Callable[[Value, str], str] = _format_d_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -302,39 +302,39 @@ class D(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="JSONValue([",
                 close="])",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_template(
                 template="JSONValue([JSONValue({key}), {value}])",
                 format_value=_format_d_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._static_preamble: Sequence[str] = ("import std.json;",)
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ("import std.json;",)
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -291,13 +291,13 @@ class Dart(metaclass=LanguageCls):
         """Initialize Dart language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
+        self.set_format_config: SetFormatConfig = set_format.value
 
         date_tp = date_format.value.type_produced
         dt_tp = datetime_format.value.type_produced
@@ -308,7 +308,7 @@ class Dart(metaclass=LanguageCls):
             set_opener_template=None,
             narrow_dict_values=True,
         )
-        self._sequence_open: Callable[[list[Value]], str] = (
+        self.sequence_open: Callable[[list[Value]], str] = (
             typed_sequence_open(
                 type_to_opener=openers.seq,
                 fallback=fmt.typed_opener_fallback,
@@ -316,7 +316,7 @@ class Dart(metaclass=LanguageCls):
             if fmt.typed_opener_fallback is not None
             else fmt.sequence_open
         )
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=openers.dict,
                 fallback="{",
@@ -330,18 +330,18 @@ class Dart(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = string_format
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -352,39 +352,39 @@ class Dart(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -302,15 +302,15 @@ class Elixir(metaclass=LanguageCls):
         """Initialize Elixir language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="%{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -321,22 +321,22 @@ class Elixir(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -347,36 +347,36 @@ class Elixir(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -282,15 +282,15 @@ class Erlang(metaclass=LanguageCls):
         """Initialize Erlang language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "undefined"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "undefined"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="#{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -301,20 +301,20 @@ class Erlang(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -325,36 +325,36 @@ class Erlang(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -293,15 +293,15 @@ class Fortran(metaclass=LanguageCls):
         """Initialize Fortran language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "fnull()"
-        self._true_literal = "fbool(.true.)"
-        self._false_literal = "fbool(.false.)"
+        self.null_literal = "fnull()"
+        self.true_literal = "fbool(.true.)"
+        self.false_literal = "fbool(.false.)"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="fmap([fval_t :: "),
             close="])",
             format_entry=dict_entry_with_template(
@@ -312,15 +312,15 @@ class Fortran(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = (
+        self.format_string: Callable[[str], str] = (
             format_string_concat_control(
                 quote_char="'",
                 quote_escape="''",
@@ -329,11 +329,11 @@ class Fortran(metaclass=LanguageCls):
                 escape_backslash=False,
             )
         )
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_fortran_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_fortran_entry
         )
         self.comment_format = comment_format
@@ -344,32 +344,32 @@ class Fortran(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="fmap([fval_t :: ",
                 close="])",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_template(
                 template="fentry({key}, {value})",
                 format_value=_format_fortran_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._static_preamble: Sequence[str] = (
+        self.static_preamble: Sequence[str] = (
             "module fval_m",
             "  implicit none",
             "  type :: fval_t",
@@ -404,13 +404,13 @@ class Fortran(metaclass=LanguageCls):
             "; type(fval_t) :: v; end function",
             "end module fval_m",
         )
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -310,15 +310,15 @@ class FSharp(metaclass=LanguageCls):
         """Initialize FSharp language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "FNull"
-        self._true_literal = "FBool true"
-        self._false_literal = "FBool false"
+        self.null_literal = "FNull"
+        self.true_literal = "FBool true"
+        self.false_literal = "FBool false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="FMap ["),
             close="]",
             format_entry=tuple_dict_entry(
@@ -328,17 +328,17 @@ class FSharp(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_fsharp_entry
         )
         self.comment_format = comment_format
@@ -349,37 +349,37 @@ class FSharp(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="FMap [",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=_format_fsharp_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._element_separator = "; "
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.element_separator = "; "
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_fsharp_entry
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
         _header = "type Val ="
         _f_str = "    | FStr of string"
-        self._scalar_body_preamble: dict[
+        self.scalar_body_preamble: dict[
             type,
             tuple[str, ...],
         ] = {
@@ -404,9 +404,9 @@ class FSharp(metaclass=LanguageCls):
                 "    | FDatetime of System.DateTime",
             ),
         }
-        self._compute_body_preamble: Callable[
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -335,11 +335,11 @@ class Go(metaclass=LanguageCls):
         """Initialize Go language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
 
         _type_names: dict[type, str] = {
@@ -364,7 +364,7 @@ class Go(metaclass=LanguageCls):
             dict_type_template="map[string]{inner}",
             fallback_value_type="any",
         )
-        self._set_format_config: SetFormatConfig = dataclasses.replace(
+        self.set_format_config: SetFormatConfig = dataclasses.replace(
             set_format.value,
             set_open=typed_set_open(
                 type_to_opener=make_type_to_opener(
@@ -374,16 +374,14 @@ class Go(metaclass=LanguageCls):
                 fallback="map[any]struct{}{",
             ),
         )
-        self._sequence_open: Callable[[list[Value]], str] = (
-            typed_sequence_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=init_element_to_type,
-                    opener_template="[]{type_name}{{",
-                ),
-                fallback="[]any{",
-            )
+        self.sequence_open: Callable[[list[Value]], str] = typed_sequence_open(
+            type_to_opener=make_type_to_opener(
+                element_to_type=init_element_to_type,
+                opener_template="[]{type_name}{{",
+            ),
+            fallback="[]any{",
         )
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=init_element_to_type,
@@ -400,25 +398,25 @@ class Go(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open="{",
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=True,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_go_set_entry
         )
         self.comment_format = comment_format
@@ -429,41 +427,41 @@ class Go(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[][2]any{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ("package main",)
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ("package main",)
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -209,15 +209,15 @@ class Groovy(metaclass=LanguageCls):
         """Initialize Groovy language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="["),
             close="]",
             format_entry=dict_entry_with_separator(
@@ -228,20 +228,20 @@ class Groovy(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = (
+        self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar
         )
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -252,39 +252,39 @@ class Groovy(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="def {name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -475,15 +475,15 @@ class Haskell(metaclass=LanguageCls):
         """Initialize Haskell language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "HNull"
-        self._true_literal = "HBool True"
-        self._false_literal = "HBool False"
+        self.null_literal = "HNull"
+        self.true_literal = "HBool True"
+        self.false_literal = "HBool False"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="HMap ["),
             close="]",
             format_entry=tuple_dict_entry(
@@ -493,23 +493,23 @@ class Haskell(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = functools.partial(
+        self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,
             control_char_fmt="\\x{:02x}",
         )
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -520,32 +520,32 @@ class Haskell(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="HMap [",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = True
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = True
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
         _overloaded_strings = ("{-# LANGUAGE OverloadedStrings #-}",)
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
@@ -556,8 +556,8 @@ class Haskell(metaclass=LanguageCls):
             )
         )
 
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = _build_scalar_body_preamble(
             date_format=date_format,
@@ -567,4 +567,4 @@ class Haskell(metaclass=LanguageCls):
                 "instance IsString Val where\n    fromString = HStr"
             ),
         )
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -205,15 +205,15 @@ class Hcl(metaclass=LanguageCls):
         """Initialize HCL language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -224,20 +224,20 @@ class Hcl(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=True,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -248,39 +248,39 @@ class Hcl(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" = ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -386,17 +386,17 @@ class Java(metaclass=LanguageCls):
         """Initialize Java language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
         java_dict_entry = dict_entry_with_template(
             template="Map.entry({key}, {value})",
             format_value=passthrough_sequence_entry,
         )
-        self._set_format_config: SetFormatConfig = set_format.value
+        self.set_format_config: SetFormatConfig = set_format.value
 
         date_tp = date_format.value.type_produced
         cfg = self._opener_config
@@ -408,7 +408,7 @@ class Java(metaclass=LanguageCls):
             set_opener_template=None,
             narrow_dict_values=False,
         )
-        self._sequence_open: Callable[[list[Value]], str] = (
+        self.sequence_open: Callable[[list[Value]], str] = (
             typed_sequence_open(
                 type_to_opener=openers.seq,
                 fallback=fmt.typed_opener_fallback,
@@ -416,23 +416,23 @@ class Java(metaclass=LanguageCls):
             if fmt.typed_opener_fallback is not None
             else fmt.sequence_open
         )
-        self._dict_format_config: DictFormatConfig = dict_format.value
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.dict_format_config: DictFormatConfig = dict_format.value
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -443,41 +443,41 @@ class Java(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="new java.util.ArrayList<>(java.util.Arrays.asList(",
                 close="))",
                 preamble_lines=("import java.util.Map;",),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             java_dict_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = True
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = True
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="var {name} = {value};")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -323,30 +323,30 @@ class JavaScript(metaclass=LanguageCls):
         """Initialize JavaScript language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = dict_format.value
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = dict_format.value
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = string_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
-        self._format_integer: Callable[[int], str] = (
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
@@ -359,44 +359,44 @@ class JavaScript(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
         _base_decl: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             line_ending.wrap_formatter(formatter=_base_decl)
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             line_ending.wrap_formatter(
                 formatter=variable_formatter(template="{name} = {value};"),
             )
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -317,31 +317,31 @@ class Julia(metaclass=LanguageCls):
         """Initialize Julia language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nothing"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nothing"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = dict_format.value
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = dict_format.value
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -352,44 +352,44 @@ class Julia(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" => ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -433,11 +433,11 @@ class Kotlin(metaclass=LanguageCls):
         """Initialize Kotlin language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
 
         cfg = self._opener_config
@@ -448,7 +448,7 @@ class Kotlin(metaclass=LanguageCls):
             py_type=datetime_format.value.type_produced,
         )
 
-        self._sequence_open: Callable[[list[Value]], str] = (
+        self.sequence_open: Callable[[list[Value]], str] = (
             _kotlin_list_sequence_open(
                 cfg=cfg,
                 date_type=date_type_name,
@@ -464,7 +464,7 @@ class Kotlin(metaclass=LanguageCls):
             set_opener_template=set_format.value.set_opener_template or None,
             narrow_dict_values=False,
         )
-        self._set_format_config: SetFormatConfig = dataclasses.replace(
+        self.set_format_config: SetFormatConfig = dataclasses.replace(
             set_format.value,
             set_open=typed_set_open(
                 type_to_opener=openers.set,
@@ -472,7 +472,7 @@ class Kotlin(metaclass=LanguageCls):
             ),
         )
         dict_spec: _KotlinDictSpec = dict_format.value
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=cfg.element_to_type(
@@ -494,25 +494,25 @@ class Kotlin(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = (
+        self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar
         )
-        self._format_integer: Callable[[int], str] = (
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -523,44 +523,44 @@ class Kotlin(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="linkedMapOf<String, Any?>(",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" to ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -257,19 +257,19 @@ class Lua(metaclass=LanguageCls):
         """Initialize Lua language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         lua_dict_entry = dict_entry_with_template(
             template="[{key}] = {value}",
             format_value=passthrough_sequence_entry,
         )
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=lua_dict_entry,
@@ -277,18 +277,18 @@ class Lua(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = string_format
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_lua_set_entry
         )
         self.comment_format = comment_format
@@ -299,36 +299,36 @@ class Lua(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             lua_dict_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = True
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = True
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="local {name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -323,24 +323,24 @@ class Matlab(metaclass=LanguageCls):
         """Initialize Matlab language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "[]"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "[]"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = dict_format.value
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = dict_format.value
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = (
+        self.format_string: Callable[[str], str] = (
             format_string_concat_control(
                 quote_char='"',
                 quote_escape='""',
@@ -349,11 +349,11 @@ class Matlab(metaclass=LanguageCls):
                 escape_backslash=True,
             )
         )
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -364,36 +364,36 @@ class Matlab(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="struct(",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_matlab_dict_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -239,15 +239,15 @@ class Mojo(metaclass=LanguageCls):
         """Initialize Mojo language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "None"
-        self._true_literal = "True"
-        self._false_literal = "False"
+        self.null_literal = "None"
+        self.true_literal = "True"
+        self.false_literal = "False"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -258,20 +258,20 @@ class Mojo(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=True,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -282,36 +282,36 @@ class Mojo(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_mojo_ordered_map_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="var {name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -355,15 +355,15 @@ class Nim(metaclass=LanguageCls):
         """Initialize Nim language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -374,22 +374,22 @@ class Nim(metaclass=LanguageCls):
             preamble_lines=("import json",),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -400,41 +400,41 @@ class Nim(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=("import json",),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
         _is_sequence = sequence_format is self.sequence_formats.SEQ
         _is_const = declaration_style is self.declaration_styles.CONST
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _make_variable_declaration(
                 sequence_mode=_is_sequence,
                 keyword=declaration_style.value,
                 force_sequence=_is_const,
             )
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _make_variable_assignment(sequence_mode=_is_sequence)
         )
         _json = ("import json",)
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {
             str: _json,
             int: _json,
             float: _json,
@@ -444,11 +444,11 @@ class Nim(metaclass=LanguageCls):
             datetime.date: date_format.value.preamble_lines,
             datetime.datetime: datetime_format.value.preamble_lines,
         }
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -212,15 +212,15 @@ class Norg(metaclass=LanguageCls):
         """Initialize Norg language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -231,20 +231,20 @@ class Norg(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -255,43 +255,43 @@ class Norg(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(
                 template="* {name}\n@code json\n{value}\n@end",
             )
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(
                 template="* {name}\n@code json\n{value}\n@end",
             )
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -260,15 +260,15 @@ class ObjectiveC(metaclass=LanguageCls):
         """Initialize Objective-C language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "[NSNull null]"
-        self._true_literal = "@YES"
-        self._false_literal = "@NO"
+        self.null_literal = "[NSNull null]"
+        self.true_literal = "@YES"
+        self.false_literal = "@NO"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="@{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -279,20 +279,18 @@ class ObjectiveC(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = _format_objc_string
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = _format_objc_string
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_objc_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
-            _format_objc_entry
-        )
+        self.format_set_entry: Callable[[Value, str], str] = _format_objc_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -301,41 +299,41 @@ class ObjectiveC(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="@{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=_format_objc_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="id {name} = {value};")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._static_preamble: Sequence[str] = (
+        self.static_preamble: Sequence[str] = (
             "#import <Foundation/Foundation.h>",
         )
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -317,15 +317,15 @@ class OCaml(metaclass=LanguageCls):
         """Initialize OCaml language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "ONull"
-        self._true_literal = "OBool true"
-        self._false_literal = "OBool false"
+        self.null_literal = "ONull"
+        self.true_literal = "OBool true"
+        self.false_literal = "OBool false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="OMap ["),
             close="]",
             format_entry=tuple_dict_entry(
@@ -335,21 +335,21 @@ class OCaml(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_ocaml_entry
         )
         self.comment_format = comment_format
@@ -360,34 +360,34 @@ class OCaml(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="OMap [",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=_format_ocaml_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._element_separator = "; "
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.element_separator = "; "
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_ocaml_entry
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
         _h = "type val_t ="
         _date_constructor = (
             "  | OStr of string"
@@ -399,7 +399,7 @@ class OCaml(metaclass=LanguageCls):
             if datetime_format.value.type_produced is str
             else "  | ODatetime of ((int * int * int) * (int * int * int))"
         )
-        self._scalar_body_preamble: dict[
+        self.scalar_body_preamble: dict[
             type,
             tuple[str, ...],
         ] = {
@@ -416,9 +416,9 @@ class OCaml(metaclass=LanguageCls):
             ordereddict: (_h, "  | OMap of (string * val_t) list"),
             set: (_h, "  | OSet of val_t list"),
         }
-        self._compute_body_preamble: Callable[
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -222,15 +222,15 @@ class Occam(metaclass=LanguageCls):
         """Initialize Occam language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "MOBILE LIT(lit.null)"
-        self._true_literal = "MOBILE LIT(lit.bool; TRUE)"
-        self._false_literal = "MOBILE LIT(lit.bool; FALSE)"
+        self.null_literal = "MOBILE LIT(lit.null)"
+        self.true_literal = "MOBILE LIT(lit.bool; TRUE)"
+        self.false_literal = "MOBILE LIT(lit.bool; FALSE)"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(
                 open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
             ),
@@ -243,20 +243,20 @@ class Occam(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_occam_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             _format_occam_entry
         )
         self.comment_format = comment_format
@@ -267,34 +267,34 @@ class Occam(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
                 close="])",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_template(
                 template="MOBILE LIT(lit.pair; MOBILE []BYTE {key}; {value})",
                 format_value=_format_occam_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(
                 template="VAL MOBILE LIT {name} IS {value}:",
             )
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} := {value}")
         )
-        self._static_preamble: Sequence[str] = (
+        self.static_preamble: Sequence[str] = (
             "MOBILE DATA TYPE LIT IS\n"
             "  CASE\n"
             "    lit.null\n"
@@ -308,13 +308,13 @@ class Occam(metaclass=LanguageCls):
             "    lit.set ; MOBILE []MOBILE LIT\n"
             ":",
         )
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -295,15 +295,15 @@ class Perl(metaclass=LanguageCls):
         """Initialize Perl language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "undef"
-        self._true_literal = "1"
-        self._false_literal = "0"
+        self.null_literal = "undef"
+        self.true_literal = "1"
+        self.false_literal = "0"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -314,22 +314,22 @@ class Perl(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = string_format
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -340,44 +340,44 @@ class Perl(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" => ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="my ${name} = {value};")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="${name} = {value};")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -262,15 +262,15 @@ class Php(metaclass=LanguageCls):
         """Initialize Php language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="["),
             close="]",
             format_entry=dict_entry_with_separator(
@@ -281,22 +281,22 @@ class Php(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = string_format
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -307,39 +307,39 @@ class Php(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" => ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="${name} = {value};")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="${name} = {value};")
         )
-        self._static_preamble: Sequence[str] = ("<?php",)
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ("<?php",)
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -230,15 +230,15 @@ class PowerShell(metaclass=LanguageCls):
         """Initialize PowerShell language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "$null"
-        self._true_literal = "$true"
-        self._false_literal = "$false"
+        self.null_literal = "$null"
+        self.true_literal = "$true"
+        self.false_literal = "$false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="@{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -249,20 +249,20 @@ class PowerShell(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = _format_string
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = _format_string
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -273,39 +273,39 @@ class PowerShell(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[ordered]@{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" = ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = "; "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = "; "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="${name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="${name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -638,15 +638,15 @@ class Python(metaclass=LanguageCls):
         """Initialize Python language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "None"
-        self._true_literal = "True"
-        self._false_literal = "False"
+        self.null_literal = "None"
+        self.true_literal = "True"
+        self.false_literal = "False"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -657,24 +657,24 @@ class Python(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
 
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = string_format
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -685,22 +685,22 @@ class Python(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="OrderedDict([",
                 close="])",
                 preamble_lines=("from collections import OrderedDict",),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
         bytes_hint = bytes_format.type_hint
         date_hint = date_format.type_hint
         datetime_hint = datetime_format.type_hint
@@ -715,25 +715,25 @@ class Python(metaclass=LanguageCls):
                 set_hint=set_hint,
             )
         )
-        self._format_variable_declaration = decl_fmt
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_declaration = decl_fmt
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = (
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = (
             "from typing import Any",
         )

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -283,15 +283,15 @@ class R(metaclass=LanguageCls):
         """Initialize R language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "NULL"
-        self._true_literal = "TRUE"
-        self._false_literal = "FALSE"
+        self.null_literal = "NULL"
+        self.true_literal = "TRUE"
+        self.false_literal = "FALSE"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="list("),
             close=")",
             format_entry=empty_dict_key,
@@ -299,18 +299,18 @@ class R(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = integer_format
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = integer_format
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -321,39 +321,39 @@ class R(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="list(",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" = ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} <- {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} <- {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -205,15 +205,15 @@ class Racket(metaclass=LanguageCls):
         """Initialize Racket language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "(void)"
-        self._true_literal = "#t"
-        self._false_literal = "#f"
+        self.null_literal = "(void)"
+        self.true_literal = "#t"
+        self.false_literal = "#f"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="(hash "),
             close=")",
             format_entry=dict_entry_with_separator(
@@ -224,20 +224,20 @@ class Racket(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -248,39 +248,39 @@ class Racket(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="(hash ",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = " "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = " "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="(define {name} {value})")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="(set! {name} {value})")
         )
-        self._static_preamble: Sequence[str] = ("#lang racket",)
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ("#lang racket",)
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -279,15 +279,15 @@ class Ruby(metaclass=LanguageCls):
         """Initialize Ruby language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -298,23 +298,23 @@ class Ruby(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = string_format
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -325,44 +325,44 @@ class Ruby(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" => ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -385,32 +385,32 @@ class Rust(metaclass=LanguageCls):
         """Initialize Rust language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "None::<()>"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "None::<()>"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = dict_format.value
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = dict_format.value
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -421,41 +421,41 @@ class Rust(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="HashMap::from([",
                 close="])",
                 preamble_lines=("use std::collections::HashMap;",),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             tuple_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value};")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -380,11 +380,11 @@ class Scala(metaclass=LanguageCls):
         """Initialize Scala language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
         date_tp = date_format.value.type_produced
         dt_tp = datetime_format.value.type_produced
@@ -396,14 +396,14 @@ class Scala(metaclass=LanguageCls):
             set_opener_template=set_format.value.set_opener_template or None,
             narrow_dict_values=False,
         )
-        self._set_format_config: SetFormatConfig = dataclasses.replace(
+        self.set_format_config: SetFormatConfig = dataclasses.replace(
             set_format.value,
             set_open=typed_set_open(
                 type_to_opener=openers.set,
                 fallback=set_format.value.set_open([]),
             ),
         )
-        self._sequence_open: Callable[[list[Value]], str] = (
+        self.sequence_open: Callable[[list[Value]], str] = (
             _resolve_sequence_open(
                 cfg=self._opener_config,
                 sequence_format=sequence_format,
@@ -415,7 +415,7 @@ class Scala(metaclass=LanguageCls):
             )
         )
         dict_spec: _ScalaDictSpec = dict_format.value
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=self._opener_config.element_to_type(
@@ -437,22 +437,22 @@ class Scala(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=dict_spec.preamble_lines,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = format_string_backslash
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -463,44 +463,44 @@ class Scala(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="scala.collection.immutable.ListMap(",
                 close=")",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=" -> ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -314,15 +314,15 @@ class Swift(metaclass=LanguageCls):
         """Initialize Swift language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "nil"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "nil"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="["),
             close="]",
             format_entry=dict_entry_with_separator(
@@ -333,25 +333,25 @@ class Swift(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = functools.partial(
+        self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,
             control_char_fmt="\\u{{{:x}}}",
         )
-        self._format_integer: Callable[[int], str] = (
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             fmt.format_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -362,44 +362,44 @@ class Swift(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="[",
                 close="]",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = (
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = (
             date_scalar_preamble(
                 date_format=date_format,
                 datetime_format=datetime_format,
             )
         )
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -243,14 +243,14 @@ class Toml(metaclass=LanguageCls):
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._null_literal = '""'
-        self._true_literal = "true"
-        self._false_literal = "false"
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.null_literal = '""'
+        self.true_literal = "true"
+        self.false_literal = "false"
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=_format_toml_dict_entry,
@@ -258,23 +258,23 @@ class Toml(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = functools.partial(
+        self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,
             control_char_fmt="\\u{:04x}",
         )
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -285,36 +285,36 @@ class Toml(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             _format_toml_dict_entry
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = True
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = True
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -344,32 +344,32 @@ class TypeScript(metaclass=LanguageCls):
         """Initialize TypeScript language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = dict_format.value
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = dict_format.value
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
 
-        self._format_string: Callable[[str], str] = string_format
-        self._format_integer: Callable[[int], str] = (
+        self.format_string: Callable[[str], str] = string_format
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -380,44 +380,44 @@ class TypeScript(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
         _base_decl: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             line_ending.wrap_formatter(formatter=_base_decl)
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             line_ending.wrap_formatter(
                 formatter=variable_formatter(template="{name} = {value};"),
             )
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -262,9 +262,9 @@ class VisualBasic(metaclass=LanguageCls):
         """Initialize VisualBasic language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "Nothing"
-        self._true_literal = "True"
-        self._false_literal = "False"
+        self.null_literal = "Nothing"
+        self.true_literal = "True"
+        self.false_literal = "False"
         element_to_type = make_element_to_type(
             str_type="String",
             bool_type="Boolean",
@@ -296,9 +296,9 @@ class VisualBasic(metaclass=LanguageCls):
             format_entry=passthrough_sequence_entry,
             typed_opener_fallback=None,
         )
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = SetFormatConfig(
+        self.set_format_config: SetFormatConfig = SetFormatConfig(
             set_open=typed_set_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=element_to_type,
@@ -311,8 +311,8 @@ class VisualBasic(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
         )
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(
                 open_str=(
                     f"New Dictionary(Of String, {_DEFAULT_VALUE_TYPE}) From {{"
@@ -326,20 +326,20 @@ class VisualBasic(metaclass=LanguageCls):
             preamble_lines=("Imports System.Collections.Generic",),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = _format_string_vb
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_string: Callable[[str], str] = _format_string_vb
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -350,8 +350,8 @@ class VisualBasic(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str=(
                     f"New Dictionary(Of String, {_DEFAULT_VALUE_TYPE}) From {{"
@@ -360,28 +360,28 @@ class VisualBasic(metaclass=LanguageCls):
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             braced_dict_entry(format_value=passthrough_sequence_entry)
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = False
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = False
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _format_variable_declaration
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -218,15 +218,15 @@ class Yaml(metaclass=LanguageCls):
         """Initialize YAML language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = "null"
-        self._true_literal = "true"
-        self._false_literal = "false"
+        self.null_literal = "null"
+        self.true_literal = "true"
+        self.false_literal = "false"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
@@ -237,23 +237,23 @@ class Yaml(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
+        self.trailing_comma_config: TrailingCommaConfig = TrailingCommaConfig(
             multiline_trailing_comma=False,
         )
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = functools.partial(
+        self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,
             control_char_fmt="\\x{:02x}",
         )
-        self._format_integer: Callable[[int], str] = str
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_integer: Callable[[int], str] = str
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             passthrough_sequence_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = (
+        self.format_set_entry: Callable[[Value, str], str] = (
             passthrough_set_entry
         )
         self.comment_format = comment_format
@@ -264,39 +264,39 @@ class Yaml(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str="{",
                 close="}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_separator(
                 separator=": ",
                 format_value=passthrough_sequence_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name}: {value}")
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name}: {value}")
         )
-        self._static_preamble: Sequence[str] = ()
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -312,15 +312,15 @@ class Zig(metaclass=LanguageCls):
         """Initialize Zig language specification."""
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self._null_literal = ".nil"
-        self._true_literal = ".{ .bool = true }"
-        self._false_literal = ".{ .bool = false }"
+        self.null_literal = ".nil"
+        self.true_literal = ".{ .bool = true }"
+        self.false_literal = ".{ .bool = false }"
         fmt = sequence_format.value
-        self._sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
-        self._set_format_config: SetFormatConfig = set_format.value
-        self._sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        self._dict_format_config: DictFormatConfig = DictFormatConfig(
+        self.set_format_config: SetFormatConfig = set_format.value
+        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=fixed_dict_open(open_str=".{ .map = &.{"),
             close="}}",
             format_entry=dict_entry_with_template(
@@ -331,25 +331,25 @@ class Zig(metaclass=LanguageCls):
             preamble_lines=(),
             narrowed_open=None,
         )
-        self._trailing_comma_config: TrailingCommaConfig = trailing_comma.value
-        self._format_bytes: Callable[[bytes], str] = bytes_format
-        self._format_date: Callable[[datetime.date], str] = date_format
-        self._format_datetime: Callable[[datetime.datetime], str] = (
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self._format_string: Callable[[str], str] = functools.partial(
+        self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,
             control_char_fmt="\\x{:02x}",
         )
-        self._format_integer: Callable[[int], str] = (
+        self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(
                 numeric_separator=numeric_separator,
             )
         )
-        self._format_sequence_entry: Callable[[Value, str], str] = (
+        self.format_sequence_entry: Callable[[Value, str], str] = (
             _format_zig_entry
         )
-        self._format_set_entry: Callable[[Value, str], str] = _format_zig_entry
+        self.format_set_entry: Callable[[Value, str], str] = _format_zig_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_format = dict_format
@@ -358,32 +358,32 @@ class Zig(metaclass=LanguageCls):
         self.string_format = string_format
         self.trailing_comma = trailing_comma
         self.line_ending = line_ending
-        self._comment_config: CommentConfig = comment_format.value
-        self._ordered_map_format_config: OrderedMapFormatConfig = (
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
                 open_str=".{ .map = &.{",
                 close="}}",
                 preamble_lines=(),
             )
         )
-        self._format_ordered_map_entry: Callable[[str, Value, str], str] = (
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_template(
                 template=".{{ .key = {key}, .val = {value} }}",
                 format_value=_format_zig_entry,
             )
         )
-        self._indent = indent
-        self._indent_closing_delimiter = False
-        self._element_separator = ", "
-        self._skip_null_dict_values = False
-        self._supports_collection_comments = True
-        self._format_variable_declaration: Callable[[str, str, Value], str] = (
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.element_separator = ", "
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter
         )
-        self._format_variable_assignment: Callable[[str, str, Value], str] = (
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self._static_preamble: Sequence[str] = (
+        self.static_preamble: Sequence[str] = (
             "const ZVal = union(enum) {",
             "    nil,",
             "    bool: bool,",
@@ -396,13 +396,13 @@ class Zig(metaclass=LanguageCls):
             "};",
             "const ZKV = struct { key: []const u8, val: ZVal };",
         )
-        self._static_body_preamble: Sequence[str] = ()
-        self._scalar_preamble: dict[type, tuple[str, ...]] = {}
-        self._scalar_body_preamble: dict[type, tuple[str, ...]] = {}
-        self._compute_body_preamble: Callable[
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
+        self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
         ] = body_preamble_from_scalars(
-            scalar_body_preamble=self._scalar_body_preamble,
+            scalar_body_preamble=self.scalar_body_preamble,
         )
 
-        self._type_hint_collection_preamble_lines: tuple[str, ...] = ()
+        self.type_hint_collection_preamble_lines: tuple[str, ...] = ()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -794,7 +794,7 @@ def _build_date_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
-        default_format = spec._format_date
+        default_format = spec.format_date
         for fmt in list(spec.date_formats):
             if fmt is default_format:
                 continue
@@ -823,7 +823,7 @@ def _build_datetime_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
-        default_format = spec._format_datetime
+        default_format = spec.format_datetime
         for fmt in list(spec.datetime_formats):
             if fmt is default_format:
                 continue
@@ -1105,7 +1105,7 @@ def _build_bytes_format_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_name, lang_config in _LANGUAGES.items():
         spec = lang_config.lang_cls()
-        default_format = spec._format_bytes
+        default_format = spec.format_bytes
         non_defaults = [
             fmt for fmt in spec.bytes_formats if fmt is not default_format
         ]

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 """Tests for YAML comment handling that cannot be integration cases."""
 
 import pytest
@@ -167,7 +166,7 @@ def test_yaml_comment_block_scalar_not_extracted() -> None:
 )
 def test_comment_prefix(language: Language, expected: str) -> None:
     """Each language has the expected comment prefix."""
-    assert language._comment_config.prefix == expected
+    assert language.comment_config.prefix == expected
 
 
 @pytest.mark.parametrize(
@@ -181,4 +180,4 @@ def test_comment_prefix(language: Language, expected: str) -> None:
 )
 def test_comment_suffix(language: Language) -> None:
     """Each language has an empty comment suffix."""
-    assert language._comment_config.suffix == ""
+    assert language.comment_config.suffix == ""

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 """Language-specific tests for literalizer converter."""
 
 import json
@@ -32,7 +31,7 @@ from literalizer.languages import (
     TypeScript,
 )
 from literalizer.languages.cobol import (
-    _bump_levels,
+    _bump_levels,  # pyright: ignore[reportPrivateUsage]
 )
 
 COBOL = Cobol(
@@ -524,7 +523,7 @@ def test_toml_non_quoted_dict_key() -> None:
     When the key does not start with a double-quote character the
     bare-key optimization is skipped and the key is used verbatim.
     """
-    result = TOML._dict_format_config.format_entry(
+    result = TOML.dict_format_config.format_entry(
         "plain_key", "value", '"value"'
     )
     assert result == 'plain_key = "value"'

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 """Hypothesis roundtrip tests for literalizer converter."""
 
 import ast
@@ -133,14 +132,14 @@ def test_roundtrip_dict(data: dict[str, _JSONValue]) -> None:
 @given(data=st.binary())
 def test_roundtrip_bytes_python(data: bytes) -> None:
     """Format_bytes_python -> ast.literal_eval round-trips."""
-    result = PYTHON_BYTES._format_bytes(data)
+    result = PYTHON_BYTES.format_bytes(data)
     assert ast.literal_eval(node_or_string=result) == data
 
 
 @given(data=st.binary())
 def test_roundtrip_bytes_hex(data: bytes) -> None:
     """Format_bytes_hex -> bytes.fromhex round-trips."""
-    result = PYTHON._format_bytes(data)
+    result = PYTHON.format_bytes(data)
     assert bytes.fromhex(result.strip('"')) == data
 
 


### PR DESCRIPTION
## Summary
- Reverts #763 which prefixed internal Language protocol attributes with underscores

## Test plan
- [x] All 7620 tests pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical rename across the `Language` protocol, core formatting logic, and all language implementations could cause runtime breakage if any attribute name was missed, but it does not change formatting algorithms intentionally.
> 
> **Overview**
> Reverts the prior change that prefixed `Language` protocol “internal” fields with underscores by renaming them back to public attribute names (e.g. `null_literal`, `sequence_open`, `dict_format_config`, `static_preamble`).
> 
> Updates the core literalization engine (`_core.py`) and every language spec to use the restored names, and drops the associated linter/ruff/pylint per-file ignores that allowed private/protected access in `_core.py` and tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b27b69d40ed7233fbd104918755dd87223a28c8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->