### PR TITLE
Document ruamel.yaml column semantics in _parse_after_token

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -64,8 +64,15 @@ def _parse_after_token(
 ) -> _ParsedAfterToken:
     """Parse an after-element comment token.
 
-    The *column* of the token determines whether its first line
-    is an inline comment (column > 0) or a standalone comment.
+    ruamel.yaml stores each comment as a ``CommentToken`` whose
+    ``column`` attribute records the column position where the
+    comment appeared in the original YAML source.  An inline
+    comment (one that follows a value on the same line) always has
+    ``column > 0`` because it appears after at least some content.
+    A standalone comment that starts at the beginning of a line has
+    ``column == 0``.  We use this to decide whether the first line
+    of the token should be treated as an inline comment or as a
+    standalone (before-next-element) comment.
     """
     value: str = token.value
     column: int = token.column


### PR DESCRIPTION
## Summary
- Expands the docstring of `_parse_after_token` to explain how ruamel.yaml assigns `column` values to `CommentToken` objects and why `column > 0` reliably distinguishes inline from standalone comments.

Closes #994

## Test plan
- [x] All 10593 existing tests pass
- [x] Pre-commit hooks pass (pydocstringformatter, interrogate, ruff, mypy, pyright, ty, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change: expands `_parse_after_token` docstring without altering parsing logic or data handling.
> 
> **Overview**
> Clarifies `_parse_after_token`’s docstring to explicitly document how ruamel.yaml’s `CommentToken.column` distinguishes *inline* (`column > 0`) from *standalone* (`column == 0`) comments, and how that drives whether the first token line is treated as inline vs “before next element”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f702c0cf63842668fb728b5c0da611423f2a2525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->