### PR TITLE
Fix Nim LET and CONST supports_redefinition

### DIFF
--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1,5 +1,6 @@
 """Nim language specification."""
 
+import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Sequence
@@ -52,6 +53,13 @@ from literalizer._language import (
     no_type_hint_preamble,
 )
 from literalizer._types import Value
+
+
+@dataclasses.dataclass(frozen=True)
+class _NimDeclarationStyleConfig(DeclarationStyleConfig):
+    """Nim-specific declaration style config with a keyword field."""
+
+    keyword: str = ""
 
 
 @beartype
@@ -256,29 +264,32 @@ class Nim(metaclass=LanguageCls):
     class DeclarationStyles(enum.Enum):
         """Declaration style options."""
 
-        VAR = DeclarationStyleConfig(
+        VAR = _NimDeclarationStyleConfig(
             formatter=_make_variable_declaration(
-                sequence_mode=False,
+                sequence_mode=True,
                 keyword="var",
                 force_sequence=False,
             ),
             supports_redefinition=True,
+            keyword="var",
         )
-        LET = DeclarationStyleConfig(
+        LET = _NimDeclarationStyleConfig(
             formatter=_make_variable_declaration(
-                sequence_mode=False,
+                sequence_mode=True,
                 keyword="let",
                 force_sequence=False,
             ),
             supports_redefinition=False,
+            keyword="let",
         )
-        CONST = DeclarationStyleConfig(
+        CONST = _NimDeclarationStyleConfig(
             formatter=_make_variable_declaration(
-                sequence_mode=False,
+                sequence_mode=True,
                 keyword="const",
                 force_sequence=True,
             ),
             supports_redefinition=False,
+            keyword="const",
         )
 
     class DictEntryStyles(enum.Enum):
@@ -495,12 +506,16 @@ class Nim(metaclass=LanguageCls):
         self.supports_collection_comments = True
         _is_sequence = sequence_format is self.sequence_formats.SEQ
         _is_const = declaration_style is self.declaration_styles.CONST
-        self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            _make_variable_declaration(
-                sequence_mode=_is_sequence,
-                keyword=declaration_style.name.lower(),
+        if _is_sequence:
+            _declaration_formatter = declaration_style.value.formatter
+        else:
+            _declaration_formatter = _make_variable_declaration(
+                sequence_mode=False,
+                keyword=declaration_style.value.keyword,
                 force_sequence=_is_const,
             )
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
+            _declaration_formatter
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _make_variable_assignment(sequence_mode=_is_sequence)


### PR DESCRIPTION
## Summary

Nim's `DeclarationStyles` used plain string values, which caused `_find_redefinition_style` to treat all three styles (VAR, LET, CONST) as supporting redefinition. In Nim, `let` (immutable binding) and `const` (compile-time constant) do not support reassignment. This converts the enum to use `DeclarationStyleConfig` with explicit `supports_redefinition` flags: `True` for VAR, `False` for LET and CONST.

Prompted by https://github.com/adamtheturtle/literalizer/pull/841#pullrequestreview-4048903823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Nim declaration style enum values from strings to config objects and adjusts formatter selection, which could affect Nim output formatting or any downstream code that relied on the previous `.value` strings.
> 
> **Overview**
> Fixes Nim `DeclarationStyles` so `LET` and `CONST` are treated as *non-redefinable* (while `VAR` remains redefinable) by switching enum members from plain strings to `DeclarationStyleConfig` instances.
> 
> Updates Nim variable declaration formatting to read the configured formatter/keyword from the new config and to keep sequence vs non-sequence declaration behavior consistent, including the special `const` sequence handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c604a43e266a3e01dcff8b39462b9cd7ff726552. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->