### PR TITLE
Replace dataclasses.replace with abstractions in language specs

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -8,6 +8,8 @@ from typing import Protocol, runtime_checkable
 
 from beartype import beartype
 
+from literalizer._formatters.collection_openers import typed_set_open
+from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._types import Value
 
 
@@ -87,6 +89,25 @@ class SetFormatConfig:
     empty_set: str | None
     preamble_lines: tuple[str, ...]
     set_opener_template: str
+
+    def with_typed_opener(
+        self,
+        *,
+        type_to_opener: Callable[[type | ListType | DictType], str | None],
+        fallback: str,
+    ) -> "SetFormatConfig":
+        """Return a copy with ``set_open`` replaced by a typed opener.
+
+        The *type_to_opener* callable is used to infer the opener from the
+        element type.  When inference fails, *fallback* is used instead.
+        """
+        return dataclasses.replace(
+            self,
+            set_open=typed_set_open(
+                type_to_opener=type_to_opener,
+                fallback=fallback,
+            ),
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -14,7 +14,6 @@ from literalizer._formatters.collection_openers import (
     make_type_to_opener,
     typed_dict_open,
     typed_sequence_open,
-    typed_set_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -415,12 +414,9 @@ class CSharp(metaclass=LanguageCls):
             narrow_dict_values=False,
             dict_key_type=default_dict_key_type,
         )
-        self.set_format_config = dataclasses.replace(
-            self.set_format_config,
-            set_open=typed_set_open(
-                type_to_opener=openers.set,
-                fallback=self.set_format_config.set_open([]),
-            ),
+        self.set_format_config = self.set_format_config.with_typed_opener(
+            type_to_opener=openers.set,
+            fallback=self.set_format_config.set_open([]),
         )
         self.sequence_open: Callable[[list[Value]], str] = (
             typed_sequence_open(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -1,6 +1,5 @@
 """Go language specification."""
 
-import dataclasses
 import datetime
 import enum
 from collections.abc import Callable
@@ -11,12 +10,10 @@ from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
     fixed_sequence_open,
-    fixed_set_open,
     make_element_to_type,
     make_type_to_opener,
     typed_dict_open,
     typed_sequence_open,
-    typed_set_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -30,6 +27,7 @@ from literalizer._formatters.format_entries import (
     passthrough_sequence_entry,
     variable_formatter,
 )
+from literalizer._formatters.format_factories import set_format_factory
 from literalizer._formatters.format_floats import (
     format_float_fixed,
     format_float_repr,
@@ -209,13 +207,19 @@ class Go(metaclass=LanguageCls):
     class SetFormats(enum.Enum):
         """Set type options for Go."""
 
-        SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="map[any]struct{}{"),
-            close="}",
-            empty_set=None,
-            preamble_lines=(),
-            set_opener_template="",
+        SET = enum.member(
+            value=set_format_factory(
+                open_template="map[{type}]struct{{}}{{",
+                close="}}",
+                empty_template=None,
+                preamble_lines=(),
+                set_opener_template="",
+            )
         )
+
+        def __call__(self, default_type: str) -> SetFormatConfig:
+            """Create a set format config for the given type."""
+            return self.value(default_type)
 
     class CommentFormats(enum.Enum):
         """Comment style options."""
@@ -421,15 +425,17 @@ class Go(metaclass=LanguageCls):
             dict_type_template=f"map[{default_dict_key_type}]{{inner}}",
             fallback_value_type="any",
         )
-        self.set_format_config: SetFormatConfig = dataclasses.replace(
-            set_format.value,
-            set_open=typed_set_open(
+        base_set_config: SetFormatConfig = set_format(
+            default_type=default_set_element_type,
+        )
+        self.set_format_config: SetFormatConfig = (
+            base_set_config.with_typed_opener(
                 type_to_opener=make_type_to_opener(
                     element_to_type=init_element_to_type,
                     opener_template="map[{type_name}]struct{{}}{{",
                 ),
-                fallback=f"map[{default_set_element_type}]struct{{}}{{",
-            ),
+                fallback=base_set_config.set_open([]),
+            )
         )
         self.sequence_open: Callable[[list[Value]], str] = typed_sequence_open(
             type_to_opener=make_type_to_opener(

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -15,7 +15,6 @@ from literalizer._formatters.collection_openers import (
     make_type_to_opener,
     typed_dict_open,
     typed_sequence_open,
-    typed_set_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -532,12 +531,9 @@ class Kotlin(metaclass=LanguageCls):
             narrow_dict_values=False,
             dict_key_type=default_dict_key_type,
         )
-        self.set_format_config = dataclasses.replace(
-            self.set_format_config,
-            set_open=typed_set_open(
-                type_to_opener=openers.set,
-                fallback=self.set_format_config.set_open([]),
-            ),
+        self.set_format_config = self.set_format_config.with_typed_opener(
+            type_to_opener=openers.set,
+            fallback=self.set_format_config.set_open([]),
         )
         resolved_dict_opener = dict_format.value.opener_template.replace(
             "{key_type}",

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -1,6 +1,5 @@
 """Mojo language specification."""
 
-import dataclasses
 import datetime
 import enum
 from typing import TYPE_CHECKING
@@ -10,7 +9,6 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import (
     make_element_to_type,
     make_type_to_opener,
-    typed_set_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -319,27 +317,24 @@ class Mojo(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format(
             default_type=default_set_element_type,
         )
-        self.set_format_config = dataclasses.replace(
-            self.set_format_config,
-            set_open=typed_set_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=make_element_to_type(
-                        str_type="String",
-                        bool_type="Bool",
-                        int_type="Int",
-                        float_type="Float64",
-                        mixed_numeric_type="String",
-                        bytes_type=None,
-                        date_type=None,
-                        datetime_type=None,
-                        list_template="List[{inner}]",
-                        dict_type_template=None,
-                        fallback_value_type=None,
-                    ),
-                    opener_template="Set[{type_name}](",
+        self.set_format_config = self.set_format_config.with_typed_opener(
+            type_to_opener=make_type_to_opener(
+                element_to_type=make_element_to_type(
+                    str_type="String",
+                    bool_type="Bool",
+                    int_type="Int",
+                    float_type="Float64",
+                    mixed_numeric_type="String",
+                    bytes_type=None,
+                    date_type=None,
+                    datetime_type=None,
+                    list_template="List[{inner}]",
+                    dict_type_template=None,
+                    fallback_value_type=None,
                 ),
-                fallback=self.set_format_config.set_open([]),
+                opener_template="Set[{type_name}](",
             ),
+            fallback=self.set_format_config.set_open([]),
         )
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = dict_format(

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1,6 +1,5 @@
 """Rust language specification."""
 
-import dataclasses
 import datetime
 import enum
 from collections.abc import Callable
@@ -9,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from beartype import beartype
 
-from literalizer._formatters.collection_openers import fixed_dict_open
 from literalizer._formatters.format_dates import (
     format_date_iso,
     format_datetime_iso,
@@ -23,6 +21,7 @@ from literalizer._formatters.format_entries import (
     variable_formatter,
 )
 from literalizer._formatters.format_factories import (
+    dict_format_factory,
     sequence_format_factory,
     set_format_factory,
 )
@@ -292,26 +291,42 @@ class Rust(metaclass=LanguageCls):
     class DictFormats(enum.Enum):
         """Dict/map format options."""
 
-        HASH_MAP = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="HashMap::from(["),
-            close="])",
-            format_entry=tuple_dict_entry(
-                format_value=passthrough_sequence_entry
-            ),
-            empty_dict="HashMap::<&str, &str>::from([])",
-            preamble_lines=("use std::collections::HashMap;",),
-            narrowed_open=None,
+        HASH_MAP = enum.member(
+            value=dict_format_factory(
+                open_template="HashMap::from([",
+                close="])",
+                format_entry=tuple_dict_entry(
+                    format_value=passthrough_sequence_entry
+                ),
+                empty_template="HashMap::<{key_type}, {type}>::from([])",
+                preamble_lines=("use std::collections::HashMap;",),
+                narrowed_open=None,
+            )
         )
-        BTREE_MAP = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="BTreeMap::from(["),
-            close="])",
-            format_entry=tuple_dict_entry(
-                format_value=passthrough_sequence_entry
-            ),
-            empty_dict="BTreeMap::<&str, &str>::from([])",
-            preamble_lines=("use std::collections::BTreeMap;",),
-            narrowed_open=None,
+        BTREE_MAP = enum.member(
+            value=dict_format_factory(
+                open_template="BTreeMap::from([",
+                close="])",
+                format_entry=tuple_dict_entry(
+                    format_value=passthrough_sequence_entry
+                ),
+                empty_template="BTreeMap::<{key_type}, {type}>::from([])",
+                preamble_lines=("use std::collections::BTreeMap;",),
+                narrowed_open=None,
+            )
         )
+
+        def __call__(
+            self,
+            default_type: str,
+            *,
+            default_key_type: str = "&str",
+        ) -> DictFormatConfig:
+            """Create a dict format config for the given type."""
+            return self.value(
+                default_type,
+                default_key_type=default_key_type,
+            )
 
     class EmptyDictKey(enum.Enum):
         """Empty dict key options."""
@@ -462,18 +477,9 @@ class Rust(metaclass=LanguageCls):
             default_type=default_set_element_type,
         )
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
-        base_dict_config: DictFormatConfig = dict_format.value
-        base_empty_dict = base_dict_config.empty_dict
-        self.dict_format_config: DictFormatConfig = dataclasses.replace(
-            base_dict_config,
-            empty_dict=(
-                base_empty_dict.replace(
-                    "<&str, &str>",
-                    f"<{default_dict_key_type}, {default_dict_value_type}>",
-                )
-                if base_empty_dict is not None
-                else None
-            ),
+        self.dict_format_config: DictFormatConfig = dict_format(
+            default_type=default_dict_value_type,
+            default_key_type=default_dict_key_type,
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -16,7 +16,6 @@ from literalizer._formatters.collection_openers import (
     make_type_to_opener,
     typed_dict_open,
     typed_sequence_open,
-    typed_set_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -444,12 +443,11 @@ class Scala(metaclass=LanguageCls):
             set_opener_template=set_format.value.set_opener_template or None,
             narrow_dict_values=False,
         )
-        self.set_format_config: SetFormatConfig = dataclasses.replace(
-            set_format.value,
-            set_open=typed_set_open(
+        self.set_format_config: SetFormatConfig = (
+            set_format.value.with_typed_opener(
                 type_to_opener=openers.set,
                 fallback=set_format.value.set_open([]),
-            ),
+            )
         )
         self.sequence_open: Callable[[list[Value]], str] = (
             _resolve_sequence_open(

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -1,6 +1,5 @@
 """Visual Basic (.NET) language specification."""
 
-import dataclasses
 import datetime
 import enum
 from typing import TYPE_CHECKING
@@ -11,7 +10,6 @@ from literalizer._formatters.collection_openers import (
     make_element_to_type,
     make_type_to_opener,
     typed_sequence_open,
-    typed_set_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -392,15 +390,12 @@ class VisualBasic(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format(
             default_type=default_set_element_type,
         )
-        self.set_format_config = dataclasses.replace(
-            self.set_format_config,
-            set_open=typed_set_open(
-                type_to_opener=make_type_to_opener(
-                    element_to_type=element_to_type,
-                    opener_template="New HashSet(Of {type_name}) From {{",
-                ),
-                fallback=self.set_format_config.set_open([]),
+        self.set_format_config = self.set_format_config.with_typed_opener(
+            type_to_opener=make_type_to_opener(
+                element_to_type=element_to_type,
+                opener_template="New HashSet(Of {type_name}) From {{",
             ),
+            fallback=self.set_format_config.set_open([]),
         )
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = dict_format(


### PR DESCRIPTION
## Summary
- Adds `SetFormatConfig.with_typed_opener` method to encapsulate the recurring pattern of replacing `set_open` with a `typed_set_open` callable, eliminating `dataclasses.replace` from 6 language files (scala, csharp, kotlin, vb, mojo, go).
- Converts Go's `SetFormats` enum to use `set_format_factory` so the default element type is templated rather than hardcoded to `"any"`.
- Converts Rust's `DictFormats` enum to use `dict_format_factory` with `{key_type}`/`{type}` templates, replacing the post-hoc string substitution via `dataclasses.replace`.
- No `dataclasses.replace` calls remain in `src/literalizer/languages/`.

## Test plan
- [x] All 8406 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical refactors, but it changes how Go set openers and Rust empty dict literals are constructed, which could subtly affect emitted code for typed/empty collections.
> 
> **Overview**
> **Refactors set opener configuration** by adding `SetFormatConfig.with_typed_opener()` and updating C#, Kotlin, Scala, Mojo, VB, and Go to use it instead of ad-hoc `dataclasses.replace(... typed_set_open(...))`.
> 
> **Makes collection formats more templated**: Go’s `SetFormats` now uses `set_format_factory` so the default element type is injected via templates, and Rust’s `DictFormats` now uses `dict_format_factory` (including `{key_type}`/`{type}` in `empty_dict`) so `Rust.__init__` no longer does post-hoc string substitution for empty map literals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4ceed77c97f93b2fada5bf71a356167af4f5b1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->