### PR TITLE
Guard key slicing against non-quoted keys

### DIFF
--- a/src/literalizer/_formatters/format_entries.py
+++ b/src/literalizer/_formatters/format_entries.py
@@ -10,16 +10,18 @@ from literalizer._types import Value
 
 @beartype
 def strip_key_quotes(key: str) -> str:
-    """Return the content between surrounding quotes, or *key* unchanged.
+    """Strip the surrounding quotes from a formatted key string.
 
-    Handles double- and single-quoted strings.  If *key* is not a
-    quoted string (e.g. a formatted integer literal), it is returned
-    as-is.
+    Handles double- and single-quoted strings.
 
     Example::
 
         strip_key_quotes('"name"')  # => 'name'
-        strip_key_quotes("42")      # => '42'
+
+    Raises ``ValueError`` for unquoted keys.  All current input
+    formats produce quoted string keys; this guard exists so that
+    adding a new input format with non-string keys surfaces
+    immediately rather than silently slicing the wrong characters.
     """
     min_quoted_length = 2
     if (
@@ -28,7 +30,8 @@ def strip_key_quotes(key: str) -> str:
         and key[-1] == key[0]
     ):
         return key[1:-1]
-    return key  # pragma: no cover
+    msg = f"Expected a quoted key, got {key!r}"  # pragma: no cover
+    raise ValueError(msg)  # pragma: no cover
 
 
 @beartype

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -151,8 +151,7 @@ def _key_to_cobol_name(key_str: str) -> str:
     reserved words.  The result is truncated to 28 characters (leaving
     room for the prefix).
     """
-    inner = strip_key_quotes(key=key_str)
-    name = inner.replace('""', '"') if inner != key_str else key_str
+    name = strip_key_quotes(key=key_str).replace('""', '"')
     name = name.upper()
     name = re.sub(pattern=r"[^A-Z0-9]", repl="-", string=name)
     name = re.sub(pattern=r"-+", repl="-", string=name).strip("-")

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -62,12 +62,11 @@ def _format_json5_dict_entry(key: str, _val: Value, value: str) -> str:
     stripped for cleaner idiomatic JSON5 output.
     """
     inner = strip_key_quotes(key=key)
-    if inner != key:  # pragma: no branch
-        identifier_pattern = re.compile(
-            pattern=r"^[A-Za-z_$][A-Za-z0-9_$]*$",
-        )
-        if identifier_pattern.match(string=inner):
-            return f"{inner}: {value}"
+    identifier_pattern = re.compile(
+        pattern=r"^[A-Za-z_$][A-Za-z0-9_$]*$",
+    )
+    if identifier_pattern.match(string=inner):
+        return f"{inner}: {value}"
     return f"{key}: {value}"
 
 

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -63,10 +63,9 @@ def _format_toml_dict_entry(key: str, _val: Value, value: str) -> str:
     cleaner idiomatic output.
     """
     inner = strip_key_quotes(key=key)
-    if inner != key:
-        bare_key_pattern = re.compile(pattern=r"^[A-Za-z0-9_-]+$")
-        if bare_key_pattern.match(string=inner):
-            return f"{inner} = {value}"
+    bare_key_pattern = re.compile(pattern=r"^[A-Za-z0-9_-]+$")
+    if bare_key_pattern.match(string=inner):
+        return f"{inner} = {value}"
     return f"{key} = {value}"
 
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -532,15 +532,14 @@ def test_toml_integer_dict_key() -> None:
 
 
 def test_toml_non_quoted_dict_key() -> None:
-    """TOML format_dict_entry with a key that is not a quoted string.
-
-    When the key does not start with a double-quote character the
-    bare-key optimization is skipped and the key is used verbatim.
+    """TOML format_dict_entry rejects a key that is not a quoted
+    string.
     """
-    result = TOML.dict_format_config.format_entry(
-        "plain_key", "value", '"value"'
-    )
-    assert result == 'plain_key = "value"'
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="Expected a quoted",
+    ):
+        TOML.dict_format_config.format_entry("plain_key", "value", '"value"')
 
 
 def test_cobol_string_control_characters() -> None:


### PR DESCRIPTION
## Summary
- Several `format_dict_entry` helpers used `key[1:-1]` to strip quotes from formatted keys, assuming keys are always quoted strings. This breaks for non-string keys (e.g. integers) which format as unquoted literals.
- Added guards in `json5.py`, `cobol.py`, and `format_entries.py` to check that keys are actually quoted before slicing, matching the pattern already used in `toml.py`.

## Test plan
- [x] All 8498 existing tests pass
- [x] Pre-commit hooks (ruff, mypy, pyright, ty) pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `ValueError` path when dict-entry formatters receive unquoted keys, which may break callers that previously relied on permissive behavior. Changes are localized to key-formatting logic for JSON5/TOML/COBOL and related tests.
> 
> **Overview**
> Adds a shared `strip_key_quotes()` helper and switches JSON5/COBOL and Ruby-style symbol dict-entry formatting to use it instead of naive `key[1:-1]` slicing, so unquoted/non-string keys fail fast with a clear error.
> 
> Updates TOML key handling to always validate keys are quoted before attempting the bare-key optimization, and adjusts tests to expect a `ValueError` when `format_entry` is called with an unquoted key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3817a9c071d92f235f51e4cf75aef2e3227fe851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->