### PR TITLE
Replace find_command with exclude_patterns in lint workflows

### DIFF
--- a/.github/actions/find-lint-files/action.yml
+++ b/.github/actions/find-lint-files/action.yml
@@ -16,12 +16,13 @@ inputs:
       beyond '**/*.yml' (used for change detection).
     required: false
     default: ''
-  find_command:
+  exclude_patterns:
     description: >-
-      Shell command to find all lintable files (must output
-      null-delimited paths). Used on non-PR events or when
-      config files changed.
-    required: true
+      Newline-separated filename patterns to exclude from the
+      find command (e.g. "input.yaml"). Used on non-PR events
+      or when config files changed.
+    required: false
+    default: ''
 
 outputs:
   found:
@@ -67,13 +68,47 @@ runs:
       env:
         CONFIG_CHANGED: ${{ steps.changes.outputs.config_any_changed }}
         LANG_FILES: ${{ steps.changes.outputs.lang_all_modified_files }}
-        FIND_COMMAND: ${{ inputs.find_command }}
+        LANG_PATTERNS: ${{ inputs.lang_patterns }}
+        EXCLUDE_PATTERNS: ${{ inputs.exclude_patterns }}
       run: |-
         if [ "${{ github.event_name }}" = "pull_request" ] && [ "$CONFIG_CHANGED" != "true" ]; then
           # shellcheck disable=SC2086
           for f in $LANG_FILES; do [ -f "$f" ] && printf '%s\0' "$f"; done
         else
-          eval "$FIND_COMMAND"
+          # Build a find command from lang_patterns and exclude_patterns.
+          # Each lang_pattern is a glob like "dir/**/*.ext"; extract the
+          # search directory from the first pattern and collect -name args
+          # from all of them.
+          first_dir=""
+          name_args=()
+          while IFS= read -r pattern; do
+            [ -z "$pattern" ] && continue
+            # Skip negation patterns (handled by exclude_patterns)
+            [[ "$pattern" == !* ]] && continue
+            dir="${pattern%%/\*\*/*}"
+            name_part="${pattern##*/}"
+            if [ -z "$first_dir" ]; then
+              first_dir="$dir"
+            fi
+            if [ ${#name_args[@]} -gt 0 ]; then
+              name_args+=("-o")
+            fi
+            name_args+=("-name" "$name_part")
+          done <<< "$LANG_PATTERNS"
+
+          exclude_args=()
+          if [ -n "$EXCLUDE_PATTERNS" ]; then
+            while IFS= read -r pattern; do
+              [ -z "$pattern" ] && continue
+              exclude_args+=("!" "-name" "$pattern")
+            done <<< "$EXCLUDE_PATTERNS"
+          fi
+
+          if [ ${#name_args[@]} -gt 2 ]; then
+            find "$first_dir" \( "${name_args[@]}" \) "${exclude_args[@]}" -print0
+          else
+            find "$first_dir" "${name_args[@]}" "${exclude_args[@]}" -print0
+          fi
         fi > /tmp/files-to-lint
         if [ -s /tmp/files-to-lint ]; then
           echo "found=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lint-ada.yml
+++ b/.github/workflows/lint-ada.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           lang_patterns: tests/integration/cases/**/*.adb
           extra_config_patterns: check_ada_golden_syntax.py
-          find_command: find tests/integration/cases -name "*.adb" -print0
       - name: Install GNAT
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get install -y gnat

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.sh
-          find_command: find tests/integration/cases -name "*.sh" -print0
       - name: Check Bash syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 bash -n < /tmp/files-to-lint

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.c
-          find_command: find tests/integration/cases -name "*.c" -print0
       - name: Check C syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-to-lint

--- a/.github/workflows/lint-clojure.yml
+++ b/.github/workflows/lint-clojure.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.clj
-          find_command: find tests/integration/cases -name "*.clj" -print0
       - name: Install clj-kondo
         if: steps.find-files.outputs.found == 'true'
         uses: DeLaGuardo/setup-clojure@13

--- a/.github/workflows/lint-cobol.yml
+++ b/.github/workflows/lint-cobol.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cob
-          find_command: find tests/integration/cases -name "*.cob" -print0
       - name: Install GnuCOBOL
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get install -y gnucobol

--- a/.github/workflows/lint-commonlisp.yml
+++ b/.github/workflows/lint-commonlisp.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.lisp
-          find_command: find tests/integration/cases -name "*.lisp" -print0
       - name: Install SBCL
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get install -y sbcl

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cpp
-          find_command: find tests/integration/cases -name "*.cpp" -print0
       - name: Check C++ syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint

--- a/.github/workflows/lint-crystal.yml
+++ b/.github/workflows/lint-crystal.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cr
-          find_command: find tests/integration/cases -name "*.cr" -print0
       - name: Install Crystal
         if: steps.find-files.outputs.found == 'true'
         uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           lang_patterns: tests/integration/cases/**/*.cs
           extra_config_patterns: check_csharp_golden_syntax.py
-          find_command: find tests/integration/cases -name "*.cs" -print0
       - name: Initialize .NET runtime
         if: steps.find-files.outputs.found == 'true'
         run: |

--- a/.github/workflows/lint-d.yml
+++ b/.github/workflows/lint-d.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.d
-          find_command: find tests/integration/cases -name "*.d" -print0
       - name: Install DMD
         if: steps.find-files.outputs.found == 'true'
         uses: dlang-community/setup-dlang@v2

--- a/.github/workflows/lint-dart.yml
+++ b/.github/workflows/lint-dart.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.dart
-          find_command: find tests/integration/cases -name "*.dart" -print0
       - name: Install Dart
         if: steps.find-files.outputs.found == 'true'
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.ex
-          find_command: find tests/integration/cases -name "*.ex" -print0
       - name: Install Elixir
         if: steps.find-files.outputs.found == 'true'
         uses: erlef/setup-beam@v1

--- a/.github/workflows/lint-elm.yml
+++ b/.github/workflows/lint-elm.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           lang_patterns: tests/integration/cases/**/*.elm
           extra_config_patterns: check_elm_golden_syntax.py
-          find_command: find tests/integration/cases -name "*.elm" -print0
       - name: Install elm-format and elm
         if: steps.find-files.outputs.found == 'true'
         run: npm install -g elm-format elm

--- a/.github/workflows/lint-erlang.yml
+++ b/.github/workflows/lint-erlang.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.erl
-          find_command: find tests/integration/cases -name "*.erl" -print0
       - name: Install Erlang
         if: steps.find-files.outputs.found == 'true'
         uses: erlef/setup-beam@v1

--- a/.github/workflows/lint-fortran.yml
+++ b/.github/workflows/lint-fortran.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.f90
-          find_command: find tests/integration/cases -name "*.f90" -print0
       - name: Install gfortran
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get install -y gfortran

--- a/.github/workflows/lint-fsharp.yml
+++ b/.github/workflows/lint-fsharp.yml
@@ -19,8 +19,6 @@ jobs:
           lang_patterns: |
             tests/integration/cases/**/*.fs
             tests/integration/cases/**/*.fsi
-          find_command: find tests/integration/cases \( -name "*.fs" -o -name "*.fsi"
-            \) -print0
       - name: Initialize .NET runtime
         if: steps.find-files.outputs.found == 'true'
         run: |

--- a/.github/workflows/lint-gleam.yml
+++ b/.github/workflows/lint-gleam.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.gleam
-          find_command: find tests/integration/cases -name "*.gleam" -print0
       - name: Install Gleam
         if: steps.find-files.outputs.found == 'true'
         uses: erlef/setup-beam@v1

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.go
-          find_command: find tests/integration/cases -name "*.go" -print0
       - name: Check Go syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 gofmt -e < /tmp/files-to-lint

--- a/.github/workflows/lint-groovy.yml
+++ b/.github/workflows/lint-groovy.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.groovy
-          find_command: find tests/integration/cases -name "*.groovy" -print0
       - name: Install Groovy
         if: steps.find-files.outputs.found == 'true'
         uses: wtfjoke/setup-groovy@v3

--- a/.github/workflows/lint-haskell.yml
+++ b/.github/workflows/lint-haskell.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.hs
-          find_command: find tests/integration/cases -name "*.hs" -print0
       - uses: haskell-actions/setup@v2
         if: steps.find-files.outputs.found == 'true'
         with:

--- a/.github/workflows/lint-hcl.yml
+++ b/.github/workflows/lint-hcl.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.hcl
-          find_command: find tests/integration/cases -name "*.hcl" -print0
       - name: Install hcl2json
         if: steps.find-files.outputs.found == 'true'
         run: go install github.com/tmccombs/hcl2json@latest

--- a/.github/workflows/lint-java.yml
+++ b/.github/workflows/lint-java.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.java
-          find_command: find tests/integration/cases -name "*.java" -print0
       - name: Check Java syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.js
-          find_command: find tests/integration/cases -name "*.js" -print0
       - name: Check JavaScript syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint-json5.yml
+++ b/.github/workflows/lint-json5.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.json5
-          find_command: find tests/integration/cases -name "*.json5" -print0
       - name: Install json5
         if: steps.find-files.outputs.found == 'true'
         run: npm install -g json5

--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.jsonnet
-          find_command: find tests/integration/cases -name "*.jsonnet" -print0
       - name: Install jsonnet
         if: steps.find-files.outputs.found == 'true'
         run: |

--- a/.github/workflows/lint-julia.yml
+++ b/.github/workflows/lint-julia.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.jl
-          find_command: find tests/integration/cases -name "*.jl" -print0
       - name: Install Julia
         if: steps.find-files.outputs.found == 'true'
         uses: julia-actions/setup-julia@v2

--- a/.github/workflows/lint-kotlin.yml
+++ b/.github/workflows/lint-kotlin.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.kts
-          find_command: find tests/integration/cases -name "*.kts" -print0
       - name: Install Kotlin
         if: steps.find-files.outputs.found == 'true'
         uses: fwilhe2/setup-kotlin@v1

--- a/.github/workflows/lint-lua.yml
+++ b/.github/workflows/lint-lua.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.lua
-          find_command: find tests/integration/cases -name "*.lua" -print0
       - name: Install Lua
         if: steps.find-files.outputs.found == 'true'
         uses: leafo/gh-actions-lua@v12

--- a/.github/workflows/lint-matlab.yml
+++ b/.github/workflows/lint-matlab.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/Matlab*.m
-          find_command: find tests/integration/cases -name "Matlab*.m" -print0
       - name: Install Octave
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get update && sudo apt-get install -y octave

--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.mojo
-          find_command: find tests/integration/cases -name "*.mojo" -print0
       - name: Install pixi
         if: steps.find-files.outputs.found == 'true'
         uses: fabasoad/setup-mojo-action@v3

--- a/.github/workflows/lint-nim.yml
+++ b/.github/workflows/lint-nim.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.nim
-          find_command: find tests/integration/cases -name "*.nim" -print0
       - name: Install Nim
         if: steps.find-files.outputs.found == 'true'
         uses: jiro4989/setup-nim-action@v2

--- a/.github/workflows/lint-norg.yml
+++ b/.github/workflows/lint-norg.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.norg
-          find_command: find tests/integration/cases -name "*.norg" -print0
       - name: Install tree-sitter CLI
         if: steps.find-files.outputs.found == 'true'
         run: npm install tree-sitter-cli

--- a/.github/workflows/lint-objectivec.yml
+++ b/.github/workflows/lint-objectivec.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/objective_c*.m
-          find_command: find tests/integration/cases -name "objective_c*.m" -print0
       - name: Check Objective-C syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint-ocaml.yml
+++ b/.github/workflows/lint-ocaml.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.ml
-          find_command: find tests/integration/cases -name "*.ml" -print0
       - name: Install OCaml
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get install -y ocaml

--- a/.github/workflows/lint-occam.yml
+++ b/.github/workflows/lint-occam.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           lang_patterns: tests/integration/cases/**/*.occ
           extra_config_patterns: check_occam_golden_syntax.py
-          find_command: find tests/integration/cases -name "*.occ" -print0
       - name: Install uv
         if: steps.find-files.outputs.found == 'true'
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/lint-perl.yml
+++ b/.github/workflows/lint-perl.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.pl
-          find_command: find tests/integration/cases -name "*.pl" -print0
       - name: Install Perl dependencies
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.php
-          find_command: find tests/integration/cases -name "*.php" -print0
       - name: Check PHP syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 php -l < /tmp/files-to-lint

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.ps1
-          find_command: find tests/integration/cases -name "*.ps1" -print0
       - name: Check PowerShell syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.R
-          find_command: find tests/integration/cases -name "*.R" -print0
       - name: Install R
         if: steps.find-files.outputs.found == 'true'
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/lint-racket.yml
+++ b/.github/workflows/lint-racket.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.rkt
-          find_command: find tests/integration/cases -name "*.rkt" -print0
       - name: Install Racket
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get install -y racket

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.rb
-          find_command: find tests/integration/cases -name "*.rb" -print0
       - name: Check Ruby syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.rs
-          find_command: find tests/integration/cases -name "*.rs" -print0
       - name: Check Rust syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint-scala.yml
+++ b/.github/workflows/lint-scala.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.scala
-          find_command: find tests/integration/cases -name "*.scala" -print0
       - name: Install Scala
         if: steps.find-files.outputs.found == 'true'
         uses: coursier/setup-action@v3

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.swift
-          find_command: find tests/integration/cases -name "*.swift" -print0
       - name: Install Swift
         if: steps.find-files.outputs.found == 'true'
         uses: SwiftyLab/setup-swift@v1

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -20,7 +20,6 @@ jobs:
           extra_config_patterns: |
             pyproject.toml
             check_toml_syntax.py
-          find_command: find tests/integration/cases -name "*.toml" -print0
       - uses: astral-sh/setup-uv@v7
         if: steps.find-files.outputs.found == 'true'
         with:

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.ts
-          find_command: find tests/integration/cases -name "*.ts" -print0
       - name: Install TypeScript
         if: steps.find-files.outputs.found == 'true'
         run: npm install -g typescript

--- a/.github/workflows/lint-visualbasic.yml
+++ b/.github/workflows/lint-visualbasic.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           lang_patterns: tests/integration/cases/**/*.vb
           extra_config_patterns: check_vb_golden_syntax.py
-          find_command: find tests/integration/cases -name "*.vb" -print0
       - name: Initialize .NET runtime
         if: steps.find-files.outputs.found == 'true'
         run: |

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -19,8 +19,7 @@ jobs:
           lang_patterns: |
             tests/integration/cases/**/*.yaml
             !tests/integration/cases/**/input.yaml
-          find_command: find tests/integration/cases -name "*.yaml" ! -name "input.yaml"
-            -print0
+          exclude_patterns: input.yaml
       - name: Install uv
         if: steps.find-files.outputs.found == 'true'
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/lint-zig.yml
+++ b/.github/workflows/lint-zig.yml
@@ -17,7 +17,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.zig
-          find_command: find tests/integration/cases -name "*.zig" -print0
       - name: Install Zig
         if: steps.find-files.outputs.found == 'true'
         uses: mlugg/setup-zig@v2


### PR DESCRIPTION
## Summary

- Removes the `find_command` input from the `find-lint-files` composite action, replacing it with an optional `exclude_patterns` input
- The action now derives the `find` command automatically from the existing `lang_patterns` input, eliminating redundant information across all 49 lint workflows
- Only `lint-yaml.yml` uses `exclude_patterns` (to skip `input.yaml`); all other workflows just drop the `find_command` line

## Test plan

- [ ] CI passes on all lint workflows
- [ ] Verify YAML lint correctly excludes `input.yaml`
- [ ] Verify F# lint finds both `*.fs` and `*.fsi` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the composite action that determines which files are linted across many CI workflows; mistakes in the derived `find` construction could cause missing or extra files to be linted, affecting CI signal.
> 
> **Overview**
> Updates the `find-lint-files` composite action to **remove the `find_command` input** and instead **derive the `find ... -print0` invocation from `lang_patterns`**, with a new optional `exclude_patterns` input for filename-level exclusions.
> 
> All lint workflows are updated to drop the now-redundant `find_command` configuration; `lint-yaml.yml` additionally uses `exclude_patterns: input.yaml` to preserve the previous exclusion behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd0dc778b0cc5d197ae56805c8e04658de7b66a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->