### PR TITLE
DRY up hardcoded uv version with YAML anchor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 fail_fast: true
 
+.uv_version: &uv_version uv==0.9.5
+
 ci:
   skip:
     - actionlint
@@ -98,7 +100,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck
@@ -107,7 +109,7 @@ repos:
         language: python
         types_or: [shell]
         exclude: ^tests/integration/cases/
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -116,7 +118,7 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt
@@ -125,7 +127,7 @@ repos:
         language: python
         types_or: [shell]
         exclude: ^tests/integration/cases/
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -134,7 +136,7 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -143,7 +145,7 @@ repos:
         language: python
         types_or: [python]
         exclude: ^tests/integration/cases/
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: mypy
@@ -153,7 +155,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
@@ -162,7 +164,7 @@ repos:
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: check-manifest
         name: check-manifest
@@ -170,7 +172,7 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright
         name: pyright
@@ -179,7 +181,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright-docs
         name: pyright-docs
@@ -188,7 +190,7 @@ repos:
           --command="pyright"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright-verifytypes
         name: pyright-verifytypes
@@ -197,7 +199,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: ty
         name: ty
@@ -206,7 +208,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: ty-docs
         name: ty-docs
@@ -215,7 +217,7 @@ repos:
           --command="ty check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyrefly
         name: pyrefly
@@ -224,7 +226,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyrefly-docs
         name: pyrefly-docs
@@ -233,7 +235,7 @@ repos:
           --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: vulture
         name: vulture
@@ -241,7 +243,7 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: vulture-docs
@@ -250,7 +252,7 @@ repos:
           --command="vulture"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyroma
@@ -259,7 +261,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [toml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: deptry
@@ -267,7 +269,7 @@ repos:
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pylint
@@ -276,7 +278,7 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pylint-docs
         name: pylint-docs
@@ -285,7 +287,7 @@ repos:
         language: python
         stages: [manual]
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: ruff-check-fix
         name: Ruff check fix
@@ -293,7 +295,7 @@ repos:
         language: python
         types_or: [python]
         exclude: ^tests/integration/cases/
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-check-fix-docs
@@ -301,7 +303,7 @@ repos:
         entry: uv run --extra=dev doccmd --language=python --command="ruff check --fix"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -310,7 +312,7 @@ repos:
         language: python
         types_or: [python]
         exclude: ^tests/integration/cases/
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-format-fix-docs
@@ -319,7 +321,7 @@ repos:
           format"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: doc8
@@ -327,7 +329,7 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: interrogate
@@ -336,7 +338,7 @@ repos:
         language: python
         types_or: [python]
         exclude: ^tests/integration/cases/
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: interrogate-docs
@@ -345,7 +347,7 @@ repos:
           --command="interrogate"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -354,7 +356,7 @@ repos:
         language: python
         types_or: [toml]
         files: pyproject.toml
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: linkcheck
@@ -365,7 +367,7 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: spelling
         name: spelling
@@ -375,7 +377,7 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: docs
         name: Build Documentation
@@ -383,7 +385,7 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: yamlfix
         name: yamlfix
@@ -391,7 +393,7 @@ repos:
         language: python
         types_or: [yaml]
         exclude: ^tests/integration/cases/
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: zizmor
@@ -400,7 +402,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -408,5 +410,5 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]


### PR DESCRIPTION
## Summary
- Extract the hardcoded `uv==0.9.5` version string (repeated 36 times) into a single YAML anchor `.uv_version` at the top of `.pre-commit-config.yaml`
- All 36 `additional_dependencies` entries now reference `*uv_version` instead of the literal string
- Future uv version bumps only need to change one line

Closes #1001

## Test plan
- [x] YAML parses correctly (`yaml.safe_load`)
- [x] `pre-commit validate-config` passes (warning about unexpected key is expected and harmless)
- [x] All pre-commit hooks pass
- [x] yamlfix formats the file without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config refactor: it only deduplicates the `uv` version string in `.pre-commit-config.yaml` and should not change hook behavior unless a YAML consumer mishandles anchors.
> 
> **Overview**
> Introduces a top-level YAML anchor `.uv_version` for `uv==0.9.5` and replaces all repeated `additional_dependencies: [uv==0.9.5]` entries with `additional_dependencies: [*uv_version]` in `.pre-commit-config.yaml`, making future `uv` version bumps a one-line change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb3e5af9bc82262c5d9b360697a6e472a71a7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->