### PR TITLE
Fix missing line_prefix for all-null dict collapse

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1169,7 +1169,7 @@ def _literalize(
     )
 
     if isinstance(lines_or_early, str):
-        return lines_or_early
+        return f"{line_prefix}{lines_or_early}"
 
     body = "\n".join(lines_or_early)
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -249,6 +249,20 @@ def test_java_dict_all_null_values_include_delimiters() -> None:
     assert result.code == "Map.ofEntries()"
 
 
+def test_java_dict_all_null_values_with_pre_indent_level() -> None:
+    """Java all-null dict with pre_indent_level includes line_prefix."""
+    result = literalize_json(
+        json_string=json.dumps(obj={"a": None, "b": None}),
+        language=JAVA,
+        pre_indent_level=1,
+        include_delimiters=True,
+        variable_name=None,
+        new_variable=True,
+        error_on_coercion=False,
+    )
+    assert result.code == "    Map.ofEntries()"
+
+
 def test_java_yaml_dict_null_values_with_comments() -> None:
     """Java YAML dict with null values and comments does not crash."""
     yaml_string = "# comment\nname: Alice\nscore: null\n"


### PR DESCRIPTION
## Summary
- Fixes the early-return path in `_literalize` to prepend `line_prefix` when `_format_collection_lines` returns a collapsed all-null dict as a string
- Adds regression test for `pre_indent_level=1` with an all-null Java dict

Fixes #808

## Test plan
- [x] New test `test_java_dict_all_null_values_with_pre_indent_level` passes
- [x] Existing test `test_java_dict_all_null_values_include_delimiters` still passes (pre_indent_level=0)
- [x] Full test suite passes (8391 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small formatting fix limited to an early-return path when collapsing all-null dicts, plus a focused regression test; main risk is minor output formatting changes for that edge case.
> 
> **Overview**
> Fixes `_literalize`’s early-return path so when `_format_collection_lines` collapses an all-null dict into a single-line empty-collection literal, the result still includes the configured `line_prefix` (e.g. from `pre_indent_level`).
> 
> Adds a regression test covering Java `Map.ofEntries()` output for an all-null dict with `pre_indent_level=1` to ensure the indentation prefix is preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92404d7c356002cbdf227df8afc1dcc09938788e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->