### PR TITLE
Fix mixed-type error reporting for nested dict/list containers

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -482,35 +482,55 @@ def _describe_heterogeneous_types(*, data: Value) -> str:
     return ", ".join(sorted(_collect_scalar_type_names(data=data)))
 
 
-def _find_first_mixed_values(*, data: Value) -> Sequence[Value]:
+def _find_first_mixed_values(
+    *,
+    data: Value,
+    container_type: type,
+) -> Sequence[Value]:
     """Return the first collection of children in *data* that spans
     multiple type families.
 
-    Walks the tree until it finds a dict-values or list-elements level
-    where ``_dict_values_mixed_types`` is ``True``.
+    Only considers collections whose immediate container matches
+    *container_type* (``dict`` or ``list``).
     """
     children: Sequence[Value]
     match data:
         case ordereddict() | dict():
             children = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+            if container_type is dict and _dict_values_mixed_types(
+                values=children,
+            ):
+                return children
         case list():
             children = data
+            if container_type is list and _dict_values_mixed_types(
+                values=children,
+            ):
+                return children
         case _:
             return []
-    if _dict_values_mixed_types(values=children):
-        return children
     for child in children:
-        result = _find_first_mixed_values(data=child)
+        result = _find_first_mixed_values(
+            data=child,
+            container_type=container_type,
+        )
         if result:
             return result
     return []
 
 
-def _describe_mixed_type_families(*, data: Value) -> str:
+def _describe_mixed_type_families(
+    *,
+    data: Value,
+    container_type: type,
+) -> str:
     """Return a sorted, comma-separated string of type families for the
     first collection in *data* whose children span multiple families.
     """
-    values = _find_first_mixed_values(data=data)
+    values = _find_first_mixed_values(
+        data=data,
+        container_type=container_type,
+    )
     return ", ".join(sorted({_value_type_family(value=v) for v in values}))
 
 
@@ -1197,7 +1217,10 @@ def _apply_coercions(
                 )
                 raise HeterogeneousCoercionError(msg)
             if _has_mixed_dict_values(data=data):
-                types = _describe_mixed_type_families(data=data)
+                types = _describe_mixed_type_families(
+                    data=data,
+                    container_type=dict,
+                )
                 msg = (
                     "Dict contains values of mixed types "
                     "that would be coerced to strings"
@@ -1205,7 +1228,10 @@ def _apply_coercions(
                 )
                 raise HeterogeneousCoercionError(msg)
             if _has_mixed_list_values(data=data):
-                types = _describe_mixed_type_families(data=data)
+                types = _describe_mixed_type_families(
+                    data=data,
+                    container_type=list,
+                )
                 msg = (
                     "List contains elements of mixed types "
                     "that would be coerced to strings"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -976,6 +976,36 @@ def test_error_on_coercion_json_raises_for_mixed_list_values() -> None:
         )
 
 
+def test_error_on_coercion_json_mixed_dict_inside_mixed_list() -> None:
+    """Error message reports dict type families when a mixed dict is
+    nested inside a mixed list.
+
+    ``_find_first_mixed_values`` must only consider dicts (not lists)
+    when called from the ``_has_mixed_dict_values`` error path, otherwise
+    it finds the enclosing mixed list first and reports wrong types.
+    """
+    expected_msg = re.escape(
+        pattern="Dict contains values of mixed types "
+        "that would be coerced to strings (found types: list, str)",
+    )
+    with pytest.raises(
+        expected_exception=HeterogeneousCoercionError,
+        match=f"^{expected_msg}$",
+    ):
+        literalize(
+            source=json.dumps(
+                obj={"wrapper": [{"a": "x", "b": [1]}, "text"]},
+            ),
+            input_format=InputFormat.JSON,
+            language=MOJO,
+            pre_indent_level=0,
+            include_delimiters=True,
+            variable_name=None,
+            new_variable=True,
+            error_on_coercion=True,
+        )
+
+
 def test_error_on_coercion_json_raises_for_mixed_dict_shapes() -> None:
     """Error_on_coercion raises when a list has dicts with different
     keys, including when the list is nested inside a dict.


### PR DESCRIPTION
## Summary
- `_find_first_mixed_values` previously treated dicts and lists identically when searching for mixed-type collections, so a mixed list wrapping a mixed dict would be found first, producing wrong type families in the error message (e.g., "dict, str" instead of "list, str")
- Added a `container_type` parameter to `_find_first_mixed_values` and `_describe_mixed_type_families` so the search only considers the relevant container kind
- Added a regression test with a mixed dict nested inside a mixed list

## Test plan
- [x] New test `test_error_on_coercion_json_mixed_dict_inside_mixed_list` passes
- [x] Full test suite (10594 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only mixed-type *error reporting* by narrowing the search to the relevant container kind, plus a focused regression test; coercion behavior is otherwise unchanged.
> 
> **Overview**
> Fixes mixed-type coercion error messages so they report the type families for the **correct container level** when mixed dicts/lists are nested (e.g., a mixed dict inside a mixed list).
> 
> This updates `_find_first_mixed_values`/`_describe_mixed_type_families` to accept a `container_type` filter and wires it into the `error_on_coercion` paths for `_has_mixed_dict_values` vs `_has_mixed_list_values`, and adds a regression test covering the nested mixed dict-in-list case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bed35cc1ac33032bbe53f59a4db10c4489a6d89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->