### PR TITLE
Add default values to literalize() parameters

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1498,11 +1498,11 @@ def literalize(
     source: str,
     input_format: InputFormat,
     language: Language,
-    pre_indent_level: int,
-    include_delimiters: bool,
-    variable_name: str | None,
-    new_variable: bool,
-    error_on_coercion: bool,
+    pre_indent_level: int = 0,
+    include_delimiters: bool = True,
+    variable_name: str | None = None,
+    new_variable: bool = True,
+    error_on_coercion: bool = False,
 ) -> LiteralizeResult:
     r"""Convert a JSON, JSON5, YAML, or TOML string to a native
     language literal.


### PR DESCRIPTION
## Summary
- Add sensible default values to the 5 optional parameters of `literalize()`: `pre_indent_level=0`, `include_delimiters=True`, `variable_name=None`, `new_variable=True`, `error_on_coercion=False`
- Reduces boilerplate for callers who just need the common defaults

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to a large refactor of the public conversion API (removing `convert_json_to_native_literal`, introducing `literalize`/`InputFormat`/`LiteralizeResult`) plus substantial CI/pre-commit workflow expansion across many languages and new runtime dependencies.
> 
> **Overview**
> **Replaces the old JSON-only conversion entrypoint with a new `literalize()` API** that parses `JSON`, `JSON5`, `YAML`, and `TOML`, returns a richer `LiteralizeResult`, and exposes new public types/configs via `literalizer.__init__`.
> 
> **Adds comment preservation for YAML/TOML** by extracting comments (including scalar inline/before comments) and emitting them using the target language’s comment syntax, with fallback behavior for languages that can’t embed comments inside literals.
> 
> **Significantly expands repo tooling and CI**: introduces a composite action to lint only changed fixtures, adds dozens of per-language syntax lint jobs, parallelizes pytest (`-n auto`), tightens completion checks, and broadens `pre-commit`/`pyproject.toml` dev tooling (mypy/pyright/pylint/etc.), plus doc updates and packaging manifest additions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3dd49c00bb60f1b5c0ef791db3d0f62ff2689d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->