### PR TITLE
Use textwrap.dedent for multi-line test strings

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -574,17 +574,19 @@ def test_cobol_level_number_cap() -> None:
     """COBOL level numbers are capped at 49 for deeply nested
     structures.
     """
-    yaml_string = (
-        "a:\n"
-        "  b:\n"
-        "    c:\n"
-        "      d:\n"
-        "        e:\n"
-        "          f:\n"
-        "            g:\n"
-        "              h:\n"
-        "                i:\n"
-        "                  value: deep\n"
+    yaml_string = textwrap.dedent(
+        text="""\
+        a:
+          b:
+            c:
+              d:
+                e:
+                  f:
+                    g:
+                      h:
+                        i:
+                          value: deep
+        """
     )
     result = literalize_yaml(
         yaml_string=yaml_string,

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -200,29 +200,31 @@ _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {  # pyrefly: ignore[bad-ass
         declaration="$my_var = 42;", assignment="$my_var = 42;"
     ),
     HASKELL: _VariableSyntax(
-        declaration=(
-            "data Val = HInt Integer\n"
-            "instance Num Val where\n"
-            "    fromInteger = HInt\n"
-            '    a + b = error "not implemented"\n'
-            '    a * b = error "not implemented"\n'
-            '    abs a = error "not implemented"\n'
-            '    signum a = error "not implemented"\n'
-            "    negate (HInt n) = HInt (negate n)\n"
-            '    negate _ = error "not implemented"\n'
-            "my_var = 42"
+        declaration=textwrap.dedent(
+            text="""\
+            data Val = HInt Integer
+            instance Num Val where
+                fromInteger = HInt
+                a + b = error "not implemented"
+                a * b = error "not implemented"
+                abs a = error "not implemented"
+                signum a = error "not implemented"
+                negate (HInt n) = HInt (negate n)
+                negate _ = error "not implemented"
+            my_var = 42"""
         ),
-        assignment=(
-            "data Val = HInt Integer\n"
-            "instance Num Val where\n"
-            "    fromInteger = HInt\n"
-            '    a + b = error "not implemented"\n'
-            '    a * b = error "not implemented"\n'
-            '    abs a = error "not implemented"\n'
-            '    signum a = error "not implemented"\n'
-            "    negate (HInt n) = HInt (negate n)\n"
-            '    negate _ = error "not implemented"\n'
-            "my_var = 42"
+        assignment=textwrap.dedent(
+            text="""\
+            data Val = HInt Integer
+            instance Num Val where
+                fromInteger = HInt
+                a + b = error "not implemented"
+                a * b = error "not implemented"
+                abs a = error "not implemented"
+                signum a = error "not implemented"
+                negate (HInt n) = HInt (negate n)
+                negate _ = error "not implemented"
+            my_var = 42"""
         ),
     ),
     DART: _VariableSyntax(
@@ -232,11 +234,17 @@ _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {  # pyrefly: ignore[bad-ass
         declaration="my_var = 42", assignment="my_var = 42"
     ),
     FSHARP: _VariableSyntax(
-        declaration=(
-            "type Val =\n    | FInt of int64\nlet my_var: Val = FInt 42L"
+        declaration=textwrap.dedent(
+            text="""\
+            type Val =
+                | FInt of int64
+            let my_var: Val = FInt 42L"""
         ),
-        assignment=(
-            "type Val =\n    | FInt of int64\nlet my_var: Val = FInt 42L"
+        assignment=textwrap.dedent(
+            text="""\
+            type Val =
+                | FInt of int64
+            let my_var: Val = FInt 42L"""
         ),
     ),
     CLOJURE: _VariableSyntax(


### PR DESCRIPTION
## Summary

Replace concatenated string literals (`"...\n"` style) with `textwrap.dedent` triple-quoted strings in test data for Haskell, F#, and COBOL tests. This matches the pattern already used elsewhere in the test suite and makes the embedded code/data structures easier to read at a glance.

## Test plan

- [x] All 93 tests in `test_variables.py` and `test_languages.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test fixture formatting (switching multiline literals to `textwrap.dedent`) with no production logic impact.
> 
> **Overview**
> Refactors several multiline test fixtures to use `textwrap.dedent` triple-quoted strings instead of manual string concatenation.
> 
> This affects the deeply-nested COBOL YAML input in `test_cobol_level_number_cap` and the expected Haskell/F# declaration/assignment snippets in `test_variables.py`, improving readability while keeping the test semantics the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0c37100e8b44e9ac0590df13f0aaeb041326d53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->