### PR TITLE
Rename EmptyDictKeyError to InvalidDictKeyError

### DIFF
--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -13,9 +13,11 @@ class YAMLParseError(ParseError):
     """Raised when a YAML string cannot be parsed."""
 
 
-class EmptyDictKeyError(Exception):
-    """Raised when a dict contains an empty-string key and the language
-    specification is configured to reject them.
+class InvalidDictKeyError(Exception):
+    """Raised when a dict key cannot be represented in the target language.
+
+    This includes empty-string keys and keys containing characters that
+    the language's label syntax does not support.
     """
 
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -48,7 +48,7 @@ from literalizer._language import (
     no_type_hint_preamble,
 )
 from literalizer._types import Value
-from literalizer.exceptions import EmptyDictKeyError
+from literalizer.exceptions import InvalidDictKeyError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -76,7 +76,7 @@ def _format_r_dict_entry_error(key: str, _val: Value, value: str) -> str:
             "Use empty_dict_key=R.EmptyDictKey.POSITIONAL to emit them "
             "as unnamed list elements instead."
         )
-        raise EmptyDictKeyError(msg)
+        raise InvalidDictKeyError(msg)
     return f"{key} = {value}"
 
 
@@ -109,7 +109,7 @@ class R(metaclass=LanguageCls):
             * ``EmptyDictKey.POSITIONAL`` — emit as an unnamed
               positional list element.
             * ``EmptyDictKey.ERROR`` — raise
-              :class:`~literalizer.exceptions.EmptyDictKeyError`.
+              :class:`~literalizer.exceptions.InvalidDictKeyError`.
     """
 
     extension = ".R"

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -9,8 +9,8 @@ from literalizer import (
     literalize_yaml,
 )
 from literalizer.exceptions import (
-    EmptyDictKeyError,
     HeterogeneousCoercionError,
+    InvalidDictKeyError,
     ParseError,
     YAMLParseError,
 )
@@ -579,7 +579,7 @@ def test_r_empty_dict_key_positional_is_default() -> None:
 
 
 def test_r_empty_dict_key_error() -> None:
-    """R with ERROR empty_dict_key raises EmptyDictKeyError."""
+    """R with ERROR empty_dict_key raises InvalidDictKeyError."""
     spec = R(
         date_format=R.date_formats.R,
         datetime_format=R.datetime_formats.R,
@@ -588,7 +588,7 @@ def test_r_empty_dict_key_error() -> None:
         sequence_format=R.sequence_formats.LIST,
     )
     yaml_string = '{"": "value"}\n'
-    with pytest.raises(expected_exception=EmptyDictKeyError):
+    with pytest.raises(expected_exception=InvalidDictKeyError):
         literalize_yaml(
             yaml_string=yaml_string,
             language=spec,


### PR DESCRIPTION
## Summary
- Renames `EmptyDictKeyError` to `InvalidDictKeyError` to better reflect that the exception covers any dict key that cannot be represented in the target language, not just empty-string keys.
- Updates all references in `r.py` and `test_yaml.py`.

## Test plan
- [ ] Existing tests pass with the renamed exception
- [ ] R empty-dict-key error test uses `InvalidDictKeyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename of an exception type with corresponding updates to R formatting and YAML tests; main risk is downstream code still importing the old exception name.
> 
> **Overview**
> Renames the dict-key exception from `EmptyDictKeyError` to `InvalidDictKeyError` and expands the docstring to cover any dict key that can’t be represented in a target language (including empty keys and unsupported characters).
> 
> Updates the R language formatter to raise `InvalidDictKeyError` for empty-string dict keys when configured to error, and adjusts the YAML test to expect the new exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba89303baa4fe381132931cc5b0d99a2bc6cfe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->