### PR TITLE
Clean up lint workflow: caching, concurrency, and consistency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -187,7 +187,9 @@ jobs:
           lang_patterns: tests/integration/cases/**/*.jsonnet
       - name: Install jsonnet
         if: steps.find-files.outputs.found == 'true'
-        run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+        run: |-
+          go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Check Jsonnet syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-


### PR DESCRIPTION
## Summary

- Add `concurrency` group with `cancel-in-progress: true` to avoid wasting runner minutes on superseded pushes
- Fix missing `enable-cache` on `lint-yaml`'s `setup-uv` step
- Rename misleading `build` job to `pre-commit`
- Replace `apt-get` with `go install` for jsonnet; combine `lint-hcl`'s split go-install/PATH steps
- Convert 10 `while` loops to `xargs -0 -n1` one-liners (ruby, javascript, typescript, cobol, perl, d, crystal, objective-c, zig)
- Normalize all `apt-get` calls to consistently use `update -qq` before `install -y -qq`

## Test plan

- [ ] Verify `completion-lint` references `pre-commit` correctly
- [ ] Confirm `go install` jsonnet works on ubuntu runners (Go is pre-installed)
- [ ] Check that `xargs -0 -n1` replacements still fail correctly on syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to CI workflow wiring; main risk is accidental lint false-positives/negatives or job failures due to command/install adjustments.
> 
> **Overview**
> Adds workflow-level `concurrency` with `cancel-in-progress` to avoid running superseded lint jobs, and renames the main `build` job to `pre-commit` (updating `completion-lint` dependencies accordingly).
> 
> Improves CI efficiency/consistency by enabling `setup-uv` caching in `lint-yaml`, normalizing various `apt-get` installs to `update -qq && install -y -qq`, switching Jsonnet installation to `go install`, and simplifying several per-file syntax checks from shell loops to `xargs -0 -n1` invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ebb194c6b95b3d897258741bcd32239770d1c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->