### PR TITLE
Replace getattr with direct attribute access in Haskell

### DIFF
--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -143,12 +143,8 @@ def _build_scalar_body_preamble(
     include_hdatetime = (
         datetime_format.value.type_produced is datetime.datetime
     )
-    date_needs_is_string = bool(
-        getattr(date_format.value, "preamble_lines", ())
-    )
-    datetime_needs_is_string = bool(
-        getattr(datetime_format.value, "preamble_lines", ())
-    )
+    date_needs_is_string = bool(date_format.value.preamble_lines)
+    datetime_needs_is_string = bool(datetime_format.value.preamble_lines)
 
     def _compute(types: frozenset[type], data: Value, /) -> tuple[str, ...]:
         """Return body-preamble lines for the given *types*."""


### PR DESCRIPTION
## Summary

- Replace `getattr(date_format.value, "preamble_lines", ())` with direct `date_format.value.preamble_lines` access in the Haskell body preamble builder.
- `DateFormatConfig` and `DatetimeFormatConfig` always define `preamble_lines` (with default `()`), so the `getattr` fallback was unnecessary.

## Test plan

- [x] Pre-commit hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Haskell preamble computation; behavior should be unchanged assuming `preamble_lines` is always defined on the format config objects.
> 
> **Overview**
> Simplifies Haskell body-preamble generation by replacing `getattr(..., "preamble_lines", ())` fallbacks with direct `date_format.value.preamble_lines` / `datetime_format.value.preamble_lines` access when deciding whether `IsString` support is needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 458e809bf997b58a1434ccd83aaab82fe58719c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->