### PR TITLE
Relax beartype version pin from exact to compatible range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype==0.22.9",
+    "beartype>=0.22.9,<1",
     "pyjson5>=2",
     # We require >=0.18.16 as a minimum because some users use sphinx-toolbox,
     # which has a maximum ruamel.yaml version of 0.18.16.


### PR DESCRIPTION
## Summary
- Change `beartype==0.22.9` to `beartype>=0.22.9,<1` so downstream users can receive patch and minor updates.

Closes #989

## Test plan
- [ ] CI passes with the relaxed pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only relaxes the `beartype` runtime dependency constraint, enabling newer compatible versions without changing application code paths.
> 
> **Overview**
> Relaxes the runtime dependency requirement for `beartype` in `pyproject.toml` from an exact pin (`==0.22.9`) to a compatible range (`>=0.22.9,<1`) so downstream installs can pick up newer `beartype` releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b03a45e816bacb06e2d7e39c8ce6fc7ffcd89b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->