### PR TITLE
Use setup-odin action instead of building from source

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1026,12 +1026,9 @@ jobs:
           lang_patterns: tests/integration/cases/**/*.odin
       - name: Install Odin
         if: steps.find-files.outputs.found == 'true'
-        run: |-
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq llvm-14 clang-14
-          git clone --depth=1 https://github.com/odin-lang/Odin /tmp/odin
-          cd /tmp/odin && make release
-          echo "/tmp/odin" >> "$GITHUB_PATH"
+        uses: laytan/setup-odin@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check Odin
         if: steps.find-files.outputs.found == 'true'
         run: |-


### PR DESCRIPTION
## Summary
- Replace the manual `git clone` + `make` build of Odin in the `lint-odin` CI job with the `laytan/setup-odin@v2` action, which downloads pre-built releases

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; primary risk is potential lint breakage if the action installs a different Odin version or changes installation behavior.
> 
> **Overview**
> Updates the GitHub Actions `lint-odin` job to use `laytan/setup-odin@v2` (with `GITHUB_TOKEN`) instead of `apt-get` + cloning and building Odin from source.
> 
> This reduces CI setup time/complexity while keeping the subsequent `odin check` linting step unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ad0b6917bbaaf95439f6dc57762a727c02d656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->