### PR TITLE
Emit Fortran ieee_arithmetic import only for special floats

### DIFF
--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -446,9 +446,8 @@ class Fortran(metaclass=LanguageCls):
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _format_variable_assignment
         )
-        self.static_preamble: Sequence[str] = (
-            "module fval_m",
-            "  use, intrinsic :: ieee_arithmetic",
+        self.static_preamble: Sequence[str] = ("module fval_m",)
+        self.static_body_preamble: Sequence[str] = (
             "  implicit none",
             "  type :: fval_t",
             "    integer :: t = 0",
@@ -482,7 +481,6 @@ class Fortran(metaclass=LanguageCls):
             "; type(fval_t) :: v; end function",
             "end module fval_m",
         )
-        self.static_body_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}
         self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
         self.compute_body_preamble: Callable[
@@ -492,4 +490,6 @@ class Fortran(metaclass=LanguageCls):
         )
 
         self.type_hint_collection_preamble_lines = no_type_hint_preamble
-        self.special_float_preamble: tuple[str, ...] = ()
+        self.special_float_preamble: tuple[str, ...] = (
+            "  use, intrinsic :: ieee_arithmetic",
+        )

--- a/tests/integration/cases/binary/Fortran.f90
+++ b/tests/integration/cases/binary/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/binary/Fortran_bytes_format_base64.f90
+++ b/tests/integration/cases/binary/Fortran_bytes_format_base64.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/binary/Fortran_combined.f90
+++ b/tests/integration/cases/binary/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/bool_list/Fortran.f90
+++ b/tests/integration/cases/bool_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/bool_list/Fortran_combined.f90
+++ b/tests/integration/cases/bool_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments/Fortran.f90
+++ b/tests/integration/cases/comments/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments/Fortran_combined.f90
+++ b/tests/integration/cases/comments/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_bang_in_double_quote/Fortran.f90
+++ b/tests/integration/cases/comments_bang_in_double_quote/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_bang_in_double_quote/Fortran_combined.f90
+++ b/tests/integration/cases/comments_bang_in_double_quote/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_double_hash/Fortran.f90
+++ b/tests/integration/cases/comments_double_hash/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_double_hash/Fortran_combined.f90
+++ b/tests/integration/cases/comments_double_hash/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_empty_line/Fortran.f90
+++ b/tests/integration/cases/comments_empty_line/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_empty_line/Fortran_combined.f90
+++ b/tests/integration/cases/comments_empty_line/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_escaped_quote/Fortran.f90
+++ b/tests/integration/cases/comments_escaped_quote/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_escaped_quote/Fortran_combined.f90
+++ b/tests/integration/cases/comments_escaped_quote/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_escaped_single_quote/Fortran.f90
+++ b/tests/integration/cases/comments_escaped_single_quote/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_escaped_single_quote/Fortran_combined.f90
+++ b/tests/integration/cases/comments_escaped_single_quote/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_multi_line/Fortran.f90
+++ b/tests/integration/cases/comments_multi_line/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_multi_line/Fortran_combined.f90
+++ b/tests/integration/cases/comments_multi_line/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_nested_mapping/Fortran.f90
+++ b/tests/integration/cases/comments_nested_mapping/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_nested_mapping/Fortran_combined.f90
+++ b/tests/integration/cases/comments_nested_mapping/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_sequence_before/Fortran.f90
+++ b/tests/integration/cases/comments_sequence_before/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_sequence_before/Fortran_combined.f90
+++ b/tests/integration/cases/comments_sequence_before/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_sequence_inline/Fortran.f90
+++ b/tests/integration/cases/comments_sequence_inline/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_sequence_inline/Fortran_combined.f90
+++ b/tests/integration/cases/comments_sequence_inline/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_trailing/Fortran.f90
+++ b/tests/integration/cases/comments_trailing/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_trailing/Fortran_combined.f90
+++ b/tests/integration/cases/comments_trailing/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_vb_before_dim/Fortran.f90
+++ b/tests/integration/cases/comments_vb_before_dim/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/comments_vb_before_dim/Fortran_combined.f90
+++ b/tests/integration/cases/comments_vb_before_dim/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/date_list/Fortran.f90
+++ b/tests/integration/cases/date_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/date_list/Fortran_combined.f90
+++ b/tests/integration/cases/date_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/date_set/Fortran.f90
+++ b/tests/integration/cases/date_set/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/date_set/Fortran_combined.f90
+++ b/tests/integration/cases/date_set/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dates/Fortran.f90
+++ b/tests/integration/cases/dates/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dates/Fortran_combined.f90
+++ b/tests/integration/cases/dates/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/datetime_list/Fortran.f90
+++ b/tests/integration/cases/datetime_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/datetime_list/Fortran_combined.f90
+++ b/tests/integration/cases/datetime_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/deep_nesting/Fortran.f90
+++ b/tests/integration/cases/deep_nesting/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/deep_nesting/Fortran_combined.f90
+++ b/tests/integration/cases/deep_nesting/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_control_char_keys/Fortran.f90
+++ b/tests/integration/cases/dict_with_control_char_keys/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_control_char_keys/Fortran_combined.f90
+++ b/tests/integration/cases/dict_with_control_char_keys/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_hyphen_keys/Fortran.f90
+++ b/tests/integration/cases/dict_with_hyphen_keys/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_hyphen_keys/Fortran_combined.f90
+++ b/tests/integration/cases/dict_with_hyphen_keys/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_list_value/Fortran.f90
+++ b/tests/integration/cases/dict_with_list_value/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_list_value/Fortran_combined.f90
+++ b/tests/integration/cases/dict_with_list_value/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_nulls/Fortran.f90
+++ b/tests/integration/cases/dict_with_nulls/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/dict_with_nulls/Fortran_combined.f90
+++ b/tests/integration/cases/dict_with_nulls/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_dict/Fortran.f90
+++ b/tests/integration/cases/empty_dict/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_dict/Fortran_combined.f90
+++ b/tests/integration/cases/empty_dict/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_dicts_in_sequence/Fortran.f90
+++ b/tests/integration/cases/empty_dicts_in_sequence/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_dicts_in_sequence/Fortran_combined.f90
+++ b/tests/integration/cases/empty_dicts_in_sequence/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_list/Fortran.f90
+++ b/tests/integration/cases/empty_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_list/Fortran_combined.f90
+++ b/tests/integration/cases/empty_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_sequence/Fortran.f90
+++ b/tests/integration/cases/empty_sequence/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_sequence/Fortran_combined.f90
+++ b/tests/integration/cases/empty_sequence/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_set/Fortran.f90
+++ b/tests/integration/cases/empty_set/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/empty_set/Fortran_combined.f90
+++ b/tests/integration/cases/empty_set/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_list/Fortran.f90
+++ b/tests/integration/cases/float_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_list/Fortran_combined.f90
+++ b/tests/integration/cases/float_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_list/Fortran_float_format_fixed.f90
+++ b/tests/integration/cases/float_list/Fortran_float_format_fixed.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_list/Fortran_float_format_scientific.f90
+++ b/tests/integration/cases/float_list/Fortran_float_format_scientific.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_scientific_notation/Fortran.f90
+++ b/tests/integration/cases/float_scientific_notation/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_scientific_notation/Fortran_combined.f90
+++ b/tests/integration/cases/float_scientific_notation/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_scientific_notation/Fortran_float_format_fixed_s.f90
+++ b/tests/integration/cases/float_scientific_notation/Fortran_float_format_fixed_s.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/float_scientific_notation/Fortran_float_format_scientific_s.f90
+++ b/tests/integration/cases/float_scientific_notation/Fortran_float_format_scientific_s.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_key_dict/Fortran.f90
+++ b/tests/integration/cases/int_key_dict/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_key_dict/Fortran_combined.f90
+++ b/tests/integration/cases/int_key_dict/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_list/Fortran.f90
+++ b/tests/integration/cases/int_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_list/Fortran_combined.f90
+++ b/tests/integration/cases/int_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_list_large/Fortran.f90
+++ b/tests/integration/cases/int_list_large/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_list_large/Fortran_combined.f90
+++ b/tests/integration/cases/int_list_large/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_list_with_zero/Fortran.f90
+++ b/tests/integration/cases/int_list_with_zero/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_list_with_zero/Fortran_combined.f90
+++ b/tests/integration/cases/int_list_with_zero/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_set/Fortran.f90
+++ b/tests/integration/cases/int_set/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/int_set/Fortran_combined.f90
+++ b/tests/integration/cases/int_set/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_number_dict/Fortran.f90
+++ b/tests/integration/cases/mixed_number_dict/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_number_dict/Fortran_combined.f90
+++ b/tests/integration/cases/mixed_number_dict/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_number_list/Fortran.f90
+++ b/tests/integration/cases/mixed_number_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_number_list/Fortran_combined.f90
+++ b/tests/integration/cases/mixed_number_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_set/Fortran.f90
+++ b/tests/integration/cases/mixed_set/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_set/Fortran_combined.f90
+++ b/tests/integration/cases/mixed_set/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Fortran.f90
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Fortran_combined.f90
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested/Fortran.f90
+++ b/tests/integration/cases/nested/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested/Fortran_combined.f90
+++ b/tests/integration/cases/nested/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_bool_list/Fortran.f90
+++ b/tests/integration/cases/nested_bool_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_bool_list/Fortran_combined.f90
+++ b/tests/integration/cases/nested_bool_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_collection_multi_space_string/Fortran.f90
+++ b/tests/integration/cases/nested_collection_multi_space_string/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_collection_multi_space_string/Fortran_combined.f90
+++ b/tests/integration/cases/nested_collection_multi_space_string/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_deep_empty/Fortran.f90
+++ b/tests/integration/cases/nested_deep_empty/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_deep_empty/Fortran_combined.f90
+++ b/tests/integration/cases/nested_deep_empty/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_deep_mixed/Fortran.f90
+++ b/tests/integration/cases/nested_deep_mixed/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_deep_mixed/Fortran_combined.f90
+++ b/tests/integration/cases/nested_deep_mixed/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_empty_inner/Fortran.f90
+++ b/tests/integration/cases/nested_empty_inner/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_empty_inner/Fortran_combined.f90
+++ b/tests/integration/cases/nested_empty_inner/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_float_list/Fortran.f90
+++ b/tests/integration/cases/nested_float_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_float_list/Fortran_combined.f90
+++ b/tests/integration/cases/nested_float_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_float_list/Fortran_float_format_fixed_n.f90
+++ b/tests/integration/cases/nested_float_list/Fortran_float_format_fixed_n.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_float_list/Fortran_float_format_scientific_n.f90
+++ b/tests/integration/cases/nested_float_list/Fortran_float_format_scientific_n.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_list_of_dicts/Fortran.f90
+++ b/tests/integration/cases/nested_list_of_dicts/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_list_of_dicts/Fortran_combined.f90
+++ b/tests/integration/cases/nested_list_of_dicts/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_mixed_inner/Fortran.f90
+++ b/tests/integration/cases/nested_mixed_inner/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_mixed_inner/Fortran_combined.f90
+++ b/tests/integration/cases/nested_mixed_inner/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_mixed_types/Fortran.f90
+++ b/tests/integration/cases/nested_mixed_types/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_mixed_types/Fortran_combined.f90
+++ b/tests/integration/cases/nested_mixed_types/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_sequence/Fortran.f90
+++ b/tests/integration/cases/nested_sequence/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_sequence/Fortran_combined.f90
+++ b/tests/integration/cases/nested_sequence/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_sequences/Fortran.f90
+++ b/tests/integration/cases/nested_sequences/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/nested_sequences/Fortran_combined.f90
+++ b/tests/integration/cases/nested_sequences/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/no_comment/Fortran.f90
+++ b/tests/integration/cases/no_comment/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/no_comment/Fortran_combined.f90
+++ b/tests/integration/cases/no_comment/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/ordered_map/Fortran.f90
+++ b/tests/integration/cases/ordered_map/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/ordered_map/Fortran_combined.f90
+++ b/tests/integration/cases/ordered_map/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/ordered_map_int_keys/Fortran.f90
+++ b/tests/integration/cases/ordered_map_int_keys/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/ordered_map_int_keys/Fortran_combined.f90
+++ b/tests/integration/cases/ordered_map_int_keys/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/ordered_map_nested_values/Fortran.f90
+++ b/tests/integration/cases/ordered_map_nested_values/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/ordered_map_nested_values/Fortran_combined.f90
+++ b/tests/integration/cases/ordered_map_nested_values/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/pair_sequence/Fortran.f90
+++ b/tests/integration/cases/pair_sequence/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/pair_sequence/Fortran_combined.f90
+++ b/tests/integration/cases/pair_sequence/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_date/Fortran.f90
+++ b/tests/integration/cases/scalar_date/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_date/Fortran_combined.f90
+++ b/tests/integration/cases/scalar_date/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime/Fortran.f90
+++ b/tests/integration/cases/scalar_datetime/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime/Fortran_combined.f90
+++ b/tests/integration/cases/scalar_datetime/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_microsecond/Fortran.f90
+++ b/tests/integration/cases/scalar_datetime_microsecond/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_microsecond/Fortran_combined.f90
+++ b/tests/integration/cases/scalar_datetime_microsecond/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_midnight/Fortran.f90
+++ b/tests/integration/cases/scalar_datetime_midnight/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_midnight/Fortran_combined.f90
+++ b/tests/integration/cases/scalar_datetime_midnight/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_naive/Fortran.f90
+++ b/tests/integration/cases/scalar_datetime_naive/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_naive/Fortran_combined.f90
+++ b/tests/integration/cases/scalar_datetime_naive/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_non_utc/Fortran.f90
+++ b/tests/integration/cases/scalar_datetime_non_utc/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_non_utc/Fortran_combined.f90
+++ b/tests/integration/cases/scalar_datetime_non_utc/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Fortran.f90
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Fortran_combined.f90
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalars/Fortran.f90
+++ b/tests/integration/cases/scalars/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/scalars/Fortran_combined.f90
+++ b/tests/integration/cases/scalars/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/sequence_of_dicts/Fortran.f90
+++ b/tests/integration/cases/sequence_of_dicts/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/sequence_of_dicts/Fortran_combined.f90
+++ b/tests/integration/cases/sequence_of_dicts/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/set/Fortran.f90
+++ b/tests/integration/cases/set/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/set/Fortran_combined.f90
+++ b/tests/integration/cases/set/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/set_comments/Fortran.f90
+++ b/tests/integration/cases/set_comments/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/set_comments/Fortran_combined.f90
+++ b/tests/integration/cases/set_comments/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/set_comments_unsorted_order/Fortran.f90
+++ b/tests/integration/cases/set_comments_unsorted_order/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/set_comments_unsorted_order/Fortran_combined.f90
+++ b/tests/integration/cases/set_comments_unsorted_order/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/simple_dict/Fortran.f90
+++ b/tests/integration/cases/simple_dict/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/simple_dict/Fortran_combined.f90
+++ b/tests/integration/cases/simple_dict/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/simple_sequence/Fortran.f90
+++ b/tests/integration/cases/simple_sequence/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/simple_sequence/Fortran_combined.f90
+++ b/tests/integration/cases/simple_sequence/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_control_chars/Fortran.f90
+++ b/tests/integration/cases/string_control_chars/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_control_chars/Fortran_combined.f90
+++ b/tests/integration/cases/string_control_chars/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Fortran.f90
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Fortran_combined.f90
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_list/Fortran.f90
+++ b/tests/integration/cases/string_list/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_list/Fortran_combined.f90
+++ b/tests/integration/cases/string_list/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_backslash/Fortran.f90
+++ b/tests/integration/cases/string_with_backslash/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_backslash/Fortran_combined.f90
+++ b/tests/integration/cases/string_with_backslash/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_dollar/Fortran.f90
+++ b/tests/integration/cases/string_with_dollar/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_dollar/Fortran_combined.f90
+++ b/tests/integration/cases/string_with_dollar/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_dollar_brace/Fortran.f90
+++ b/tests/integration/cases/string_with_dollar_brace/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_dollar_brace/Fortran_combined.f90
+++ b/tests/integration/cases/string_with_dollar_brace/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_hash/Fortran.f90
+++ b/tests/integration/cases/string_with_hash/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/string_with_hash/Fortran_combined.f90
+++ b/tests/integration/cases/string_with_hash/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/triple_sequence/Fortran.f90
+++ b/tests/integration/cases/triple_sequence/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/triple_sequence/Fortran_combined.f90
+++ b/tests/integration/cases/triple_sequence/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/type_hints/Fortran.f90
+++ b/tests/integration/cases/type_hints/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/type_hints/Fortran_combined.f90
+++ b/tests/integration/cases/type_hints/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Fortran.f90
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Fortran_combined.f90
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Fortran.f90
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Fortran.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Fortran_combined.f90
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Fortran_combined.f90
@@ -1,5 +1,4 @@
 module fval_m
-  use, intrinsic :: ieee_arithmetic
   implicit none
   type :: fval_t
     integer :: t = 0


### PR DESCRIPTION
## Summary
- Moved `use, intrinsic :: ieee_arithmetic` from `static_preamble` (always emitted) to `special_float_preamble` (conditionally emitted only when data contains inf/nan values)
- This matches the pattern used by C, C++, Go, and Zig for their math imports
- The module body was moved from `static_preamble` to `static_body_preamble` so the conditional `use` line is placed correctly inside the module block

## Test plan
- [x] All 174 Fortran integration tests pass
- [x] Verified `bool_list` fixture no longer includes `ieee_arithmetic`
- [x] Verified `float_special_values` fixture still includes `ieee_arithmetic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Fortran preamble generation and module layout, which could affect whether generated code compiles (especially for `inf`/`nan` literals) if the conditional import logic or placement is wrong.
> 
> **Overview**
> Adjusts Fortran code generation so `use, intrinsic :: ieee_arithmetic` is **no longer always emitted**; it is now provided via `special_float_preamble` and only included when the input contains `inf`/`nan` values.
> 
> To keep the conditional `use` line inside the module scope, the module declaration (`module fval_m`) remains in `static_preamble` while the rest of the module body is moved into `static_body_preamble`. Integration fixtures are updated accordingly to remove the unconditional `ieee_arithmetic` line from generated Fortran outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ef734b14850baa99240cd18cc0370dd82327058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->