### PR TITLE
Unify typed collection opener helpers

### DIFF
--- a/src/literalizer/_formatters/collection_openers.py
+++ b/src/literalizer/_formatters/collection_openers.py
@@ -1,7 +1,6 @@
 """Collection opener functions and typed opener configuration."""
 
 import datetime
-import functools
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -176,88 +175,16 @@ def make_type_to_opener(
 
 
 @beartype
-def _typed_set_open(
-    items: list[Value],
-    *,
-    type_to_opener: Callable[[type | ListType | DictType], str | None],
-    fallback: str,
-) -> str:
-    """Infer the common element type and return the language-specific
-    opener for sets.
-
-    Uses direct ``type()`` checks on the Python runtime objects to
-    determine the element type, then passes it to *type_to_opener*
-    which returns the language-specific opening delimiter.  When
-    inference is not possible or *type_to_opener* returns ``None``,
-    *fallback* is returned instead.
-    """
-    element_type = infer_element_type(items=items)
-    if element_type is None:
-        return fallback
-    return type_to_opener(element_type) or fallback
-
-
-@beartype
-def typed_set_open(
+def typed_collection_open(
     *,
     type_to_opener: Callable[[type | ListType | DictType], str | None],
     fallback: str,
 ) -> Callable[[list[Value]], str]:
-    """Return a ``set_open`` callable that infers the common
-    element type and delegates to *type_to_opener*.
+    """Return a callable that infers the common element type and
+    delegates to *type_to_opener*.
 
-    When inference is not possible or *type_to_opener* returns
-    ``None``, *fallback* is used instead.
-
-    Example::
-
-        def my_opener(element_type: type | ListType) -> str | None:
-            if element_type is str:
-                return "Set[String]("
-            return None
-
-        set_open = typed_set_open(
-            type_to_opener=my_opener,
-            fallback="Set[String](",
-        )
-    """
-    return functools.partial(
-        _typed_set_open,
-        type_to_opener=type_to_opener,
-        fallback=fallback,
-    )
-
-
-@beartype
-def _typed_sequence_open(
-    items: list[Value],
-    *,
-    type_to_opener: Callable[[type | ListType | DictType], str | None],
-    fallback: str,
-) -> str:
-    """Infer the common element type and return the language-specific
-    opener.
-
-    Uses direct ``type()`` checks on the Python runtime objects
-    to determine the element type, then passes it to
-    *type_to_opener* which returns the language-specific opening
-    delimiter.  When inference is not possible or *type_to_opener*
-    returns ``None``, *fallback* is returned instead.
-    """
-    element_type = infer_element_type(items=items)
-    if element_type is None:
-        return fallback
-    return type_to_opener(element_type) or fallback
-
-
-@beartype
-def typed_sequence_open(
-    *,
-    type_to_opener: Callable[[type | ListType | DictType], str | None],
-    fallback: str,
-) -> Callable[[list[Value]], str]:
-    """Return a ``sequence_open`` callable that infers the common
-    element type and delegates to *type_to_opener*.
+    Works for both sequences and sets — any collection whose items
+    are presented as a ``list[Value]``.
 
     When inference is not possible or *type_to_opener* returns
     ``None``, *fallback* is used instead.
@@ -269,39 +196,21 @@ def typed_sequence_open(
                 return "[]string{"
             return None
 
-        sequence_open = typed_sequence_open(
+        sequence_open = typed_collection_open(
             type_to_opener=my_opener,
             fallback="[]any{",
         )
     """
-    return functools.partial(
-        _typed_sequence_open,
-        type_to_opener=type_to_opener,
-        fallback=fallback,
-    )
 
+    @beartype
+    def _open(items: list[Value]) -> str:
+        """Infer element type and return the opener or fallback."""
+        element_type = infer_element_type(items=items)
+        if element_type is None:
+            return fallback
+        return type_to_opener(element_type) or fallback
 
-@beartype
-def _typed_dict_open(
-    items: dict[str, Value],
-    *,
-    type_to_opener: Callable[[type | ListType | DictType], str | None],
-    fallback: str,
-) -> str:
-    """Infer a common value type and return the language-specific
-    opener.
-
-    Treats the dict values as a list and infers a common element
-    type, then passes it to *type_to_opener* which returns the
-    language-specific opening delimiter.  When inference is not
-    possible or *type_to_opener* returns ``None``, *fallback* is
-    returned instead.
-    """
-    values = list(items.values())
-    element_type = infer_element_type(items=values)
-    if element_type is None:
-        return fallback
-    return type_to_opener(element_type) or fallback
+    return _open
 
 
 @beartype
@@ -328,11 +237,16 @@ def typed_dict_open(
             fallback="map[string]any{",
         )
     """
-    return functools.partial(
-        _typed_dict_open,
-        type_to_opener=type_to_opener,
-        fallback=fallback,
-    )
+
+    @beartype
+    def _open(items: dict[str, Value]) -> str:
+        """Infer value type and return the opener or fallback."""
+        element_type = infer_element_type(items=list(items.values()))
+        if element_type is None:
+            return fallback
+        return type_to_opener(element_type) or fallback
+
+    return _open
 
 
 @dataclass(frozen=True)

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -8,7 +8,7 @@ from typing import Protocol, runtime_checkable
 
 from beartype import beartype
 
-from literalizer._formatters.collection_openers import typed_set_open
+from literalizer._formatters.collection_openers import typed_collection_open
 from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._types import Value
 
@@ -107,7 +107,7 @@ class SetFormatConfig:
         """
         return dataclasses.replace(
             self,
-            set_open=typed_set_open(
+            set_open=typed_collection_open(
                 type_to_opener=type_to_opener,
                 fallback=fallback,
             ),

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -14,8 +14,8 @@ from literalizer._formatters.collection_openers import (
     fixed_set_open,
     make_element_to_type,
     make_type_to_opener,
+    typed_collection_open,
     typed_dict_open,
-    typed_sequence_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -137,7 +137,7 @@ def _make_initializer_list_config(
     """
     element_to_type = _make_cpp_element_to_type(int_type=int_type)
     return SequenceFormatConfig(
-        sequence_open=typed_sequence_open(
+        sequence_open=typed_collection_open(
             type_to_opener=make_type_to_opener(
                 element_to_type=element_to_type,
                 opener_template="std::vector<{type_name}>{{",

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -13,8 +13,8 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
     make_type_to_opener,
+    typed_collection_open,
     typed_dict_open,
-    typed_sequence_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -441,7 +441,7 @@ class CSharp(metaclass=LanguageCls):
             fallback=self.set_format_config.set_open([]),
         )
         self.sequence_open: Callable[[list[Value]], str] = (
-            typed_sequence_open(
+            typed_collection_open(
                 type_to_opener=openers.seq,
                 fallback=fmt.typed_opener_fallback,
             )

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -10,8 +10,8 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
     fixed_sequence_open,
+    typed_collection_open,
     typed_dict_open,
-    typed_sequence_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -383,7 +383,7 @@ class Dart(metaclass=LanguageCls):
             dict_key_type=default_dict_key_type,
         )
         self.sequence_open: Callable[[list[Value]], str] = (
-            typed_sequence_open(
+            typed_collection_open(
                 type_to_opener=openers.seq,
                 fallback=fmt.typed_opener_fallback,
             )

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -13,8 +13,8 @@ from literalizer._formatters.collection_openers import (
     fixed_sequence_open,
     make_element_to_type,
     make_type_to_opener,
+    typed_collection_open,
     typed_dict_open,
-    typed_sequence_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -447,12 +447,14 @@ class Go(metaclass=LanguageCls):
                 fallback=base_set_config.set_open([]),
             )
         )
-        self.sequence_open: Callable[[list[Value]], str] = typed_sequence_open(
-            type_to_opener=make_type_to_opener(
-                element_to_type=init_element_to_type,
-                opener_template="[]{type_name}{{",
-            ),
-            fallback=f"[]{default_sequence_element_type}{{",
+        self.sequence_open: Callable[[list[Value]], str] = (
+            typed_collection_open(
+                type_to_opener=make_type_to_opener(
+                    element_to_type=init_element_to_type,
+                    opener_template="[]{type_name}{{",
+                ),
+                fallback=f"[]{default_sequence_element_type}{{",
+            )
         )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
             open_fn=typed_dict_open(

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -14,7 +14,7 @@ from literalizer._formatters.collection_openers import (
     fixed_dict_open,
     fixed_sequence_open,
     fixed_set_open,
-    typed_sequence_open,
+    typed_collection_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -500,7 +500,7 @@ class Java(metaclass=LanguageCls):
             narrow_dict_values=False,
         )
         self.sequence_open: Callable[[list[Value]], str] = (
-            typed_sequence_open(
+            typed_collection_open(
                 type_to_opener=openers.seq,
                 fallback=fmt.typed_opener_fallback,
             )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -14,8 +14,8 @@ from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
     fixed_sequence_open,
     make_type_to_opener,
+    typed_collection_open,
     typed_dict_open,
-    typed_sequence_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -112,7 +112,7 @@ def _kotlin_list_sequence_open(
             return f"listOf<{dict_resolver(element_type)}>("
         return _kotlin_type_to_opener(element_type=element_type)
 
-    return typed_sequence_open(
+    return typed_collection_open(
         type_to_opener=_combined_opener,
         fallback="listOf<Any?>(",
     )
@@ -257,7 +257,7 @@ class Kotlin(metaclass=LanguageCls):
         """Sequence type options for Kotlin."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
+            sequence_open=typed_collection_open(
                 type_to_opener=_kotlin_type_to_opener,
                 fallback="listOf<Any?>(",
             ),

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -15,8 +15,8 @@ from literalizer._formatters.collection_openers import (
     fixed_sequence_open,
     fixed_set_open,
     make_type_to_opener,
+    typed_collection_open,
     typed_dict_open,
-    typed_sequence_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -79,7 +79,7 @@ def _list_sequence_open(
     datetime_type: str | None,
 ) -> Callable[[list[Value]], str]:
     """Build a typed sequence opener for the List format."""
-    return typed_sequence_open(
+    return typed_collection_open(
         type_to_opener=make_type_to_opener(
             element_to_type=cfg.element_to_type(
                 list_template="List[{inner}]",
@@ -112,7 +112,7 @@ def _resolve_sequence_open(
             datetime_type=datetime_type,
         )
     if fmt.typed_opener_fallback is not None:
-        return typed_sequence_open(
+        return typed_collection_open(
             type_to_opener=openers.seq,
             fallback=fmt.typed_opener_fallback,
         )

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -10,7 +10,7 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import (
     make_element_to_type,
     make_type_to_opener,
-    typed_sequence_open,
+    typed_collection_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -384,7 +384,7 @@ class VisualBasic(metaclass=LanguageCls):
             opener_template="New {type_name}() {{",
         )
         fmt = SequenceFormatConfig(
-            sequence_open=typed_sequence_open(
+            sequence_open=typed_collection_open(
                 type_to_opener=vb_type_to_opener,
                 fallback=f"New {default_sequence_element_type}() {{",
             ),


### PR DESCRIPTION
## Summary
- Replaces the identical `_typed_set_open` and `_typed_sequence_open` internal helpers with a single `typed_collection_open` public function that uses a closure instead of `functools.partial`
- Simplifies `typed_dict_open` the same way, inlining the value-extraction logic into a closure
- Removes the now-unnecessary `typed_set_open` and `typed_sequence_open` aliases, updating all 9 consuming files

Closes #982

## Test plan
- [x] All 10606 existing tests pass
- [x] Pre-commit hooks (ruff, mypy, pyright, interrogate, etc.) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: replaces duplicated opener-helper implementations with a single closure-based function and updates call sites; behavior should be equivalent but could affect typed opener selection if inference/fallback wiring changed.
> 
> **Overview**
> Unifies the duplicated typed opener helpers for sequences and sets into a single `typed_collection_open`, removing the old `typed_set_open`/`typed_sequence_open` entry points and updating all language implementations to use the new helper.
> 
> Refactors `typed_dict_open` to use an inlined closure (instead of `functools.partial`) while keeping the same type-inference + fallback behavior for choosing typed map/dict openers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d62099fcb4c3d626ddfa9348b868c984eccc4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->