### PR TITLE
Make Rust empty vec type configurable

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -9,10 +9,7 @@ from typing import TYPE_CHECKING
 
 from beartype import beartype
 
-from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-)
+from literalizer._formatters.collection_openers import fixed_dict_open
 from literalizer._formatters.format_dates import (
     format_date_iso,
     format_datetime_iso,
@@ -24,7 +21,10 @@ from literalizer._formatters.format_entries import (
     tuple_dict_entry,
     variable_formatter,
 )
-from literalizer._formatters.format_factories import set_format_factory
+from literalizer._formatters.format_factories import (
+    sequence_format_factory,
+    set_format_factory,
+)
 from literalizer._formatters.format_integers import (
     format_integer_binary,
     format_integer_hex,
@@ -116,12 +116,16 @@ class Rust(metaclass=LanguageCls):
               coerced to strings.
             * ``sequence_formats.TUPLE`` — tuple literal,
               e.g. ``(1, 2, 3)``.
+
+        default_sequence_element_type: Type name used for empty
+            ``Vec`` literals, e.g. ``Vec::<String>::new()``.
+            Defaults to ``"String"``.
     """
 
     extension = ".rs"
     pygments_name = "rust"
     supports_default_set_element_type = True
-    supports_default_sequence_element_type = False
+    supports_default_sequence_element_type = True
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
 
@@ -170,46 +174,56 @@ class Rust(metaclass=LanguageCls):
     class SequenceFormats(enum.Enum):
         """Sequence type options for Rust."""
 
-        VEC = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="vec!["),
-            close="]",
-            supports_heterogeneity=False,
-            single_element_trailing_comma=False,
-            supports_trailing_comma=True,
-            empty_sequence="Vec::<String>::new()",
-            preamble_lines=(),
-            format_entry=passthrough_sequence_entry,
-            typed_opener_fallback=None,
+        VEC = enum.member(
+            value=sequence_format_factory(
+                open_template="vec![",
+                close="]",
+                supports_heterogeneity=False,
+                single_element_trailing_comma=False,
+                supports_trailing_comma=True,
+                empty_template="Vec::<{type}>::new()",
+                preamble_lines=(),
+                format_entry=passthrough_sequence_entry,
+                typed_opener_fallback_template=None,
+            )
         )
-        ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
-            close="]",
-            supports_heterogeneity=False,
-            single_element_trailing_comma=False,
-            supports_trailing_comma=True,
-            empty_sequence=None,
-            preamble_lines=(),
-            format_entry=passthrough_sequence_entry,
-            typed_opener_fallback=None,
+        ARRAY = enum.member(
+            value=sequence_format_factory(
+                open_template="[",
+                close="]",
+                supports_heterogeneity=False,
+                single_element_trailing_comma=False,
+                supports_trailing_comma=True,
+                empty_template=None,
+                preamble_lines=(),
+                format_entry=passthrough_sequence_entry,
+                typed_opener_fallback_template=None,
+            )
         )
-        TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="("),
-            close=")",
-            supports_heterogeneity=True,
-            single_element_trailing_comma=False,
-            supports_trailing_comma=True,
-            empty_sequence=None,
-            preamble_lines=(),
-            format_entry=passthrough_sequence_entry,
-            typed_opener_fallback=None,
+        TUPLE = enum.member(
+            value=sequence_format_factory(
+                open_template="(",
+                close=")",
+                supports_heterogeneity=True,
+                single_element_trailing_comma=False,
+                supports_trailing_comma=True,
+                empty_template=None,
+                preamble_lines=(),
+                format_entry=passthrough_sequence_entry,
+                typed_opener_fallback_template=None,
+            )
         )
+
+        def __call__(self, default_type: str) -> SequenceFormatConfig:
+            """Create a sequence format config for the given type."""
+            return self.value(default_type)
 
         @property
         def supports_heterogeneity(self) -> bool:
             """Whether this sequence format supports mixed-type
             elements.
             """
-            return self.value.supports_heterogeneity
+            return self(default_type="String").supports_heterogeneity
 
     class SetFormats(enum.Enum):
         """Set type options for Rust."""
@@ -381,6 +395,7 @@ class Rust(metaclass=LanguageCls):
         bytes_format: BytesFormats = BytesFormats.HEX,
         sequence_format: SequenceFormats = SequenceFormats.VEC,
         set_format: SetFormats = SetFormats.HASH_SET,
+        default_sequence_element_type: str = "String",
         default_set_element_type: str = "String",
         default_dict_key_type: str = "String",
         default_dict_value_type: str = "String",
@@ -401,7 +416,7 @@ class Rust(metaclass=LanguageCls):
         self.null_literal = "None::<()>"
         self.true_literal = "true"
         self.false_literal = "false"
-        fmt = sequence_format.value
+        fmt = sequence_format(default_type=default_sequence_element_type)
         self.sequence_format_config: SequenceFormatConfig = fmt
         self.set_format = set_format
 

--- a/tests/integration/cases/empty_sequence/Rust_default_sequence_element_type_string.rs
+++ b/tests/integration/cases/empty_sequence/Rust_default_sequence_element_type_string.rs
@@ -1,0 +1,8 @@
+use std::collections::HashMap;
+fn main() {
+    let my_data = vec![
+        "[]",
+        "{}",
+    ];
+    let _ = my_data;
+}

--- a/tests/integration/cases/simple_sequence/Rust_default_sequence_element_type_string.rs
+++ b/tests/integration/cases/simple_sequence/Rust_default_sequence_element_type_string.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let my_data = vec![
+        "1",
+        "hello",
+        "True",
+        "None",
+    ];
+    let _ = my_data;
+}


### PR DESCRIPTION
## Summary
- Add `default_sequence_element_type` parameter to `Rust`, so users can customize the type in empty `Vec` literals (e.g. `Vec::<i32>::new()` instead of the hardcoded `Vec::<String>::new()`).
- Convert `SequenceFormats` enum members to use `sequence_format_factory`, matching the pattern already used by Swift, Mojo, and C#.
- Add integration test golden files for the new variant.

Closes #786

## Test plan
- [x] All 7686 existing tests pass
- [x] New `Rust_default_sequence_element_type_string` golden files for `empty_sequence` and `simple_sequence` cases pass
- [x] Verified `Rust(default_sequence_element_type='i32')` produces `Vec::<i32>::new()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to Rust sequence formatting, primarily affecting how empty `Vec` literals are rendered and adding golden tests to lock the behavior.
> 
> **Overview**
> Rust literal generation now supports a configurable `default_sequence_element_type`, used to type empty `Vec` literals (via `Vec::<{type}>::new()`) instead of always defaulting to `String`.
> 
> `Rust.SequenceFormats` was refactored to use `sequence_format_factory` (matching other languages’ pattern) and `Rust.__init__` now builds the sequence format config with the provided default type. New integration golden files cover the default `String` behavior for empty and simple sequence cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b111d2a17791e98515e6008176fcf04b4c24c94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->