### PR TITLE
Replace taplo with tomli for TOML 1.1 lint support

### DIFF
--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -20,6 +20,7 @@ jobs:
             config:
               - '**/*.yml'
               - 'pyproject.toml'
+              - 'check_toml_syntax.py'
             lang:
               - 'tests/integration/cases/**/*.toml'
       - name: Find files to lint
@@ -39,19 +40,12 @@ jobs:
           if [ -s /tmp/files-to-lint ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         if: steps.files.outputs.found == 'true'
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
       - name: Check TOML syntax
         if: steps.files.outputs.found == 'true'
-        run: |-
-          while IFS= read -r -d '' f; do
-            uv run --with 'tomli>=2.4.0' python -c "
-          import sys, tomli
-          with open(sys.argv[1], 'rb') as fp:
-              try:
-                  tomli.load(fp)
-              except tomli.TOMLDecodeError as e:
-                  print(f'{sys.argv[1]}: {e}', file=sys.stderr)
-                  sys.exit(1)
-          " "$f" || exit 1
-          done < /tmp/files-to-lint
+        run: xargs -0 uv run --with 'tomli>=2.4.0' --no-project python check_toml_syntax.py
+          < /tmp/files-to-lint

--- a/check_toml_syntax.py
+++ b/check_toml_syntax.py
@@ -1,0 +1,21 @@
+"""Check syntax of TOML files using ``tomli``."""
+
+import sys
+from pathlib import Path
+
+import tomli
+
+
+def main() -> None:
+    """Check syntax of each given TOML file."""
+    for filename in sys.argv[1:]:
+        with Path(filename).open(mode="rb") as fp:
+            try:
+                tomli.load(fp)
+            except tomli.TOMLDecodeError as e:
+                sys.stderr.write(f"{filename}: {e}\n")
+                sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replace taplo (TOML 1.0 only) with tomli >= 2.4.0, which supports TOML 1.1 natively. This removes the workaround that skipped files using TOML 1.1 multiline inline tables. Uses `astral-sh/setup-uv` and `uv run --with` to install and run tomli.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the TOML linting workflow; main risk is false positives/negatives or workflow failures due to the new `uv`/`tomli` execution path.
> 
> **Overview**
> Updates the `Lint TOML` GitHub Action to drop `taplo lint` (and the TOML 1.1 skip workaround) and instead validate files by running a new `check_toml_syntax.py` script that parses each TOML via `tomli>=2.4.0`.
> 
> Switches tool installation to `astral-sh/setup-uv` with caching, and wires changed-file detection to rerun the job when `check_toml_syntax.py` changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e8f3fcdb234c737aab2d2768182f36af401fcf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->