### PR TITLE
Use textwrap.dedent for remaining multi-line test strings

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -418,15 +418,35 @@ def test_java_sequence_include_delimiters_uses_braces() -> None:
     argvalues=[
         (
             [1, 2, 3],
-            "new int[]{\n    1,\n    2,\n    3\n}",
+            textwrap.dedent(
+                text="""\
+                new int[]{
+                    1,
+                    2,
+                    3
+                }"""
+            ),
         ),
         (
             ["hello", "world"],
-            'new String[]{\n    "hello",\n    "world"\n}',
+            textwrap.dedent(
+                text="""\
+                new String[]{
+                    "hello",
+                    "world"
+                }"""
+            ),
         ),
         (
             [1, "hello", True],
-            'new Object[]{\n    1,\n    "hello",\n    true\n}',
+            textwrap.dedent(
+                text="""\
+                new Object[]{
+                    1,
+                    "hello",
+                    true
+                }"""
+            ),
         ),
     ],
     ids=["all_int", "all_string", "mixed"],


### PR DESCRIPTION
## Summary

- Convert 3 remaining `\n`-escaped multi-line expected strings in `test_java_typed_array_opener` to use `textwrap.dedent`, matching the style used everywhere else in the test file.

## Test plan

- [x] `test_java_typed_array_opener` passes for all 3 parametrized cases (all_int, all_string, mixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that rewrites expected string literals without altering runtime code paths.
> 
> **Overview**
> Updates `test_java_typed_array_opener` to express the three multiline expected Java array literals using `textwrap.dedent` instead of `\n`-escaped strings, aligning formatting with the rest of `tests/test_languages.py` and making indentation expectations explicit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ac6880f380f683711d08abab78dd8873dc17717. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->