### PR TITLE
Replace empty string special-value literals with UNREACHABLE in Gleam

### DIFF
--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -333,9 +333,9 @@ class Gleam(metaclass=LanguageCls):
             value=_gleam_float_wrapper(
                 inner=functools.partial(
                     format_float_repr,
-                    inf_literal="",
-                    neg_inf_literal="",
-                    nan_literal="",
+                    inf_literal="UNREACHABLE",
+                    neg_inf_literal="UNREACHABLE",
+                    nan_literal="UNREACHABLE",
                 ),
             )
         )
@@ -343,9 +343,9 @@ class Gleam(metaclass=LanguageCls):
             value=_gleam_float_wrapper(
                 inner=functools.partial(
                     format_float_scientific,
-                    inf_literal="",
-                    neg_inf_literal="",
-                    nan_literal="",
+                    inf_literal="UNREACHABLE",
+                    neg_inf_literal="UNREACHABLE",
+                    nan_literal="UNREACHABLE",
                 ),
             )
         )
@@ -353,9 +353,9 @@ class Gleam(metaclass=LanguageCls):
             value=_gleam_float_wrapper(
                 inner=functools.partial(
                     format_float_fixed,
-                    inf_literal="",
-                    neg_inf_literal="",
-                    nan_literal="",
+                    inf_literal="UNREACHABLE",
+                    neg_inf_literal="UNREACHABLE",
+                    nan_literal="UNREACHABLE",
                 ),
             )
         )


### PR DESCRIPTION
## Summary

- Replace `""` with `"UNREACHABLE"` for `inf_literal`, `neg_inf_literal`, and `nan_literal` in Gleam's `FloatFormats` inner formatters
- The `_gleam_float_wrapper` handles special float values (inf, -inf, NaN) before the inner formatters are called, so these parameters are never reached. Using `"UNREACHABLE"` makes this intent explicit instead of silently producing empty strings if the control flow ever changes.

## Test plan

- [x] All 193 Gleam tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the fallback literals for Gleam float formatting in paths that should be unreachable because `_gleam_float_wrapper` handles `inf`/`-inf`/`NaN` first. Behavior changes only if that control flow regresses, in which case output will now be a loud sentinel instead of an empty string.
> 
> **Overview**
> Makes Gleam float formatting more explicit by replacing empty-string `inf_literal`/`neg_inf_literal`/`nan_literal` values passed into the inner `format_float_*` functions with the sentinel string `"UNREACHABLE"`.
> 
> This ensures any accidental bypass of `_gleam_float_wrapper`’s special-value handling produces an obvious output rather than silently emitting an empty string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be8e2d7b3c801b9d33ce0260ef88cf7a17c4465. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->