### PR TITLE
Fix exponential performance for nested mixed-type dicts

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -692,26 +692,24 @@ def _coerce_mixed_dict_values(*, data: Value) -> Value:
     """
     match data:
         case ordereddict():
-            new_ordered_map: ordereddict = ordereddict()
-            for k, v in data.items():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-                new_ordered_map[k] = _coerce_mixed_dict_values(data=v)  # pyright: ignore[reportUnknownArgumentType]
-            ordered_map_vals: list[Value] = list(new_ordered_map.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+            ordered_map_vals: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
             if _dict_values_mixed_types(values=ordered_map_vals):
-                for k in new_ordered_map:  # pyright: ignore[reportUnknownVariableType]
-                    new_ordered_map[k] = _coerce_value_to_str(
-                        value=new_ordered_map[k],  # pyright: ignore[reportUnknownArgumentType]
-                    )
-            return new_ordered_map
+                new_ordered_map: ordereddict = ordereddict()
+                for k, v in data.items():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
+                    new_ordered_map[k] = _coerce_value_to_str(value=v)  # pyright: ignore[reportUnknownArgumentType]
+                return new_ordered_map
+            new_ordered_map_recursed: ordereddict = ordereddict()
+            for k, v in data.items():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
+                new_ordered_map_recursed[k] = _coerce_mixed_dict_values(data=v)  # pyright: ignore[reportUnknownArgumentType]
+            return new_ordered_map_recursed
         case dict():
-            new_dict: dict[str, Value] = {
+            if _dict_values_mixed_types(values=list(data.values())):
+                return {
+                    k: _coerce_value_to_str(value=v) for k, v in data.items()
+                }
+            return {
                 k: _coerce_mixed_dict_values(data=v) for k, v in data.items()
             }
-            if _dict_values_mixed_types(values=list(new_dict.values())):
-                new_dict = {
-                    k: _coerce_value_to_str(value=v)
-                    for k, v in new_dict.items()
-                }
-            return new_dict
         case list():
             return [_coerce_mixed_dict_values(data=v) for v in data]
         case _:
@@ -737,10 +735,9 @@ def _coerce_mixed_list_values(*, data: Value) -> Value:
                 k: _coerce_mixed_list_values(data=v) for k, v in data.items()
             }
         case list():
-            new_list = [_coerce_mixed_list_values(data=v) for v in data]
-            if _dict_values_mixed_types(values=new_list):
-                return [_coerce_value_to_str(value=v) for v in new_list]
-            return new_list
+            if _dict_values_mixed_types(values=data):
+                return [_coerce_value_to_str(value=v) for v in data]
+            return [_coerce_mixed_list_values(data=v) for v in data]
         case _:
             return data
 

--- a/tests/integration/cases/deep_nesting/Dhall.dhall
+++ b/tests/integration/cases/deep_nesting/Dhall.dhall
@@ -1,3 +1,3 @@
 let my_data = {
-  level1 = {level2 = "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}", tags = "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]"},
+  level1 = {level2 = "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}", tags = "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]"},
 } in my_data

--- a/tests/integration/cases/deep_nesting/Mojo.mojo
+++ b/tests/integration/cases/deep_nesting/Mojo.mojo
@@ -1,5 +1,5 @@
 def main():
     var my_data = {
-        "level1": {"level2": "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}", "tags": "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]"},
+        "level1": {"level2": "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}", "tags": "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]"},
     }
     _ = my_data

--- a/tests/integration/cases/deep_nesting/Mojo_combined.mojo
+++ b/tests/integration/cases/deep_nesting/Mojo_combined.mojo
@@ -1,9 +1,9 @@
 def main():
     var my_data = {
-        "level1": {"level2": "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}", "tags": "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]"},
+        "level1": {"level2": "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}", "tags": "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]"},
     }
     _ = my_data
     my_data = {
-        "level1": {"level2": "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}", "tags": "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]"},
+        "level1": {"level2": "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}", "tags": "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]"},
     }
     _ = my_data

--- a/tests/integration/cases/deep_nesting/Nim.nim
+++ b/tests/integration/cases/deep_nesting/Nim.nim
@@ -1,4 +1,4 @@
 import json
 var my_data = %* {
-    "level1": {"level2": "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}", "tags": "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]"}
+    "level1": {"level2": "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}", "tags": "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]"}
 }

--- a/tests/integration/cases/deep_nesting/Nim_combined.nim
+++ b/tests/integration/cases/deep_nesting/Nim_combined.nim
@@ -1,7 +1,7 @@
 import json
 var my_data = %* {
-    "level1": {"level2": "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}", "tags": "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]"}
+    "level1": {"level2": "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}", "tags": "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]"}
 }
 my_data = %* {
-    "level1": {"level2": "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}", "tags": "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]"}
+    "level1": {"level2": "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}", "tags": "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]"}
 }

--- a/tests/integration/cases/deep_nesting/Rust.rs
+++ b/tests/integration/cases/deep_nesting/Rust.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 fn main() {
     let my_data = HashMap::from([
-        ("level1", HashMap::from([("level2", "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}"), ("tags", "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]")])),
+        ("level1", HashMap::from([("level2", "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}"), ("tags", "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]")])),
     ]);
     let _ = my_data;
 }

--- a/tests/integration/cases/deep_nesting/Rust_combined.rs
+++ b/tests/integration/cases/deep_nesting/Rust_combined.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 fn main() {
     let mut my_data = HashMap::from([
-        ("level1", HashMap::from([("level2", "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}"), ("tags", "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]")])),
+        ("level1", HashMap::from([("level2", "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}"), ("tags", "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]")])),
     ]);
     my_data = HashMap::from([
-        ("level1", HashMap::from([("level2", "{\"level3\": \"{\\\"level4\\\": {\\\"value\\\": \\\"deep\\\", \\\"items\\\": \\\"[\\\\\\\"a\\\\\\\", \\\\\\\"b\\\\\\\"]\\\"}}\", \"sibling\": \"42\"}"), ("tags", "[{\"name\": \"tag1\", \"meta\": \"{\\\"priority\\\": \\\"1\\\", \\\"labels\\\": \\\"[\\\\\\\"x\\\\\\\", \\\\\\\"y\\\\\\\"]\\\"}\"}]")])),
+        ("level1", HashMap::from([("level2", "{\"level3\": {\"level4\": {\"value\": \"deep\", \"items\": [\"a\", \"b\"]}}, \"sibling\": 42}"), ("tags", "[{\"name\": \"tag1\", \"meta\": {\"priority\": 1, \"labels\": [\"x\", \"y\"]}}]")])),
     ]);
     let _ = my_data;
 }


### PR DESCRIPTION
## Summary

- Fix O(2^n) performance degradation in `_coerce_mixed_dict_values()` and `_coerce_mixed_list_values()` by coercing top-down instead of bottom-up
- Avoids exponential escape-nesting when deeply nested dicts have mixed-type values in heterogeneity-coercing languages (Rust, Dhall, Mojo, Nim)
- Updates golden files for affected languages to reflect cleaner output without redundant escaping

Closes #1031

## Test plan

- [x] All 10606 existing tests pass
- [x] Golden files regenerated for affected languages (Dhall, Mojo, Nim, Rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coercion order in core literalization logic, which can affect output formatting for mixed-type dicts/lists across languages and could introduce subtle behavior differences. Scope is limited to heterogeneity-coercion paths and is covered by updated integration golden files.
> 
> **Overview**
> Fixes mixed-type collection coercion to work *top-down* rather than recursing first, avoiding exponential work/escaping in deeply nested structures.
> 
> `_coerce_mixed_dict_values` and `_coerce_mixed_list_values` now detect mixed-type siblings at the current container and immediately stringify elements/values (instead of recursing and then re-coercing), reducing redundant conversions.
> 
> Updates deep-nesting integration golden files (Dhall, Mojo, Nim, Rust) to reflect cleaner, less double-escaped output when nested mixed-type dicts are coerced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b24a3575a5ba06ed25235144a635e6f4ea3274b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->