### PR TITLE
Fix Bash above-line comments breaking variable assignment

### DIFF
--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -390,7 +390,7 @@ class Bash(metaclass=LanguageCls):
         self.element_separator = " "
         self.skip_null_dict_values = False
         self.supports_collection_comments = True
-        self.supports_scalar_before_comments = True
+        self.supports_scalar_before_comments = False
         self.supports_scalar_inline_comments = True
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
             declaration_style.value.formatter

--- a/tests/integration/cases/comment_scalar/Bash.sh
+++ b/tests/integration/cases/comment_scalar/Bash.sh
@@ -1,2 +1,2 @@
-declare my_data=# note
-42
+# note
+declare my_data=42

--- a/tests/integration/cases/comment_scalar/Bash_combined.sh
+++ b/tests/integration/cases/comment_scalar/Bash_combined.sh
@@ -1,4 +1,4 @@
-declare my_data=# note
-42
-my_data=# note
-42
+# note
+declare my_data=42
+# note
+my_data=42

--- a/tests/integration/cases/comment_scalar_document_markers/Bash.sh
+++ b/tests/integration/cases/comment_scalar_document_markers/Bash.sh
@@ -1,2 +1,2 @@
-declare my_data=# note
-42
+# note
+declare my_data=42

--- a/tests/integration/cases/comment_scalar_document_markers/Bash_combined.sh
+++ b/tests/integration/cases/comment_scalar_document_markers/Bash_combined.sh
@@ -1,4 +1,4 @@
-declare my_data=# note
-42
-my_data=# note
-42
+# note
+declare my_data=42
+# note
+my_data=42


### PR DESCRIPTION
## Summary

- `declare my_data=# note` followed by `42` on the next line is broken Bash — the `#` starts a comment, so `my_data` gets an empty string instead of `42`
- Set `supports_scalar_before_comments = False` for Bash so above-line comments go on a separate line before the declaration, matching how Python and Go handle this
- Affects `comment_scalar` and `comment_scalar_document_markers` test cases

## Test plan

- [x] `uv run pytest tests/integration/ --regen-all` — 9050 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: flips a Bash formatter capability flag and updates integration fixtures; behavior change is limited to how scalar-before comments are placed in generated Bash assignments.
> 
> **Overview**
> Fixes generated Bash variable assignments that were being broken by *before-line* scalar comments (e.g., `declare x=# note`), by disabling `supports_scalar_before_comments` for Bash so these comments are emitted as standalone `# ...` lines above the declaration/assignment.
> 
> Updates the `comment_scalar` and `comment_scalar_document_markers` integration expected outputs to reflect the new comment placement for both declaration and reassignment cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c3b5f2ba34315ec002bba11e0f58052c3dea410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->