### PR TITLE
Add kw_only to frozen _LanguageSpec

### DIFF
--- a/src/literalizer/_converter.py
+++ b/src/literalizer/_converter.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class _LanguageSpec:
     """Describes how a language formats scalar literals and collections.
 


### PR DESCRIPTION
## Summary
`_LanguageSpec` keeps `frozen=True` and adds `kw_only=True` so all six format fields must be passed by keyword. Existing `_LANGUAGE_SPECS` entries already use keywords.

## Testing
`uv run pytest tests/` — 34 passed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to constructor call semantics for the internal `_LanguageSpec` dataclass; only external/custom instantiations using positional args could break.
> 
> **Overview**
> **Makes `_LanguageSpec` keyword-only.** The `_LanguageSpec` dataclass in `src/literalizer/_converter.py` now uses `kw_only=True` while remaining `frozen=True`, requiring all spec fields to be passed by keyword when constructing language specs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be5177ffcfa518d86a0f2422e55bd5dd10103ca8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->