### PR TITLE
Escape carriage returns in Objective-C string literals

### DIFF
--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -66,8 +66,8 @@ def _format_objc_entry(_original: Value, formatted: str) -> str:
 def _format_objc_string(value: str) -> str:
     r"""Format a string as an Objective-C ``NSString`` literal.
 
-    Escapes backslashes, double quotes, newlines, and tabs, then wraps
-    the result in ``@"..."``.
+    Escapes backslashes, double quotes, newlines, carriage returns, and
+    tabs, then wraps the result in ``@"..."``.
 
     Example: ``hello "world"`` → ``@"hello \"world\""``.
     """
@@ -75,6 +75,7 @@ def _format_objc_string(value: str) -> str:
         value.replace("\\", "\\\\")
         .replace('"', '\\"')
         .replace("\n", "\\n")
+        .replace("\r", "\\r")
         .replace("\t", "\\t")
     )
     return f'@"{escaped}"'

--- a/tests/integration/cases/string_control_chars/ObjectiveC.m
+++ b/tests/integration/cases/string_control_chars/ObjectiveC.m
@@ -1,8 +1,8 @@
 #import <Foundation/Foundation.h>
 void _check(void) {
 id my_data = @[
-    @"line1\nline2",
-    @"line1line2",
+    @"line1\r\nline2",
+    @"line1\rline2",
     @"",
 ];
     (void)my_data;

--- a/tests/integration/cases/string_control_chars/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_control_chars/ObjectiveC_combined.m
@@ -1,13 +1,13 @@
 #import <Foundation/Foundation.h>
 void _check(void) {
 id my_data = @[
-    @"line1\nline2",
-    @"line1line2",
+    @"line1\r\nline2",
+    @"line1\rline2",
     @"",
 ];
 my_data = @[
-    @"line1\nline2",
-    @"line1line2",
+    @"line1\r\nline2",
+    @"line1\rline2",
     @"",
 ];
     (void)my_data;


### PR DESCRIPTION
## Summary
- Add missing `\r` escape in `_format_objc_string` so embedded carriage returns produce valid `@"..."` literals instead of raw control characters
- Matches the behavior of the generic `format_string_backslash` helper
- Updates golden test files to reflect the corrected output

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to Objective-C string escaping plus updated golden integration outputs; main risk is minor output diffs for strings containing `\r`.
> 
> **Overview**
> Fixes Objective-C string literal generation by escaping carriage returns (`\r`) in `_format_objc_string`, preventing raw control characters from appearing inside `@"..."` literals.
> 
> Updates the string control-character integration golden files to expect `\r`-escaped output (including CRLF and standalone CR cases).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13c39c54d7901666d7c9869b949e1b4704c79e6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->