### PR TITLE
Replace Callable[...] with Protocol classes in format factories

### DIFF
--- a/src/literalizer/_formatters/format_factories.py
+++ b/src/literalizer/_formatters/format_factories.py
@@ -1,6 +1,7 @@
 """Factory functions for building format configurations."""
 
 from collections.abc import Callable
+from typing import Protocol, runtime_checkable
 
 from beartype import beartype
 
@@ -16,6 +17,36 @@ from literalizer._language import (
     SetFormatConfig,
 )
 from literalizer._types import Value
+
+
+@runtime_checkable
+class _DictFormatBuilder(Protocol):
+    """Protocol for the callable returned by ``dict_format_factory``."""
+
+    def __call__(
+        self,
+        default_type: str,
+        *,
+        default_key_type: str = "",
+    ) -> DictFormatConfig:
+        """Build a ``DictFormatConfig`` with the given default type."""
+        ...
+
+
+@runtime_checkable
+class _OrderedMapFormatBuilder(Protocol):
+    """Protocol for the callable returned by
+    ``ordered_map_format_factory``.
+    """
+
+    def __call__(
+        self,
+        default_type: str,
+        *,
+        default_key_type: str = "",
+    ) -> OrderedMapFormatConfig:
+        """Build an ``OrderedMapFormatConfig`` with the given default type."""
+        ...
 
 
 @beartype
@@ -129,7 +160,7 @@ def dict_format_factory(
     empty_template: str | None,
     preamble_lines: tuple[str, ...],
     narrowed_open: str | None,
-) -> Callable[..., DictFormatConfig]:
+) -> _DictFormatBuilder:
     """Return a callable that builds a ``DictFormatConfig`` for a given
     type.
 
@@ -170,7 +201,7 @@ def ordered_map_format_factory(
     open_template: str,
     close: str,
     preamble_lines: tuple[str, ...],
-) -> Callable[..., OrderedMapFormatConfig]:
+) -> _OrderedMapFormatBuilder:
     """Return a callable that builds an ``OrderedMapFormatConfig``.
 
     Templates use ``{type}`` and optionally ``{key_type}`` as

--- a/src/literalizer/_formatters/format_factories.py
+++ b/src/literalizer/_formatters/format_factories.py
@@ -30,7 +30,7 @@ class _DictFormatBuilder(Protocol):
         default_key_type: str = "",
     ) -> DictFormatConfig:
         """Build a ``DictFormatConfig`` with the given default type."""
-        ...
+        ...  # pylint: disable=unnecessary-ellipsis
 
 
 @runtime_checkable
@@ -46,7 +46,7 @@ class _OrderedMapFormatBuilder(Protocol):
         default_key_type: str = "",
     ) -> OrderedMapFormatConfig:
         """Build an ``OrderedMapFormatConfig`` with the given default type."""
-        ...
+        ...  # pylint: disable=unnecessary-ellipsis
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace vague `Callable[..., DictFormatConfig]` and `Callable[..., OrderedMapFormatConfig]` return types with explicit `_DictFormatBuilder` and `_OrderedMapFormatBuilder` Protocol classes
- The Protocol `__call__` signatures match the inner `_build` functions exactly: `(default_type: str, *, default_key_type: str = "") -> ...`
- Protocols are `@runtime_checkable` for compatibility with beartype

Closes #1009

## Test plan
- [x] All 10591 tests pass
- [x] mypy passes with no issues
- [x] All pre-commit hooks pass (including interrogate, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change that tightens the return types of `dict_format_factory` and `ordered_map_format_factory` without altering runtime behavior, aside from enabling clearer static/type-checking contracts.
> 
> **Overview**
> Replaces the generic `Callable[..., DictFormatConfig]` / `Callable[..., OrderedMapFormatConfig]` return annotations in `format_factories.py` with explicit, `@runtime_checkable` `Protocol` builder types (`_DictFormatBuilder`, `_OrderedMapFormatBuilder`) whose `__call__` signatures match the inner `_build` functions (including `default_key_type`).
> 
> This improves type precision for callers of these factories while keeping the produced format configs and factory logic unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eed68f775f027d9c297016b90a68dc000a3b5364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->