### PR TITLE
Only escape \#{  in Crystal/Elixir strings

### DIFF
--- a/src/literalizer/_formatters/format_strings.py
+++ b/src/literalizer/_formatters/format_strings.py
@@ -201,10 +201,11 @@ def format_string_backslash_dollar(value: str) -> str:
 
 @beartype
 def format_string_backslash_hash(value: str) -> str:
-    r"""Format a string using backslash escaping, including ``#``.
+    r"""Format a string using backslash escaping, including ``#{``.
 
-    Escapes backslashes, double quotes, newlines, tabs, and hash signs
-    with a backslash prefix, then wraps the result in double quotes.
+    Escapes backslashes, double quotes, newlines, tabs, and the
+    interpolation sequence ``#{`` with a backslash prefix, then wraps the
+    result in double quotes.
 
     Example: ``Issue #{42}`` -> ``"Issue \#{42}"``.
     """
@@ -214,7 +215,7 @@ def format_string_backslash_hash(value: str) -> str:
         .replace("\r", "\\r")
         .replace("\n", "\\n")
         .replace("\t", "\\t")
-        .replace("#", "\\#")
+        .replace("#{", "\\#{")
     )
     return f'"{escaped}"'
 

--- a/tests/integration/cases/comments_escaped_quote/Crystal.cr
+++ b/tests/integration/cases/comments_escaped_quote/Crystal.cr
@@ -1,3 +1,3 @@
 my_data = {
-    "key" => "value \" \# not a comment",  # real
+    "key" => "value \" # not a comment",  # real
 }

--- a/tests/integration/cases/comments_escaped_quote/Crystal_combined.cr
+++ b/tests/integration/cases/comments_escaped_quote/Crystal_combined.cr
@@ -1,6 +1,6 @@
 my_data = {
-    "key" => "value \" \# not a comment",  # real
+    "key" => "value \" # not a comment",  # real
 }
 my_data = {
-    "key" => "value \" \# not a comment",  # real
+    "key" => "value \" # not a comment",  # real
 }

--- a/tests/integration/cases/comments_escaped_quote/Elixir.ex
+++ b/tests/integration/cases/comments_escaped_quote/Elixir.ex
@@ -1,7 +1,7 @@
 defmodule Check do
   def x do
     my_data = %{
-    "key" => "value \" \# not a comment",  # real
+    "key" => "value \" # not a comment",  # real
 }
     _ = my_data
   end

--- a/tests/integration/cases/comments_escaped_quote/Elixir_combined.ex
+++ b/tests/integration/cases/comments_escaped_quote/Elixir_combined.ex
@@ -1,7 +1,7 @@
 defmodule Check do
   def x do
     my_data = %{
-    "key" => "value \" \# not a comment",  # real
+    "key" => "value \" # not a comment",  # real
 }
     _ = my_data
   end

--- a/tests/integration/cases/string_with_hash/Crystal.cr
+++ b/tests/integration/cases/string_with_hash/Crystal.cr
@@ -1,4 +1,4 @@
 my_data = [
     "issue \#{42}",
-    "color \#red",
+    "color #red",
 ]

--- a/tests/integration/cases/string_with_hash/Crystal_combined.cr
+++ b/tests/integration/cases/string_with_hash/Crystal_combined.cr
@@ -1,8 +1,8 @@
 my_data = [
     "issue \#{42}",
-    "color \#red",
+    "color #red",
 ]
 my_data = [
     "issue \#{42}",
-    "color \#red",
+    "color #red",
 ]

--- a/tests/integration/cases/string_with_hash/Elixir.ex
+++ b/tests/integration/cases/string_with_hash/Elixir.ex
@@ -2,7 +2,7 @@ defmodule Check do
   def x do
     my_data = [
     "issue \#{42}",
-    "color \#red",
+    "color #red",
 ]
     _ = my_data
   end

--- a/tests/integration/cases/string_with_hash/Elixir_combined.ex
+++ b/tests/integration/cases/string_with_hash/Elixir_combined.ex
@@ -2,7 +2,7 @@ defmodule Check do
   def x do
     my_data = [
     "issue \#{42}",
-    "color \#red",
+    "color #red",
 ]
     _ = my_data
   end


### PR DESCRIPTION
## Summary
- Fix `format_string_backslash_hash` to escape only `#{` instead of all `#` characters
- Crystal and Elixir only interpolate `#{…}` — a bare `#` not followed by `{` is already a literal
- Previously, strings like `"color #red"` were unnecessarily emitted as `"color \#red"`

Addresses https://github.com/adamtheturtle/literalizer/pull/810#discussion_r3006121978

## Test plan
- [x] All 8025 tests pass, 76 skipped
- [x] `string_with_hash` and `comments_escaped_quote` golden files updated for Crystal and Elixir

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a narrow change to string escaping rules for Crystal/Elixir output plus updates to golden integration fixtures; no security-sensitive logic or data handling changes.
> 
> **Overview**
> Adjusts Crystal/Elixir string escaping so `format_string_backslash_hash` only escapes the interpolation opener `#{` rather than every `#`, avoiding unnecessary backslashes in literals like `"color #red"` while still preventing unintended interpolation.
> 
> Updates the affected Crystal/Elixir integration golden files (`string_with_hash`, `comments_escaped_quote`) to match the new emitted string literals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14e967aa6065c5d78bb3e945897788fc3e853dcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->