### PR TITLE
Extract shared helpers from check_*_syntax.py scripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,7 +84,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.gleam
-          extra_config_patterns: check_gleam_syntax.py
+          extra_config_patterns: |
+            check_gleam_syntax.py
+            check_syntax_helpers.py
       - name: Install Gleam
         if: steps.find-files.outputs.found == 'true'
         uses: erlef/setup-beam@v1
@@ -358,7 +360,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cs
-          extra_config_patterns: check_csharp_syntax.py
+          extra_config_patterns: |
+            check_csharp_syntax.py
+            check_syntax_helpers.py
       - name: Initialize .NET runtime
         if: steps.find-files.outputs.found == 'true'
         run: |
@@ -796,7 +800,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.adb
-          extra_config_patterns: check_ada_syntax.py
+          extra_config_patterns: |
+            check_ada_syntax.py
+            check_syntax_helpers.py
       - name: Install GNAT
         if: steps.find-files.outputs.found == 'true'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq gnat
@@ -983,7 +989,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.purs
-          extra_config_patterns: check_purescript_syntax.py
+          extra_config_patterns: |
+            check_purescript_syntax.py
+            check_syntax_helpers.py
       - uses: purescript-contrib/setup-purescript@main
         if: steps.find-files.outputs.found == 'true'
         with:
@@ -1165,7 +1173,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.vb
-          extra_config_patterns: check_vb_syntax.py
+          extra_config_patterns: |
+            check_vb_syntax.py
+            check_syntax_helpers.py
       - name: Initialize .NET runtime
         if: steps.find-files.outputs.found == 'true'
         run: |

--- a/check_ada_syntax.py
+++ b/check_ada_syntax.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from check_syntax_helpers import fail_on_error
+
 
 def main() -> None:
     """Check syntax of the given Ada golden file."""
@@ -23,10 +25,11 @@ def main() -> None:
             check=False,
             cwd=tmpdir,
         )
-    if result.returncode != 0:
-        msg = f"{filename}: Ada syntax error\n{result.stderr}"
-        sys.stderr.write(msg)
-        sys.exit(1)
+    fail_on_error(
+        result=result,
+        filename=filename,
+        label="Ada syntax error",
+    )
 
 
 if __name__ == "__main__":

--- a/check_csharp_syntax.py
+++ b/check_csharp_syntax.py
@@ -7,44 +7,18 @@ import sys
 import tempfile
 from pathlib import Path
 
-_DOTNET_ENV = {
-    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
-    "DOTNET_NOLOGO": "1",
-}
-
-
-def _target_framework(dotnet_path: str) -> str:
-    """Return the target framework moniker for the installed
-    ``dotnet``.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        dotnet_tmp = Path(tmpdir) / "tmp"
-        dotnet_tmp.mkdir()
-        env = os.environ.copy()
-        env.update(
-            {
-                "TMPDIR": dotnet_tmp.as_posix(),
-                "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
-            }
-        )
-        result = subprocess.run(
-            args=[dotnet_path, "--version"],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-        )
-    version = result.stdout.strip()
-    major_minor = ".".join(version.split(sep=".")[:2])
-    return f"net{major_minor}"
+from check_syntax_helpers import (
+    DOTNET_ENV,
+    dotnet_target_framework,
+    fail_on_error,
+)
 
 
 def main() -> None:
     """Check syntax of the given C# golden file."""
     filename = sys.argv[1]
     dotnet_path: str = shutil.which(cmd="dotnet") or "dotnet"
-    target_framework = _target_framework(dotnet_path=dotnet_path)
+    target_framework = dotnet_target_framework(dotnet_path=dotnet_path)
     content = Path(filename).read_text(encoding="utf-8")
 
     csproj = (
@@ -77,7 +51,7 @@ def main() -> None:
             {
                 "TMPDIR": dotnet_tmp.as_posix(),
                 "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
+                **DOTNET_ENV,
             }
         )
         result = subprocess.run(
@@ -87,12 +61,11 @@ def main() -> None:
             check=False,
             env=env,
         )
-    if result.returncode != 0:
-        msg = (
-            f"{filename}: dotnet build failed\n{result.stderr}{result.stdout}"
-        )
-        sys.stderr.write(msg)
-        sys.exit(1)
+    fail_on_error(
+        result=result,
+        filename=filename,
+        label="dotnet build failed",
+    )
 
 
 if __name__ == "__main__":

--- a/check_gleam_syntax.py
+++ b/check_gleam_syntax.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from check_syntax_helpers import fail_on_error
+
 _GLEAM_TOML = """\
 name = "check"
 version = "1.0.0"
@@ -32,13 +34,11 @@ def main() -> None:
             check=False,
             cwd=tmpdir,
         )
-        if deps_result.returncode != 0:
-            msg = (
-                f"gleam deps download failed\n"
-                f"{deps_result.stderr}{deps_result.stdout}"
-            )
-            sys.stderr.write(msg)
-            sys.exit(1)
+        fail_on_error(
+            result=deps_result,
+            filename=filename,
+            label="gleam deps download failed",
+        )
         src = Path(filename)
         target = src_dir / "check.gleam"
         target.write_text(
@@ -52,13 +52,11 @@ def main() -> None:
             check=False,
             cwd=tmpdir,
         )
-        if result.returncode != 0:
-            msg = (
-                f"{filename}: gleam check failed\n"
-                f"{result.stderr}{result.stdout}"
-            )
-            sys.stderr.write(msg)
-            sys.exit(1)
+        fail_on_error(
+            result=result,
+            filename=filename,
+            label="gleam check failed",
+        )
 
 
 if __name__ == "__main__":

--- a/check_purescript_syntax.py
+++ b/check_purescript_syntax.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from check_syntax_helpers import fail_on_error
+
 _PRELUDE_PURS = """\
 module Prelude where
 foreign import negate :: forall a. a -> a
@@ -43,13 +45,11 @@ def main() -> None:
             text=True,
             check=False,
         )
-        if result.returncode != 0:
-            msg = (
-                f"{filename}: purs compile failed\n"
-                f"{result.stderr}{result.stdout}"
-            )
-            sys.stderr.write(msg)
-            sys.exit(1)
+        fail_on_error(
+            result=result,
+            filename=filename,
+            label="purs compile failed",
+        )
 
 
 if __name__ == "__main__":

--- a/check_syntax_helpers.py
+++ b/check_syntax_helpers.py
@@ -1,0 +1,52 @@
+"""Shared helpers for ``check_*_syntax.py`` scripts."""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DOTNET_ENV = {
+    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
+    "DOTNET_NOLOGO": "1",
+}
+
+
+def dotnet_target_framework(dotnet_path: str) -> str:
+    """Return the target framework moniker for the installed
+    ``dotnet``.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dotnet_tmp = Path(tmpdir) / "tmp"
+        dotnet_tmp.mkdir()
+        env = os.environ.copy()
+        env.update(
+            {
+                "TMPDIR": dotnet_tmp.as_posix(),
+                "HOME": dotnet_tmp.as_posix(),
+                **DOTNET_ENV,
+            }
+        )
+        result = subprocess.run(
+            args=[dotnet_path, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+    version = result.stdout.strip()
+    major_minor = ".".join(version.split(sep=".")[:2])
+    return f"net{major_minor}"
+
+
+def fail_on_error(
+    result: subprocess.CompletedProcess[str],
+    *,
+    filename: str,
+    label: str,
+) -> None:
+    """Write an error message and exit if *result* indicates failure."""
+    if result.returncode != 0:
+        msg = f"{filename}: {label}\n{result.stderr}{result.stdout}"
+        sys.stderr.write(msg)
+        sys.exit(1)

--- a/check_vb_syntax.py
+++ b/check_vb_syntax.py
@@ -7,44 +7,18 @@ import sys
 import tempfile
 from pathlib import Path
 
-_DOTNET_ENV = {
-    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
-    "DOTNET_NOLOGO": "1",
-}
-
-
-def _target_framework(dotnet_path: str) -> str:
-    """Return the target framework moniker for the installed
-    ``dotnet``.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        dotnet_tmp = Path(tmpdir) / "tmp"
-        dotnet_tmp.mkdir()
-        env = os.environ.copy()
-        env.update(
-            {
-                "TMPDIR": dotnet_tmp.as_posix(),
-                "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
-            }
-        )
-        result = subprocess.run(
-            args=[dotnet_path, "--version"],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-        )
-    version = result.stdout.strip()
-    major_minor = ".".join(version.split(sep=".")[:2])
-    return f"net{major_minor}"
+from check_syntax_helpers import (
+    DOTNET_ENV,
+    dotnet_target_framework,
+    fail_on_error,
+)
 
 
 def main() -> None:
     """Check syntax of the given VB.NET golden file."""
     filename = sys.argv[1]
     dotnet_path: str = shutil.which(cmd="dotnet") or "dotnet"
-    target_framework = _target_framework(dotnet_path=dotnet_path)
+    target_framework = dotnet_target_framework(dotnet_path=dotnet_path)
     content = Path(filename).read_text(encoding="utf-8")
 
     vbproj = (
@@ -76,7 +50,7 @@ def main() -> None:
             {
                 "TMPDIR": dotnet_tmp.as_posix(),
                 "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
+                **DOTNET_ENV,
             }
         )
         result = subprocess.run(
@@ -86,12 +60,11 @@ def main() -> None:
             check=False,
             env=env,
         )
-    if result.returncode != 0:
-        msg = (
-            f"{filename}: dotnet build failed\n{result.stderr}{result.stdout}"
-        )
-        sys.stderr.write(msg)
-        sys.exit(1)
+    fail_on_error(
+        result=result,
+        filename=filename,
+        label="dotnet build failed",
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,7 @@ ignore = [
     "tests/**",
     "zizmor.yml",
     "check_csharp_syntax.py",
+    "check_syntax_helpers.py",
     ".clj-kondo",
     ".clj-kondo/**",
 ]
@@ -298,6 +299,7 @@ follow_untyped_imports = true
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
+search-path = [ ".", "src" ]
 
 [tool.pyright]
 enableTypeIgnoreComments = false


### PR DESCRIPTION
## Summary
- Extract duplicated `_target_framework()` and `_DOTNET_ENV` from `check_csharp_syntax.py` and `check_vb_syntax.py` into a new `check_syntax_helpers.py` module
- Extract common subprocess error-handling pattern into `fail_on_error()`, used by ada, csharp, vb, gleam, and purescript check scripts
- Update CI workflow `extra_config_patterns` to include the shared helper for cache invalidation
- Add pyrefly `search-path` config so it can resolve root-level module imports

Closes #1005

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, pyright, pyrefly, ty, vulture, etc.)
- [ ] CI lint jobs pass for all affected languages (ada, csharp, vb, gleam, purescript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it deletes the previous public conversion API and introduces a large new parsing/formatting pipeline (new dependencies, coercion logic, and comment handling) alongside major CI workflow changes that can affect build stability and release/publish behavior.
> 
> **Overview**
> **Replaces the legacy JSON-only API** (`convert_json_to_native_literal`) with a new public `literalize` entrypoint and `InputFormat` enum, returning a richer `LiteralizeResult` (e.g. `preamble`, `body_preamble`, `bare_code`, `declaration_code`).
> 
> **Adds multi-format parsing and comment preservation**: JSON5 support via `pyjson5`, YAML via `ruamel.yaml`, and TOML via `tomlkit`, including new `_comments.py` logic to extract/attach YAML/TOML comments (and to handle languages that can’t embed comments inline).
> 
> **Expands tooling and CI**: introduces a composite `find-lint-files` action and a large set of per-language syntax-check lint jobs for integration fixtures; runs pytest in parallel (`xdist`), tightens/extends pre-commit hooks and type-checking tooling, updates packaging manifest/metadata, and makes small workflow fixes (Dependabot detection, publish-site input, safer env handling in release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b5da05ed6275abab378ce8080d42586c46500a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->