### PR TITLE
Reuse _wrap_mojo in _wrap_mojo_combined

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -209,8 +209,8 @@ def _wrap_objc(content: str, variable_name: str) -> str:
 
 
 @beartype
-def _in_mojo_main(content: str, _variable_name: str) -> str:
-    """Indent content and wrap in a Mojo ``def main():`` function.
+def _wrap_mojo(content: str, variable_name: str) -> str:
+    """Wrap a Mojo variable declaration in a main function.
 
     Mojo does not support top-level code.  No statements, expressions,
     or variable declarations are allowed at module scope, so generated
@@ -222,19 +222,11 @@ def _in_mojo_main(content: str, _variable_name: str) -> str:
     (``new_variable=False``) omit it.  The distinction is stylistic
     since Mojo does not require ``var`` inside functions.
     """
-    indented = "\n".join(f"    {line}" for line in content.splitlines())
-    return f"def main():\n{indented}"
-
-
-@beartype
-def _wrap_mojo(content: str, variable_name: str) -> str:
-    """Wrap a Mojo variable declaration in a main function."""
     # Consume the variable so ``--Werror`` does not flag the
     # "assignment was never used" warning.
-    return _in_mojo_main(
-        content=content + f"\n_ = {variable_name}",
-        _variable_name=variable_name,
-    )
+    content = content + f"\n_ = {variable_name}"
+    indented = "\n".join(f"    {line}" for line in content.splitlines())
+    return f"def main():\n{indented}"
 
 
 @beartype
@@ -245,17 +237,16 @@ def _wrap_mojo_combined(
 ) -> str:
     """Wrap Mojo declaration and assignment in a main function.
 
-    This cannot use ``_newline_combined(wrap=_wrap_mojo)`` because the
-    Mojo ``--Werror`` flag treats an assignment that is immediately
+    Mojo ``--Werror`` treats an assignment that is immediately
     overwritten without being read as an error
     (``assignment to 'x' was never used``).  A bare ``_ = variable``
     must appear *between* the declaration and the reassignment, not
     only at the end.
     """
     use = f"_ = {variable_name}"
-    return _in_mojo_main(
-        content=declaration + f"\n{use}\n" + assignment + f"\n{use}",
-        _variable_name=variable_name,
+    return _wrap_mojo(
+        content=declaration + f"\n{use}\n" + assignment,
+        variable_name=variable_name,
     )
 
 


### PR DESCRIPTION
## Summary

- `_wrap_mojo_combined` now delegates to `_wrap_mojo` instead of calling `_in_mojo_main` directly, mirroring the pattern used by `_wrap_ada_combined`.
- Inlined `_in_mojo_main` into `_wrap_mojo` since it had no other callers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that changes how Mojo golden-file wrappers are composed, with minimal behavioral impact aside from potential output formatting around unused-variable consumption for Mojo.
> 
> **Overview**
> Refactors the Mojo integration-test wrappers by inlining the former helper (previously `_in_mojo_main`) into `_wrap_mojo` and having `_wrap_mojo_combined` delegate to `_wrap_mojo` instead of duplicating the wrapping logic.
> 
> This keeps the Mojo `--Werror` unused-assignment workaround, ensuring a `_ = variable` read is inserted between declaration and reassignment while relying on `_wrap_mojo` to append the final variable consumption and indentation/wrapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 940f7ca086d02e4e226d4c79a1a8d65e558cf600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->