### PR TITLE
Add lint-lang composite action to reduce lint workflow boilerplate

### DIFF
--- a/.github/actions/lint-lang/action.yml
+++ b/.github/actions/lint-lang/action.yml
@@ -1,10 +1,10 @@
 ---
 name: Lint language files
 description: >-
-  Checkout the repo, find files to lint, and optionally run a lint
-  command.  For workflows that need custom setup between finding
-  files and linting, omit lint_command and use the 'found' output
-  to gate subsequent steps.
+  Find files to lint and optionally run a lint command.  The repo
+  must already be checked out.  For workflows that need custom
+  setup between finding files and linting, omit lint_command and
+  use the 'found' output to gate subsequent steps.
 
 inputs:
   lang_patterns:
@@ -40,9 +40,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-      with:
-        persist-credentials: false
     - uses: ./.github/actions/find-lint-files
       id: find-files
       with:

--- a/.github/workflows/lint-ada.yml
+++ b/.github/workflows/lint-ada.yml
@@ -10,6 +10,9 @@ jobs:
   lint-ada:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -10,6 +10,9 @@ jobs:
   lint-bash:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.sh

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -10,6 +10,9 @@ jobs:
   lint-c:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.c

--- a/.github/workflows/lint-clojure.yml
+++ b/.github/workflows/lint-clojure.yml
@@ -10,6 +10,9 @@ jobs:
   lint-clojure:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-cobol.yml
+++ b/.github/workflows/lint-cobol.yml
@@ -10,6 +10,9 @@ jobs:
   lint-cobol:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.cob

--- a/.github/workflows/lint-commonlisp.yml
+++ b/.github/workflows/lint-commonlisp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-common-lisp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.lisp

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-cpp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.cpp

--- a/.github/workflows/lint-crystal.yml
+++ b/.github/workflows/lint-crystal.yml
@@ -10,6 +10,9 @@ jobs:
   lint-crystal:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-csharp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-d.yml
+++ b/.github/workflows/lint-d.yml
@@ -10,6 +10,9 @@ jobs:
   lint-d:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-dart.yml
+++ b/.github/workflows/lint-dart.yml
@@ -10,6 +10,9 @@ jobs:
   lint-dart:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-dhall.yml
+++ b/.github/workflows/lint-dhall.yml
@@ -10,6 +10,9 @@ jobs:
   lint-dhall:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.dhall

--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -10,6 +10,9 @@ jobs:
   lint-elixir:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-elm.yml
+++ b/.github/workflows/lint-elm.yml
@@ -10,6 +10,9 @@ jobs:
   lint-elm:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-erlang.yml
+++ b/.github/workflows/lint-erlang.yml
@@ -10,6 +10,9 @@ jobs:
   lint-erlang:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-fortran.yml
+++ b/.github/workflows/lint-fortran.yml
@@ -10,6 +10,9 @@ jobs:
   lint-fortran:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.f90

--- a/.github/workflows/lint-fsharp.yml
+++ b/.github/workflows/lint-fsharp.yml
@@ -10,6 +10,9 @@ jobs:
   lint-fsharp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: |

--- a/.github/workflows/lint-gleam.yml
+++ b/.github/workflows/lint-gleam.yml
@@ -10,6 +10,9 @@ jobs:
   lint-gleam:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -10,6 +10,9 @@ jobs:
   lint-go:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.go

--- a/.github/workflows/lint-groovy.yml
+++ b/.github/workflows/lint-groovy.yml
@@ -10,6 +10,9 @@ jobs:
   lint-groovy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-haskell.yml
+++ b/.github/workflows/lint-haskell.yml
@@ -10,6 +10,9 @@ jobs:
   lint-haskell:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-hcl.yml
+++ b/.github/workflows/lint-hcl.yml
@@ -10,6 +10,9 @@ jobs:
   lint-hcl:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.hcl

--- a/.github/workflows/lint-java.yml
+++ b/.github/workflows/lint-java.yml
@@ -10,6 +10,9 @@ jobs:
   lint-java:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.java

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -10,6 +10,9 @@ jobs:
   lint-javascript:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.js

--- a/.github/workflows/lint-json5.yml
+++ b/.github/workflows/lint-json5.yml
@@ -10,6 +10,9 @@ jobs:
   lint-json5:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.json5

--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -10,6 +10,9 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.jsonnet

--- a/.github/workflows/lint-julia.yml
+++ b/.github/workflows/lint-julia.yml
@@ -10,6 +10,9 @@ jobs:
   lint-julia:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-kotlin.yml
+++ b/.github/workflows/lint-kotlin.yml
@@ -10,6 +10,9 @@ jobs:
   lint-kotlin:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-lua.yml
+++ b/.github/workflows/lint-lua.yml
@@ -10,6 +10,9 @@ jobs:
   lint-lua:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-matlab.yml
+++ b/.github/workflows/lint-matlab.yml
@@ -10,6 +10,9 @@ jobs:
   lint-matlab:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/Matlab*.m

--- a/.github/workflows/lint-mojo.yml
+++ b/.github/workflows/lint-mojo.yml
@@ -10,6 +10,9 @@ jobs:
   lint-mojo:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-nim.yml
+++ b/.github/workflows/lint-nim.yml
@@ -10,6 +10,9 @@ jobs:
   lint-nim:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-norg.yml
+++ b/.github/workflows/lint-norg.yml
@@ -10,6 +10,9 @@ jobs:
   lint-norg:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-objectivec.yml
+++ b/.github/workflows/lint-objectivec.yml
@@ -10,6 +10,9 @@ jobs:
   lint-objective-c:
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/objective_c*.m

--- a/.github/workflows/lint-ocaml.yml
+++ b/.github/workflows/lint-ocaml.yml
@@ -10,6 +10,9 @@ jobs:
   lint-ocaml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.ml

--- a/.github/workflows/lint-occam.yml
+++ b/.github/workflows/lint-occam.yml
@@ -10,6 +10,9 @@ jobs:
   lint-occam:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-perl.yml
+++ b/.github/workflows/lint-perl.yml
@@ -10,6 +10,9 @@ jobs:
   lint-perl:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.pl

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -10,6 +10,9 @@ jobs:
   lint-php:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.php

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -10,6 +10,9 @@ jobs:
   lint-powershell:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.ps1

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -10,6 +10,9 @@ jobs:
   lint-r:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-racket.yml
+++ b/.github/workflows/lint-racket.yml
@@ -10,6 +10,9 @@ jobs:
   lint-racket:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.rkt

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -10,6 +10,9 @@ jobs:
   lint-ruby:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.rb

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -10,6 +10,9 @@ jobs:
   lint-rust:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-scala.yml
+++ b/.github/workflows/lint-scala.yml
@@ -10,6 +10,9 @@ jobs:
   lint-scala:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -10,6 +10,9 @@ jobs:
   lint-swift:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -10,6 +10,9 @@ jobs:
   lint-toml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -10,6 +10,9 @@ jobs:
   lint-typescript:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         with:
           lang_patterns: tests/integration/cases/**/*.ts

--- a/.github/workflows/lint-visualbasic.yml
+++ b/.github/workflows/lint-visualbasic.yml
@@ -10,6 +10,9 @@ jobs:
   lint-vb:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -10,6 +10,9 @@ jobs:
   lint-yaml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:

--- a/.github/workflows/lint-zig.yml
+++ b/.github/workflows/lint-zig.yml
@@ -10,6 +10,9 @@ jobs:
   lint-zig:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/lint-lang
         id: lint-lang
         with:


### PR DESCRIPTION
## Summary

- Adds a new `lint-lang` composite action that wraps checkout + `find-lint-files` + optional lint command execution into a single reusable step
- Updates all 50 `lint-<lang>.yml` workflows to use it: simple workflows (23) collapse to a single step with `lint_command`; complex ones (27) that need `uses:` setup actions still save ~4 lines by combining checkout + find-lint-files
- Net result: 500 deletions, 302 insertions across 51 files

## Test plan

- [ ] Verify CI passes on this PR (all 50 lint workflows still run correctly)
- [ ] Spot-check a few workflow runs to confirm file detection and lint commands execute as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many GitHub Actions workflows and centralizes lint execution via an `eval`-based composite step, so small mistakes could break CI or change how commands run. No production code is affected.
> 
> **Overview**
> Introduces a new composite action, `./.github/actions/lint-lang`, that wraps `find-lint-files` and optionally runs a provided `lint_command` only when matching files are found, exposing a `found` output for gating later steps.
> 
> Refactors the language lint workflows to use `lint-lang` instead of calling `find-lint-files` directly, moving per-language install+lint logic either into `lint_command` (for simple cases) or updating step guards to reference `steps.lint-lang.outputs.found` (for workflows that still need separate setup actions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370fcd6cf054cda1b3835c6121f7111a16c3d831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->