### PR TITLE
Extract _handle_special_float() helper

### DIFF
--- a/src/literalizer/_formatters/format_floats.py
+++ b/src/literalizer/_formatters/format_floats.py
@@ -5,6 +5,23 @@ import math
 from beartype import beartype
 
 
+def _handle_special_float(
+    *,
+    value: float,
+    inf_literal: str,
+    neg_inf_literal: str,
+    nan_literal: str,
+) -> str | None:
+    """Return a literal for inf, -inf, or nan; ``None`` for finite
+    values.
+    """
+    if math.isinf(value):
+        return neg_inf_literal if value < 0 else inf_literal
+    if math.isnan(value):
+        return nan_literal
+    return None
+
+
 @beartype
 def format_float_repr(
     value: float,
@@ -20,10 +37,14 @@ def format_float_repr(
 
     Special values (inf, -inf, nan) use the provided literals.
     """
-    if math.isinf(value):
-        return neg_inf_literal if value < 0 else inf_literal
-    if math.isnan(value):
-        return nan_literal
+    special = _handle_special_float(
+        value=value,
+        inf_literal=inf_literal,
+        neg_inf_literal=neg_inf_literal,
+        nan_literal=nan_literal,
+    )
+    if special is not None:
+        return special
     return repr(value)
 
 
@@ -44,11 +65,14 @@ def format_float_scientific(
     compact, but a trailing ``.0`` is preserved to keep the value
     recognizable as a float.
     """
-    # inf, -inf, nan do not have an "e" component.
-    if math.isinf(value):
-        return neg_inf_literal if value < 0 else inf_literal
-    if math.isnan(value):
-        return nan_literal
+    special = _handle_special_float(
+        value=value,
+        inf_literal=inf_literal,
+        neg_inf_literal=neg_inf_literal,
+        nan_literal=nan_literal,
+    )
+    if special is not None:
+        return special
     raw = f"{value:e}"
     mantissa, exponent_part = raw.split(sep="e")
     # Strip trailing zeros but keep at least one decimal digit.
@@ -73,8 +97,12 @@ def format_float_fixed(
 
     Example: ``1500.0`` -> ``"1500.000000"``, ``0.001`` -> ``"0.001000"``.
     """
-    if math.isinf(value):
-        return neg_inf_literal if value < 0 else inf_literal
-    if math.isnan(value):
-        return nan_literal
+    special = _handle_special_float(
+        value=value,
+        inf_literal=inf_literal,
+        neg_inf_literal=neg_inf_literal,
+        nan_literal=nan_literal,
+    )
+    if special is not None:
+        return special
     return f"{value:f}"


### PR DESCRIPTION
## Summary
- Extracts the duplicated inf/nan/neg-inf check block from all three float formatters into a shared `_handle_special_float()` helper
- The helper returns the appropriate literal string for special values, or `None` for finite values

Closes #980

## Test plan
- [x] All 175 existing tests pass
- [x] All pre-commit hooks pass (mypy, pyright, ty, pyrefly, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only de-duplicates the special-case branching for `inf`, `-inf`, and `nan` without changing the formatting logic for finite values.
> 
> **Overview**
> Refactors `format_float_repr`, `format_float_scientific`, and `format_float_fixed` to delegate `inf`/`-inf`/`nan` handling to a new `_handle_special_float()` helper, removing duplicated checks and standardizing the early-return behavior for special float values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad28b6cd00d92ce277c93c855c865a860f7f276f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->