### PR TITLE
Reuse _wrap_ada in _wrap_ada_combined

### DIFF
--- a/tests/integration/cases/binary/Ada_combined.adb
+++ b/tests/integration/cases/binary/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/bool_list/Ada_combined.adb
+++ b/tests/integration/cases/bool_list/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments/Ada_combined.adb
+++ b/tests/integration/cases/comments/Ada_combined.adb
@@ -21,6 +21,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_bang_in_double_quote/Ada_combined.adb
+++ b/tests/integration/cases/comments_bang_in_double_quote/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_double_hash/Ada_combined.adb
+++ b/tests/integration/cases/comments_double_hash/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_empty_line/Ada_combined.adb
+++ b/tests/integration/cases/comments_empty_line/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_escaped_quote/Ada_combined.adb
+++ b/tests/integration/cases/comments_escaped_quote/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_escaped_single_quote/Ada_combined.adb
+++ b/tests/integration/cases/comments_escaped_single_quote/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_multi_line/Ada_combined.adb
+++ b/tests/integration/cases/comments_multi_line/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_nested_mapping/Ada_combined.adb
+++ b/tests/integration/cases/comments_nested_mapping/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_sequence_before/Ada_combined.adb
+++ b/tests/integration/cases/comments_sequence_before/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_sequence_inline/Ada_combined.adb
+++ b/tests/integration/cases/comments_sequence_inline/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_trailing/Ada_combined.adb
+++ b/tests/integration/cases/comments_trailing/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/comments_vb_before_dim/Ada_combined.adb
+++ b/tests/integration/cases/comments_vb_before_dim/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/date_list/Ada_combined.adb
+++ b/tests/integration/cases/date_list/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/date_set/Ada_combined.adb
+++ b/tests/integration/cases/date_set/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/dates/Ada_combined.adb
+++ b/tests/integration/cases/dates/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/datetime_list/Ada_combined.adb
+++ b/tests/integration/cases/datetime_list/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/deep_nesting/Ada_combined.adb
+++ b/tests/integration/cases/deep_nesting/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/dict_with_control_char_keys/Ada_combined.adb
+++ b/tests/integration/cases/dict_with_control_char_keys/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/dict_with_list_value/Ada_combined.adb
+++ b/tests/integration/cases/dict_with_list_value/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/dict_with_nulls/Ada_combined.adb
+++ b/tests/integration/cases/dict_with_nulls/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/empty_dict/Ada_combined.adb
+++ b/tests/integration/cases/empty_dict/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AMap'(1 .. 0 => ANull);
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/empty_dicts_in_sequence/Ada_combined.adb
+++ b/tests/integration/cases/empty_dicts_in_sequence/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/empty_list/Ada_combined.adb
+++ b/tests/integration/cases/empty_list/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AList'(1 .. 0 => ANull);
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/empty_sequence/Ada_combined.adb
+++ b/tests/integration/cases/empty_sequence/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/empty_set/Ada_combined.adb
+++ b/tests/integration/cases/empty_set/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := ASet'(1 .. 0 => ANull);
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/float_list/Ada_combined.adb
+++ b/tests/integration/cases/float_list/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/int_key_dict/Ada_combined.adb
+++ b/tests/integration/cases/int_key_dict/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/int_list/Ada_combined.adb
+++ b/tests/integration/cases/int_list/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/int_list_large/Ada_combined.adb
+++ b/tests/integration/cases/int_list_large/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/int_list_with_zero/Ada_combined.adb
+++ b/tests/integration/cases/int_list_with_zero/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/int_set/Ada_combined.adb
+++ b/tests/integration/cases/int_set/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/mixed_number_dict/Ada_combined.adb
+++ b/tests/integration/cases/mixed_number_dict/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/mixed_number_list/Ada_combined.adb
+++ b/tests/integration/cases/mixed_number_list/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/mixed_set/Ada_combined.adb
+++ b/tests/integration/cases/mixed_set/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Ada_combined.adb
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested/Ada_combined.adb
+++ b/tests/integration/cases/nested/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_bool_list/Ada_combined.adb
+++ b/tests/integration/cases/nested_bool_list/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_collection_multi_space_string/Ada_combined.adb
+++ b/tests/integration/cases/nested_collection_multi_space_string/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_deep_empty/Ada_combined.adb
+++ b/tests/integration/cases/nested_deep_empty/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_deep_mixed/Ada_combined.adb
+++ b/tests/integration/cases/nested_deep_mixed/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_empty_inner/Ada_combined.adb
+++ b/tests/integration/cases/nested_empty_inner/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_float_list/Ada_combined.adb
+++ b/tests/integration/cases/nested_float_list/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_list_of_dicts/Ada_combined.adb
+++ b/tests/integration/cases/nested_list_of_dicts/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_mixed_inner/Ada_combined.adb
+++ b/tests/integration/cases/nested_mixed_inner/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_mixed_types/Ada_combined.adb
+++ b/tests/integration/cases/nested_mixed_types/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_sequence/Ada_combined.adb
+++ b/tests/integration/cases/nested_sequence/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/nested_sequences/Ada_combined.adb
+++ b/tests/integration/cases/nested_sequences/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/no_comment/Ada_combined.adb
+++ b/tests/integration/cases/no_comment/Ada_combined.adb
@@ -13,6 +13,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/ordered_map/Ada_combined.adb
+++ b/tests/integration/cases/ordered_map/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/ordered_map_nested_values/Ada_combined.adb
+++ b/tests/integration/cases/ordered_map_nested_values/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/pair_sequence/Ada_combined.adb
+++ b/tests/integration/cases/pair_sequence/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalar_date/Ada_combined.adb
+++ b/tests/integration/cases/scalar_date/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("2024-01-15");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalar_datetime/Ada_combined.adb
+++ b/tests/integration/cases/scalar_datetime/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("2024-01-15T12:30:00+00:00");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalar_datetime_microsecond/Ada_combined.adb
+++ b/tests/integration/cases/scalar_datetime_microsecond/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("2024-01-15T12:30:00.123456+00:00");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalar_datetime_midnight/Ada_combined.adb
+++ b/tests/integration/cases/scalar_datetime_midnight/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("2024-01-15T00:00:00");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalar_datetime_naive/Ada_combined.adb
+++ b/tests/integration/cases/scalar_datetime_naive/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("2024-01-15T12:30:00");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalar_datetime_non_utc/Ada_combined.adb
+++ b/tests/integration/cases/scalar_datetime_non_utc/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("2024-01-15T18:00:00+05:30");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Ada_combined.adb
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("2024-01-15T12:30:45.123456");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/scalars/Ada_combined.adb
+++ b/tests/integration/cases/scalars/Ada_combined.adb
@@ -21,6 +21,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/sequence_of_dicts/Ada_combined.adb
+++ b/tests/integration/cases/sequence_of_dicts/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/set/Ada_combined.adb
+++ b/tests/integration/cases/set/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/set_comments/Ada_combined.adb
+++ b/tests/integration/cases/set_comments/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/set_comments_unsorted_order/Ada_combined.adb
+++ b/tests/integration/cases/set_comments_unsorted_order/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/simple_dict/Ada_combined.adb
+++ b/tests/integration/cases/simple_dict/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/simple_sequence/Ada_combined.adb
+++ b/tests/integration/cases/simple_sequence/Ada_combined.adb
@@ -19,6 +19,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/string_control_chars/Ada_combined.adb
+++ b/tests/integration/cases/string_control_chars/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Ada_combined.adb
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Ada_combined.adb
@@ -9,6 +9,5 @@ procedure Check is
       my_data := AStr ("hello ""world"" -- not a comment");
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/string_list/Ada_combined.adb
+++ b/tests/integration/cases/string_list/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/string_with_backslash/Ada_combined.adb
+++ b/tests/integration/cases/string_with_backslash/Ada_combined.adb
@@ -25,6 +25,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/string_with_dollar/Ada_combined.adb
+++ b/tests/integration/cases/string_with_dollar/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/string_with_hash/Ada_combined.adb
+++ b/tests/integration/cases/string_with_hash/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/triple_sequence/Ada_combined.adb
+++ b/tests/integration/cases/triple_sequence/Ada_combined.adb
@@ -17,6 +17,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/type_hints/Ada_combined.adb
+++ b/tests/integration/cases/type_hints/Ada_combined.adb
@@ -25,6 +25,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Ada_combined.adb
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Ada_combined.adb
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Ada_combined.adb
@@ -15,6 +15,5 @@ procedure Check is
       );
    end Check_Assignment;
 begin
-   Check_Declaration;
-   Check_Assignment;
+   null;
 end Check;

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -174,24 +174,20 @@ def _wrap_ada_combined(
     _variable_name: str,
 ) -> str:
     """Ada: declaration in one nested procedure, assignment in another."""
-    decl_indented = "      " + declaration.replace("\n", "\n      ")
-    assign_indented = "      " + assignment.replace("\n", "\n      ")
-    return (
-        "procedure Check is\n"
-        "   procedure Check_Declaration is\n"
+    decl_indented = "   " + declaration.replace("\n", "\n   ")
+    assign_indented = "   " + assignment.replace("\n", "\n   ")
+    inner = (
+        "procedure Check_Declaration is\n"
         f"{decl_indented}\n"
-        "   begin\n"
-        "      null;\n"
-        "   end Check_Declaration;\n"
-        "   procedure Check_Assignment is\n"
-        "   begin\n"
-        f"{assign_indented}\n"
-        "   end Check_Assignment;\n"
         "begin\n"
-        "   Check_Declaration;\n"
-        "   Check_Assignment;\n"
-        "end Check;"
+        "   null;\n"
+        "end Check_Declaration;\n"
+        "procedure Check_Assignment is\n"
+        "begin\n"
+        f"{assign_indented}\n"
+        "end Check_Assignment;"
     )
+    return _wrap_ada(content=inner, _variable_name=_variable_name)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- `_wrap_ada_combined` now builds the two inner procedures as a string and delegates the outer procedure wrapping to `_wrap_ada`, reducing duplication.
- The outer `begin` block uses `null;` instead of explicit sub-procedure calls — both are valid Ada and the nested procedures are still fully syntax-checked.
- Updated 77 golden files to match the simplified output.

## Test plan
- [x] All 160 Ada tests pass
- [x] Full integration suite passes (8065 passed, 79 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to integration test code generation and expected golden outputs, with no production logic affected. Main risk is test fragility if any tooling depended on the exact Ada combined output formatting/call structure.
> 
> **Overview**
> Refactors `tests/integration/test_integration.py` so `_wrap_ada_combined` constructs the two nested procedures (`Check_Declaration`/`Check_Assignment`) as a single string and delegates outer wrapping/indentation to `_wrap_ada`, reducing duplicated formatting logic.
> 
> Updates all Ada `*_combined.adb` golden files to reflect the simplified wrapper: the outer `Check` body now contains only `null;` (no calls to the nested procedures), while the nested procedures still include the declaration/assignment code for syntax checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb7933a57502df0714cc439ee6309b0a80d53ebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->