### PR TITLE
Remove module-level variable globals from Gleam

### DIFF
--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -215,21 +215,6 @@ class Gleam(metaclass=LanguageCls):
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
 
-    _GVAL_TYPE_DECL = (
-        "pub type GVal {\n"
-        "  GNull\n"
-        "  GBool(Bool)\n"
-        "  GInt(Int)\n"
-        "  GFloat(Float)\n"
-        "  GStr(String)\n"
-        "  GList(List(GVal))\n"
-        "  GDict(List(#(String, GVal)))\n"
-        "  GSet(List(GVal))\n"
-        "}"
-    )
-
-    _GVAL_PREAMBLE: tuple[str, ...] = (_GVAL_TYPE_DECL,)
-
     class DateFormats(enum.Enum):
         """Date format options for Gleam."""
 
@@ -596,7 +581,18 @@ class Gleam(metaclass=LanguageCls):
                 dict,
                 set,
             ),
-            self._GVAL_PREAMBLE,
+            (
+                "pub type GVal {\n"
+                "  GNull\n"
+                "  GBool(Bool)\n"
+                "  GInt(Int)\n"
+                "  GFloat(Float)\n"
+                "  GStr(String)\n"
+                "  GList(List(GVal))\n"
+                "  GDict(List(#(String, GVal)))\n"
+                "  GSet(List(GVal))\n"
+                "}",
+            ),
         )
         self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
         self.compute_body_preamble: Callable[


### PR DESCRIPTION
## Summary
- Move the three pre-built float formatter instances (`_format_gleam_float_repr`, `_format_gleam_float_scientific`, `_format_gleam_float_fixed`) from module-level variables into inline definitions within the `FloatFormats` enum members
- Inline `_GVAL_TYPE_DECL` and `_GVAL_PREAMBLE` constants directly into the `scalar_preamble` assignment, since they were each used only once
- Pure helper functions remain module-level as they are stateless and cannot be referenced from nested enum class bodies due to Python scoping rules

## Test plan
- [x] All 193 Gleam tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only restructures where Gleam float formatters and the `GVal` type preamble are defined, without changing formatting behavior or external interfaces.
> 
> **Overview**
> Removes module-level globals in `gleam.py` by inlining the three pre-built float formatter instances directly into the `Gleam.FloatFormats` enum members.
> 
> Also inlines the `GVal` type declaration/preamble string into the `scalar_preamble` initialization, eliminating one-off `_GVAL_TYPE_DECL`/`_GVAL_PREAMBLE` constants while keeping the emitted Gleam preamble content the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b60b6b971e685c6c9a71701f680cdc27d8e422fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->