### PR TITLE
Replace lambda with named inner function in _newline_combined

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -64,7 +64,12 @@ def _newline_combined(
     """Build a combined_wrap that joins declaration and assignment with a
     newline and passes through *wrap*.
     """
-    return lambda d, a, v: wrap(d + "\n" + a, v)
+
+    def combined_wrap(declaration: str, assignment: str, value: str) -> str:
+        """Join declaration and assignment with a newline, then wrap."""
+        return wrap(declaration + "\n" + assignment, value)
+
+    return combined_wrap
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace cryptic `lambda d, a, v:` with a named inner function `combined_wrap` with descriptive parameter names (`declaration`, `assignment`, `value`)

## Test plan
- [ ] Pre-commit hooks pass (confirmed locally)
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to integration test helper code; behavior should be unchanged aside from clearer naming and easier debugging.
> 
> **Overview**
> Refactors `tests/integration/test_integration.py` by replacing the inline `lambda` returned from `_newline_combined` with a named inner function `combined_wrap` using descriptive parameter names and a short docstring.
> 
> No functional behavior is intended to change; the wrapper still concatenates declaration + assignment with a newline before calling `wrap`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfefa92a36d03f17a6824e8887cdb20d7ba7ab34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->