### PR TITLE
Expand languages.rst with guidance on language selection and customization

### DIFF
--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -3,6 +3,139 @@
 Languages
 =========
 
+Every target language is a class in :mod:`literalizer.languages`.
+You import the class, optionally configure it, and pass an instance to
+:func:`~literalizer.literalize`.
+
+Selecting a language
+--------------------
+
+Each language class lives in :mod:`literalizer.languages` and is listed in
+:data:`~literalizer.languages.ALL_LANGUAGES`.
+Create an instance with its defaults, or override individual format options:
+
+.. code-block:: python
+
+   """Select and configure a language."""
+
+   from literalizer import InputFormat, literalize
+   from literalizer.languages import Python
+
+   # Use all defaults
+   result = literalize(
+       source='{"x": 1}',
+       input_format=InputFormat.JSON,
+       language=Python(),
+   )
+
+   # Override specific formats
+   result = literalize(
+       source='{"x": 1}',
+       input_format=InputFormat.JSON,
+       language=Python(
+           sequence_format=Python.sequence_formats.LIST,
+           string_format=Python.string_formats.SINGLE,
+           trailing_comma=Python.trailing_commas.NO,
+       ),
+   )
+
+Format options
+--------------
+
+Language classes define nested :class:`~enum.Enum` classes that control how
+each data type is rendered.
+The available enums vary by language, but the most common ones are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Enum
+     - Controls
+   * - ``DateFormats``
+     - How ``datetime.date`` values are rendered (e.g. ISO string, constructor call).
+   * - ``DatetimeFormats``
+     - How ``datetime.datetime`` values are rendered.
+   * - ``BytesFormats``
+     - Bytes encoding (hex, base64, or language-native).
+   * - ``SequenceFormats``
+     - Collection type for lists (e.g. ``TUPLE``, ``LIST``, ``ARRAY``, ``VEC``, ``SLICE``).
+   * - ``SetFormats``
+     - Collection type for sets (e.g. ``SET``, ``FROZENSET``, ``HASHSET``).
+   * - ``DictFormats``
+     - Map type (e.g. ``DEFAULT``, ``ORDERED``, ``HASHMAP``).
+   * - ``StringFormats``
+     - Quote style (``SINGLE``, ``DOUBLE``, ``BACKTICK``, ``RAW``).
+   * - ``IntegerFormats``
+     - Numeric base (``DECIMAL``, ``HEX``, ``OCTAL``, ``BINARY``).
+   * - ``FloatFormats``
+     - Float rendering (``REPR``, ``FIXED``, ``SCIENTIFIC``).
+   * - ``CommentFormats``
+     - Comment syntax (``HASH``, ``DOUBLE_SLASH``, etc.).
+   * - ``DeclarationStyles``
+     - Variable declaration keyword (``ASSIGN``, ``LET``, ``VAR``, ``CONST``).
+   * - ``TrailingCommas``
+     - Whether to emit a trailing comma in multi-line collections.
+   * - ``LineEndings``
+     - Statement terminator (``SEMICOLON``, ``NEWLINE``, ``NONE``).
+
+Access a language's enum members through the class itself, e.g.
+``Go.sequence_formats.SLICE`` for Go slices or ``Go.date_formats.GO``
+for the ``time.Date(...)`` constructor.
+
+Each ``__init__`` parameter has a sensible default, so you only need to
+specify the options you want to change.
+
+Custom language implementations
+-------------------------------
+
+To support a language that is not built in, create a class that satisfies
+the :class:`~literalizer.Language` protocol.
+Use ``metaclass=LanguageCls`` and define the required nested enum classes
+and attributes:
+
+.. skip doccmd[all]: next
+
+.. code-block:: python
+
+   import enum
+
+   from literalizer._formatters.collection_openers import fixed_sequence_open
+   from literalizer._formatters.format_entries import passthrough_sequence_entry
+   from literalizer._language import LanguageCls, SequenceFormatConfig
+
+
+   class MyLanguage(metaclass=LanguageCls):
+
+       extension = ".my"
+       pygments_name = None
+
+       class SequenceFormats(enum.Enum):
+           LIST = SequenceFormatConfig(
+               sequence_open=fixed_sequence_open(open_str="["),
+               close="]",
+               supports_heterogeneity=True,
+               single_element_trailing_comma=False,
+               supports_trailing_comma=True,
+               empty_sequence="[]",
+               preamble_lines=(),
+               format_entry=passthrough_sequence_entry,
+               typed_opener_fallback=None,
+               uses_typed_literal_for_scalars=False,
+               requires_uniform_record_shapes=False,
+               declared_type=None,
+           )
+
+       # ... define the remaining required enums and attributes ...
+
+Look at any built-in language module under ``literalizer/languages/`` for a
+complete working example.
+The :class:`~literalizer.Language` protocol documents every required
+attribute.
+
+Built-in languages
+------------------
+
 .. automodule:: literalizer.languages
    :members:
    :undoc-members:

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -109,6 +109,7 @@ dicts
 durations
 elixirc
 enum
+enums
 erlc
 fmt
 fnull


### PR DESCRIPTION
## Summary

- Adds introductory prose, code examples, and a format options reference table to `docs/source/languages.rst`
- Covers how to select and configure a language, what format enum options are available, and how to create custom language implementations
- Moves the existing autodoc output under a "Built-in languages" subsection

Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; risk is limited to potential confusion from inaccurate examples or enum names, with no runtime impact.
> 
> **Overview**
> Expands `docs/source/languages.rst` with guidance on selecting a language, configuring common format enums, and implementing a custom language (including a concrete code example), and moves the autodoc content under a new **Built-in languages** section.
> 
> Updates `spelling_private_dict.txt` to include `enums` for docs spellchecking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6c0bc4f1cbb58e3c44b8f8ed6e8cbaae32f6d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->