### PR TITLE
Add bytes roundtrip tests for more languages

### DIFF
--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -184,7 +184,7 @@ def test_roundtrip_bytes_erlang_binary(data: bytes) -> None:
         return
     match = re.fullmatch(pattern=r"<<(.+)>>", string=result)
     assert match is not None
-    byte_values = [int(x.strip()) for x in match.group(1).split(",")]
+    byte_values = [int(x.strip()) for x in match.group(1).split(sep=",")]
     assert bytes(byte_values) == data
 
 
@@ -261,5 +261,5 @@ def test_roundtrip_yaml_binary_erlang(data: bytes) -> None:
         return
     match = re.fullmatch(pattern=r"<<(.+)>>", string=code)
     assert match is not None
-    byte_values = [int(x.strip()) for x in match.group(1).split(",")]
+    byte_values = [int(x.strip()) for x in match.group(1).split(sep=",")]
     assert bytes(byte_values) == data

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -3,12 +3,23 @@
 import ast
 import base64
 import json
+import re
 
+import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from literalizer import InputFormat, literalize
-from literalizer.languages import Python
+from literalizer._language import Language
+from literalizer.languages import (
+    Cpp,
+    Erlang,
+    Go,
+    Java,
+    Python,
+    Rust,
+    Swift,
+)
 
 # Use LIST sequence format so that ast.literal_eval returns plain lists,
 # matching the JSON input directly without any conversion step.
@@ -154,3 +165,101 @@ def test_roundtrip_yaml_binary_python(data: bytes) -> None:
     )
     code = result.code.rstrip(",")
     assert ast.literal_eval(node_or_string=code) == data.hex()
+
+
+RUST_LANG = Rust()
+GO_LANG = Go()
+JAVA_LANG = Java()
+SWIFT_LANG = Swift()
+CPP_LANG = Cpp()
+ERLANG_LANG = Erlang()
+
+
+@given(data=st.binary())
+def test_roundtrip_bytes_erlang_binary(data: bytes) -> None:
+    """Erlang binary literal round-trips."""
+    result = ERLANG_LANG.format_bytes(data)
+    if not data:
+        assert result == "<<>>"
+        return
+    match = re.fullmatch(pattern=r"<<(.+)>>", string=result)
+    assert match is not None
+    byte_values = [int(x.strip()) for x in match.group(1).split(",")]
+    assert bytes(byte_values) == data
+
+
+@pytest.mark.parametrize(
+    argnames="language",
+    argvalues=[
+        pytest.param(RUST_LANG, id="Rust"),
+        pytest.param(GO_LANG, id="Go"),
+        pytest.param(JAVA_LANG, id="Java"),
+        pytest.param(SWIFT_LANG, id="Swift"),
+        pytest.param(CPP_LANG, id="Cpp"),
+    ],
+)
+@given(data=st.binary())
+def test_roundtrip_bytes_hex_languages(
+    language: Language,
+    data: bytes,
+) -> None:
+    """Format_bytes_hex round-trips for non-Python languages."""
+    result = language.format_bytes(data)
+    assert bytes.fromhex(result.strip('"')) == data
+
+
+@pytest.mark.parametrize(
+    argnames="language",
+    argvalues=[
+        pytest.param(RUST_LANG, id="Rust"),
+        pytest.param(GO_LANG, id="Go"),
+        pytest.param(JAVA_LANG, id="Java"),
+        pytest.param(SWIFT_LANG, id="Swift"),
+        pytest.param(CPP_LANG, id="Cpp"),
+    ],
+)
+@given(data=st.binary())
+def test_roundtrip_yaml_binary_hex_languages(
+    language: Language,
+    data: bytes,
+) -> None:
+    """YAML !!binary -> literalize (hex-format languages) round-trips."""
+    encoded = base64.b64encode(s=data).decode()
+    yaml_string = f"- !!binary |\n  {encoded}\n"
+    result = literalize(
+        source=yaml_string,
+        input_format=InputFormat.YAML,
+        language=language,
+        pre_indent_level=0,
+        include_delimiters=False,
+        variable_name=None,
+        new_variable=True,
+        error_on_coercion=False,
+    )
+    code = result.code.rstrip(",")
+    assert bytes.fromhex(code.strip('"')) == data
+
+
+@given(data=st.binary())
+def test_roundtrip_yaml_binary_erlang(data: bytes) -> None:
+    """YAML !!binary -> literalize (Erlang binary format) round-trips."""
+    encoded = base64.b64encode(s=data).decode()
+    yaml_string = f"- !!binary |\n  {encoded}\n"
+    result = literalize(
+        source=yaml_string,
+        input_format=InputFormat.YAML,
+        language=ERLANG_LANG,
+        pre_indent_level=0,
+        include_delimiters=False,
+        variable_name=None,
+        new_variable=True,
+        error_on_coercion=False,
+    )
+    code = result.code.rstrip(",")
+    if not data:
+        assert code == "<<>>"
+        return
+    match = re.fullmatch(pattern=r"<<(.+)>>", string=code)
+    assert match is not None
+    byte_values = [int(x.strip()) for x in match.group(1).split(",")]
+    assert bytes(byte_values) == data


### PR DESCRIPTION
## Summary
- Add hypothesis roundtrip tests for Rust, Go, Java, Swift, C++, and Erlang bytes formatting
- Test both direct `format_bytes` calls and the full YAML `!!binary` → `literalize` pipeline
- Erlang's unique binary literal format (`<<72, 101, ...>>`) gets dedicated roundtrip coverage

Closes #988

## Test plan
- [x] All 18 roundtrip tests pass (`pytest tests/test_roundtrip.py`)
- [x] Type checks pass (pyright, mypy)
- [x] Linting passes (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to tests and add broader coverage for `format_bytes` and YAML `!!binary` handling across languages without modifying production logic.
> 
> **Overview**
> Expands `tests/test_roundtrip.py` to property-test bytes literal formatting beyond Python, adding Hypothesis roundtrip coverage for Rust, Go, Java, Swift, C++, and Erlang.
> 
> Adds parametrized assertions for hex-based `format_bytes` outputs and end-to-end YAML `!!binary` → `literalize` roundtrips, plus dedicated parsing/empty-case handling for Erlang’s `<<...>>` binary literal format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62fb04fe434bb7b15b6303422f423b631ba03cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->