### PR TITLE
Move special float handling from format helpers to callers

### DIFF
--- a/src/literalizer/_formatters/format_floats.py
+++ b/src/literalizer/_formatters/format_floats.py
@@ -1,78 +1,28 @@
-"""Float formatting functions."""
-
-import math
+"""Float formatting functions for finite values."""
 
 from beartype import beartype
 
 
-def _handle_special_float(
-    *,
-    value: float,
-    inf_literal: str,
-    neg_inf_literal: str,
-    nan_literal: str,
-) -> str | None:
-    """Return a literal for inf, -inf, or nan; ``None`` for finite
-    values.
-    """
-    if math.isinf(value):
-        return neg_inf_literal if value < 0 else inf_literal
-    if math.isnan(value):
-        return nan_literal
-    return None
-
-
 @beartype
-def format_float_repr(
-    value: float,
-    *,
-    inf_literal: str,
-    neg_inf_literal: str,
-    nan_literal: str,
-) -> str:
-    """Format a float using Python's ``repr``.
+def format_float_repr(value: float) -> str:
+    """Format a finite float using Python's ``repr``.
 
     This produces the shortest representation that round-trips:
     ``1500.0`` stays as ``"1500.0"``, ``0.001`` as ``"0.001"``.
-
-    Special values (inf, -inf, nan) use the provided literals.
     """
-    special = _handle_special_float(
-        value=value,
-        inf_literal=inf_literal,
-        neg_inf_literal=neg_inf_literal,
-        nan_literal=nan_literal,
-    )
-    if special is not None:
-        return special
     return repr(value)
 
 
 @beartype
-def format_float_scientific(
-    value: float,
-    *,
-    inf_literal: str,
-    neg_inf_literal: str,
-    nan_literal: str,
-) -> str:
-    """Format a float in scientific notation.
+def format_float_scientific(value: float) -> str:
+    """Format a finite float in scientific notation.
 
     Example: ``1500.0`` -> ``"1.5e3"``, ``0.001`` -> ``"1e-3"``.
 
-    Special values (inf, -inf, nan) use the provided literals.
     Trailing zeros in the coefficient are stripped so the output is
     compact, but a trailing ``.0`` is preserved to keep the value
     recognizable as a float.
     """
-    special = _handle_special_float(
-        value=value,
-        inf_literal=inf_literal,
-        neg_inf_literal=neg_inf_literal,
-        nan_literal=nan_literal,
-    )
-    if special is not None:
-        return special
     raw = f"{value:e}"
     mantissa, exponent_part = raw.split(sep="e")
     # Strip trailing zeros but keep at least one decimal digit.
@@ -86,23 +36,9 @@ def format_float_scientific(
 
 
 @beartype
-def format_float_fixed(
-    value: float,
-    *,
-    inf_literal: str,
-    neg_inf_literal: str,
-    nan_literal: str,
-) -> str:
-    """Format a float in fixed-point notation (``%f``).
+def format_float_fixed(value: float) -> str:
+    """Format a finite float in fixed-point notation (``%f``).
 
     Example: ``1500.0`` -> ``"1500.000000"``, ``0.001`` -> ``"0.001000"``.
     """
-    special = _handle_special_float(
-        value=value,
-        inf_literal=inf_literal,
-        neg_inf_literal=neg_inf_literal,
-        nan_literal=nan_literal,
-    )
-    if special is not None:
-        return special
     return f"{value:f}"

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -201,33 +201,16 @@ class Ada(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="1.0 / 0.0",
-                neg_inf_literal="-1.0 / 0.0",
-                nan_literal="0.0 / 0.0",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="1.0 / 0.0",
-                neg_inf_literal="-1.0 / 0.0",
-                nan_literal="0.0 / 0.0",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="1.0 / 0.0",
-                neg_inf_literal="-1.0 / 0.0",
-                nan_literal="0.0 / 0.0",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-1.0 / 0.0" if value < 0 else "1.0 / 0.0"
+            if math.isnan(value):
+                return "0.0 / 0.0"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -217,33 +217,16 @@ class Bash(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf" if value < 0 else "inf"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -205,33 +205,16 @@ class C(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-INFINITY" if value < 0 else "INFINITY"
+            if math.isnan(value):
+                return "NAN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -166,33 +166,18 @@ class Clojure(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Double/POSITIVE_INFINITY",
-                neg_inf_literal="Double/NEGATIVE_INFINITY",
-                nan_literal="Double/NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Double/POSITIVE_INFINITY",
-                neg_inf_literal="Double/NEGATIVE_INFINITY",
-                nan_literal="Double/NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Double/POSITIVE_INFINITY",
-                neg_inf_literal="Double/NEGATIVE_INFINITY",
-                nan_literal="Double/NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "Double/NEGATIVE_INFINITY"
+                return "Double/POSITIVE_INFINITY"
+            if math.isnan(value):
+                return "Double/NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -341,33 +341,16 @@ class Cobol(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="9.99E99",
-                neg_inf_literal="-9.99E99",
-                nan_literal="0.0",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="9.99E99",
-                neg_inf_literal="-9.99E99",
-                nan_literal="0.0",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="9.99E99",
-                neg_inf_literal="-9.99E99",
-                nan_literal="0.0",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-9.99E99" if value < 0 else "9.99E99"
+            if math.isnan(value):
+                return "0.0"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -185,33 +185,16 @@ class CommonLisp(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal=_CL_INF,
-                neg_inf_literal=_CL_NEG_INF,
-                nan_literal=_CL_NAN,
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal=_CL_INF,
-                neg_inf_literal=_CL_NEG_INF,
-                nan_literal=_CL_NAN,
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal=_CL_INF,
-                neg_inf_literal=_CL_NEG_INF,
-                nan_literal=_CL_NAN,
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return _CL_NEG_INF if value < 0 else _CL_INF
+            if math.isnan(value):
+                return _CL_NAN
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -411,33 +411,16 @@ class Cpp(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-INFINITY" if value < 0 else "INFINITY"
+            if math.isnan(value):
+                return "NAN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -222,33 +222,18 @@ class Crystal(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Float64::INFINITY",
-                neg_inf_literal="-Float64::INFINITY",
-                nan_literal="Float64::NAN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Float64::INFINITY",
-                neg_inf_literal="-Float64::INFINITY",
-                nan_literal="Float64::NAN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Float64::INFINITY",
-                neg_inf_literal="-Float64::INFINITY",
-                nan_literal="Float64::NAN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "-Float64::INFINITY"
+                return "Float64::INFINITY"
+            if math.isnan(value):
+                return "Float64::NAN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -280,33 +280,18 @@ class CSharp(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="double.PositiveInfinity",
-                neg_inf_literal="double.NegativeInfinity",
-                nan_literal="double.NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="double.PositiveInfinity",
-                neg_inf_literal="double.NegativeInfinity",
-                nan_literal="double.NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="double.PositiveInfinity",
-                neg_inf_literal="double.NegativeInfinity",
-                nan_literal="double.NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "double.NegativeInfinity"
+                return "double.PositiveInfinity"
+            if math.isnan(value):
+                return "double.NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -197,33 +197,16 @@ class D(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="double.infinity",
-                neg_inf_literal="-double.infinity",
-                nan_literal="double.nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="double.infinity",
-                neg_inf_literal="-double.infinity",
-                nan_literal="double.nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="double.infinity",
-                neg_inf_literal="-double.infinity",
-                nan_literal="double.nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-double.infinity" if value < 0 else "double.infinity"
+            if math.isnan(value):
+                return "double.nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -249,33 +249,18 @@ class Dart(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="double.infinity",
-                neg_inf_literal="double.negativeInfinity",
-                nan_literal="double.nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="double.infinity",
-                neg_inf_literal="double.negativeInfinity",
-                nan_literal="double.nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="double.infinity",
-                neg_inf_literal="double.negativeInfinity",
-                nan_literal="double.nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "double.negativeInfinity"
+                return "double.infinity"
+            if math.isnan(value):
+                return "double.nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -284,33 +284,16 @@ class Dhall(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Infinity" if value < 0 else "Infinity"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -237,33 +237,16 @@ class Elixir(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal=":infinity",
-                neg_inf_literal=":negative_infinity",
-                nan_literal=":nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal=":infinity",
-                neg_inf_literal=":negative_infinity",
-                nan_literal=":nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal=":infinity",
-                neg_inf_literal=":negative_infinity",
-                nan_literal=":nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return ":negative_infinity" if value < 0 else ":infinity"
+            if math.isnan(value):
+                return ":nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import functools
 import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -97,10 +96,6 @@ def _format_elm_integer_hex(value: int) -> str:
 
 def _elm_float_wrapper(
     inner: Callable[[float], str],
-    *,
-    inf_literal: str = "EFloat (1 / 0)",
-    neg_inf_literal: str = "EFloat (-(1 / 0))",
-    nan_literal: str = "EFloat (0 / 0)",
 ) -> Callable[[float], str]:
     """Wrap a float formatter to produce ``EFloat`` constructors."""
 
@@ -108,9 +103,11 @@ def _elm_float_wrapper(
     def _format(value: float) -> str:
         """Format a float with an ``EFloat`` constructor."""
         if math.isinf(value):
-            return neg_inf_literal if value < 0 else inf_literal
+            if value < 0:
+                return "EFloat (-(1 / 0))"
+            return "EFloat (1 / 0)"
         if math.isnan(value):
-            return nan_literal
+            return "EFloat (0 / 0)"
         formatted = inner(value)
         if formatted.startswith("-"):
             return f"EFloat ({formatted})"
@@ -119,30 +116,11 @@ def _elm_float_wrapper(
     return _format
 
 
-_format_elm_float_repr = _elm_float_wrapper(
-    inner=functools.partial(
-        format_float_repr,
-        inf_literal="",
-        neg_inf_literal="",
-        nan_literal="",
-    ),
-)
+_format_elm_float_repr = _elm_float_wrapper(inner=format_float_repr)
 _format_elm_float_scientific = _elm_float_wrapper(
-    inner=functools.partial(
-        format_float_scientific,
-        inf_literal="",
-        neg_inf_literal="",
-        nan_literal="",
-    ),
+    inner=format_float_scientific,
 )
-_format_elm_float_fixed = _elm_float_wrapper(
-    inner=functools.partial(
-        format_float_fixed,
-        inf_literal="",
-        neg_inf_literal="",
-        nan_literal="",
-    ),
-)
+_format_elm_float_fixed = _elm_float_wrapper(inner=format_float_fixed)
 
 
 @beartype

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -238,33 +238,16 @@ class Erlang(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf" if value < 0 else "inf"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -258,33 +258,18 @@ class Fortran(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="ieee_value(0.0, ieee_positive_inf)",
-                neg_inf_literal="ieee_value(0.0, ieee_negative_inf)",
-                nan_literal="ieee_value(0.0, ieee_quiet_nan)",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="ieee_value(0.0, ieee_positive_inf)",
-                neg_inf_literal="ieee_value(0.0, ieee_negative_inf)",
-                nan_literal="ieee_value(0.0, ieee_quiet_nan)",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="ieee_value(0.0, ieee_positive_inf)",
-                neg_inf_literal="ieee_value(0.0, ieee_negative_inf)",
-                nan_literal="ieee_value(0.0, ieee_quiet_nan)",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "ieee_value(0.0, ieee_negative_inf)"
+                return "ieee_value(0.0, ieee_positive_inf)"
+            if math.isnan(value):
+                return "ieee_value(0.0, ieee_quiet_nan)"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -268,33 +268,16 @@ class FSharp(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="infinity",
-                neg_inf_literal="-infinity",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="infinity",
-                neg_inf_literal="-infinity",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="infinity",
-                neg_inf_literal="-infinity",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-infinity" if value < 0 else "infinity"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import functools
 import math
 from collections.abc import Callable
 from types import MappingProxyType
@@ -133,10 +132,6 @@ def _gleam_integer_wrapper(
 
 def _gleam_float_wrapper(
     inner: Callable[[float], str],
-    *,
-    inf_literal: str = "GFloat(todo)",
-    neg_inf_literal: str = "GFloat(todo)",
-    nan_literal: str = "GFloat(todo)",
 ) -> Callable[[float], str]:
     """Wrap a float formatter to produce ``GFloat`` constructors."""
 
@@ -144,9 +139,9 @@ def _gleam_float_wrapper(
     def _format(value: float) -> str:
         """Format a float with a ``GFloat`` constructor."""
         if math.isinf(value):
-            return neg_inf_literal if value < 0 else inf_literal
+            return "GFloat(todo)"
         if math.isnan(value):
-            return nan_literal
+            return "GFloat(todo)"
         return f"GFloat({inner(value)})"
 
     return _format
@@ -335,35 +330,12 @@ class Gleam(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=_gleam_float_wrapper(
-                inner=functools.partial(
-                    format_float_repr,
-                    inf_literal="UNREACHABLE",
-                    neg_inf_literal="UNREACHABLE",
-                    nan_literal="UNREACHABLE",
-                ),
-            )
-        )
+        REPR = enum.member(value=_gleam_float_wrapper(inner=format_float_repr))
         SCIENTIFIC = enum.member(
-            value=_gleam_float_wrapper(
-                inner=functools.partial(
-                    format_float_scientific,
-                    inf_literal="UNREACHABLE",
-                    neg_inf_literal="UNREACHABLE",
-                    nan_literal="UNREACHABLE",
-                ),
-            )
+            value=_gleam_float_wrapper(inner=format_float_scientific)
         )
         FIXED = enum.member(
-            value=_gleam_float_wrapper(
-                inner=functools.partial(
-                    format_float_fixed,
-                    inf_literal="UNREACHABLE",
-                    neg_inf_literal="UNREACHABLE",
-                    nan_literal="UNREACHABLE",
-                ),
-            )
+            value=_gleam_float_wrapper(inner=format_float_fixed)
         )
 
         def __call__(self, value: float, /) -> str:

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -269,33 +269,16 @@ class Go(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="math.Inf(1)",
-                neg_inf_literal="math.Inf(-1)",
-                nan_literal="math.NaN()",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="math.Inf(1)",
-                neg_inf_literal="math.Inf(-1)",
-                nan_literal="math.NaN()",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="math.Inf(1)",
-                neg_inf_literal="math.Inf(-1)",
-                nan_literal="math.NaN()",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "math.Inf(-1)" if value < 0 else "math.Inf(1)"
+            if math.isnan(value):
+                return "math.NaN()"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -178,33 +178,18 @@ class Groovy(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "Double.NEGATIVE_INFINITY"
+                return "Double.POSITIVE_INFINITY"
+            if math.isnan(value):
+                return "Double.NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -434,33 +435,16 @@ class Haskell(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="(1/0)",
-                neg_inf_literal="(-1/0)",
-                nan_literal="(0/0)",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="(1/0)",
-                neg_inf_literal="(-1/0)",
-                nan_literal="(0/0)",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="(1/0)",
-                neg_inf_literal="(-1/0)",
-                nan_literal="(0/0)",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "(-1/0)" if value < 0 else "(1/0)"
+            if math.isnan(value):
+                return "(0/0)"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -170,33 +170,16 @@ class Hcl(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf" if value < 0 else "inf"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -341,33 +341,18 @@ class Java(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "Double.NEGATIVE_INFINITY"
+                return "Double.POSITIVE_INFINITY"
+            if math.isnan(value):
+                return "Double.NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -265,33 +265,16 @@ class JavaScript(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Infinity" if value < 0 else "Infinity"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -197,33 +198,16 @@ class Json5(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Infinity" if value < 0 else "Infinity"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -199,33 +200,16 @@ class Jsonnet(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal='"Infinity"',
-                neg_inf_literal='"-Infinity"',
-                nan_literal='"NaN"',
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal='"Infinity"',
-                neg_inf_literal='"-Infinity"',
-                nan_literal='"NaN"',
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal='"Infinity"',
-                neg_inf_literal='"-Infinity"',
-                nan_literal='"NaN"',
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return '"-Infinity"' if value < 0 else '"Infinity"'
+            if math.isnan(value):
+                return '"NaN"'
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -254,33 +254,16 @@ class Julia(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Inf" if value < 0 else "Inf"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -384,33 +384,18 @@ class Kotlin(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Double.POSITIVE_INFINITY",
-                neg_inf_literal="Double.NEGATIVE_INFINITY",
-                nan_literal="Double.NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "Double.NEGATIVE_INFINITY"
+                return "Double.POSITIVE_INFINITY"
+            if math.isnan(value):
+                return "Double.NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -212,33 +212,16 @@ class Lua(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="math.huge",
-                neg_inf_literal="-math.huge",
-                nan_literal="(0/0)",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="math.huge",
-                neg_inf_literal="-math.huge",
-                nan_literal="(0/0)",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="math.huge",
-                neg_inf_literal="-math.huge",
-                nan_literal="(0/0)",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-math.huge" if value < 0 else "math.huge"
+            if math.isnan(value):
+                return "(0/0)"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -288,33 +288,16 @@ class Matlab(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Inf" if value < 0 else "Inf"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -219,33 +219,18 @@ class Mojo(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="std.math.inf[DType.float64]()",
-                neg_inf_literal="-std.math.inf[DType.float64]()",
-                nan_literal="std.math.nan[DType.float64]()",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="std.math.inf[DType.float64]()",
-                neg_inf_literal="-std.math.inf[DType.float64]()",
-                nan_literal="std.math.nan[DType.float64]()",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="std.math.inf[DType.float64]()",
-                neg_inf_literal="-std.math.inf[DType.float64]()",
-                nan_literal="std.math.nan[DType.float64]()",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "-std.math.inf[DType.float64]()"
+                return "std.math.inf[DType.float64]()"
+            if math.isnan(value):
+                return "std.math.nan[DType.float64]()"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
 
@@ -297,33 +297,16 @@ class Nim(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Inf" if value < 0 else "Inf"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -178,33 +178,16 @@ class Norg(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf" if value < 0 else "inf"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -3,7 +3,7 @@
 import base64
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -230,33 +230,16 @@ class ObjectiveC(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="INFINITY",
-                neg_inf_literal="-INFINITY",
-                nan_literal="NAN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-INFINITY" if value < 0 else "INFINITY"
+            if math.isnan(value):
+                return "NAN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -261,33 +261,16 @@ class OCaml(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="infinity",
-                neg_inf_literal="neg_infinity",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="infinity",
-                neg_inf_literal="neg_infinity",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="infinity",
-                neg_inf_literal="neg_infinity",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "neg_infinity" if value < 0 else "infinity"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -188,33 +188,16 @@ class Occam(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf" if value < 0 else "inf"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -193,33 +193,16 @@ class Odin(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="math.inf_f64(1)",
-                neg_inf_literal="math.inf_f64(-1)",
-                nan_literal="math.nan_f64()",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="math.inf_f64(1)",
-                neg_inf_literal="math.inf_f64(-1)",
-                nan_literal="math.nan_f64()",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="math.inf_f64(1)",
-                neg_inf_literal="math.inf_f64(-1)",
-                nan_literal="math.nan_f64()",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "math.inf_f64(-1)" if value < 0 else "math.inf_f64(1)"
+            if math.isnan(value):
+                return "math.nan_f64()"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -224,33 +224,16 @@ class Perl(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Inf" if value < 0 else "Inf"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -192,33 +192,16 @@ class Php(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="INF",
-                neg_inf_literal="-INF",
-                nan_literal="NAN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="INF",
-                neg_inf_literal="-INF",
-                nan_literal="NAN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="INF",
-                neg_inf_literal="-INF",
-                nan_literal="NAN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-INF" if value < 0 else "INF"
+            if math.isnan(value):
+                return "NAN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -195,33 +195,18 @@ class PowerShell(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="[double]::PositiveInfinity",
-                neg_inf_literal="[double]::NegativeInfinity",
-                nan_literal="[double]::NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="[double]::PositiveInfinity",
-                neg_inf_literal="[double]::NegativeInfinity",
-                nan_literal="[double]::NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="[double]::PositiveInfinity",
-                neg_inf_literal="[double]::NegativeInfinity",
-                nan_literal="[double]::NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "[double]::NegativeInfinity"
+                return "[double]::PositiveInfinity"
+            if math.isnan(value):
+                return "[double]::NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import functools
 import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -98,10 +97,6 @@ def _format_purescript_integer_hex(value: int) -> str:
 @beartype
 def _purescript_float_wrapper(
     inner: Callable[[float], str],
-    *,
-    inf_literal: str,
-    neg_inf_literal: str,
-    nan_literal: str,
 ) -> Callable[[float], str]:
     """Wrap a float formatter to produce ``PFloat`` constructors."""
 
@@ -109,9 +104,11 @@ def _purescript_float_wrapper(
     def _format(value: float) -> str:
         """Format a float with a ``PFloat`` constructor."""
         if math.isinf(value):
-            return neg_inf_literal if value < 0 else inf_literal
+            if value < 0:
+                return "PFloat (-(1.0 / 0.0))"
+            return "PFloat (1.0 / 0.0)"
         if math.isnan(value):
-            return nan_literal
+            return "PFloat (0.0 / 0.0)"
         formatted = inner(value)
         if formatted.startswith("-"):
             return f"PFloat ({formatted})"
@@ -121,37 +118,13 @@ def _purescript_float_wrapper(
 
 
 _format_purescript_float_repr = _purescript_float_wrapper(
-    inner=functools.partial(
-        format_float_repr,
-        inf_literal="",
-        neg_inf_literal="",
-        nan_literal="",
-    ),
-    inf_literal="PFloat (1.0 / 0.0)",
-    neg_inf_literal="PFloat (-(1.0 / 0.0))",
-    nan_literal="PFloat (0.0 / 0.0)",
+    inner=format_float_repr,
 )
 _format_purescript_float_scientific = _purescript_float_wrapper(
-    inner=functools.partial(
-        format_float_scientific,
-        inf_literal="",
-        neg_inf_literal="",
-        nan_literal="",
-    ),
-    inf_literal="PFloat (1.0 / 0.0)",
-    neg_inf_literal="PFloat (-(1.0 / 0.0))",
-    nan_literal="PFloat (0.0 / 0.0)",
+    inner=format_float_scientific,
 )
 _format_purescript_float_fixed = _purescript_float_wrapper(
-    inner=functools.partial(
-        format_float_fixed,
-        inf_literal="",
-        neg_inf_literal="",
-        nan_literal="",
-    ),
-    inf_literal="PFloat (1.0 / 0.0)",
-    neg_inf_literal="PFloat (-(1.0 / 0.0))",
-    nan_literal="PFloat (0.0 / 0.0)",
+    inner=format_float_fixed,
 )
 
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
@@ -670,33 +671,16 @@ class Python(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal='float("inf")',
-                neg_inf_literal='float("-inf")',
-                nan_literal='float("nan")',
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal='float("inf")',
-                neg_inf_literal='float("-inf")',
-                nan_literal='float("nan")',
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal='float("inf")',
-                neg_inf_literal='float("-inf")',
-                nan_literal='float("nan")',
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return 'float("-inf")' if value < 0 else 'float("inf")'
+            if math.isnan(value):
+                return 'float("nan")'
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -240,33 +240,16 @@ class R(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Inf" if value < 0 else "Inf"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -170,33 +170,16 @@ class Racket(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="+inf.0",
-                neg_inf_literal="-inf.0",
-                nan_literal="+nan.0",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="+inf.0",
-                neg_inf_literal="-inf.0",
-                nan_literal="+nan.0",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="+inf.0",
-                neg_inf_literal="-inf.0",
-                nan_literal="+nan.0",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf.0" if value < 0 else "+inf.0"
+            if math.isnan(value):
+                return "+nan.0"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -225,33 +225,16 @@ class Raku(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Inf",
-                neg_inf_literal="-Inf",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Inf" if value < 0 else "Inf"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -230,33 +230,16 @@ class Ruby(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Float::INFINITY",
-                neg_inf_literal="-Float::INFINITY",
-                nan_literal="Float::NAN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Float::INFINITY",
-                neg_inf_literal="-Float::INFINITY",
-                nan_literal="Float::NAN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Float::INFINITY",
-                neg_inf_literal="-Float::INFINITY",
-                nan_literal="Float::NAN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Float::INFINITY" if value < 0 else "Float::INFINITY"
+            if math.isnan(value):
+                return "Float::NAN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -343,33 +343,16 @@ class Rust(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="f64::INFINITY",
-                neg_inf_literal="f64::NEG_INFINITY",
-                nan_literal="f64::NAN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="f64::INFINITY",
-                neg_inf_literal="f64::NEG_INFINITY",
-                nan_literal="f64::NAN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="f64::INFINITY",
-                neg_inf_literal="f64::NEG_INFINITY",
-                nan_literal="f64::NAN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "f64::NEG_INFINITY" if value < 0 else "f64::INFINITY"
+            if math.isnan(value):
+                return "f64::NAN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
 
@@ -326,33 +326,18 @@ class Scala(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Double.PositiveInfinity",
-                neg_inf_literal="Double.NegativeInfinity",
-                nan_literal="Double.NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Double.PositiveInfinity",
-                neg_inf_literal="Double.NegativeInfinity",
-                nan_literal="Double.NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Double.PositiveInfinity",
-                neg_inf_literal="Double.NegativeInfinity",
-                nan_literal="Double.NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "Double.NegativeInfinity"
+                return "Double.PositiveInfinity"
+            if math.isnan(value):
+                return "Double.NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -170,33 +170,16 @@ class Scheme(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="+inf.0",
-                neg_inf_literal="-inf.0",
-                nan_literal="+nan.0",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="+inf.0",
-                neg_inf_literal="-inf.0",
-                nan_literal="+nan.0",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="+inf.0",
-                neg_inf_literal="-inf.0",
-                nan_literal="+nan.0",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf.0" if value < 0 else "+inf.0"
+            if math.isnan(value):
+                return "+nan.0"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -272,33 +273,16 @@ class Swift(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Double.infinity",
-                neg_inf_literal="-Double.infinity",
-                nan_literal="Double.nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Double.infinity",
-                neg_inf_literal="-Double.infinity",
-                nan_literal="Double.nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Double.infinity",
-                neg_inf_literal="-Double.infinity",
-                nan_literal="Double.nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Double.infinity" if value < 0 else "Double.infinity"
+            if math.isnan(value):
+                return "Double.nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -222,33 +222,18 @@ class SystemVerilog(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="$bitstoreal(64'h7FF0000000000000)",
-                neg_inf_literal="$bitstoreal(64'hFFF0000000000000)",
-                nan_literal="$bitstoreal(64'h7FF8000000000000)",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="$bitstoreal(64'h7FF0000000000000)",
-                neg_inf_literal="$bitstoreal(64'hFFF0000000000000)",
-                nan_literal="$bitstoreal(64'h7FF8000000000000)",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="$bitstoreal(64'h7FF0000000000000)",
-                neg_inf_literal="$bitstoreal(64'hFFF0000000000000)",
-                nan_literal="$bitstoreal(64'h7FF8000000000000)",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "$bitstoreal(64'hFFF0000000000000)"
+                return "$bitstoreal(64'h7FF0000000000000)"
+            if math.isnan(value):
+                return "$bitstoreal(64'h7FF8000000000000)"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -203,33 +204,16 @@ class Toml(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="inf",
-                neg_inf_literal="-inf",
-                nan_literal="nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-inf" if value < 0 else "inf"
+            if math.isnan(value):
+                return "nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -278,33 +278,16 @@ class TypeScript(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Infinity",
-                neg_inf_literal="-Infinity",
-                nan_literal="NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-Infinity" if value < 0 else "Infinity"
+            if math.isnan(value):
+                return "NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -262,33 +262,18 @@ class VisualBasic(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="Double.PositiveInfinity",
-                neg_inf_literal="Double.NegativeInfinity",
-                nan_literal="Double.NaN",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="Double.PositiveInfinity",
-                neg_inf_literal="Double.NegativeInfinity",
-                nan_literal="Double.NaN",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="Double.PositiveInfinity",
-                neg_inf_literal="Double.NegativeInfinity",
-                nan_literal="Double.NaN",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "Double.NegativeInfinity"
+                return "Double.PositiveInfinity"
+            if math.isnan(value):
+                return "Double.NaN"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -184,33 +185,16 @@ class Yaml(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal=".inf",
-                neg_inf_literal="-.inf",
-                nan_literal=".nan",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal=".inf",
-                neg_inf_literal="-.inf",
-                nan_literal=".nan",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal=".inf",
-                neg_inf_literal="-.inf",
-                nan_literal=".nan",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                return "-.inf" if value < 0 else ".inf"
+            if math.isnan(value):
+                return ".nan"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -3,6 +3,7 @@
 import datetime
 import enum
 import functools
+import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -241,33 +242,18 @@ class Zig(metaclass=LanguageCls):
     class FloatFormats(enum.Enum):
         """Float format options."""
 
-        REPR = enum.member(
-            value=functools.partial(
-                format_float_repr,
-                inf_literal="std.math.inf(f64)",
-                neg_inf_literal="-std.math.inf(f64)",
-                nan_literal="std.math.nan(f64)",
-            )
-        )
-        SCIENTIFIC = enum.member(
-            value=functools.partial(
-                format_float_scientific,
-                inf_literal="std.math.inf(f64)",
-                neg_inf_literal="-std.math.inf(f64)",
-                nan_literal="std.math.nan(f64)",
-            )
-        )
-        FIXED = enum.member(
-            value=functools.partial(
-                format_float_fixed,
-                inf_literal="std.math.inf(f64)",
-                neg_inf_literal="-std.math.inf(f64)",
-                nan_literal="std.math.nan(f64)",
-            )
-        )
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
 
         def __call__(self, value: float, /) -> str:
             """Format a float."""
+            if math.isinf(value):
+                if value < 0:
+                    return "-std.math.inf(f64)"
+                return "std.math.inf(f64)"
+            if math.isnan(value):
+                return "std.math.nan(f64)"
             return self.value(value=value)
 
     class IntegerFormats(enum.Enum):


### PR DESCRIPTION
## Summary
- The `format_float_repr`, `format_float_scientific`, and `format_float_fixed` functions now only handle finite floats — the `_handle_special_float` helper and `inf_literal`/`neg_inf_literal`/`nan_literal` parameters are removed.
- Each language's `FloatFormats.__call__` (or custom wrapper for Elm, PureScript, Gleam) now handles special float values (inf, -inf, nan) directly with language-specific literals.
- This eliminates the `functools.partial` wrapping in standard languages and removes dummy sentinel literals in custom wrapper languages.

## Test plan
- [x] All 10605 existing tests pass
- [x] Manual verification of float formatting across standard languages (Rust, Python, CommonLisp, Jsonnet, SystemVerilog) and custom-wrapper languages (Elm, PureScript, Gleam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches float formatting across many language backends; mistakes could change emitted literals for `inf`/`nan` or break round-tripping in specific languages despite largely mechanical changes.
> 
> **Overview**
> **Special-float handling is moved out of shared float formatters and into language implementations.** `format_float_repr`, `format_float_scientific`, and `format_float_fixed` now assume *finite* inputs and drop the `_handle_special_float` helper plus the `inf`/`nan` literal parameters.
> 
> Each language’s `FloatFormats.__call__` (and custom wrappers like Elm/PureScript/Gleam) now explicitly checks `math.isinf`/`math.isnan` and returns the appropriate language-specific literal, eliminating widespread `functools.partial` wrappers and dummy sentinel arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d257093afb43d060e5059f896b03c561831db245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->