### PR TITLE
Replace `or` with `is not None` in TypedOpenerConfig

### DIFF
--- a/src/literalizer/_formatters/collection_openers.py
+++ b/src/literalizer/_formatters/collection_openers.py
@@ -444,9 +444,19 @@ class TypedOpenerConfig:
             float_type=self._float_type,
             bytes_type=self._bytes_type,
             mixed_numeric_type=self._mixed_numeric_type,
-            date_type=date_type or self._date_type,
-            datetime_type=datetime_type or self._datetime_type,
-            list_template=list_template or self._list_template,
+            date_type=(
+                date_type if date_type is not None else self._date_type
+            ),
+            datetime_type=(
+                datetime_type
+                if datetime_type is not None
+                else self._datetime_type
+            ),
+            list_template=(
+                list_template
+                if list_template is not None
+                else self._list_template
+            ),
             dict_type_template=resolved_template,
             fallback_value_type=(
                 self._fallback_value_type if enable_dict_type else None
@@ -516,7 +526,9 @@ class TypedOpenerConfig:
             set=make_type_to_opener(
                 element_to_type=dict_set_resolver,
                 opener_template=(
-                    set_opener_template or self._set_opener_template
+                    set_opener_template
+                    if set_opener_template is not None
+                    else self._set_opener_template
                 ),
             ),
         )


### PR DESCRIPTION
## Summary\n- Replace `or` fallback pattern with `is not None` checks in `TypedOpenerConfig.element_to_type()` and `TypedOpenerConfig.build()` so that `\"\"` is treated as a valid override value instead of being silently ignored\n- Affects `date_type`, `datetime_type`, `list_template`, and `set_opener_template` parameters\n\n## Test plan\n- [x] All 340 existing tests pass\n- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)\n\nCloses #801

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, behavior change is limited to how optional override parameters are resolved and primarily affects callers that intentionally pass falsy values like empty strings.
> 
> **Overview**
> Fixes `TypedOpenerConfig` override handling by replacing `x or default` fallbacks with explicit `is not None` checks.
> 
> This means falsy-but-valid override values (notably `""`) are now preserved for `date_type`, `datetime_type`, `list_template`, and `set_opener_template`, instead of being silently replaced by the config defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5abfed98adcc8fb5ec9ffc9dd3e2fdb764b895b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->