### PR TITLE
Use DeclarationStyleConfig for HCL, Norg, TOML, and YAML

### DIFF
--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -33,6 +33,7 @@ from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
+    DeclarationStyleConfig,
     DictFormatConfig,
     LanguageCls,
     OrderedMapFormatConfig,
@@ -141,7 +142,10 @@ class Hcl(metaclass=LanguageCls):
     class DeclarationStyles(enum.Enum):
         """Declaration style options."""
 
-        ASSIGN = "assign"
+        ASSIGN = DeclarationStyleConfig(
+            formatter=variable_formatter(template="{name} = {value}"),
+            supports_redefinition=False,
+        )
 
     class DictEntryStyles(enum.Enum):
         """Dict entry style options."""
@@ -319,7 +323,7 @@ class Hcl(metaclass=LanguageCls):
         self.skip_null_dict_values = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            variable_formatter(template="{name} = {value}")
+            declaration_style.value.formatter
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -33,6 +33,7 @@ from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
+    DeclarationStyleConfig,
     DictFormatConfig,
     LanguageCls,
     OrderedMapFormatConfig,
@@ -148,7 +149,12 @@ class Norg(metaclass=LanguageCls):
     class DeclarationStyles(enum.Enum):
         """Declaration style options."""
 
-        BLOCK = "block"
+        BLOCK = DeclarationStyleConfig(
+            formatter=variable_formatter(
+                template="* {name}\n@code json\n{value}\n@end",
+            ),
+            supports_redefinition=False,
+        )
 
     class DictEntryStyles(enum.Enum):
         """Dict entry style options."""
@@ -326,9 +332,7 @@ class Norg(metaclass=LanguageCls):
         self.skip_null_dict_values = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            variable_formatter(
-                template="* {name}\n@code json\n{value}\n@end",
-            )
+            declaration_style.value.formatter
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -38,6 +38,7 @@ from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
+    DeclarationStyleConfig,
     DictFormatConfig,
     LanguageCls,
     OrderedMapFormatConfig,
@@ -180,7 +181,10 @@ class Toml(metaclass=LanguageCls):
     class DeclarationStyles(enum.Enum):
         """Declaration style options."""
 
-        ASSIGN = "assign"
+        ASSIGN = DeclarationStyleConfig(
+            formatter=variable_formatter(template="{name} = {value}"),
+            supports_redefinition=False,
+        )
 
     class DictEntryStyles(enum.Enum):
         """Dict entry style options."""
@@ -355,7 +359,7 @@ class Toml(metaclass=LanguageCls):
         self.skip_null_dict_values = True
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            variable_formatter(template="{name} = {value}")
+            declaration_style.value.formatter
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -38,6 +38,7 @@ from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
+    DeclarationStyleConfig,
     DictFormatConfig,
     LanguageCls,
     OrderedMapFormatConfig,
@@ -156,7 +157,10 @@ class Yaml(metaclass=LanguageCls):
     class DeclarationStyles(enum.Enum):
         """Declaration style options."""
 
-        ASSIGN = "assign"
+        ASSIGN = DeclarationStyleConfig(
+            formatter=variable_formatter(template="{name}: {value}"),
+            supports_redefinition=False,
+        )
 
     class DictEntryStyles(enum.Enum):
         """Dict entry style options."""
@@ -337,7 +341,7 @@ class Yaml(metaclass=LanguageCls):
         self.skip_null_dict_values = False
         self.supports_collection_comments = True
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            variable_formatter(template="{name}: {value}")
+            declaration_style.value.formatter
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name}: {value}")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -58,17 +58,6 @@ def _find_redefinition_style(
     return None
 
 
-def _declaration_only_combined(
-    declaration: str,
-    _assignment: str,
-    _variable_name: str,
-) -> str:
-    """Return just the declaration, ignoring assignment and variable
-    name.
-    """
-    return declaration
-
-
 def _newline_combined(
     wrap: Callable[[str, str], str],
 ) -> Callable[[str, str, str], str]:
@@ -527,7 +516,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Json5.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Json5,
         wrap=_wrap_identity,
-        combined_wrap=_declaration_only_combined,
+        combined_wrap=_newline_combined(wrap=_wrap_identity),
     ),
     literalizer.languages.TypeScript.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.TypeScript,
@@ -606,7 +595,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Hcl.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Hcl,
         wrap=_wrap_identity,
-        combined_wrap=_declaration_only_combined,
+        combined_wrap=_newline_combined(wrap=_wrap_identity),
         wrap_variable_name="my_data",
     ),
     literalizer.languages.Julia.__name__: _LanguageConfig(
@@ -724,7 +713,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Norg.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Norg,
         wrap=_wrap_identity,
-        combined_wrap=_declaration_only_combined,
+        combined_wrap=_newline_combined(wrap=_wrap_identity),
         wrap_variable_name="my_data",
     ),
     literalizer.languages.VisualBasic.__name__: _LanguageConfig(
@@ -748,7 +737,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Toml.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Toml,
         wrap=_wrap_identity,
-        combined_wrap=_declaration_only_combined,
+        combined_wrap=_newline_combined(wrap=_wrap_identity),
         wrap_variable_name="my_data",
     ),
     literalizer.languages.ObjectiveC.__name__: _LanguageConfig(
@@ -766,7 +755,7 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     literalizer.languages.Yaml.__name__: _LanguageConfig(
         lang_cls=literalizer.languages.Yaml,
         wrap=_wrap_identity,
-        combined_wrap=_declaration_only_combined,
+        combined_wrap=_newline_combined(wrap=_wrap_identity),
     ),
 }
 


### PR DESCRIPTION
## Summary

HCL, Norg, TOML, and YAML had string-valued `DeclarationStyles` enums, which caused `_find_redefinition_style` in the integration tests to assume they support variable redefinition. The test worked around this with `_declaration_only_combined`, which silently discarded the assignment output. This replaces the strings with `DeclarationStyleConfig(supports_redefinition=False)` so the combined tests skip these languages properly, and removes the `_declaration_only_combined` workaround.

## Test plan

- [x] All 8018 integration tests pass, 464 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to language-spec formatting metadata and integration test wrapping logic, mainly affecting whether combined declaration/assignment tests run for certain languages.
> 
> **Overview**
> Aligns `Hcl`, `Norg`, `Toml`, and `Yaml` `DeclarationStyles` with the typed `DeclarationStyleConfig` (including `supports_redefinition=False`) and routes `format_variable_declaration` through the selected style’s configured formatter instead of hardcoded templates.
> 
> Updates integration tests to stop silently dropping assignment output: removes the `_declaration_only_combined` workaround and uses the standard newline-combined wrapper for `Json5` and for the affected languages, so combined declaration/assignment golden tests are now skipped when redefinition isn’t supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 785b1d58fb86df79389ba970574b6df48c845627. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->