### PR TITLE
Document why min_dicts_for_widening threshold is 2

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -921,6 +921,8 @@ def _compute_dict_open_override(
         for item in items
         if isinstance(item, dict) and not isinstance(item, ordereddict)
     ]
+    # Widening compares openers across dicts, so we need at least two
+    # to have anything to compare.
     min_dicts_for_widening = 2
     if len(dicts) < min_dicts_for_widening:
         return None


### PR DESCRIPTION
Closes #995

Add a comment explaining that the threshold of 2 exists because widening compares openers across dicts, so at least two are needed for there to be anything to compare.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; adds an inline comment without altering runtime behavior.
> 
> **Overview**
> Adds a clarifying comment in `src/literalizer/_core.py` explaining why `_compute_dict_open_override` requires at least two dicts (`min_dicts_for_widening = 2`) before attempting widening, since widening compares openers across multiple dicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1914325ceb0d66f09ac9d415931620ace10b521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->