### PR TITLE
Escape HCL interpolation syntax in string literals

### DIFF
--- a/src/literalizer/_formatters/format_strings.py
+++ b/src/literalizer/_formatters/format_strings.py
@@ -214,6 +214,28 @@ def format_string_backslash_dollar(value: str) -> str:
 
 
 @beartype
+def format_string_backslash_hcl(value: str) -> str:
+    r"""Format a string with HCL interpolation escaping.
+
+    Escapes backslashes, double quotes, newlines, and tabs with a backslash
+    prefix.  Additionally doubles ``$`` before ``{`` and ``%`` before ``{``
+    to prevent HCL template interpolation / directive syntax.
+
+    Example: ``prefix ${HOME}`` -> ``"prefix $${HOME}"``.
+    """
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+        .replace("${", "$${")
+        .replace("%{", "%%{")
+    )
+    return f'"{escaped}"'
+
+
+@beartype
 def format_string_backslash_hash(value: str) -> str:
     r"""Format a string using backslash escaping, including ``#{``.
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -28,7 +28,7 @@ from literalizer._formatters.format_floats import (
     format_float_repr,
     format_float_scientific,
 )
-from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._formatters.format_strings import format_string_backslash_hcl
 from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
@@ -283,7 +283,7 @@ class Hcl(metaclass=LanguageCls):
         self.format_datetime: Callable[[datetime.datetime], str] = (
             datetime_format
         )
-        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_string: Callable[[str], str] = format_string_backslash_hcl
         self.format_float: Callable[[float], str] = float_format
         self.format_integer: Callable[[int], str] = str
         self.format_sequence_entry: Callable[[Value, str], str] = (

--- a/tests/integration/cases/string_with_dollar_brace/Hcl.hcl
+++ b/tests/integration/cases/string_with_dollar_brace/Hcl.hcl
@@ -1,4 +1,4 @@
 my_data = [
-    "prefix ${HOME} suffix",
-    "${interpolated}",
+    "prefix $${HOME} suffix",
+    "$${interpolated}",
 ]


### PR DESCRIPTION
## Summary
- HCL uses `${...}` for interpolation and `%{...}` for template directives. Strings containing these sequences need the leading character doubled (`$${`, `%%{`) to produce literal output.
- Added `format_string_backslash_hcl` formatter that handles this escaping, and switched HCL to use it instead of the generic `format_string_backslash`.
- Updated the `string_with_dollar_brace` golden file accordingly.

Fixes review comment on #858: https://github.com/adamtheturtle/literalizer/pull/858#discussion_r3030647314

## Test plan
- [x] All 86 HCL integration tests pass
- [x] `string_with_dollar` test still passes (bare `$` without `{` is unchanged)
- [x] `string_with_dollar_brace` golden file now has correct `$${...}` escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HCL string literal escaping to rewrite `${`/`%{` into `$${`/`%%{`, which can alter rendered config output for any affected strings. Risk is limited to HCL formatting behavior and covered by updated integration golden tests.
> 
> **Overview**
> HCL string formatting now *escapes HCL interpolation and template directive syntax* by doubling the leading character in `${...}` and `%{...}` sequences (emitting `$${...}` and `%%{...}`) while still backslash-escaping quotes, backslashes, and control escapes.
> 
> The HCL language spec is switched to use the new `format_string_backslash_hcl` formatter, and the `string_with_dollar_brace` integration golden output is updated to match the new escaping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97fb13e7ce46287995980e04610dd593b178dd35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->