### PR TITLE
Add actionable context to exception messages

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -471,12 +471,7 @@ def _collect_scalar_type_names(*, data: Value) -> set[str]:
             for v in data:
                 names |= _collect_scalar_type_names(data=v)
         case _:
-            bucket = _scalar_type_bucket(value=data)
-            # Every Value scalar (including None) has a type bucket;
-            # the None return only applies to collections, which are
-            # handled above.
-            if bucket is not None:  # pragma: no branch
-                names.add(bucket.__name__)
+            names.add(_value_type_family(value=data))
     return names
 
 

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -469,12 +469,13 @@ def _collect_scalar_type_names(*, data: Value) -> set[str]:
                 names |= _collect_scalar_type_names(data=v)
         case set():
             for v in data:
-                bucket = _scalar_type_bucket(value=v)
-                if bucket is not None:
-                    names.add(bucket.__name__)
+                names |= _collect_scalar_type_names(data=v)
         case _:
             bucket = _scalar_type_bucket(value=data)
-            if bucket is not None:
+            # Every Value scalar (including None) has a type bucket;
+            # the None return only applies to collections, which are
+            # handled above.
+            if bucket is not None:  # pragma: no branch
                 names.add(bucket.__name__)
     return names
 

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -487,6 +487,39 @@ def _describe_heterogeneous_types(*, data: Value) -> str:
     return ", ".join(sorted(_collect_scalar_type_names(data=data)))
 
 
+def _collect_mixed_type_families(*, data: Value) -> set[str]:
+    """Collect type family names from *data*, including collection types.
+
+    Unlike `_collect_scalar_type_names` which recurses into collections,
+    this reports the type family of each direct child value so that
+    mixed-type errors can show "dict, str" or "int, list" instead of
+    only scalar types.
+    """
+    families: set[str] = set()
+    match data:
+        case ordereddict() | dict():
+            values: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+            if _dict_values_mixed_types(values=values):
+                return {_value_type_family(value=v) for v in values}
+            for v in values:
+                families |= _collect_mixed_type_families(data=v)
+        case list():
+            if _dict_values_mixed_types(values=data):
+                return {_value_type_family(value=v) for v in data}
+            for v in data:
+                families |= _collect_mixed_type_families(data=v)
+        case _:
+            families.add(_value_type_family(value=data))
+    return families
+
+
+def _describe_mixed_type_families(*, data: Value) -> str:
+    """Return a sorted, comma-separated string of type families in
+    *data*, including collection types.
+    """
+    return ", ".join(sorted(_collect_mixed_type_families(data=data)))
+
+
 @beartype
 def _check_heterogeneous(*, data: Value) -> None:
     """Recursively check for heterogeneous all-scalar collections and
@@ -1153,11 +1186,9 @@ def _apply_coercions(
                 spec.sequence_format_config.requires_uniform_record_shapes
                 and _has_mixed_dict_shapes(data=data)
             ):
-                types = _describe_heterogeneous_types(data=data)
                 msg = (
                     "List contains dicts with different key sets "
                     "that would be padded with null values"
-                    f" (found types: {types})"
                 )
                 raise HeterogeneousCoercionError(msg)
             _check_heterogeneous(data=data)
@@ -1170,7 +1201,7 @@ def _apply_coercions(
                 )
                 raise HeterogeneousCoercionError(msg)
             if _has_mixed_dict_values(data=data):
-                types = _describe_heterogeneous_types(data=data)
+                types = _describe_mixed_type_families(data=data)
                 msg = (
                     "Dict contains values of mixed types "
                     "that would be coerced to strings"
@@ -1178,7 +1209,7 @@ def _apply_coercions(
                 )
                 raise HeterogeneousCoercionError(msg)
             if _has_mixed_list_values(data=data):
-                types = _describe_heterogeneous_types(data=data)
+                types = _describe_mixed_type_families(data=data)
                 msg = (
                     "List contains elements of mixed types "
                     "that would be coerced to strings"

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -487,37 +487,36 @@ def _describe_heterogeneous_types(*, data: Value) -> str:
     return ", ".join(sorted(_collect_scalar_type_names(data=data)))
 
 
-def _collect_mixed_type_families(*, data: Value) -> set[str]:
-    """Collect type family names from *data*, including collection types.
+def _find_first_mixed_values(*, data: Value) -> Sequence[Value]:
+    """Return the first collection of children in *data* that spans
+    multiple type families.
 
-    Unlike `_collect_scalar_type_names` which recurses into collections,
-    this reports the type family of each direct child value so that
-    mixed-type errors can show "dict, str" or "int, list" instead of
-    only scalar types.
+    Walks the tree until it finds a dict-values or list-elements level
+    where ``_dict_values_mixed_types`` is ``True``.
     """
-    families: set[str] = set()
+    children: Sequence[Value]
     match data:
         case ordereddict() | dict():
-            values: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-            if _dict_values_mixed_types(values=values):
-                return {_value_type_family(value=v) for v in values}
-            for v in values:
-                families |= _collect_mixed_type_families(data=v)
+            children = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
         case list():
-            if _dict_values_mixed_types(values=data):
-                return {_value_type_family(value=v) for v in data}
-            for v in data:
-                families |= _collect_mixed_type_families(data=v)
+            children = data
         case _:
-            families.add(_value_type_family(value=data))
-    return families
+            return []
+    if _dict_values_mixed_types(values=children):
+        return children
+    for child in children:
+        result = _find_first_mixed_values(data=child)
+        if result:
+            return result
+    return []
 
 
 def _describe_mixed_type_families(*, data: Value) -> str:
-    """Return a sorted, comma-separated string of type families in
-    *data*, including collection types.
+    """Return a sorted, comma-separated string of type families for the
+    first collection in *data* whose children span multiple families.
     """
-    return ", ".join(sorted(_collect_mixed_type_families(data=data)))
+    values = _find_first_mixed_values(data=data)
+    return ", ".join(sorted({_value_type_family(value=v) for v in values}))
 
 
 @beartype

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -457,15 +457,46 @@ def _has_heterogeneous_sibling_lists(*, data: Value) -> bool:
             return False
 
 
+def _collect_scalar_type_names(*, data: Value) -> set[str]:
+    """Collect the names of scalar type buckets found in *data*."""
+    names: set[str] = set()
+    match data:
+        case ordereddict() | dict():
+            for v in data.values():  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                names |= _collect_scalar_type_names(data=v)  # pyright: ignore[reportUnknownArgumentType]
+        case list():
+            for v in data:
+                names |= _collect_scalar_type_names(data=v)
+        case set():
+            for v in data:
+                bucket = _scalar_type_bucket(value=v)
+                if bucket is not None:
+                    names.add(bucket.__name__)
+        case _:
+            bucket = _scalar_type_bucket(value=data)
+            if bucket is not None:
+                names.add(bucket.__name__)
+    return names
+
+
+def _describe_heterogeneous_types(*, data: Value) -> str:
+    """Return a sorted, comma-separated string of scalar type names in
+    *data*.
+    """
+    return ", ".join(sorted(_collect_scalar_type_names(data=data)))
+
+
 @beartype
 def _check_heterogeneous(*, data: Value) -> None:
     """Recursively check for heterogeneous all-scalar collections and
     raise if found.
     """
     if _has_heterogeneous(data=data):
+        types = _describe_heterogeneous_types(data=data)
         msg = (
             "Collection contains heterogeneous scalar types "
             "that would be coerced to strings"
+            f" (found types: {types})"
         )
         raise HeterogeneousCoercionError(msg)
 
@@ -1121,28 +1152,36 @@ def _apply_coercions(
                 spec.sequence_format_config.requires_uniform_record_shapes
                 and _has_mixed_dict_shapes(data=data)
             ):
+                types = _describe_heterogeneous_types(data=data)
                 msg = (
                     "List contains dicts with different key sets "
                     "that would be padded with null values"
+                    f" (found types: {types})"
                 )
                 raise HeterogeneousCoercionError(msg)
             _check_heterogeneous(data=data)
             if _has_heterogeneous_sibling_lists(data=data):
+                types = _describe_heterogeneous_types(data=data)
                 msg = (
                     "Collection contains heterogeneous scalar types "
                     "that would be coerced to strings"
+                    f" (found types: {types})"
                 )
                 raise HeterogeneousCoercionError(msg)
             if _has_mixed_dict_values(data=data):
+                types = _describe_heterogeneous_types(data=data)
                 msg = (
                     "Dict contains values of mixed types "
                     "that would be coerced to strings"
+                    f" (found types: {types})"
                 )
                 raise HeterogeneousCoercionError(msg)
             if _has_mixed_list_values(data=data):
+                types = _describe_heterogeneous_types(data=data)
                 msg = (
                     "List contains elements of mixed types "
                     "that would be coerced to strings"
+                    f" (found types: {types})"
                 )
                 raise HeterogeneousCoercionError(msg)
         else:

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -133,7 +133,7 @@ def _format_dhall_dict_entry(key: str, _val: Value, value: str) -> str:
     raw = _unescape_dhall_string(value=inner)
     if not raw or not _BACKTICK_LABEL_RE.match(string=raw):
         msg = (
-            "Dhall does not support this dict key. "
+            f"Dhall does not support the dict key {key}. "
             "Backtick-quoted labels must be non-empty and contain only "
             "printable ASCII (no backticks or control characters)."
         )

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -86,7 +86,8 @@ def _list_of_open(items: list[Any]) -> str:
     """
     if any(item is None for item in items):
         msg = (
-            "Java's List.of() does not accept null elements. "
+            f"Java's List.of() does not accept null elements"
+            f" (got {len(items)} items, including null). "
             "Use sequence_format=ARRAY instead."
         )
         raise NullInCollectionError(msg)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -72,7 +72,7 @@ def _format_r_dict_entry_error(key: str, _val: Value, value: str) -> str:
     """Format an R named list entry, raising on empty-string keys."""
     if key == '""':
         msg = (
-            "R does not support empty-string dict keys. "
+            f"R does not support the dict key {key}. "
             "Use empty_dict_key=R.EmptyDictKey.POSITIONAL to emit them "
             "as unnamed list elements instead."
         )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -872,7 +872,14 @@ def test_error_on_coercion_json_no_raise_for_homogeneous_dict() -> None:
 
 def test_error_on_coercion_json_raises_for_mixed_dict_values() -> None:
     """Error_on_coercion raises when a dict has values of mixed types."""
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="Dict contains values of mixed types "
+        "that would be coerced to strings (found types: list, str)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=json.dumps(
                 obj={"name": "Bob", "tags": ["admin", "user"]},
@@ -889,7 +896,14 @@ def test_error_on_coercion_json_raises_for_mixed_dict_values() -> None:
 
 def test_error_on_coercion_json_raises_for_mixed_list_values() -> None:
     """Error_on_coercion raises when a list has mixed element types."""
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="List contains elements of mixed types "
+        "that would be coerced to strings (found types: list, str)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=json.dumps(obj=["hello", ["nested"]]),
             input_format=InputFormat.JSON,
@@ -912,7 +926,14 @@ def test_error_on_coercion_json_raises_for_mixed_dict_shapes() -> None:
             {"type": "update"},
         ],
     }
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="List contains dicts with different key sets "
+        "that would be padded with null values",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=json.dumps(obj=data),
             input_format=InputFormat.JSON,
@@ -947,7 +968,14 @@ def test_error_on_coercion_json_no_raise_for_uniform_dict_shapes() -> None:
 
 def test_error_on_coercion_json_raises_for_mixed_dict_none_list() -> None:
     """Error_on_coercion raises when a dict has None alongside a list."""
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="Dict contains values of mixed types "
+        "that would be coerced to strings (found types: list, none)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=json.dumps(
                 obj={"tags": ["admin"], "extra": None},

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,6 +1,7 @@
 """Tests for literalizer JSON conversion."""
 
 import json
+import re
 import textwrap
 
 import pytest
@@ -550,9 +551,13 @@ MOJO = Mojo(
 
 def test_error_on_coercion_json_raises() -> None:
     """Error_on_coercion raises for heterogeneous JSON arrays."""
+    expected_msg = re.escape(
+        pattern="Collection contains heterogeneous scalar types "
+        "that would be coerced to strings (found types: float, int)"
+    )
     with pytest.raises(
         expected_exception=HeterogeneousCoercionError,
-        match=r"found types:.*float.*int",
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source="[1, 2.5, 3]",
@@ -591,9 +596,13 @@ def test_error_on_coercion_json_no_raise_homogeneous() -> None:
 
 def test_error_on_coercion_json_raises_sibling_lists() -> None:
     """Error_on_coercion raises for heterogeneous sibling sub-lists."""
+    expected_msg = re.escape(
+        pattern="Collection contains heterogeneous scalar types "
+        "that would be coerced to strings (found types: int, str)"
+    )
     with pytest.raises(
         expected_exception=HeterogeneousCoercionError,
-        match=r"found types:.*int.*str",
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source='[[1, 2], ["a", "b"]]',
@@ -611,9 +620,13 @@ def test_error_on_coercion_json_raises_nested_sibling_lists() -> None:
     """Error_on_coercion raises for nested heterogeneous sibling
     sub-lists.
     """
+    expected_msg = re.escape(
+        pattern="Collection contains heterogeneous scalar types "
+        "that would be coerced to strings (found types: int, str)"
+    )
     with pytest.raises(
         expected_exception=HeterogeneousCoercionError,
-        match=r"found types:.*int.*str",
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source='[[[1, 2], ["a", "b"]]]',
@@ -729,9 +742,14 @@ def test_r_empty_dict_key_error_json() -> None:
         bytes_format=R.bytes_formats.HEX,
         sequence_format=R.sequence_formats.LIST,
     )
+    expected_msg = re.escape(
+        pattern='R does not support the dict key "". '
+        "Use empty_dict_key=R.EmptyDictKey.POSITIONAL to emit them "
+        "as unnamed list elements instead."
+    )
     with pytest.raises(
         expected_exception=InvalidDictKeyError,
-        match=r'dict key ""',
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source=json.dumps(obj={"": "value"}),
@@ -946,9 +964,14 @@ def test_error_on_coercion_json_raises_for_mixed_dict_none_list() -> None:
 
 def test_dhall_empty_dict_key_error_json() -> None:
     """Dhall raises InvalidDictKeyError for empty-string dict keys."""
+    expected_msg = re.escape(
+        pattern='Dhall does not support the dict key "". '
+        "Backtick-quoted labels must be non-empty and contain only "
+        "printable ASCII (no backticks or control characters)."
+    )
     with pytest.raises(
         expected_exception=InvalidDictKeyError,
-        match=r'dict key ""',
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source=json.dumps(obj={"": "value"}),
@@ -980,9 +1003,14 @@ def test_dhall_control_char_in_string_json() -> None:
 
 def test_dhall_control_char_key_error_json() -> None:
     """Dhall rejects control characters in dict keys."""
+    expected_msg = re.escape(
+        pattern='Dhall does not support the dict key "\\u{0001}". '
+        "Backtick-quoted labels must be non-empty and contain only "
+        "printable ASCII (no backticks or control characters)."
+    )
     with pytest.raises(
         expected_exception=InvalidDictKeyError,
-        match="dict key",
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source=json.dumps(obj={"\x01": "value"}),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -550,7 +550,10 @@ MOJO = Mojo(
 
 def test_error_on_coercion_json_raises() -> None:
     """Error_on_coercion raises for heterogeneous JSON arrays."""
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=r"found types:.*float.*int",
+    ):
         literalize(
             source="[1, 2.5, 3]",
             input_format=InputFormat.JSON,
@@ -588,7 +591,10 @@ def test_error_on_coercion_json_no_raise_homogeneous() -> None:
 
 def test_error_on_coercion_json_raises_sibling_lists() -> None:
     """Error_on_coercion raises for heterogeneous sibling sub-lists."""
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=r"found types:.*int.*str",
+    ):
         literalize(
             source='[[1, 2], ["a", "b"]]',
             input_format=InputFormat.JSON,
@@ -605,7 +611,10 @@ def test_error_on_coercion_json_raises_nested_sibling_lists() -> None:
     """Error_on_coercion raises for nested heterogeneous sibling
     sub-lists.
     """
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=r"found types:.*int.*str",
+    ):
         literalize(
             source='[[[1, 2], ["a", "b"]]]',
             input_format=InputFormat.JSON,
@@ -720,7 +729,10 @@ def test_r_empty_dict_key_error_json() -> None:
         bytes_format=R.bytes_formats.HEX,
         sequence_format=R.sequence_formats.LIST,
     )
-    with pytest.raises(expected_exception=InvalidDictKeyError):
+    with pytest.raises(
+        expected_exception=InvalidDictKeyError,
+        match=r'dict key ""',
+    ):
         literalize(
             source=json.dumps(obj={"": "value"}),
             input_format=InputFormat.JSON,
@@ -934,7 +946,10 @@ def test_error_on_coercion_json_raises_for_mixed_dict_none_list() -> None:
 
 def test_dhall_empty_dict_key_error_json() -> None:
     """Dhall raises InvalidDictKeyError for empty-string dict keys."""
-    with pytest.raises(expected_exception=InvalidDictKeyError):
+    with pytest.raises(
+        expected_exception=InvalidDictKeyError,
+        match=r'dict key ""',
+    ):
         literalize(
             source=json.dumps(obj={"": "value"}),
             input_format=InputFormat.JSON,
@@ -965,7 +980,10 @@ def test_dhall_control_char_in_string_json() -> None:
 
 def test_dhall_control_char_key_error_json() -> None:
     """Dhall rejects control characters in dict keys."""
-    with pytest.raises(expected_exception=InvalidDictKeyError):
+    with pytest.raises(
+        expected_exception=InvalidDictKeyError,
+        match="dict key",
+    ):
         literalize(
             source=json.dumps(obj={"\x01": "value"}),
             input_format=InputFormat.JSON,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -894,6 +894,66 @@ def test_error_on_coercion_json_raises_for_mixed_dict_values() -> None:
         )
 
 
+def test_error_on_coercion_json_raises_for_nested_mixed_dict_values() -> None:
+    """Error_on_coercion raises when a nested dict has mixed types.
+
+    Uses a dict with multiple values where the first child (a
+    homogeneous dict) does not have mixed types, so the search must
+    skip past it and its scalar leaves before finding the mixed one.
+    """
+    expected_msg = re.escape(
+        pattern="Dict contains values of mixed types "
+        "that would be coerced to strings (found types: list, str)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
+        literalize(
+            source=json.dumps(
+                obj={
+                    "a": {"x": 1},
+                    "b": {"x": "hello", "y": [1]},
+                },
+            ),
+            input_format=InputFormat.JSON,
+            language=MOJO,
+            pre_indent_level=0,
+            include_delimiters=True,
+            variable_name=None,
+            new_variable=True,
+            error_on_coercion=True,
+        )
+
+
+def test_error_on_coercion_json_raises_for_nested_mixed_list_values() -> None:
+    """Error_on_coercion raises when a nested list has mixed types.
+
+    Uses a list whose first element is a homogeneous list, so the
+    search must skip past it before finding the mixed second element.
+    """
+    expected_msg = re.escape(
+        pattern="List contains elements of mixed types "
+        "that would be coerced to strings (found types: list, str)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
+        literalize(
+            source=json.dumps(
+                obj=[[1, 2], ["hello", ["nested"]]],
+            ),
+            input_format=InputFormat.JSON,
+            language=MOJO,
+            pre_indent_level=0,
+            include_delimiters=True,
+            variable_name=None,
+            new_variable=True,
+            error_on_coercion=True,
+        )
+
+
 def test_error_on_coercion_json_raises_for_mixed_list_values() -> None:
     """Error_on_coercion raises when a list has mixed element types."""
     expected_msg = re.escape(

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -724,7 +724,10 @@ def test_java_list_rejects_null_elements() -> None:
     spec = Java(
         sequence_format=Java.sequence_formats.LIST,
     )
-    with pytest.raises(expected_exception=NullInCollectionError):
+    with pytest.raises(
+        expected_exception=NullInCollectionError,
+        match="3 items, including null",
+    ):
         literalize(
             source=json.dumps(obj=[1, None, "hello"]),
             input_format=InputFormat.JSON,

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,6 +1,7 @@
 """Language-specific tests for literalizer converter."""
 
 import json
+import re
 import textwrap
 
 import pytest
@@ -724,9 +725,14 @@ def test_java_list_rejects_null_elements() -> None:
     spec = Java(
         sequence_format=Java.sequence_formats.LIST,
     )
+    expected_msg = re.escape(
+        pattern="Java's List.of() does not accept null elements"
+        " (got 3 items, including null). "
+        "Use sequence_format=ARRAY instead."
+    )
     with pytest.raises(
         expected_exception=NullInCollectionError,
-        match="3 items, including null",
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source=json.dumps(obj=[1, None, "hello"]),

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -611,7 +611,10 @@ def test_r_empty_dict_key_error() -> None:
         sequence_format=R.sequence_formats.LIST,
     )
     yaml_string = '{"": "value"}\n'
-    with pytest.raises(expected_exception=InvalidDictKeyError):
+    with pytest.raises(
+        expected_exception=InvalidDictKeyError,
+        match=r'dict key ""',
+    ):
         literalize(
             source=yaml_string,
             input_format=InputFormat.YAML,
@@ -1012,7 +1015,10 @@ def test_error_on_coercion_raises_for_mixed_dict_none_list() -> None:
 def test_dhall_empty_dict_key_error() -> None:
     """Dhall raises InvalidDictKeyError for empty-string dict keys."""
     yaml_string = '{"": "value"}\n'
-    with pytest.raises(expected_exception=InvalidDictKeyError):
+    with pytest.raises(
+        expected_exception=InvalidDictKeyError,
+        match=r'dict key ""',
+    ):
         literalize(
             source=yaml_string,
             input_format=InputFormat.YAML,
@@ -1045,7 +1051,10 @@ def test_dhall_control_char_in_string() -> None:
 def test_dhall_control_char_key_error() -> None:
     """Dhall rejects control characters in dict keys."""
     yaml_string = '{"\\x01": "value"}\n'
-    with pytest.raises(expected_exception=InvalidDictKeyError):
+    with pytest.raises(
+        expected_exception=InvalidDictKeyError,
+        match="dict key",
+    ):
         literalize(
             source=yaml_string,
             input_format=InputFormat.YAML,

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,5 +1,6 @@
 """Tests for YAML-related literalizer functionality."""
 
+import re
 import textwrap
 
 import pytest
@@ -611,9 +612,14 @@ def test_r_empty_dict_key_error() -> None:
         sequence_format=R.sequence_formats.LIST,
     )
     yaml_string = '{"": "value"}\n'
+    expected_msg = re.escape(
+        pattern='R does not support the dict key "". '
+        "Use empty_dict_key=R.EmptyDictKey.POSITIONAL to emit them "
+        "as unnamed list elements instead."
+    )
     with pytest.raises(
         expected_exception=InvalidDictKeyError,
-        match=r'dict key ""',
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source=yaml_string,
@@ -1015,9 +1021,14 @@ def test_error_on_coercion_raises_for_mixed_dict_none_list() -> None:
 def test_dhall_empty_dict_key_error() -> None:
     """Dhall raises InvalidDictKeyError for empty-string dict keys."""
     yaml_string = '{"": "value"}\n'
+    expected_msg = re.escape(
+        pattern='Dhall does not support the dict key "". '
+        "Backtick-quoted labels must be non-empty and contain only "
+        "printable ASCII (no backticks or control characters)."
+    )
     with pytest.raises(
         expected_exception=InvalidDictKeyError,
-        match=r'dict key ""',
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source=yaml_string,
@@ -1051,9 +1062,14 @@ def test_dhall_control_char_in_string() -> None:
 def test_dhall_control_char_key_error() -> None:
     """Dhall rejects control characters in dict keys."""
     yaml_string = '{"\\x01": "value"}\n'
+    expected_msg = re.escape(
+        pattern='Dhall does not support the dict key "\\u{0001}". '
+        "Backtick-quoted labels must be non-empty and contain only "
+        "printable ASCII (no backticks or control characters)."
+    )
     with pytest.raises(
         expected_exception=InvalidDictKeyError,
-        match="dict key",
+        match=f"^{expected_msg}$",
     ):
         literalize(
             source=yaml_string,

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -912,7 +912,14 @@ def test_error_on_coercion_raises_for_mixed_dict_values() -> None:
           - user
     """,
     )
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="Dict contains values of mixed types "
+        "that would be coerced to strings (found types: list, str)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=yaml_string,
             input_format=InputFormat.YAML,
@@ -934,7 +941,14 @@ def test_error_on_coercion_raises_for_mixed_list_values() -> None:
           - nested
     """,
     )
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="List contains elements of mixed types "
+        "that would be coerced to strings (found types: list, str)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=yaml_string,
             input_format=InputFormat.YAML,
@@ -959,7 +973,14 @@ def test_error_on_coercion_raises_for_mixed_dict_shapes() -> None:
           - type: update
     """,
     )
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="List contains dicts with different key sets "
+        "that would be padded with null values",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=yaml_string,
             input_format=InputFormat.YAML,
@@ -1005,7 +1026,14 @@ def test_error_on_coercion_raises_for_mixed_dict_none_list() -> None:
         extra:
     """,
     )
-    with pytest.raises(expected_exception=HeterogeneousCoercionError):
+    expected_msg = re.escape(
+        pattern="Dict contains values of mixed types "
+        "that would be coerced to strings (found types: list, none)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
         literalize(
             source=yaml_string,
             input_format=InputFormat.YAML,


### PR DESCRIPTION
## Summary
- `HeterogeneousCoercionError` now includes the mixed scalar types found (e.g. `found types: float, int`)
- `InvalidDictKeyError` now includes the offending dict key in the message
- `NullInCollectionError` now includes the collection size
- Updated existing tests to verify the contextual information via `match=`

Closes #985

## Test plan
- [x] All 267 existing tests pass
- [x] Updated tests verify error messages contain the expected context
- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to enriching exception messages and adding helper logic used only when raising errors, with updated tests to pin message content.
> 
> **Overview**
> Improves multiple error paths to include actionable context in raised exceptions.
> 
> `HeterogeneousCoercionError` messages now append the detected scalar/type families (including for sibling lists and mixed dict/list value coercions), `InvalidDictKeyError` for Dhall/R now includes the offending key, and Java `NullInCollectionError` for `List.of()` now reports the collection size. Tests were updated (and expanded for nested mixed-type cases) to assert the exact error messages via `match=`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04d8259f4d818317fa07fbf2aab937ed2a4a551a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->