### PR TITLE
Remove default for supports_default_set_type

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -175,7 +175,7 @@ class LanguageCls(type):
     LineEndings: type[enum.Enum]
     extension: str
     pygments_name: str
-    supports_default_set_type = False
+    supports_default_set_type: bool
 
 
 @runtime_checkable

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -83,6 +83,7 @@ class Ada(metaclass=LanguageCls):
 
     extension = ".adb"
     pygments_name = "ada"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -96,6 +96,7 @@ class Bash(metaclass=LanguageCls):
 
     extension = ".sh"
     pygments_name = "bash"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Bash."""

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -78,6 +78,7 @@ class C(metaclass=LanguageCls):
 
     extension = ".c"
     pygments_name = "c"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for C."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -48,6 +48,7 @@ class Clojure(metaclass=LanguageCls):
 
     extension = ".clj"
     pygments_name = "clojure"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Clojure."""

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -222,6 +222,7 @@ class Cobol(metaclass=LanguageCls):
 
     extension = ".cob"
     pygments_name = "cobol"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -52,6 +52,7 @@ class CommonLisp(metaclass=LanguageCls):
 
     extension = ".lisp"
     pygments_name = "common-lisp"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for CommonLisp."""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -150,6 +150,7 @@ class Cpp(metaclass=LanguageCls):
 
     extension = ".cpp"
     pygments_name = "cpp"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for C++."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -60,6 +60,7 @@ class Crystal(metaclass=LanguageCls):
 
     extension = ".cr"
     pygments_name = "crystal"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Crystal."""

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -88,6 +88,7 @@ class CSharp(metaclass=LanguageCls):
 
     extension = ".cs"
     pygments_name = "csharp"
+    supports_default_set_type = False
 
     _opener_config = TypedOpenerConfig(
         str_type="string",

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -75,6 +75,7 @@ class D(metaclass=LanguageCls):
 
     extension = ".d"
     pygments_name = "d"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for D."""

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -73,6 +73,7 @@ class Dart(metaclass=LanguageCls):
 
     extension = ".dart"
     pygments_name = "dart"
+    supports_default_set_type = False
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -101,6 +101,7 @@ class Elixir(metaclass=LanguageCls):
 
     extension = ".ex"
     pygments_name = "elixir"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Elixir."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -111,6 +111,7 @@ class Erlang(metaclass=LanguageCls):
 
     extension = ".erl"
     pygments_name = "erlang"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Erlang."""

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -140,6 +140,7 @@ class Fortran(metaclass=LanguageCls):
 
     extension = ".f90"
     pygments_name = "fortran"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -118,6 +118,7 @@ class FSharp(metaclass=LanguageCls):
 
     extension = ".fs"
     pygments_name = "fsharp"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for FSharp."""

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -131,6 +131,7 @@ class Go(metaclass=LanguageCls):
 
     extension = ".go"
     pygments_name = "go"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Go."""

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -50,6 +50,7 @@ class Groovy(metaclass=LanguageCls):
 
     extension = ".groovy"
     pygments_name = "groovy"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Groovy."""

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -288,6 +288,7 @@ class Haskell(metaclass=LanguageCls):
 
     extension = ".hs"
     pygments_name = "haskell"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Haskell."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -48,6 +48,7 @@ class Hcl(metaclass=LanguageCls):
 
     extension = ".hcl"
     pygments_name = "hcl"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Hcl."""

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -115,6 +115,7 @@ class Java(metaclass=LanguageCls):
 
     extension = ".java"
     pygments_name = "java"
+    supports_default_set_type = False
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -78,6 +78,7 @@ class JavaScript(metaclass=LanguageCls):
 
     extension = ".js"
     pygments_name = "javascript"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for JavaScript."""

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -82,6 +82,7 @@ class Julia(metaclass=LanguageCls):
 
     extension = ".jl"
     pygments_name = "julia"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for Julia."""

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -177,6 +177,7 @@ class Kotlin(metaclass=LanguageCls):
 
     extension = ".kts"
     pygments_name = "kotlin"
+    supports_default_set_type = False
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -88,6 +88,7 @@ class Lua(metaclass=LanguageCls):
 
     extension = ".lua"
     pygments_name = "lua"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Lua."""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -145,6 +145,7 @@ class Matlab(metaclass=LanguageCls):
 
     extension = ".m"
     pygments_name = "matlab"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Matlab."""

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -66,6 +66,7 @@ class Mojo(metaclass=LanguageCls):
 
     extension = ".mojo"
     pygments_name = "mojo"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Mojo."""

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -133,6 +133,7 @@ class Nim(metaclass=LanguageCls):
 
     extension = ".nim"
     pygments_name = "nim"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Nim."""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -59,6 +59,7 @@ class Norg(metaclass=LanguageCls):
     extension = ".norg"
     # Pygments has no Norg lexer.
     pygments_name = "text"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Norg."""

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -88,6 +88,7 @@ class ObjectiveC(metaclass=LanguageCls):
 
     extension = ".m"
     pygments_name = "objective-c"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -110,6 +110,7 @@ class OCaml(metaclass=LanguageCls):
 
     extension = ".ml"
     pygments_name = "ocaml"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -65,6 +65,7 @@ class Occam(metaclass=LanguageCls):
     extension = ".occ"
     # Pygments has no occam lexer.
     pygments_name = "text"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -95,6 +95,7 @@ class Perl(metaclass=LanguageCls):
 
     extension = ".pl"
     pygments_name = "perl"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Perl."""

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -61,6 +61,7 @@ class Php(metaclass=LanguageCls):
 
     extension = ".php"
     pygments_name = "php"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Php."""

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -73,6 +73,7 @@ class PowerShell(metaclass=LanguageCls):
 
     extension = ".ps1"
     pygments_name = "powershell"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for PowerShell."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -361,6 +361,7 @@ class Python(metaclass=LanguageCls):
 
     extension = ".py"
     pygments_name = "python"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for Python."""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -105,6 +105,7 @@ class R(metaclass=LanguageCls):
 
     extension = ".R"
     pygments_name = "r"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for R."""

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -48,6 +48,7 @@ class Racket(metaclass=LanguageCls):
 
     extension = ".rkt"
     pygments_name = "racket"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Racket."""

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -78,6 +78,7 @@ class Ruby(metaclass=LanguageCls):
 
     extension = ".rb"
     pygments_name = "ruby"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Ruby."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -119,6 +119,7 @@ class Rust(metaclass=LanguageCls):
 
     extension = ".rs"
     pygments_name = "rust"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Rust."""

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -127,6 +127,7 @@ class Scala(metaclass=LanguageCls):
 
     extension = ".scala"
     pygments_name = "scala"
+    supports_default_set_type = False
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -85,6 +85,7 @@ class Toml(metaclass=LanguageCls):
 
     extension = ".toml"
     pygments_name = "toml"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Toml."""

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -86,6 +86,7 @@ class TypeScript(metaclass=LanguageCls):
 
     extension = ".ts"
     pygments_name = "typescript"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for TypeScript."""

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -126,6 +126,7 @@ class VisualBasic(metaclass=LanguageCls):
 
     extension = ".vb"
     pygments_name = "vb.net"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for VisualBasic."""

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -61,6 +61,7 @@ class Yaml(metaclass=LanguageCls):
 
     extension = ".yaml"
     pygments_name = "yaml"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Yaml."""

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -119,6 +119,7 @@ class Zig(metaclass=LanguageCls):
 
     extension = ".zig"
     pygments_name = "zig"
+    supports_default_set_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""


### PR DESCRIPTION
## Summary

- Remove the default value (`False`) from `supports_default_set_type` on `LanguageCls`, replacing it with a `bool` type annotation
- Explicitly set `supports_default_set_type = False` in all 45 language classes (Swift already had `True`)
- This ensures every language must declare its set type support explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes an implicit default on `LanguageCls`, which can break downstream/custom language implementations that relied on the previous default value. Broad mechanical edits across many language specs increase the chance of a missed or inconsistent declaration, though behavior should remain unchanged for built-ins.
> 
> **Overview**
> Makes `supports_default_set_type` an **explicitly required** attribute on `LanguageCls` by removing its default value and leaving only a `bool` annotation.
> 
> Updates all built-in language specs to **declare `supports_default_set_type = False` explicitly** (with existing languages like Swift still setting `True`), ensuring set-type support is always spelled out per language rather than inherited implicitly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e51d58c0892f9bf9cc70e4965daa8e15e0a285e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->