### PR TITLE
Remove dead `or value is None` branch

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -596,7 +596,7 @@ def _coerce_value_to_str(*, value: Value) -> str:
     if isinstance(value, str):
         return value
     bucket = _scalar_type_bucket(value=value)
-    if bucket is not None or value is None:
+    if bucket is not None:
         return _coerce_scalar_to_str(value=value)
     if isinstance(value, set):
         sorted_items = sorted(value, key=lambda v: (type(v).__name__, repr(v)))


### PR DESCRIPTION
## Summary
- Remove unreachable `or value is None` check in `_coerce_value_to_str`
- `_scalar_type_bucket(value=None)` returns `type(None)` (not `None`), so `bucket is not None` already handles `value is None`

Closes #984

## Test plan
- [x] All 10591 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant `value is None` branch without changing behavior, since `_scalar_type_bucket(None)` already returns a non-`None` bucket.
> 
> **Overview**
> Simplifies `_coerce_value_to_str` by dropping an unreachable `or value is None` check and relying solely on the `_scalar_type_bucket` result to decide scalar string coercion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecc9fd522742b8fdf224edea94abf9521591604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->