### PR TITLE
Extract shared lint workflow steps into composite action

### DIFF
--- a/.github/actions/find-lint-files/action.yml
+++ b/.github/actions/find-lint-files/action.yml
@@ -1,8 +1,8 @@
 ---
 name: Find lint files
 description: >-
-  Common setup for lint workflows: checkout, detect changed files,
-  and produce a null-delimited list at /tmp/files-to-lint.
+  Detect changed files and produce a null-delimited list at
+  /tmp/files-to-lint. The repo must already be checked out.
 
 inputs:
   lang_patterns:
@@ -31,9 +31,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-      with:
-        persist-credentials: false
     - id: build-yaml
       shell: bash
       run: |-

--- a/.github/workflows/lint-ada.yml
+++ b/.github/workflows/lint-ada.yml
@@ -10,6 +10,9 @@ jobs:
   lint-ada:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -10,6 +10,9 @@ jobs:
   lint-bash:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -10,6 +10,9 @@ jobs:
   lint-c:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-clojure.yml
+++ b/.github/workflows/lint-clojure.yml
@@ -10,6 +10,9 @@ jobs:
   lint-clojure:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-cobol.yml
+++ b/.github/workflows/lint-cobol.yml
@@ -10,6 +10,9 @@ jobs:
   lint-cobol:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-commonlisp.yml
+++ b/.github/workflows/lint-commonlisp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-common-lisp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-cpp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-crystal.yml
+++ b/.github/workflows/lint-crystal.yml
@@ -10,6 +10,9 @@ jobs:
   lint-crystal:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-csharp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-d.yml
+++ b/.github/workflows/lint-d.yml
@@ -10,6 +10,9 @@ jobs:
   lint-d:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-dart.yml
+++ b/.github/workflows/lint-dart.yml
@@ -10,6 +10,9 @@ jobs:
   lint-dart:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -10,6 +10,9 @@ jobs:
   lint-elixir:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-elm.yml
+++ b/.github/workflows/lint-elm.yml
@@ -10,6 +10,9 @@ jobs:
   lint-elm:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-erlang.yml
+++ b/.github/workflows/lint-erlang.yml
@@ -10,6 +10,9 @@ jobs:
   lint-erlang:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-fortran.yml
+++ b/.github/workflows/lint-fortran.yml
@@ -10,6 +10,9 @@ jobs:
   lint-fortran:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-fsharp.yml
+++ b/.github/workflows/lint-fsharp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-fsharp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-gleam.yml
+++ b/.github/workflows/lint-gleam.yml
@@ -10,6 +10,9 @@ jobs:
   lint-gleam:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -10,6 +10,9 @@ jobs:
   lint-go:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-groovy.yml
+++ b/.github/workflows/lint-groovy.yml
@@ -10,6 +10,9 @@ jobs:
   lint-groovy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-haskell.yml
+++ b/.github/workflows/lint-haskell.yml
@@ -10,6 +10,9 @@ jobs:
   lint-haskell:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-hcl.yml
+++ b/.github/workflows/lint-hcl.yml
@@ -10,6 +10,9 @@ jobs:
   lint-hcl:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-java.yml
+++ b/.github/workflows/lint-java.yml
@@ -10,6 +10,9 @@ jobs:
   lint-java:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -10,6 +10,9 @@ jobs:
   lint-javascript:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-json5.yml
+++ b/.github/workflows/lint-json5.yml
@@ -10,6 +10,9 @@ jobs:
   lint-json5:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -10,6 +10,9 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-julia.yml
+++ b/.github/workflows/lint-julia.yml
@@ -10,6 +10,9 @@ jobs:
   lint-julia:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-kotlin.yml
+++ b/.github/workflows/lint-kotlin.yml
@@ -10,6 +10,9 @@ jobs:
   lint-kotlin:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-lua.yml
+++ b/.github/workflows/lint-lua.yml
@@ -10,6 +10,9 @@ jobs:
   lint-lua:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-matlab.yml
+++ b/.github/workflows/lint-matlab.yml
@@ -10,6 +10,9 @@ jobs:
   lint-matlab:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -10,6 +10,9 @@ jobs:
   lint-mojo:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-nim.yml
+++ b/.github/workflows/lint-nim.yml
@@ -10,6 +10,9 @@ jobs:
   lint-nim:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-norg.yml
+++ b/.github/workflows/lint-norg.yml
@@ -10,6 +10,9 @@ jobs:
   lint-norg:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-objectivec.yml
+++ b/.github/workflows/lint-objectivec.yml
@@ -10,6 +10,9 @@ jobs:
   lint-objective-c:
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-ocaml.yml
+++ b/.github/workflows/lint-ocaml.yml
@@ -10,6 +10,9 @@ jobs:
   lint-ocaml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-occam.yml
+++ b/.github/workflows/lint-occam.yml
@@ -10,6 +10,9 @@ jobs:
   lint-occam:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-perl.yml
+++ b/.github/workflows/lint-perl.yml
@@ -10,6 +10,9 @@ jobs:
   lint-perl:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -10,6 +10,9 @@ jobs:
   lint-php:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -10,6 +10,9 @@ jobs:
   lint-powershell:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -10,6 +10,9 @@ jobs:
   lint-r:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-racket.yml
+++ b/.github/workflows/lint-racket.yml
@@ -10,6 +10,9 @@ jobs:
   lint-racket:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -10,6 +10,9 @@ jobs:
   lint-ruby:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -10,6 +10,9 @@ jobs:
   lint-rust:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-scala.yml
+++ b/.github/workflows/lint-scala.yml
@@ -10,6 +10,9 @@ jobs:
   lint-scala:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -10,6 +10,9 @@ jobs:
   lint-swift:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -10,6 +10,9 @@ jobs:
   lint-toml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -10,6 +10,9 @@ jobs:
   lint-typescript:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-visualbasic.yml
+++ b/.github/workflows/lint-visualbasic.yml
@@ -10,6 +10,9 @@ jobs:
   lint-vb:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -10,6 +10,9 @@ jobs:
   lint-yaml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:

--- a/.github/workflows/lint-zig.yml
+++ b/.github/workflows/lint-zig.yml
@@ -10,6 +10,9 @@ jobs:
   lint-zig:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/find-lint-files
         id: find-files
         with:


### PR DESCRIPTION
## Summary

- Creates a new `find-lint-files` composite action (`.github/actions/find-lint-files/action.yml`) that encapsulates the checkout, changed-files detection, and file-finding logic shared across all 49 lint workflows.
- Updates all 49 `lint-*.yml` workflows to use the composite action, keeping only their unique setup/install and lint steps.
- Removes ~1,000 lines of duplicated boilerplate while preserving identical behavior.

## Test plan

- [ ] Verify CI lint workflows still trigger and pass on a PR with language file changes
- [ ] Verify lint workflows skip correctly when no relevant files are changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the shared file-detection logic used by many lint workflows, so small behavior differences in glob patterns, YAML generation, or `eval`ed find commands could cause CI to lint the wrong set of files or skip unexpectedly.
> 
> **Overview**
> **Refactors CI lint workflows** by introducing a reusable composite action, `./.github/actions/find-lint-files`, that encapsulates changed-file detection (via `tj-actions/changed-files`) and generation of a null-delimited `/tmp/files-to-lint` list.
> 
> All `lint-*.yml` workflows are updated to call this action with language-specific `lang_patterns` (and optional `extra_config_patterns`) plus a `find_command`, and to gate their install/lint steps on the action’s `found` output, removing the duplicated inline scripting previously repeated in each workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8d59bd45fa89faecb0a03053871b4950f3ea3dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->