### PR TITLE
Replace combined_wrap lambdas with named function

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -58,6 +58,17 @@ def _find_redefinition_style(
     return None
 
 
+def _declaration_only_combined(
+    declaration: str,
+    _assignment: str,
+    _variable_name: str,
+) -> str:
+    """Return just the declaration, ignoring assignment and variable
+    name.
+    """
+    return declaration
+
+
 def _newline_combined(
     wrap: Callable[[str, str], str],
 ) -> Callable[[str, str, str], str]:
@@ -516,7 +527,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Json5.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Json5,
         wrap=_wrap_identity,
-        combined_wrap=lambda d, _a, _v: d,
+        combined_wrap=_declaration_only_combined,
     ),
     literalizer.languages.TypeScript.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.TypeScript,
@@ -595,7 +606,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Hcl.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Hcl,
         wrap=_wrap_identity,
-        combined_wrap=lambda d, _a, _v: d,
+        combined_wrap=_declaration_only_combined,
         wrap_variable_name="my_data",
     ),
     literalizer.languages.Julia.__name__: _LanguageConfig(
@@ -713,7 +724,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Norg.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Norg,
         wrap=_wrap_identity,
-        combined_wrap=lambda d, _a, _v: d,
+        combined_wrap=_declaration_only_combined,
         wrap_variable_name="my_data",
     ),
     literalizer.languages.VisualBasic.__name__: _LanguageConfig(
@@ -737,7 +748,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Toml.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Toml,
         wrap=_wrap_identity,
-        combined_wrap=lambda d, _a, _v: d,
+        combined_wrap=_declaration_only_combined,
         wrap_variable_name="my_data",
     ),
     literalizer.languages.ObjectiveC.__name__: _LanguageConfig(
@@ -755,7 +766,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Yaml.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Yaml,
         wrap=_wrap_identity,
-        combined_wrap=lambda d, _a, _v: d,
+        combined_wrap=_declaration_only_combined,
     ),
 }
 


### PR DESCRIPTION
## Summary
- Extracted the repeated `lambda d, _a, _v: d` pattern used by Json5, Hcl, Norg, Toml, and Yaml into a named `_declaration_only_combined` function
- Improves readability with no behavior change

Closes #848

## Test plan
- [x] All 8326 integration tests pass
- [x] Pre-commit hooks pass (pydocstringformatter, ruff, mypy, pyright, ty, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to integration test configuration; it centralizes a repeated wrapper function and should not change runtime behavior beyond potential miswiring of the test harness.
> 
> **Overview**
> Refactors `tests/integration/test_integration.py` to introduce `_declaration_only_combined()` and reuse it for languages whose `combined_wrap` should return only the declaration.
> 
> Replaces several inline `lambda d, _a, _v: d` definitions (e.g., `Json5`, `Hcl`, `Norg`, `Toml`, `Yaml`) with the shared helper to improve readability and reduce duplication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be8df314e2f8c68efd483da296ae75c815187ec0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->