### PR TITLE
Extract FloatSpecialsMixin to deduplicate special float handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,8 +393,8 @@ ignore_names = [
     # Enum __call__ used implicitly when enum members are passed as callables
     "__call__",
     # FloatSpecialsMixin nonmember attributes read by mixin __call__
-    "POS_INF",
-    "NEG_INF",
+    "POSITIVE_INFINITY",
+    "NEGATIVE_INFINITY",
     "NAN",
     # Enum members accessed by consumers iterating format enums
     "ALLOW",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,10 +392,6 @@ ignore_names = [
     "warning_is_error",
     # Enum __call__ used implicitly when enum members are passed as callables
     "__call__",
-    # FloatSpecialsMixin nonmember attributes read by mixin __call__
-    "POSITIVE_INFINITY",
-    "NEGATIVE_INFINITY",
-    "NAN",
     # Enum members accessed by consumers iterating format enums
     "ALLOW",
     "ARRAY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,6 +392,10 @@ ignore_names = [
     "warning_is_error",
     # Enum __call__ used implicitly when enum members are passed as callables
     "__call__",
+    # FloatSpecialsMixin nonmember attributes read by mixin __call__
+    "pos_inf",
+    "neg_inf",
+    "nan",
     # Enum members accessed by consumers iterating format enums
     "ALLOW",
     "ARRAY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,9 +393,9 @@ ignore_names = [
     # Enum __call__ used implicitly when enum members are passed as callables
     "__call__",
     # FloatSpecialsMixin nonmember attributes read by mixin __call__
-    "pos_inf",
-    "neg_inf",
-    "nan",
+    "POS_INF",
+    "NEG_INF",
+    "NAN",
     # Enum members accessed by consumers iterating format enums
     "ALLOW",
     "ARRAY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,10 +392,6 @@ ignore_names = [
     "warning_is_error",
     # Enum __call__ used implicitly when enum members are passed as callables
     "__call__",
-    # FloatSpecialsMixin class attributes set by __init_subclass__
-    "POSITIVE_INFINITY",
-    "NEGATIVE_INFINITY",
-    "NAN",
     # Enum members accessed by consumers iterating format enums
     "ALLOW",
     "ARRAY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,6 +392,10 @@ ignore_names = [
     "warning_is_error",
     # Enum __call__ used implicitly when enum members are passed as callables
     "__call__",
+    # FloatSpecialsMixin class attributes set by __init_subclass__
+    "POSITIVE_INFINITY",
+    "NEGATIVE_INFINITY",
+    "NAN",
     # Enum members accessed by consumers iterating format enums
     "ALLOW",
     "ARRAY",

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -127,6 +127,8 @@ init
 initialisation
 initializer
 initializers
+isinf
+isnan
 iso
 iterable
 javac
@@ -143,6 +145,7 @@ localhost
 luac
 matlab
 misclassifies
+mixin
 multiline
 mypy
 namespaces

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -59,6 +59,7 @@ JSONDecodeError
 Jsonnet
 LocalDate
 Lua
+Mixin
 Mojo
 NEL
 Nim

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import math
 from collections.abc import Callable, Sequence
-from typing import Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from beartype import beartype
 
@@ -175,26 +175,44 @@ class SequenceFormat(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
 
-@beartype
-def format_special_float(
-    *,
-    value: float,
-    positive_infinity: str,
-    negative_infinity: str,
-    nan: str,
-) -> str | None:
-    """Return the special-float literal, or ``None`` for finite values.
+class FloatSpecialsMixin:
+    """Mixin for ``FloatFormats`` enums that provides ``__call__``.
 
-    Called from each language's ``FloatFormats.__call__`` to centralise
-    the ``isinf``/``isnan`` dispatch.
+    Subclasses pass ``positive_infinity``, ``negative_infinity``, and
+    ``nan`` as keyword arguments to the class definition.  The mixin
+    stores them and provides a ``__call__`` that handles the
+    ``isinf``/``isnan`` dispatch, delegating finite values to the enum
+    member's formatter.
     """
-    if math.isinf(value):
-        if value < 0:
-            return negative_infinity
-        return positive_infinity
-    if math.isnan(value):
-        return nan
-    return None
+
+    _positive_infinity: str
+    _negative_infinity: str
+    _nan: str
+
+    def __init_subclass__(
+        cls,
+        *,
+        positive_infinity: str = "",
+        negative_infinity: str = "",
+        nan: str = "",
+        **kwargs: object,
+    ) -> None:
+        """Store float-special strings as class attributes."""
+        super().__init_subclass__(**kwargs)
+        cls._positive_infinity = positive_infinity
+        cls._negative_infinity = negative_infinity
+        cls._nan = nan
+
+    def __call__(self, value: float, /) -> str:
+        """Format a float, handling inf and nan."""
+        if math.isinf(value):
+            if value < 0:
+                return self._negative_infinity
+            return self._positive_infinity
+        if math.isnan(value):
+            return self._nan
+        formatter: Callable[[float], str] = cast("enum.Enum", self).value
+        return formatter(value)
 
 
 class LanguageCls(type):

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -175,47 +175,26 @@ class SequenceFormat(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
 
-class FloatSpecialsMixin:
-    """Mixin for FloatFormats enums that handles inf/nan dispatch.
+@beartype
+def format_special_float(
+    *,
+    value: float,
+    positive_infinity: str,
+    negative_infinity: str,
+    nan: str,
+) -> str | None:
+    """Return the special-float literal, or ``None`` for finite values.
 
-    Subclasses pass three keyword arguments to the class definition:
-
-    - ``positive_infinity`` — string returned for positive infinity
-    - ``negative_infinity`` — string returned for negative infinity
-    - ``nan`` — string returned for NaN
-
-    The ``__call__`` method checks for special float values first and
-    delegates to the enum member's formatter for finite values.
+    Called from each language's ``FloatFormats.__call__`` to centralise
+    the ``isinf``/``isnan`` dispatch.
     """
-
-    POSITIVE_INFINITY: str
-    NEGATIVE_INFINITY: str
-    NAN: str
-    value: Callable[[float], str]
-
-    def __init_subclass__(
-        cls,
-        *,
-        positive_infinity: str = "",
-        negative_infinity: str = "",
-        nan: str = "",
-        **kwargs: object,
-    ) -> None:
-        """Store float-special strings as class attributes."""
-        super().__init_subclass__(**kwargs)
-        cls.POSITIVE_INFINITY = positive_infinity
-        cls.NEGATIVE_INFINITY = negative_infinity
-        cls.NAN = nan
-
-    def __call__(self, value: float, /) -> str:
-        """Format a float, handling inf and nan via class constants."""
-        if math.isinf(value):
-            if value < 0:
-                return self.NEGATIVE_INFINITY
-            return self.POSITIVE_INFINITY
-        if math.isnan(value):
-            return self.NAN
-        return self.value(value)
+    if math.isinf(value):
+        if value < 0:
+            return negative_infinity
+        return positive_infinity
+    if math.isnan(value):
+        return nan
+    return None
 
 
 class LanguageCls(type):

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -178,29 +178,42 @@ class SequenceFormat(Protocol):
 class FloatSpecialsMixin:
     """Mixin for FloatFormats enums that handles inf/nan dispatch.
 
-    Subclasses must define three ``enum.nonmember`` class attributes:
+    Subclasses pass three keyword arguments to the class definition:
 
-    - ``POSITIVE_INFINITY`` — string returned for positive infinity
-    - ``NEGATIVE_INFINITY`` — string returned for negative infinity
-    - ``NAN`` — string returned for NaN
+    - ``positive_infinity`` — string returned for positive infinity
+    - ``negative_infinity`` — string returned for negative infinity
+    - ``nan`` — string returned for NaN
 
     The ``__call__`` method checks for special float values first and
-    delegates to ``self.value(value=value)`` for finite values.
+    delegates to the enum member's formatter for finite values.
     """
+
+    POSITIVE_INFINITY: str
+    NEGATIVE_INFINITY: str
+    NAN: str
+
+    def __init_subclass__(
+        cls,
+        *,
+        positive_infinity: str = "",
+        negative_infinity: str = "",
+        nan: str = "",
+        **kwargs: object,
+    ) -> None:
+        """Store float-special strings as class attributes."""
+        super().__init_subclass__(**kwargs)
+        cls.POSITIVE_INFINITY = positive_infinity
+        cls.NEGATIVE_INFINITY = negative_infinity
+        cls.NAN = nan
 
     def __call__(self, value: float, /) -> str:
         """Format a float, handling inf and nan via class constants."""
-        # Attributes ``POSITIVE_INFINITY``, ``NEGATIVE_INFINITY``,
-        # ``NAN``, and ``value`` are provided by enum subclasses via
-        # ``enum.nonmember()`` / ``enum.member()``.  Accessed through
-        # ``vars()`` so that all three type checkers (mypy, pyright,
-        # ty) stay happy without per-line suppression comments.
-        attrs = vars(type(self))
         if math.isinf(value):
-            key = "NEGATIVE_INFINITY" if value < 0 else "POSITIVE_INFINITY"
-            return cast("str", attrs[key])
+            if value < 0:
+                return self.NEGATIVE_INFINITY
+            return self.POSITIVE_INFINITY
         if math.isnan(value):
-            return cast("str", attrs["NAN"])
+            return self.NAN
         formatter = cast(
             "Callable[[float], str]",
             self.value,  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # ty: ignore[unresolved-attribute]

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -180,9 +180,9 @@ class FloatSpecialsMixin:
 
     Subclasses must define three ``enum.nonmember`` class attributes:
 
-    - ``pos_inf`` — string returned for positive infinity
-    - ``neg_inf`` — string returned for negative infinity
-    - ``nan`` — string returned for NaN
+    - ``POS_INF`` — string returned for positive infinity
+    - ``NEG_INF`` — string returned for negative infinity
+    - ``NAN`` — string returned for NaN
 
     The ``__call__`` method checks for special float values first and
     delegates to ``self.value(value=value)`` for finite values.
@@ -190,17 +190,17 @@ class FloatSpecialsMixin:
 
     def __call__(self, value: float, /) -> str:
         """Format a float, handling inf and nan via class constants."""
-        # Attributes ``pos_inf``, ``neg_inf``, ``nan``, and ``value``
+        # Attributes ``POS_INF``, ``NEG_INF``, ``NAN``, and ``value``
         # are provided by enum subclasses via ``enum.nonmember()`` /
         # ``enum.member()``.  Accessed through ``vars()`` so that all
         # three type checkers (mypy, pyright, ty) stay happy without
         # per-line suppression comments.
         attrs = vars(type(self))
         if math.isinf(value):
-            inf = attrs["neg_inf"] if value < 0 else attrs["pos_inf"]
+            inf = attrs["NEG_INF"] if value < 0 else attrs["POS_INF"]
             return cast("str", inf)
         if math.isnan(value):
-            return cast("str", attrs["nan"])
+            return cast("str", attrs["NAN"])
         formatter = cast(
             "Callable[[float], str]",
             self.value,  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # ty: ignore[unresolved-attribute]

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import math
 from collections.abc import Callable, Sequence
-from typing import Protocol, cast, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from beartype import beartype
 
@@ -191,6 +191,7 @@ class FloatSpecialsMixin:
     POSITIVE_INFINITY: str
     NEGATIVE_INFINITY: str
     NAN: str
+    value: Callable[[float], str]
 
     def __init_subclass__(
         cls,
@@ -214,11 +215,7 @@ class FloatSpecialsMixin:
             return self.POSITIVE_INFINITY
         if math.isnan(value):
             return self.NAN
-        formatter = cast(
-            "Callable[[float], str]",
-            self.value,  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # ty: ignore[unresolved-attribute]
-        )
-        return formatter(value)
+        return self.value(value)
 
 
 class LanguageCls(type):

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -3,8 +3,9 @@
 import dataclasses
 import datetime
 import enum
+import math
 from collections.abc import Callable, Sequence
-from typing import Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from beartype import beartype
 
@@ -172,6 +173,39 @@ class SequenceFormat(Protocol):
     def supports_heterogeneity(self) -> bool:
         """Whether this sequence format supports mixed-type elements."""
         ...  # pylint: disable=unnecessary-ellipsis
+
+
+class FloatSpecialsMixin:
+    """Mixin for FloatFormats enums that handles inf/nan dispatch.
+
+    Subclasses must define three ``enum.nonmember`` class attributes:
+
+    - ``pos_inf`` — string returned for positive infinity
+    - ``neg_inf`` — string returned for negative infinity
+    - ``nan`` — string returned for NaN
+
+    The ``__call__`` method checks for special float values first and
+    delegates to ``self.value(value=value)`` for finite values.
+    """
+
+    def __call__(self, value: float, /) -> str:
+        """Format a float, handling inf and nan via class constants."""
+        # Attributes ``pos_inf``, ``neg_inf``, ``nan``, and ``value``
+        # are provided by enum subclasses via ``enum.nonmember()`` /
+        # ``enum.member()``.  Accessed through ``vars()`` so that all
+        # three type checkers (mypy, pyright, ty) stay happy without
+        # per-line suppression comments.
+        attrs = vars(type(self))
+        if math.isinf(value):
+            inf = attrs["neg_inf"] if value < 0 else attrs["pos_inf"]
+            return cast("str", inf)
+        if math.isnan(value):
+            return cast("str", attrs["nan"])
+        formatter = cast(
+            "Callable[[float], str]",
+            self.value,  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # ty: ignore[unresolved-attribute]
+        )
+        return formatter(value)
 
 
 class LanguageCls(type):

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -180,8 +180,8 @@ class FloatSpecialsMixin:
 
     Subclasses must define three ``enum.nonmember`` class attributes:
 
-    - ``POS_INF`` — string returned for positive infinity
-    - ``NEG_INF`` — string returned for negative infinity
+    - ``POSITIVE_INFINITY`` — string returned for positive infinity
+    - ``NEGATIVE_INFINITY`` — string returned for negative infinity
     - ``NAN`` — string returned for NaN
 
     The ``__call__`` method checks for special float values first and
@@ -190,15 +190,15 @@ class FloatSpecialsMixin:
 
     def __call__(self, value: float, /) -> str:
         """Format a float, handling inf and nan via class constants."""
-        # Attributes ``POS_INF``, ``NEG_INF``, ``NAN``, and ``value``
-        # are provided by enum subclasses via ``enum.nonmember()`` /
-        # ``enum.member()``.  Accessed through ``vars()`` so that all
-        # three type checkers (mypy, pyright, ty) stay happy without
-        # per-line suppression comments.
+        # Attributes ``POSITIVE_INFINITY``, ``NEGATIVE_INFINITY``,
+        # ``NAN``, and ``value`` are provided by enum subclasses via
+        # ``enum.nonmember()`` / ``enum.member()``.  Accessed through
+        # ``vars()`` so that all three type checkers (mypy, pyright,
+        # ty) stay happy without per-line suppression comments.
         attrs = vars(type(self))
         if math.isinf(value):
-            inf = attrs["NEG_INF"] if value < 0 else attrs["POS_INF"]
-            return cast("str", inf)
+            key = "NEGATIVE_INFINITY" if value < 0 else "POSITIVE_INFINITY"
+            return cast("str", attrs[key])
         if math.isnan(value):
             return cast("str", attrs["NAN"])
         formatter = cast(

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -198,25 +198,14 @@ class Ada(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="1.0 / 0.0",
+        negative_infinity="-1.0 / 0.0",
+        nan="0.0 / 0.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="1.0 / 0.0")
-        NEGATIVE_INFINITY = enum.nonmember(value="-1.0 / 0.0")
-        NAN = enum.nonmember(value="0.0 / 0.0")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -201,9 +201,9 @@ class Ada(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="1.0 / 0.0")
-        neg_inf = enum.nonmember(value="-1.0 / 0.0")
-        nan = enum.nonmember(value="0.0 / 0.0")
+        POS_INF = enum.nonmember(value="1.0 / 0.0")
+        NEG_INF = enum.nonmember(value="-1.0 / 0.0")
+        NAN = enum.nonmember(value="0.0 / 0.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -198,12 +198,14 @@ class Ada(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="1.0 / 0.0",
+        negative_infinity="-1.0 / 0.0",
+        nan="0.0 / 0.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="1.0 / 0.0")
-        NEGATIVE_INFINITY = enum.nonmember(value="-1.0 / 0.0")
-        NAN = enum.nonmember(value="0.0 / 0.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -34,6 +33,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -198,20 +198,16 @@ class Ada(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="1.0 / 0.0")
+        neg_inf = enum.nonmember(value="-1.0 / 0.0")
+        nan = enum.nonmember(value="0.0 / 0.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-1.0 / 0.0" if value < 0 else "1.0 / 0.0"
-            if math.isnan(value):
-                return "0.0 / 0.0"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -198,14 +198,25 @@ class Ada(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="1.0 / 0.0",
-        negative_infinity="-1.0 / 0.0",
-        nan="0.0 / 0.0",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="1.0 / 0.0")
+        NEGATIVE_INFINITY = enum.nonmember(value="-1.0 / 0.0")
+        NAN = enum.nonmember(value="0.0 / 0.0")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -201,8 +201,8 @@ class Ada(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="1.0 / 0.0")
-        NEG_INF = enum.nonmember(value="-1.0 / 0.0")
+        POSITIVE_INFINITY = enum.nonmember(value="1.0 / 0.0")
+        NEGATIVE_INFINITY = enum.nonmember(value="-1.0 / 0.0")
         NAN = enum.nonmember(value="0.0 / 0.0")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -38,6 +37,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -214,20 +214,16 @@ class Bash(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="inf")
+        neg_inf = enum.nonmember(value="-inf")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf" if value < 0 else "inf"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -217,8 +217,8 @@ class Bash(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="inf")
-        NEG_INF = enum.nonmember(value="-inf")
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -214,14 +214,25 @@ class Bash(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="inf",
-        negative_infinity="-inf",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -217,9 +217,9 @@ class Bash(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="inf")
-        neg_inf = enum.nonmember(value="-inf")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="inf")
+        NEG_INF = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -214,25 +214,14 @@ class Bash(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -214,12 +214,14 @@ class Bash(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -205,9 +205,9 @@ class C(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="INFINITY")
-        neg_inf = enum.nonmember(value="-INFINITY")
-        nan = enum.nonmember(value="NAN")
+        POS_INF = enum.nonmember(value="INFINITY")
+        NEG_INF = enum.nonmember(value="-INFINITY")
+        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -38,6 +37,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -202,20 +202,16 @@ class C(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="INFINITY")
+        neg_inf = enum.nonmember(value="-INFINITY")
+        nan = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-INFINITY" if value < 0 else "INFINITY"
-            if math.isnan(value):
-                return "NAN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -202,25 +202,14 @@ class C(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INFINITY",
+        negative_infinity="-INFINITY",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
-        NAN = enum.nonmember(value="NAN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -205,8 +205,8 @@ class C(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="INFINITY")
-        NEG_INF = enum.nonmember(value="-INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
         NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -202,14 +202,25 @@ class C(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="INFINITY",
-        negative_infinity="-INFINITY",
-        nan="NAN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
+        NAN = enum.nonmember(value="NAN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -202,12 +202,14 @@ class C(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INFINITY",
+        negative_infinity="-INFINITY",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
-        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -166,8 +166,8 @@ class Clojure(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Double/POSITIVE_INFINITY")
-        NEG_INF = enum.nonmember(value="Double/NEGATIVE_INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="Double/POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double/NEGATIVE_INFINITY")
         NAN = enum.nonmember(value="Double/NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -163,14 +163,25 @@ class Clojure(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Double/POSITIVE_INFINITY",
-        negative_infinity="Double/NEGATIVE_INFINITY",
-        nan="Double/NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Double/POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double/NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double/NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -163,25 +163,14 @@ class Clojure(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double/POSITIVE_INFINITY",
+        negative_infinity="Double/NEGATIVE_INFINITY",
+        nan="Double/NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double/POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double/NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double/NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -36,6 +35,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -163,22 +163,16 @@ class Clojure(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Double/POSITIVE_INFINITY")
+        neg_inf = enum.nonmember(value="Double/NEGATIVE_INFINITY")
+        nan = enum.nonmember(value="Double/NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "Double/NEGATIVE_INFINITY"
-                return "Double/POSITIVE_INFINITY"
-            if math.isnan(value):
-                return "Double/NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -163,12 +163,14 @@ class Clojure(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double/POSITIVE_INFINITY",
+        negative_infinity="Double/NEGATIVE_INFINITY",
+        nan="Double/NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double/POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double/NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double/NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -166,9 +166,9 @@ class Clojure(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Double/POSITIVE_INFINITY")
-        neg_inf = enum.nonmember(value="Double/NEGATIVE_INFINITY")
-        nan = enum.nonmember(value="Double/NaN")
+        POS_INF = enum.nonmember(value="Double/POSITIVE_INFINITY")
+        NEG_INF = enum.nonmember(value="Double/NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double/NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -341,8 +341,8 @@ class Cobol(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="9.99E99")
-        NEG_INF = enum.nonmember(value="-9.99E99")
+        POSITIVE_INFINITY = enum.nonmember(value="9.99E99")
+        NEGATIVE_INFINITY = enum.nonmember(value="-9.99E99")
         NAN = enum.nonmember(value="0.0")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -338,25 +338,14 @@ class Cobol(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="9.99E99",
+        negative_infinity="-9.99E99",
+        nan="0.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="9.99E99")
-        NEGATIVE_INFINITY = enum.nonmember(value="-9.99E99")
-        NAN = enum.nonmember(value="0.0")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -338,14 +338,25 @@ class Cobol(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="9.99E99",
-        negative_infinity="-9.99E99",
-        nan="0.0",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="9.99E99")
+        NEGATIVE_INFINITY = enum.nonmember(value="-9.99E99")
+        NAN = enum.nonmember(value="0.0")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -341,9 +341,9 @@ class Cobol(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="9.99E99")
-        neg_inf = enum.nonmember(value="-9.99E99")
-        nan = enum.nonmember(value="0.0")
+        POS_INF = enum.nonmember(value="9.99E99")
+        NEG_INF = enum.nonmember(value="-9.99E99")
+        NAN = enum.nonmember(value="0.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -338,12 +338,14 @@ class Cobol(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="9.99E99",
+        negative_infinity="-9.99E99",
+        nan="0.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="9.99E99")
-        NEGATIVE_INFINITY = enum.nonmember(value="-9.99E99")
-        NAN = enum.nonmember(value="0.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 import re
 from typing import TYPE_CHECKING
 
@@ -34,6 +33,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -338,20 +338,16 @@ class Cobol(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="9.99E99")
+        neg_inf = enum.nonmember(value="-9.99E99")
+        nan = enum.nonmember(value="0.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-9.99E99" if value < 0 else "9.99E99"
-            if math.isnan(value):
-                return "0.0"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -185,8 +185,8 @@ class CommonLisp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value=_CL_INF)
-        NEG_INF = enum.nonmember(value=_CL_NEG_INF)
+        POSITIVE_INFINITY = enum.nonmember(value=_CL_INF)
+        NEGATIVE_INFINITY = enum.nonmember(value=_CL_NEG_INF)
         NAN = enum.nonmember(value=_CL_NAN)
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -34,13 +34,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -182,25 +182,14 @@ class CommonLisp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity=_CL_INF,
+        negative_infinity=_CL_NEG_INF,
+        nan=_CL_NAN,
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value=_CL_INF)
-        NEGATIVE_INFINITY = enum.nonmember(value=_CL_NEG_INF)
-        NAN = enum.nonmember(value=_CL_NAN)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -185,9 +185,9 @@ class CommonLisp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value=_CL_INF)
-        neg_inf = enum.nonmember(value=_CL_NEG_INF)
-        nan = enum.nonmember(value=_CL_NAN)
+        POS_INF = enum.nonmember(value=_CL_INF)
+        NEG_INF = enum.nonmember(value=_CL_NEG_INF)
+        NAN = enum.nonmember(value=_CL_NAN)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -182,12 +182,14 @@ class CommonLisp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity=_CL_INF,
+        negative_infinity=_CL_NEG_INF,
+        nan=_CL_NAN,
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value=_CL_INF)
-        NEGATIVE_INFINITY = enum.nonmember(value=_CL_NEG_INF)
-        NAN = enum.nonmember(value=_CL_NAN)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -34,13 +34,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -182,14 +182,25 @@ class CommonLisp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity=_CL_INF,
-        negative_infinity=_CL_NEG_INF,
-        nan=_CL_NAN,
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value=_CL_INF)
+        NEGATIVE_INFINITY = enum.nonmember(value=_CL_NEG_INF)
+        NAN = enum.nonmember(value=_CL_NAN)
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -35,6 +34,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -182,20 +182,16 @@ class CommonLisp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value=_CL_INF)
+        neg_inf = enum.nonmember(value=_CL_NEG_INF)
+        nan = enum.nonmember(value=_CL_NAN)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return _CL_NEG_INF if value < 0 else _CL_INF
-            if math.isnan(value):
-                return _CL_NAN
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -52,6 +51,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -408,20 +408,16 @@ class Cpp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="INFINITY")
+        neg_inf = enum.nonmember(value="-INFINITY")
+        nan = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-INFINITY" if value < 0 else "INFINITY"
-            if math.isnan(value):
-                return "NAN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -51,7 +51,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -59,6 +58,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -408,14 +408,25 @@ class Cpp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="INFINITY",
-        negative_infinity="-INFINITY",
-        nan="NAN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
+        NAN = enum.nonmember(value="NAN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -411,8 +411,8 @@ class Cpp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="INFINITY")
-        NEG_INF = enum.nonmember(value="-INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
         NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -411,9 +411,9 @@ class Cpp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="INFINITY")
-        neg_inf = enum.nonmember(value="-INFINITY")
-        nan = enum.nonmember(value="NAN")
+        POS_INF = enum.nonmember(value="INFINITY")
+        NEG_INF = enum.nonmember(value="-INFINITY")
+        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -58,7 +59,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -408,25 +408,14 @@ class Cpp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INFINITY",
+        negative_infinity="-INFINITY",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
-        NAN = enum.nonmember(value="NAN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -408,12 +408,14 @@ class Cpp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INFINITY",
+        negative_infinity="-INFINITY",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
-        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -222,9 +222,9 @@ class Crystal(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Float64::INFINITY")
-        neg_inf = enum.nonmember(value="-Float64::INFINITY")
-        nan = enum.nonmember(value="Float64::NAN")
+        POS_INF = enum.nonmember(value="Float64::INFINITY")
+        NEG_INF = enum.nonmember(value="-Float64::INFINITY")
+        NAN = enum.nonmember(value="Float64::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -219,14 +219,25 @@ class Crystal(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Float64::INFINITY",
-        negative_infinity="-Float64::INFINITY",
-        nan="Float64::NAN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Float64::INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Float64::INFINITY")
+        NAN = enum.nonmember(value="Float64::NAN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -39,6 +38,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -219,22 +219,16 @@ class Crystal(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Float64::INFINITY")
+        neg_inf = enum.nonmember(value="-Float64::INFINITY")
+        nan = enum.nonmember(value="Float64::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "-Float64::INFINITY"
-                return "Float64::INFINITY"
-            if math.isnan(value):
-                return "Float64::NAN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -219,25 +219,14 @@ class Crystal(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Float64::INFINITY",
+        negative_infinity="-Float64::INFINITY",
+        nan="Float64::NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Float64::INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Float64::INFINITY")
-        NAN = enum.nonmember(value="Float64::NAN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -222,8 +222,8 @@ class Crystal(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Float64::INFINITY")
-        NEG_INF = enum.nonmember(value="-Float64::INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="Float64::INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Float64::INFINITY")
         NAN = enum.nonmember(value="Float64::NAN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -219,12 +219,14 @@ class Crystal(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Float64::INFINITY",
+        negative_infinity="-Float64::INFINITY",
+        nan="Float64::NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Float64::INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Float64::INFINITY")
-        NAN = enum.nonmember(value="Float64::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -277,12 +277,14 @@ class CSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="double.PositiveInfinity",
+        negative_infinity="double.NegativeInfinity",
+        nan="double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="double.PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="double.NegativeInfinity")
-        NAN = enum.nonmember(value="double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -61,7 +62,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -277,25 +277,14 @@ class CSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="double.PositiveInfinity",
+        negative_infinity="double.NegativeInfinity",
+        nan="double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="double.PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="double.NegativeInfinity")
-        NAN = enum.nonmember(value="double.NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -55,6 +54,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -277,22 +277,16 @@ class CSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="double.PositiveInfinity")
+        neg_inf = enum.nonmember(value="double.NegativeInfinity")
+        nan = enum.nonmember(value="double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "double.NegativeInfinity"
-                return "double.PositiveInfinity"
-            if math.isnan(value):
-                return "double.NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -280,9 +280,9 @@ class CSharp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="double.PositiveInfinity")
-        neg_inf = enum.nonmember(value="double.NegativeInfinity")
-        nan = enum.nonmember(value="double.NaN")
+        POS_INF = enum.nonmember(value="double.PositiveInfinity")
+        NEG_INF = enum.nonmember(value="double.NegativeInfinity")
+        NAN = enum.nonmember(value="double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -54,7 +54,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -62,6 +61,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -277,14 +277,25 @@ class CSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="double.PositiveInfinity",
-        negative_infinity="double.NegativeInfinity",
-        nan="double.NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="double.PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="double.NegativeInfinity")
+        NAN = enum.nonmember(value="double.NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -280,8 +280,8 @@ class CSharp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="double.PositiveInfinity")
-        NEG_INF = enum.nonmember(value="double.NegativeInfinity")
+        POSITIVE_INFINITY = enum.nonmember(value="double.PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="double.NegativeInfinity")
         NAN = enum.nonmember(value="double.NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -42,6 +41,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -194,20 +194,16 @@ class D(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="double.infinity")
+        neg_inf = enum.nonmember(value="-double.infinity")
+        nan = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-double.infinity" if value < 0 else "double.infinity"
-            if math.isnan(value):
-                return "double.nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -41,13 +41,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -194,25 +194,14 @@ class D(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="double.infinity",
+        negative_infinity="-double.infinity",
+        nan="double.nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-double.infinity")
-        NAN = enum.nonmember(value="double.nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -41,13 +41,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -194,14 +194,25 @@ class D(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="double.infinity",
-        negative_infinity="-double.infinity",
-        nan="double.nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-double.infinity")
+        NAN = enum.nonmember(value="double.nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -197,8 +197,8 @@ class D(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="double.infinity")
-        NEG_INF = enum.nonmember(value="-double.infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-double.infinity")
         NAN = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -194,12 +194,14 @@ class D(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="double.infinity",
+        negative_infinity="-double.infinity",
+        nan="double.nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-double.infinity")
-        NAN = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -197,9 +197,9 @@ class D(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="double.infinity")
-        neg_inf = enum.nonmember(value="-double.infinity")
-        nan = enum.nonmember(value="double.nan")
+        POS_INF = enum.nonmember(value="double.infinity")
+        NEG_INF = enum.nonmember(value="-double.infinity")
+        NAN = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -246,12 +246,14 @@ class Dart(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="double.infinity",
+        negative_infinity="double.negativeInfinity",
+        nan="double.nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="double.negativeInfinity")
-        NAN = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -43,13 +43,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -246,14 +246,25 @@ class Dart(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="double.infinity",
-        negative_infinity="double.negativeInfinity",
-        nan="double.nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="double.negativeInfinity")
+        NAN = enum.nonmember(value="double.nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -44,6 +43,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -246,22 +246,16 @@ class Dart(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="double.infinity")
+        neg_inf = enum.nonmember(value="double.negativeInfinity")
+        nan = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "double.negativeInfinity"
-                return "double.infinity"
-            if math.isnan(value):
-                return "double.nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -249,8 +249,8 @@ class Dart(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="double.infinity")
-        NEG_INF = enum.nonmember(value="double.negativeInfinity")
+        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="double.negativeInfinity")
         NAN = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -249,9 +249,9 @@ class Dart(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="double.infinity")
-        neg_inf = enum.nonmember(value="double.negativeInfinity")
-        nan = enum.nonmember(value="double.nan")
+        POS_INF = enum.nonmember(value="double.infinity")
+        NEG_INF = enum.nonmember(value="double.negativeInfinity")
+        NAN = enum.nonmember(value="double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -43,13 +43,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -246,25 +246,14 @@ class Dart(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="double.infinity",
+        negative_infinity="double.negativeInfinity",
+        nan="double.nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="double.infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="double.negativeInfinity")
-        NAN = enum.nonmember(value="double.nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -281,12 +281,14 @@ class Dhall(metaclass=LanguageCls):
 
         ERROR = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -281,25 +281,14 @@ class Dhall(metaclass=LanguageCls):
 
         ERROR = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -281,14 +281,25 @@ class Dhall(metaclass=LanguageCls):
 
         ERROR = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Infinity",
-        negative_infinity="-Infinity",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 import re
 from typing import TYPE_CHECKING
 
@@ -38,6 +37,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -281,20 +281,16 @@ class Dhall(metaclass=LanguageCls):
 
         ERROR = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Infinity")
+        neg_inf = enum.nonmember(value="-Infinity")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Infinity" if value < 0 else "Infinity"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -284,9 +284,9 @@ class Dhall(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Infinity")
-        neg_inf = enum.nonmember(value="-Infinity")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Infinity")
+        NEG_INF = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -284,8 +284,8 @@ class Dhall(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Infinity")
-        NEG_INF = enum.nonmember(value="-Infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -237,8 +237,8 @@ class Elixir(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value=":infinity")
-        NEG_INF = enum.nonmember(value=":negative_infinity")
+        POSITIVE_INFINITY = enum.nonmember(value=":infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value=":negative_infinity")
         NAN = enum.nonmember(value=":nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -237,9 +237,9 @@ class Elixir(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value=":infinity")
-        neg_inf = enum.nonmember(value=":negative_infinity")
-        nan = enum.nonmember(value=":nan")
+        POS_INF = enum.nonmember(value=":infinity")
+        NEG_INF = enum.nonmember(value=":negative_infinity")
+        NAN = enum.nonmember(value=":nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -45,13 +45,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -234,14 +234,25 @@ class Elixir(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity=":infinity",
-        negative_infinity=":negative_infinity",
-        nan=":nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value=":infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value=":negative_infinity")
+        NAN = enum.nonmember(value=":nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -45,13 +45,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -234,25 +234,14 @@ class Elixir(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity=":infinity",
+        negative_infinity=":negative_infinity",
+        nan=":nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value=":infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value=":negative_infinity")
-        NAN = enum.nonmember(value=":nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -46,6 +45,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -234,20 +234,16 @@ class Elixir(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value=":infinity")
+        neg_inf = enum.nonmember(value=":negative_infinity")
+        nan = enum.nonmember(value=":nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return ":negative_infinity" if value < 0 else ":infinity"
-            if math.isnan(value):
-                return ":nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -234,12 +234,14 @@ class Elixir(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity=":infinity",
+        negative_infinity=":negative_infinity",
+        nan=":nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value=":infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value=":negative_infinity")
-        NAN = enum.nonmember(value=":nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -39,12 +39,12 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -332,25 +332,14 @@ class Elm(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="EFloat (1 / 0)",
+        negative_infinity="EFloat (-(1 / 0))",
+        nan="EFloat (0 / 0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="EFloat (1 / 0)")
-        NEGATIVE_INFINITY = enum.nonmember(value="EFloat (-(1 / 0))")
-        NAN = enum.nonmember(value="EFloat (0 / 0)")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=_format_elm_float_repr)
         SCIENTIFIC = enum.member(value=_format_elm_float_scientific)

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -332,12 +332,14 @@ class Elm(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="EFloat (1 / 0)",
+        negative_infinity="EFloat (-(1 / 0))",
+        nan="EFloat (0 / 0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="EFloat (1 / 0)")
-        NEGATIVE_INFINITY = enum.nonmember(value="EFloat (-(1 / 0))")
-        NAN = enum.nonmember(value="EFloat (0 / 0)")
 
         REPR = enum.member(value=_format_elm_float_repr)
         SCIENTIFIC = enum.member(value=_format_elm_float_scientific)

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -335,8 +335,8 @@ class Elm(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="EFloat (1 / 0)")
-        NEG_INF = enum.nonmember(value="EFloat (-(1 / 0))")
+        POSITIVE_INFINITY = enum.nonmember(value="EFloat (1 / 0)")
+        NEGATIVE_INFINITY = enum.nonmember(value="EFloat (-(1 / 0))")
         NAN = enum.nonmember(value="EFloat (0 / 0)")
 
         REPR = enum.member(value=_format_elm_float_repr)

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -39,12 +39,12 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -332,14 +332,25 @@ class Elm(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="EFloat (1 / 0)",
-        negative_infinity="EFloat (-(1 / 0))",
-        nan="EFloat (0 / 0)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="EFloat (1 / 0)")
+        NEGATIVE_INFINITY = enum.nonmember(value="EFloat (-(1 / 0))")
+        NAN = enum.nonmember(value="EFloat (0 / 0)")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=_format_elm_float_repr)
         SCIENTIFIC = enum.member(value=_format_elm_float_scientific)

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -40,6 +39,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -102,12 +102,6 @@ def _elm_float_wrapper(
     @beartype
     def _format(value: float) -> str:
         """Format a float with an ``EFloat`` constructor."""
-        if math.isinf(value):
-            if value < 0:
-                return "EFloat (-(1 / 0))"
-            return "EFloat (1 / 0)"
-        if math.isnan(value):
-            return "EFloat (0 / 0)"
         formatted = inner(value)
         if formatted.startswith("-"):
             return f"EFloat ({formatted})"
@@ -338,17 +332,16 @@ class Elm(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="EFloat (1 / 0)")
+        neg_inf = enum.nonmember(value="EFloat (-(1 / 0))")
+        nan = enum.nonmember(value="EFloat (0 / 0)")
 
         REPR = enum.member(value=_format_elm_float_repr)
         SCIENTIFIC = enum.member(value=_format_elm_float_scientific)
         FIXED = enum.member(value=_format_elm_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -335,9 +335,9 @@ class Elm(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="EFloat (1 / 0)")
-        neg_inf = enum.nonmember(value="EFloat (-(1 / 0))")
-        nan = enum.nonmember(value="EFloat (0 / 0)")
+        POS_INF = enum.nonmember(value="EFloat (1 / 0)")
+        NEG_INF = enum.nonmember(value="EFloat (-(1 / 0))")
+        NAN = enum.nonmember(value="EFloat (0 / 0)")
 
         REPR = enum.member(value=_format_elm_float_repr)
         SCIENTIFIC = enum.member(value=_format_elm_float_scientific)

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -39,6 +38,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -235,20 +235,16 @@ class Erlang(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="inf")
+        neg_inf = enum.nonmember(value="-inf")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf" if value < 0 else "inf"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -235,12 +235,14 @@ class Erlang(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -238,9 +238,9 @@ class Erlang(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="inf")
-        neg_inf = enum.nonmember(value="-inf")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="inf")
+        NEG_INF = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -235,14 +235,25 @@ class Erlang(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="inf",
-        negative_infinity="-inf",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -238,8 +238,8 @@ class Erlang(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="inf")
-        NEG_INF = enum.nonmember(value="-inf")
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -235,25 +235,14 @@ class Erlang(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -34,6 +33,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -255,22 +255,16 @@ class Fortran(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="ieee_value(0.0, ieee_positive_inf)")
+        neg_inf = enum.nonmember(value="ieee_value(0.0, ieee_negative_inf)")
+        nan = enum.nonmember(value="ieee_value(0.0, ieee_quiet_nan)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "ieee_value(0.0, ieee_negative_inf)"
-                return "ieee_value(0.0, ieee_positive_inf)"
-            if math.isnan(value):
-                return "ieee_value(0.0, ieee_quiet_nan)"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -255,16 +255,14 @@ class Fortran(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="ieee_value(0.0, ieee_positive_inf)",
+        negative_infinity="ieee_value(0.0, ieee_negative_inf)",
+        nan="ieee_value(0.0, ieee_quiet_nan)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(
-            value="ieee_value(0.0, ieee_positive_inf)",
-        )
-        NEGATIVE_INFINITY = enum.nonmember(
-            value="ieee_value(0.0, ieee_negative_inf)",
-        )
-        NAN = enum.nonmember(value="ieee_value(0.0, ieee_quiet_nan)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -258,8 +258,12 @@ class Fortran(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="ieee_value(0.0, ieee_positive_inf)")
-        NEG_INF = enum.nonmember(value="ieee_value(0.0, ieee_negative_inf)")
+        POSITIVE_INFINITY = enum.nonmember(
+            value="ieee_value(0.0, ieee_positive_inf)",
+        )
+        NEGATIVE_INFINITY = enum.nonmember(
+            value="ieee_value(0.0, ieee_negative_inf)",
+        )
         NAN = enum.nonmember(value="ieee_value(0.0, ieee_quiet_nan)")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -258,9 +258,9 @@ class Fortran(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="ieee_value(0.0, ieee_positive_inf)")
-        neg_inf = enum.nonmember(value="ieee_value(0.0, ieee_negative_inf)")
-        nan = enum.nonmember(value="ieee_value(0.0, ieee_quiet_nan)")
+        POS_INF = enum.nonmember(value="ieee_value(0.0, ieee_positive_inf)")
+        NEG_INF = enum.nonmember(value="ieee_value(0.0, ieee_negative_inf)")
+        NAN = enum.nonmember(value="ieee_value(0.0, ieee_quiet_nan)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -255,29 +255,14 @@ class Fortran(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="ieee_value(0.0, ieee_positive_inf)",
+        negative_infinity="ieee_value(0.0, ieee_negative_inf)",
+        nan="ieee_value(0.0, ieee_quiet_nan)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(
-            value="ieee_value(0.0, ieee_positive_inf)",
-        )
-        NEGATIVE_INFINITY = enum.nonmember(
-            value="ieee_value(0.0, ieee_negative_inf)",
-        )
-        NAN = enum.nonmember(value="ieee_value(0.0, ieee_quiet_nan)")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -255,14 +255,29 @@ class Fortran(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="ieee_value(0.0, ieee_positive_inf)",
-        negative_infinity="ieee_value(0.0, ieee_negative_inf)",
-        nan="ieee_value(0.0, ieee_quiet_nan)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(
+            value="ieee_value(0.0, ieee_positive_inf)",
+        )
+        NEGATIVE_INFINITY = enum.nonmember(
+            value="ieee_value(0.0, ieee_negative_inf)",
+        )
+        NAN = enum.nonmember(value="ieee_value(0.0, ieee_quiet_nan)")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -43,13 +43,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -265,25 +265,14 @@ class FSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="infinity",
+        negative_infinity="-infinity",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-infinity")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -44,6 +43,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -265,20 +265,16 @@ class FSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="infinity")
+        neg_inf = enum.nonmember(value="-infinity")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-infinity" if value < 0 else "infinity"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -43,13 +43,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -265,14 +265,25 @@ class FSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="infinity",
-        negative_infinity="-infinity",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-infinity")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -265,12 +265,14 @@ class FSharp(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="infinity",
+        negative_infinity="-infinity",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-infinity")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -268,8 +268,8 @@ class FSharp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="infinity")
-        NEG_INF = enum.nonmember(value="-infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-infinity")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -268,9 +268,9 @@ class FSharp(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="infinity")
-        neg_inf = enum.nonmember(value="-infinity")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="infinity")
+        NEG_INF = enum.nonmember(value="-infinity")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -326,9 +326,9 @@ class Gleam(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="GFloat(todo)")
-        neg_inf = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
-        nan = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
+        POS_INF = enum.nonmember(value="GFloat(todo)")
+        NEG_INF = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
+        NAN = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
 
         REPR = enum.member(value=_gleam_float_wrapper(inner=format_float_repr))
         SCIENTIFIC = enum.member(

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -323,12 +323,14 @@ class Gleam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="GFloat(todo)",
+        negative_infinity="GFloat(todo)",
+        nan="GFloat(todo)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="GFloat(todo)")
-        NEGATIVE_INFINITY = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
-        NAN = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
 
         REPR = enum.member(value=_gleam_float_wrapper(inner=format_float_repr))
         SCIENTIFIC = enum.member(

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -42,13 +42,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -323,25 +323,14 @@ class Gleam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="GFloat(todo)",
+        negative_infinity="GFloat(todo)",
+        nan="GFloat(todo)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="GFloat(todo)")
-        NEGATIVE_INFINITY = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
-        NAN = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=_gleam_float_wrapper(inner=format_float_repr))
         SCIENTIFIC = enum.member(

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -326,8 +326,8 @@ class Gleam(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="GFloat(todo)")
-        NEG_INF = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
+        POSITIVE_INFINITY = enum.nonmember(value="GFloat(todo)")
+        NEGATIVE_INFINITY = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
         NAN = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
 
         REPR = enum.member(value=_gleam_float_wrapper(inner=format_float_repr))

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -43,6 +42,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -138,10 +138,6 @@ def _gleam_float_wrapper(
     @beartype
     def _format(value: float) -> str:
         """Format a float with a ``GFloat`` constructor."""
-        if math.isinf(value):
-            return "GFloat(todo)"
-        if math.isnan(value):
-            return "GFloat(todo)"
         return f"GFloat({inner(value)})"
 
     return _format
@@ -327,8 +323,12 @@ class Gleam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="GFloat(todo)")
+        neg_inf = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
+        nan = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
 
         REPR = enum.member(value=_gleam_float_wrapper(inner=format_float_repr))
         SCIENTIFIC = enum.member(
@@ -337,11 +337,6 @@ class Gleam(metaclass=LanguageCls):
         FIXED = enum.member(
             value=_gleam_float_wrapper(inner=format_float_fixed)
         )
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -42,13 +42,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -323,14 +323,25 @@ class Gleam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="GFloat(todo)",
-        negative_infinity="GFloat(todo)",
-        nan="GFloat(todo)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="GFloat(todo)")
+        NEGATIVE_INFINITY = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
+        NAN = enum.nonmember(value="GFloat(todo)")  # noqa: PIE796
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=_gleam_float_wrapper(inner=format_float_repr))
         SCIENTIFIC = enum.member(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -266,12 +266,14 @@ class Go(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="math.Inf(1)",
+        negative_infinity="math.Inf(-1)",
+        nan="math.NaN()",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="math.Inf(1)")
-        NEGATIVE_INFINITY = enum.nonmember(value="math.Inf(-1)")
-        NAN = enum.nonmember(value="math.NaN()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -47,7 +47,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -55,6 +54,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -266,14 +266,25 @@ class Go(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="math.Inf(1)",
-        negative_infinity="math.Inf(-1)",
-        nan="math.NaN()",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="math.Inf(1)")
+        NEGATIVE_INFINITY = enum.nonmember(value="math.Inf(-1)")
+        NAN = enum.nonmember(value="math.NaN()")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -54,7 +55,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -266,25 +266,14 @@ class Go(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="math.Inf(1)",
+        negative_infinity="math.Inf(-1)",
+        nan="math.NaN()",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="math.Inf(1)")
-        NEGATIVE_INFINITY = enum.nonmember(value="math.Inf(-1)")
-        NAN = enum.nonmember(value="math.NaN()")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -48,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -266,20 +266,16 @@ class Go(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="math.Inf(1)")
+        neg_inf = enum.nonmember(value="math.Inf(-1)")
+        nan = enum.nonmember(value="math.NaN()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "math.Inf(-1)" if value < 0 else "math.Inf(1)"
-            if math.isnan(value):
-                return "math.NaN()"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -269,8 +269,8 @@ class Go(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="math.Inf(1)")
-        NEG_INF = enum.nonmember(value="math.Inf(-1)")
+        POSITIVE_INFINITY = enum.nonmember(value="math.Inf(1)")
+        NEGATIVE_INFINITY = enum.nonmember(value="math.Inf(-1)")
         NAN = enum.nonmember(value="math.NaN()")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -269,9 +269,9 @@ class Go(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="math.Inf(1)")
-        neg_inf = enum.nonmember(value="math.Inf(-1)")
-        nan = enum.nonmember(value="math.NaN()")
+        POS_INF = enum.nonmember(value="math.Inf(1)")
+        NEG_INF = enum.nonmember(value="math.Inf(-1)")
+        NAN = enum.nonmember(value="math.NaN()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -178,9 +178,9 @@ class Groovy(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        neg_inf = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        nan = enum.nonmember(value="Double.NaN")
+        POS_INF = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEG_INF = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -175,25 +175,14 @@ class Groovy(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.POSITIVE_INFINITY",
+        negative_infinity="Double.NEGATIVE_INFINITY",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double.NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -37,13 +37,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -175,14 +175,25 @@ class Groovy(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Double.POSITIVE_INFINITY",
-        negative_infinity="Double.NEGATIVE_INFINITY",
-        nan="Double.NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double.NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -178,8 +178,8 @@ class Groovy(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEG_INF = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
         NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -175,12 +175,14 @@ class Groovy(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.POSITIVE_INFINITY",
+        negative_infinity="Double.NEGATIVE_INFINITY",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -38,6 +37,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -175,22 +175,16 @@ class Groovy(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        neg_inf = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        nan = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "Double.NEGATIVE_INFINITY"
-                return "Double.POSITIVE_INFINITY"
-            if math.isnan(value):
-                return "Double.NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -46,13 +46,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -432,14 +432,25 @@ class Haskell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="(1/0)",
-        negative_infinity="(-1/0)",
-        nan="(0/0)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="(1/0)")
+        NEGATIVE_INFINITY = enum.nonmember(value="(-1/0)")
+        NAN = enum.nonmember(value="(0/0)")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -435,8 +435,8 @@ class Haskell(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="(1/0)")
-        NEG_INF = enum.nonmember(value="(-1/0)")
+        POSITIVE_INFINITY = enum.nonmember(value="(1/0)")
+        NEGATIVE_INFINITY = enum.nonmember(value="(-1/0)")
         NAN = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -432,12 +432,14 @@ class Haskell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="(1/0)",
+        negative_infinity="(-1/0)",
+        nan="(0/0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="(1/0)")
-        NEGATIVE_INFINITY = enum.nonmember(value="(-1/0)")
-        NAN = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -435,9 +435,9 @@ class Haskell(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="(1/0)")
-        neg_inf = enum.nonmember(value="(-1/0)")
-        nan = enum.nonmember(value="(0/0)")
+        POS_INF = enum.nonmember(value="(1/0)")
+        NEG_INF = enum.nonmember(value="(-1/0)")
+        NAN = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -46,13 +46,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -432,25 +432,14 @@ class Haskell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="(1/0)",
+        negative_infinity="(-1/0)",
+        nan="(0/0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="(1/0)")
-        NEGATIVE_INFINITY = enum.nonmember(value="(-1/0)")
-        NAN = enum.nonmember(value="(0/0)")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -47,6 +46,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -432,20 +432,16 @@ class Haskell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="(1/0)")
+        neg_inf = enum.nonmember(value="(-1/0)")
+        nan = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "(-1/0)" if value < 0 else "(1/0)"
-            if math.isnan(value):
-                return "(0/0)"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -36,6 +35,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -167,20 +167,16 @@ class Hcl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="inf")
+        neg_inf = enum.nonmember(value="-inf")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf" if value < 0 else "inf"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -167,14 +167,25 @@ class Hcl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="inf",
-        negative_infinity="-inf",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -170,8 +170,8 @@ class Hcl(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="inf")
-        NEG_INF = enum.nonmember(value="-inf")
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -170,9 +170,9 @@ class Hcl(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="inf")
-        neg_inf = enum.nonmember(value="-inf")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="inf")
+        NEG_INF = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -167,25 +167,14 @@ class Hcl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -167,12 +167,14 @@ class Hcl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -341,8 +341,8 @@ class Java(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEG_INF = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
         NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -48,7 +48,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -56,6 +55,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer.exceptions import NullInCollectionError
@@ -338,14 +338,25 @@ class Java(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Double.POSITIVE_INFINITY",
-        negative_infinity="Double.NEGATIVE_INFINITY",
-        nan="Double.NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double.NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -338,12 +338,14 @@ class Java(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.POSITIVE_INFINITY",
+        negative_infinity="Double.NEGATIVE_INFINITY",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -341,9 +341,9 @@ class Java(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        neg_inf = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        nan = enum.nonmember(value="Double.NaN")
+        POS_INF = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEG_INF = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -49,6 +48,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -338,22 +338,16 @@ class Java(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        neg_inf = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        nan = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "Double.NEGATIVE_INFINITY"
-                return "Double.POSITIVE_INFINITY"
-            if math.isnan(value):
-                return "Double.NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -55,7 +56,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer.exceptions import NullInCollectionError
@@ -338,25 +338,14 @@ class Java(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.POSITIVE_INFINITY",
+        negative_infinity="Double.NEGATIVE_INFINITY",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double.NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -265,8 +265,8 @@ class JavaScript(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Infinity")
-        NEG_INF = enum.nonmember(value="-Infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -262,12 +262,14 @@ class JavaScript(metaclass=LanguageCls):
         NONE = enum.auto()
         UNDERSCORE = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -50,6 +49,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -262,20 +262,16 @@ class JavaScript(metaclass=LanguageCls):
         NONE = enum.auto()
         UNDERSCORE = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Infinity")
+        neg_inf = enum.nonmember(value="-Infinity")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Infinity" if value < 0 else "Infinity"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -49,13 +49,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -262,25 +262,14 @@ class JavaScript(metaclass=LanguageCls):
         NONE = enum.auto()
         UNDERSCORE = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -49,13 +49,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -262,14 +262,25 @@ class JavaScript(metaclass=LanguageCls):
         NONE = enum.auto()
         UNDERSCORE = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Infinity",
-        negative_infinity="-Infinity",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -265,9 +265,9 @@ class JavaScript(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Infinity")
-        neg_inf = enum.nonmember(value="-Infinity")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Infinity")
+        NEG_INF = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 import re
 from typing import TYPE_CHECKING
 
@@ -40,6 +39,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -195,20 +195,16 @@ class Json5(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Infinity")
+        neg_inf = enum.nonmember(value="-Infinity")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Infinity" if value < 0 else "Infinity"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -39,13 +39,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -195,25 +195,14 @@ class Json5(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -195,12 +195,14 @@ class Json5(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -198,8 +198,8 @@ class Json5(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Infinity")
-        NEG_INF = enum.nonmember(value="-Infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -198,9 +198,9 @@ class Json5(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Infinity")
-        neg_inf = enum.nonmember(value="-Infinity")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Infinity")
+        NEG_INF = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -39,13 +39,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -195,14 +195,25 @@ class Json5(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Infinity",
-        negative_infinity="-Infinity",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -197,14 +197,25 @@ class Jsonnet(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity='"Infinity"',
-        negative_infinity='"-Infinity"',
-        nan='"NaN"',
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value='"Infinity"')
+        NEGATIVE_INFINITY = enum.nonmember(value='"-Infinity"')
+        NAN = enum.nonmember(value='"NaN"')
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -197,25 +197,14 @@ class Jsonnet(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity='"Infinity"',
+        negative_infinity='"-Infinity"',
+        nan='"NaN"',
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value='"Infinity"')
-        NEGATIVE_INFINITY = enum.nonmember(value='"-Infinity"')
-        NAN = enum.nonmember(value='"NaN"')
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -200,8 +200,8 @@ class Jsonnet(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value='"Infinity"')
-        NEG_INF = enum.nonmember(value='"-Infinity"')
+        POSITIVE_INFINITY = enum.nonmember(value='"Infinity"')
+        NEGATIVE_INFINITY = enum.nonmember(value='"-Infinity"')
         NAN = enum.nonmember(value='"NaN"')
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 import re
 from typing import TYPE_CHECKING
 
@@ -39,6 +38,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -197,20 +197,16 @@ class Jsonnet(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value='"Infinity"')
+        neg_inf = enum.nonmember(value='"-Infinity"')
+        nan = enum.nonmember(value='"NaN"')
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return '"-Infinity"' if value < 0 else '"Infinity"'
-            if math.isnan(value):
-                return '"NaN"'
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -200,9 +200,9 @@ class Jsonnet(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value='"Infinity"')
-        neg_inf = enum.nonmember(value='"-Infinity"')
-        nan = enum.nonmember(value='"NaN"')
+        POS_INF = enum.nonmember(value='"Infinity"')
+        NEG_INF = enum.nonmember(value='"-Infinity"')
+        NAN = enum.nonmember(value='"NaN"')
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -197,12 +197,14 @@ class Jsonnet(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity='"Infinity"',
+        negative_infinity='"-Infinity"',
+        nan='"NaN"',
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value='"Infinity"')
-        NEGATIVE_INFINITY = enum.nonmember(value='"-Infinity"')
-        NAN = enum.nonmember(value='"NaN"')
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -48,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -251,20 +251,16 @@ class Julia(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Inf")
+        neg_inf = enum.nonmember(value="-Inf")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Inf" if value < 0 else "Inf"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -47,7 +47,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -55,6 +54,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -251,14 +251,25 @@ class Julia(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Inf",
-        negative_infinity="-Inf",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -254,9 +254,9 @@ class Julia(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Inf")
-        neg_inf = enum.nonmember(value="-Inf")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Inf")
+        NEG_INF = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -251,12 +251,14 @@ class Julia(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -254,8 +254,8 @@ class Julia(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Inf")
-        NEG_INF = enum.nonmember(value="-Inf")
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -54,7 +55,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -251,25 +251,14 @@ class Julia(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -381,12 +381,14 @@ class Kotlin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.POSITIVE_INFINITY",
+        negative_infinity="Double.NEGATIVE_INFINITY",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -54,7 +54,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -62,6 +61,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -381,14 +381,25 @@ class Kotlin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Double.POSITIVE_INFINITY",
-        negative_infinity="Double.NEGATIVE_INFINITY",
-        nan="Double.NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double.NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -61,7 +62,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -381,25 +381,14 @@ class Kotlin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.POSITIVE_INFINITY",
+        negative_infinity="Double.NEGATIVE_INFINITY",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        NAN = enum.nonmember(value="Double.NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -384,9 +384,9 @@ class Kotlin(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        neg_inf = enum.nonmember(value="Double.NEGATIVE_INFINITY")
-        nan = enum.nonmember(value="Double.NaN")
+        POS_INF = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEG_INF = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -384,8 +384,8 @@ class Kotlin(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Double.POSITIVE_INFINITY")
-        NEG_INF = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NEGATIVE_INFINITY")
         NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -55,6 +54,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -381,22 +381,16 @@ class Kotlin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Double.POSITIVE_INFINITY")
+        neg_inf = enum.nonmember(value="Double.NEGATIVE_INFINITY")
+        nan = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "Double.NEGATIVE_INFINITY"
-                return "Double.POSITIVE_INFINITY"
-            if math.isnan(value):
-                return "Double.NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -212,8 +212,8 @@ class Lua(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="math.huge")
-        NEG_INF = enum.nonmember(value="-math.huge")
+        POSITIVE_INFINITY = enum.nonmember(value="math.huge")
+        NEGATIVE_INFINITY = enum.nonmember(value="-math.huge")
         NAN = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -209,12 +209,14 @@ class Lua(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="math.huge",
+        negative_infinity="-math.huge",
+        nan="(0/0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="math.huge")
-        NEGATIVE_INFINITY = enum.nonmember(value="-math.huge")
-        NAN = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -212,9 +212,9 @@ class Lua(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="math.huge")
-        neg_inf = enum.nonmember(value="-math.huge")
-        nan = enum.nonmember(value="(0/0)")
+        POS_INF = enum.nonmember(value="math.huge")
+        NEG_INF = enum.nonmember(value="-math.huge")
+        NAN = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -209,25 +209,14 @@ class Lua(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="math.huge",
+        negative_infinity="-math.huge",
+        nan="(0/0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="math.huge")
-        NEGATIVE_INFINITY = enum.nonmember(value="-math.huge")
-        NAN = enum.nonmember(value="(0/0)")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -209,14 +209,25 @@ class Lua(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="math.huge",
-        negative_infinity="-math.huge",
-        nan="(0/0)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="math.huge")
+        NEGATIVE_INFINITY = enum.nonmember(value="-math.huge")
+        NAN = enum.nonmember(value="(0/0)")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -39,6 +38,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -209,20 +209,16 @@ class Lua(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="math.huge")
+        neg_inf = enum.nonmember(value="-math.huge")
+        nan = enum.nonmember(value="(0/0)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-math.huge" if value < 0 else "math.huge"
-            if math.isnan(value):
-                return "(0/0)"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -288,8 +288,8 @@ class Matlab(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Inf")
-        NEG_INF = enum.nonmember(value="-Inf")
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -36,13 +36,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -285,25 +285,14 @@ class Matlab(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -36,13 +36,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -285,14 +285,25 @@ class Matlab(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Inf",
-        negative_infinity="-Inf",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -285,12 +285,14 @@ class Matlab(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 import re
 from typing import TYPE_CHECKING
 
@@ -37,6 +36,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -285,20 +285,16 @@ class Matlab(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Inf")
+        neg_inf = enum.nonmember(value="-Inf")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Inf" if value < 0 else "Inf"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -288,9 +288,9 @@ class Matlab(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Inf")
-        neg_inf = enum.nonmember(value="-Inf")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Inf")
+        NEG_INF = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -219,9 +219,9 @@ class Mojo(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="std.math.inf[DType.float64]()")
-        neg_inf = enum.nonmember(value="-std.math.inf[DType.float64]()")
-        nan = enum.nonmember(value="std.math.nan[DType.float64]()")
+        POS_INF = enum.nonmember(value="std.math.inf[DType.float64]()")
+        NEG_INF = enum.nonmember(value="-std.math.inf[DType.float64]()")
+        NAN = enum.nonmember(value="std.math.nan[DType.float64]()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -40,6 +39,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -216,22 +216,16 @@ class Mojo(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="std.math.inf[DType.float64]()")
+        neg_inf = enum.nonmember(value="-std.math.inf[DType.float64]()")
+        nan = enum.nonmember(value="std.math.nan[DType.float64]()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "-std.math.inf[DType.float64]()"
-                return "std.math.inf[DType.float64]()"
-            if math.isnan(value):
-                return "std.math.nan[DType.float64]()"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -39,13 +39,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -216,14 +216,29 @@ class Mojo(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="std.math.inf[DType.float64]()",
-        negative_infinity="-std.math.inf[DType.float64]()",
-        nan="std.math.nan[DType.float64]()",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(
+            value="std.math.inf[DType.float64]()",
+        )
+        NEGATIVE_INFINITY = enum.nonmember(
+            value="-std.math.inf[DType.float64]()",
+        )
+        NAN = enum.nonmember(value="std.math.nan[DType.float64]()")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -39,13 +39,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -216,29 +216,14 @@ class Mojo(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="std.math.inf[DType.float64]()",
+        negative_infinity="-std.math.inf[DType.float64]()",
+        nan="std.math.nan[DType.float64]()",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(
-            value="std.math.inf[DType.float64]()",
-        )
-        NEGATIVE_INFINITY = enum.nonmember(
-            value="-std.math.inf[DType.float64]()",
-        )
-        NAN = enum.nonmember(value="std.math.nan[DType.float64]()")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -216,16 +216,14 @@ class Mojo(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="std.math.inf[DType.float64]()",
+        negative_infinity="-std.math.inf[DType.float64]()",
+        nan="std.math.nan[DType.float64]()",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(
-            value="std.math.inf[DType.float64]()",
-        )
-        NEGATIVE_INFINITY = enum.nonmember(
-            value="-std.math.inf[DType.float64]()",
-        )
-        NAN = enum.nonmember(value="std.math.nan[DType.float64]()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -219,8 +219,12 @@ class Mojo(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="std.math.inf[DType.float64]()")
-        NEG_INF = enum.nonmember(value="-std.math.inf[DType.float64]()")
+        POSITIVE_INFINITY = enum.nonmember(
+            value="std.math.inf[DType.float64]()",
+        )
+        NEGATIVE_INFINITY = enum.nonmember(
+            value="-std.math.inf[DType.float64]()",
+        )
         NAN = enum.nonmember(value="std.math.nan[DType.float64]()")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -297,8 +297,8 @@ class Nim(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Inf")
-        NEG_INF = enum.nonmember(value="-Inf")
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -44,13 +44,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -294,14 +294,25 @@ class Nim(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Inf",
-        negative_infinity="-Inf",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -297,9 +297,9 @@ class Nim(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Inf")
-        neg_inf = enum.nonmember(value="-Inf")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Inf")
+        NEG_INF = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -294,12 +294,14 @@ class Nim(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -44,13 +44,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -294,25 +294,14 @@ class Nim(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
 
@@ -45,6 +44,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -294,20 +294,16 @@ class Nim(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Inf")
+        neg_inf = enum.nonmember(value="-Inf")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Inf" if value < 0 else "Inf"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -175,25 +175,14 @@ class Norg(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -36,6 +35,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -175,20 +175,16 @@ class Norg(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="inf")
+        neg_inf = enum.nonmember(value="-inf")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf" if value < 0 else "inf"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -178,8 +178,8 @@ class Norg(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="inf")
-        NEG_INF = enum.nonmember(value="-inf")
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -175,12 +175,14 @@ class Norg(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -175,14 +175,25 @@ class Norg(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="inf",
-        negative_infinity="-inf",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -178,9 +178,9 @@ class Norg(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="inf")
-        neg_inf = enum.nonmember(value="-inf")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="inf")
+        NEG_INF = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -36,13 +36,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -227,14 +227,25 @@ class ObjectiveC(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="INFINITY",
-        negative_infinity="-INFINITY",
-        nan="NAN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
+        NAN = enum.nonmember(value="NAN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -230,8 +230,8 @@ class ObjectiveC(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="INFINITY")
-        NEG_INF = enum.nonmember(value="-INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
         NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -227,12 +227,14 @@ class ObjectiveC(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INFINITY",
+        negative_infinity="-INFINITY",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
-        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -230,9 +230,9 @@ class ObjectiveC(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="INFINITY")
-        neg_inf = enum.nonmember(value="-INFINITY")
-        nan = enum.nonmember(value="NAN")
+        POS_INF = enum.nonmember(value="INFINITY")
+        NEG_INF = enum.nonmember(value="-INFINITY")
+        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -3,7 +3,6 @@
 import base64
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -37,6 +36,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -227,20 +227,16 @@ class ObjectiveC(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="INFINITY")
+        neg_inf = enum.nonmember(value="-INFINITY")
+        nan = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-INFINITY" if value < 0 else "INFINITY"
-            if math.isnan(value):
-                return "NAN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -36,13 +36,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -227,25 +227,14 @@ class ObjectiveC(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INFINITY",
+        negative_infinity="-INFINITY",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INFINITY")
-        NAN = enum.nonmember(value="NAN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -261,9 +261,9 @@ class OCaml(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="infinity")
-        neg_inf = enum.nonmember(value="neg_infinity")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="infinity")
+        NEG_INF = enum.nonmember(value="neg_infinity")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -46,6 +45,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -258,20 +258,16 @@ class OCaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="infinity")
+        neg_inf = enum.nonmember(value="neg_infinity")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "neg_infinity" if value < 0 else "infinity"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -261,8 +261,8 @@ class OCaml(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="infinity")
-        NEG_INF = enum.nonmember(value="neg_infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="neg_infinity")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -45,13 +45,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -258,25 +258,14 @@ class OCaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="infinity",
+        negative_infinity="neg_infinity",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="neg_infinity")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -45,13 +45,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -258,14 +258,25 @@ class OCaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="infinity",
-        negative_infinity="neg_infinity",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="neg_infinity")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -258,12 +258,14 @@ class OCaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="infinity",
+        negative_infinity="neg_infinity",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="neg_infinity")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -34,13 +34,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -185,25 +185,14 @@ class Occam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -188,8 +188,8 @@ class Occam(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="inf")
-        NEG_INF = enum.nonmember(value="-inf")
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -34,13 +34,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -185,14 +185,25 @@ class Occam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="inf",
-        negative_infinity="-inf",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -35,6 +34,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -185,20 +185,16 @@ class Occam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="inf")
+        neg_inf = enum.nonmember(value="-inf")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf" if value < 0 else "inf"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -185,12 +185,14 @@ class Occam(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -188,9 +188,9 @@ class Occam(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="inf")
-        neg_inf = enum.nonmember(value="-inf")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="inf")
+        NEG_INF = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -193,8 +193,8 @@ class Odin(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="math.inf_f64(1)")
-        NEG_INF = enum.nonmember(value="math.inf_f64(-1)")
+        POSITIVE_INFINITY = enum.nonmember(value="math.inf_f64(1)")
+        NEGATIVE_INFINITY = enum.nonmember(value="math.inf_f64(-1)")
         NAN = enum.nonmember(value="math.nan_f64()")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -44,13 +44,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -190,14 +190,25 @@ class Odin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="math.inf_f64(1)",
-        negative_infinity="math.inf_f64(-1)",
-        nan="math.nan_f64()",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="math.inf_f64(1)")
+        NEGATIVE_INFINITY = enum.nonmember(value="math.inf_f64(-1)")
+        NAN = enum.nonmember(value="math.nan_f64()")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -45,6 +44,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -190,20 +190,16 @@ class Odin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="math.inf_f64(1)")
+        neg_inf = enum.nonmember(value="math.inf_f64(-1)")
+        nan = enum.nonmember(value="math.nan_f64()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "math.inf_f64(-1)" if value < 0 else "math.inf_f64(1)"
-            if math.isnan(value):
-                return "math.nan_f64()"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -44,13 +44,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -190,25 +190,14 @@ class Odin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="math.inf_f64(1)",
+        negative_infinity="math.inf_f64(-1)",
+        nan="math.nan_f64()",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="math.inf_f64(1)")
-        NEGATIVE_INFINITY = enum.nonmember(value="math.inf_f64(-1)")
-        NAN = enum.nonmember(value="math.nan_f64()")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -193,9 +193,9 @@ class Odin(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="math.inf_f64(1)")
-        neg_inf = enum.nonmember(value="math.inf_f64(-1)")
-        nan = enum.nonmember(value="math.nan_f64()")
+        POS_INF = enum.nonmember(value="math.inf_f64(1)")
+        NEG_INF = enum.nonmember(value="math.inf_f64(-1)")
+        NAN = enum.nonmember(value="math.nan_f64()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -190,12 +190,14 @@ class Odin(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="math.inf_f64(1)",
+        negative_infinity="math.inf_f64(-1)",
+        nan="math.nan_f64()",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="math.inf_f64(1)")
-        NEGATIVE_INFINITY = enum.nonmember(value="math.inf_f64(-1)")
-        NAN = enum.nonmember(value="math.nan_f64()")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -54,7 +55,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -221,25 +221,14 @@ class Perl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -224,9 +224,9 @@ class Perl(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Inf")
-        neg_inf = enum.nonmember(value="-Inf")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Inf")
+        NEG_INF = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -221,12 +221,14 @@ class Perl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -48,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -221,20 +221,16 @@ class Perl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Inf")
+        neg_inf = enum.nonmember(value="-Inf")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Inf" if value < 0 else "Inf"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -47,7 +47,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -55,6 +54,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -221,14 +221,25 @@ class Perl(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Inf",
-        negative_infinity="-Inf",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -224,8 +224,8 @@ class Perl(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Inf")
-        NEG_INF = enum.nonmember(value="-Inf")
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -50,6 +49,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -189,20 +189,16 @@ class Php(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="INF")
+        neg_inf = enum.nonmember(value="-INF")
+        nan = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-INF" if value < 0 else "INF"
-            if math.isnan(value):
-                return "NAN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -189,12 +189,14 @@ class Php(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INF",
+        negative_infinity="-INF",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INF")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INF")
-        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -192,9 +192,9 @@ class Php(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="INF")
-        neg_inf = enum.nonmember(value="-INF")
-        nan = enum.nonmember(value="NAN")
+        POS_INF = enum.nonmember(value="INF")
+        NEG_INF = enum.nonmember(value="-INF")
+        NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -49,13 +49,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -189,14 +189,25 @@ class Php(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="INF",
-        negative_infinity="-INF",
-        nan="NAN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="INF")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INF")
+        NAN = enum.nonmember(value="NAN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -49,13 +49,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -189,25 +189,14 @@ class Php(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="INF",
+        negative_infinity="-INF",
+        nan="NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="INF")
-        NEGATIVE_INFINITY = enum.nonmember(value="-INF")
-        NAN = enum.nonmember(value="NAN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -192,8 +192,8 @@ class Php(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="INF")
-        NEG_INF = enum.nonmember(value="-INF")
+        POSITIVE_INFINITY = enum.nonmember(value="INF")
+        NEGATIVE_INFINITY = enum.nonmember(value="-INF")
         NAN = enum.nonmember(value="NAN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -195,8 +195,8 @@ class PowerShell(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="[double]::PositiveInfinity")
-        NEG_INF = enum.nonmember(value="[double]::NegativeInfinity")
+        POSITIVE_INFINITY = enum.nonmember(value="[double]::PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="[double]::NegativeInfinity")
         NAN = enum.nonmember(value="[double]::NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -34,13 +34,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -192,14 +192,25 @@ class PowerShell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="[double]::PositiveInfinity",
-        negative_infinity="[double]::NegativeInfinity",
-        nan="[double]::NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="[double]::PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="[double]::NegativeInfinity")
+        NAN = enum.nonmember(value="[double]::NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -192,12 +192,14 @@ class PowerShell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="[double]::PositiveInfinity",
+        negative_infinity="[double]::NegativeInfinity",
+        nan="[double]::NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="[double]::PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="[double]::NegativeInfinity")
-        NAN = enum.nonmember(value="[double]::NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -34,13 +34,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -192,25 +192,14 @@ class PowerShell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="[double]::PositiveInfinity",
+        negative_infinity="[double]::NegativeInfinity",
+        nan="[double]::NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="[double]::PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="[double]::NegativeInfinity")
-        NAN = enum.nonmember(value="[double]::NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -35,6 +34,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -192,22 +192,16 @@ class PowerShell(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="[double]::PositiveInfinity")
+        neg_inf = enum.nonmember(value="[double]::NegativeInfinity")
+        nan = enum.nonmember(value="[double]::NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "[double]::NegativeInfinity"
-                return "[double]::PositiveInfinity"
-            if math.isnan(value):
-                return "[double]::NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -195,9 +195,9 @@ class PowerShell(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="[double]::PositiveInfinity")
-        neg_inf = enum.nonmember(value="[double]::NegativeInfinity")
-        nan = enum.nonmember(value="[double]::NaN")
+        POS_INF = enum.nonmember(value="[double]::PositiveInfinity")
+        NEG_INF = enum.nonmember(value="[double]::NegativeInfinity")
+        NAN = enum.nonmember(value="[double]::NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -40,6 +40,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -103,12 +104,6 @@ def _purescript_float_wrapper(
     @beartype
     def _format(value: float) -> str:
         """Format a float with a ``PFloat`` constructor."""
-        if math.isinf(value):
-            if value < 0:
-                return "PFloat (-(1.0 / 0.0))"
-            return "PFloat (1.0 / 0.0)"
-        if math.isnan(value):
-            return "PFloat (0.0 / 0.0)"
         formatted = inner(value)
         if formatted.startswith("-"):
             return f"PFloat ({formatted})"
@@ -378,17 +373,16 @@ class PureScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="PFloat (1.0 / 0.0)")
+        neg_inf = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
+        nan = enum.nonmember(value="PFloat (0.0 / 0.0)")
 
         REPR = enum.member(value=_format_purescript_float_repr)
         SCIENTIFIC = enum.member(value=_format_purescript_float_scientific)
         FIXED = enum.member(value=_format_purescript_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -373,12 +373,14 @@ class PureScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="PFloat (1.0 / 0.0)",
+        negative_infinity="PFloat (-(1.0 / 0.0))",
+        nan="PFloat (0.0 / 0.0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="PFloat (1.0 / 0.0)")
-        NEGATIVE_INFINITY = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
-        NAN = enum.nonmember(value="PFloat (0.0 / 0.0)")
 
         REPR = enum.member(value=_format_purescript_float_repr)
         SCIENTIFIC = enum.member(value=_format_purescript_float_scientific)

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -376,9 +376,9 @@ class PureScript(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="PFloat (1.0 / 0.0)")
-        neg_inf = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
-        nan = enum.nonmember(value="PFloat (0.0 / 0.0)")
+        POS_INF = enum.nonmember(value="PFloat (1.0 / 0.0)")
+        NEG_INF = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
+        NAN = enum.nonmember(value="PFloat (0.0 / 0.0)")
 
         REPR = enum.member(value=_format_purescript_float_repr)
         SCIENTIFIC = enum.member(value=_format_purescript_float_scientific)

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -376,8 +376,8 @@ class PureScript(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="PFloat (1.0 / 0.0)")
-        NEG_INF = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
+        POSITIVE_INFINITY = enum.nonmember(value="PFloat (1.0 / 0.0)")
+        NEGATIVE_INFINITY = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
         NAN = enum.nonmember(value="PFloat (0.0 / 0.0)")
 
         REPR = enum.member(value=_format_purescript_float_repr)

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -40,12 +40,12 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -373,25 +373,14 @@ class PureScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="PFloat (1.0 / 0.0)",
+        negative_infinity="PFloat (-(1.0 / 0.0))",
+        nan="PFloat (0.0 / 0.0)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="PFloat (1.0 / 0.0)")
-        NEGATIVE_INFINITY = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
-        NAN = enum.nonmember(value="PFloat (0.0 / 0.0)")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=_format_purescript_float_repr)
         SCIENTIFIC = enum.member(value=_format_purescript_float_scientific)

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -40,12 +40,12 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -373,14 +373,25 @@ class PureScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="PFloat (1.0 / 0.0)",
-        negative_infinity="PFloat (-(1.0 / 0.0))",
-        nan="PFloat (0.0 / 0.0)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="PFloat (1.0 / 0.0)")
+        NEGATIVE_INFINITY = enum.nonmember(value="PFloat (-(1.0 / 0.0))")
+        NAN = enum.nonmember(value="PFloat (0.0 / 0.0)")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=_format_purescript_float_repr)
         SCIENTIFIC = enum.member(value=_format_purescript_float_scientific)

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -671,9 +671,9 @@ class Python(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value='float("inf")')
-        neg_inf = enum.nonmember(value='float("-inf")')
-        nan = enum.nonmember(value='float("nan")')
+        POS_INF = enum.nonmember(value='float("inf")')
+        NEG_INF = enum.nonmember(value='float("-inf")')
+        NAN = enum.nonmember(value='float("nan")')
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -671,8 +671,8 @@ class Python(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value='float("inf")')
-        NEG_INF = enum.nonmember(value='float("-inf")')
+        POSITIVE_INFINITY = enum.nonmember(value='float("inf")')
+        NEGATIVE_INFINITY = enum.nonmember(value='float("-inf")')
         NAN = enum.nonmember(value='float("nan")')
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -58,7 +59,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
 )
 from literalizer._types import Value
 
@@ -668,25 +668,14 @@ class Python(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity='float("inf")',
+        negative_infinity='float("-inf")',
+        nan='float("nan")',
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value='float("inf")')
-        NEGATIVE_INFINITY = enum.nonmember(value='float("-inf")')
-        NAN = enum.nonmember(value='float("nan")')
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -668,12 +668,14 @@ class Python(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity='float("inf")',
+        negative_infinity='float("-inf")',
+        nan='float("nan")',
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value='float("inf")')
-        NEGATIVE_INFINITY = enum.nonmember(value='float("-inf")')
-        NAN = enum.nonmember(value='float("nan")')
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
@@ -52,6 +51,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -668,20 +668,16 @@ class Python(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value='float("inf")')
+        neg_inf = enum.nonmember(value='float("-inf")')
+        nan = enum.nonmember(value='float("nan")')
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return 'float("-inf")' if value < 0 else 'float("inf")'
-            if math.isnan(value):
-                return 'float("nan")'
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -51,7 +51,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -59,6 +58,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
 )
 from literalizer._types import Value
 
@@ -668,14 +668,25 @@ class Python(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity='float("inf")',
-        negative_infinity='float("-inf")',
-        nan='float("nan")',
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value='float("inf")')
+        NEGATIVE_INFINITY = enum.nonmember(value='float("-inf")')
+        NAN = enum.nonmember(value='float("nan")')
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -39,6 +38,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -237,20 +237,16 @@ class R(metaclass=LanguageCls):
 
         DEFAULT = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Inf")
+        neg_inf = enum.nonmember(value="-Inf")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Inf" if value < 0 else "Inf"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -240,9 +240,9 @@ class R(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Inf")
-        neg_inf = enum.nonmember(value="-Inf")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Inf")
+        NEG_INF = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -237,25 +237,14 @@ class R(metaclass=LanguageCls):
 
         DEFAULT = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -240,8 +240,8 @@ class R(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Inf")
-        NEG_INF = enum.nonmember(value="-Inf")
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -237,12 +237,14 @@ class R(metaclass=LanguageCls):
 
         DEFAULT = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -38,13 +38,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -237,14 +237,25 @@ class R(metaclass=LanguageCls):
 
         DEFAULT = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Inf",
-        negative_infinity="-Inf",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -170,8 +170,8 @@ class Racket(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="+inf.0")
-        NEG_INF = enum.nonmember(value="-inf.0")
+        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
         NAN = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -167,25 +167,14 @@ class Racket(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="+inf.0",
+        negative_infinity="-inf.0",
+        nan="+nan.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
-        NAN = enum.nonmember(value="+nan.0")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -167,14 +167,25 @@ class Racket(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="+inf.0",
-        negative_infinity="-inf.0",
-        nan="+nan.0",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
+        NAN = enum.nonmember(value="+nan.0")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -170,9 +170,9 @@ class Racket(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="+inf.0")
-        neg_inf = enum.nonmember(value="-inf.0")
-        nan = enum.nonmember(value="+nan.0")
+        POS_INF = enum.nonmember(value="+inf.0")
+        NEG_INF = enum.nonmember(value="-inf.0")
+        NAN = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -167,12 +167,14 @@ class Racket(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="+inf.0",
+        negative_infinity="-inf.0",
+        nan="+nan.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
-        NAN = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -36,6 +35,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -167,20 +167,16 @@ class Racket(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="+inf.0")
+        neg_inf = enum.nonmember(value="-inf.0")
+        nan = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf.0" if value < 0 else "+inf.0"
-            if math.isnan(value):
-                return "+nan.0"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -225,8 +225,8 @@ class Raku(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Inf")
-        NEG_INF = enum.nonmember(value="-Inf")
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -47,7 +47,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -55,6 +54,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -222,14 +222,25 @@ class Raku(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Inf",
-        negative_infinity="-Inf",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -222,12 +222,14 @@ class Raku(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -225,9 +225,9 @@ class Raku(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Inf")
-        neg_inf = enum.nonmember(value="-Inf")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Inf")
+        NEG_INF = enum.nonmember(value="-Inf")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -48,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -222,20 +222,16 @@ class Raku(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Inf")
+        neg_inf = enum.nonmember(value="-Inf")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Inf" if value < 0 else "Inf"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -54,7 +55,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -222,25 +222,14 @@ class Raku(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Inf",
+        negative_infinity="-Inf",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Inf")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -227,12 +227,14 @@ class Ruby(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Float::INFINITY",
+        negative_infinity="-Float::INFINITY",
+        nan="Float::NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Float::INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Float::INFINITY")
-        NAN = enum.nonmember(value="Float::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -230,9 +230,9 @@ class Ruby(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Float::INFINITY")
-        neg_inf = enum.nonmember(value="-Float::INFINITY")
-        nan = enum.nonmember(value="Float::NAN")
+        POS_INF = enum.nonmember(value="Float::INFINITY")
+        NEG_INF = enum.nonmember(value="-Float::INFINITY")
+        NAN = enum.nonmember(value="Float::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -49,7 +49,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -57,6 +56,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -227,14 +227,25 @@ class Ruby(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Float::INFINITY",
-        negative_infinity="-Float::INFINITY",
-        nan="Float::NAN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Float::INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Float::INFINITY")
+        NAN = enum.nonmember(value="Float::NAN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -230,8 +230,8 @@ class Ruby(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Float::INFINITY")
-        NEG_INF = enum.nonmember(value="-Float::INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="Float::INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Float::INFINITY")
         NAN = enum.nonmember(value="Float::NAN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -56,7 +57,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -227,25 +227,14 @@ class Ruby(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Float::INFINITY",
+        negative_infinity="-Float::INFINITY",
+        nan="Float::NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Float::INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Float::INFINITY")
-        NAN = enum.nonmember(value="Float::NAN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -50,6 +49,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -227,20 +227,16 @@ class Ruby(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Float::INFINITY")
+        neg_inf = enum.nonmember(value="-Float::INFINITY")
+        nan = enum.nonmember(value="Float::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Float::INFINITY" if value < 0 else "Float::INFINITY"
-            if math.isnan(value):
-                return "Float::NAN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -46,7 +46,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -54,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -340,14 +340,25 @@ class Rust(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="f64::INFINITY",
-        negative_infinity="f64::NEG_INFINITY",
-        nan="f64::NAN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="f64::INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="f64::NEG_INFINITY")
+        NAN = enum.nonmember(value="f64::NAN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -340,12 +340,14 @@ class Rust(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="f64::INFINITY",
+        negative_infinity="f64::NEG_INFINITY",
+        nan="f64::NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="f64::INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="f64::NEG_INFINITY")
-        NAN = enum.nonmember(value="f64::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -343,9 +343,9 @@ class Rust(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="f64::INFINITY")
-        neg_inf = enum.nonmember(value="f64::NEG_INFINITY")
-        nan = enum.nonmember(value="f64::NAN")
+        POS_INF = enum.nonmember(value="f64::INFINITY")
+        NEG_INF = enum.nonmember(value="f64::NEG_INFINITY")
+        NAN = enum.nonmember(value="f64::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -343,8 +343,8 @@ class Rust(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="f64::INFINITY")
-        NEG_INF = enum.nonmember(value="f64::NEG_INFINITY")
+        POSITIVE_INFINITY = enum.nonmember(value="f64::INFINITY")
+        NEGATIVE_INFINITY = enum.nonmember(value="f64::NEG_INFINITY")
         NAN = enum.nonmember(value="f64::NAN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -47,6 +46,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -340,20 +340,16 @@ class Rust(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="f64::INFINITY")
+        neg_inf = enum.nonmember(value="f64::NEG_INFINITY")
+        nan = enum.nonmember(value="f64::NAN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "f64::NEG_INFINITY" if value < 0 else "f64::INFINITY"
-            if math.isnan(value):
-                return "f64::NAN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -53,7 +54,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -340,25 +340,14 @@ class Rust(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="f64::INFINITY",
+        negative_infinity="f64::NEG_INFINITY",
+        nan="f64::NAN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="f64::INFINITY")
-        NEGATIVE_INFINITY = enum.nonmember(value="f64::NEG_INFINITY")
-        NAN = enum.nonmember(value="f64::NAN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -53,7 +54,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -323,25 +323,14 @@ class Scala(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.PositiveInfinity",
+        negative_infinity="Double.NegativeInfinity",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
-        NAN = enum.nonmember(value="Double.NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -326,9 +326,9 @@ class Scala(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Double.PositiveInfinity")
-        neg_inf = enum.nonmember(value="Double.NegativeInfinity")
-        nan = enum.nonmember(value="Double.NaN")
+        POS_INF = enum.nonmember(value="Double.PositiveInfinity")
+        NEG_INF = enum.nonmember(value="Double.NegativeInfinity")
+        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import math
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
 
@@ -47,6 +46,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -323,22 +323,16 @@ class Scala(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Double.PositiveInfinity")
+        neg_inf = enum.nonmember(value="Double.NegativeInfinity")
+        nan = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "Double.NegativeInfinity"
-                return "Double.PositiveInfinity"
-            if math.isnan(value):
-                return "Double.NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -326,8 +326,8 @@ class Scala(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Double.PositiveInfinity")
-        NEG_INF = enum.nonmember(value="Double.NegativeInfinity")
+        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
         NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -46,7 +46,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -54,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -323,14 +323,25 @@ class Scala(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Double.PositiveInfinity",
-        negative_infinity="Double.NegativeInfinity",
-        nan="Double.NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
+        NAN = enum.nonmember(value="Double.NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -323,12 +323,14 @@ class Scala(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.PositiveInfinity",
+        negative_infinity="Double.NegativeInfinity",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
-        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -167,12 +167,14 @@ class Scheme(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="+inf.0",
+        negative_infinity="-inf.0",
+        nan="+nan.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
-        NAN = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -170,8 +170,8 @@ class Scheme(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="+inf.0")
-        NEG_INF = enum.nonmember(value="-inf.0")
+        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
         NAN = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -167,25 +167,14 @@ class Scheme(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="+inf.0",
+        negative_infinity="-inf.0",
+        nan="+nan.0",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
-        NAN = enum.nonmember(value="+nan.0")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -36,6 +35,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -167,20 +167,16 @@ class Scheme(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="+inf.0")
+        neg_inf = enum.nonmember(value="-inf.0")
+        nan = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf.0" if value < 0 else "+inf.0"
-            if math.isnan(value):
-                return "+nan.0"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -35,13 +35,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -167,14 +167,25 @@ class Scheme(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="+inf.0",
-        negative_infinity="-inf.0",
-        nan="+nan.0",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="+inf.0")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf.0")
+        NAN = enum.nonmember(value="+nan.0")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -170,9 +170,9 @@ class Scheme(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="+inf.0")
-        neg_inf = enum.nonmember(value="-inf.0")
-        nan = enum.nonmember(value="+nan.0")
+        POS_INF = enum.nonmember(value="+inf.0")
+        NEG_INF = enum.nonmember(value="-inf.0")
+        NAN = enum.nonmember(value="+nan.0")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -46,7 +46,6 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -54,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -270,14 +270,25 @@ class Swift(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Double.infinity",
-        negative_infinity="-Double.infinity",
-        nan="Double.nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Double.infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Double.infinity")
+        NAN = enum.nonmember(value="Double.nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -47,6 +46,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -270,20 +270,16 @@ class Swift(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Double.infinity")
+        neg_inf = enum.nonmember(value="-Double.infinity")
+        nan = enum.nonmember(value="Double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Double.infinity" if value < 0 else "Double.infinity"
-            if math.isnan(value):
-                return "Double.nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -273,8 +273,8 @@ class Swift(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Double.infinity")
-        NEG_INF = enum.nonmember(value="-Double.infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="Double.infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Double.infinity")
         NAN = enum.nonmember(value="Double.nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -273,9 +273,9 @@ class Swift(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Double.infinity")
-        neg_inf = enum.nonmember(value="-Double.infinity")
-        nan = enum.nonmember(value="Double.nan")
+        POS_INF = enum.nonmember(value="Double.infinity")
+        NEG_INF = enum.nonmember(value="-Double.infinity")
+        NAN = enum.nonmember(value="Double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -53,7 +54,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -270,25 +270,14 @@ class Swift(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.infinity",
+        negative_infinity="-Double.infinity",
+        nan="Double.nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Double.infinity")
-        NAN = enum.nonmember(value="Double.nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -270,12 +270,14 @@ class Swift(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.infinity",
+        negative_infinity="-Double.infinity",
+        nan="Double.nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Double.infinity")
-        NAN = enum.nonmember(value="Double.nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -219,16 +219,14 @@ class SystemVerilog(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="$bitstoreal(64'h7FF0000000000000)",
+        negative_infinity="$bitstoreal(64'hFFF0000000000000)",
+        nan="$bitstoreal(64'h7FF8000000000000)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(
-            value="$bitstoreal(64'h7FF0000000000000)",
-        )
-        NEGATIVE_INFINITY = enum.nonmember(
-            value="$bitstoreal(64'hFFF0000000000000)",
-        )
-        NAN = enum.nonmember(value="$bitstoreal(64'h7FF8000000000000)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -222,8 +222,12 @@ class SystemVerilog(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="$bitstoreal(64'h7FF0000000000000)")
-        NEG_INF = enum.nonmember(value="$bitstoreal(64'hFFF0000000000000)")
+        POSITIVE_INFINITY = enum.nonmember(
+            value="$bitstoreal(64'h7FF0000000000000)",
+        )
+        NEGATIVE_INFINITY = enum.nonmember(
+            value="$bitstoreal(64'hFFF0000000000000)",
+        )
         NAN = enum.nonmember(value="$bitstoreal(64'h7FF8000000000000)")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -219,14 +219,29 @@ class SystemVerilog(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="$bitstoreal(64'h7FF0000000000000)",
-        negative_infinity="$bitstoreal(64'hFFF0000000000000)",
-        nan="$bitstoreal(64'h7FF8000000000000)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(
+            value="$bitstoreal(64'h7FF0000000000000)",
+        )
+        NEGATIVE_INFINITY = enum.nonmember(
+            value="$bitstoreal(64'hFFF0000000000000)",
+        )
+        NAN = enum.nonmember(value="$bitstoreal(64'h7FF8000000000000)")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -33,13 +33,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -219,29 +219,14 @@ class SystemVerilog(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="$bitstoreal(64'h7FF0000000000000)",
+        negative_infinity="$bitstoreal(64'hFFF0000000000000)",
+        nan="$bitstoreal(64'h7FF8000000000000)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(
-            value="$bitstoreal(64'h7FF0000000000000)",
-        )
-        NEGATIVE_INFINITY = enum.nonmember(
-            value="$bitstoreal(64'hFFF0000000000000)",
-        )
-        NAN = enum.nonmember(value="$bitstoreal(64'h7FF8000000000000)")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -222,9 +222,9 @@ class SystemVerilog(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="$bitstoreal(64'h7FF0000000000000)")
-        neg_inf = enum.nonmember(value="$bitstoreal(64'hFFF0000000000000)")
-        nan = enum.nonmember(value="$bitstoreal(64'h7FF8000000000000)")
+        POS_INF = enum.nonmember(value="$bitstoreal(64'h7FF0000000000000)")
+        NEG_INF = enum.nonmember(value="$bitstoreal(64'hFFF0000000000000)")
+        NAN = enum.nonmember(value="$bitstoreal(64'h7FF8000000000000)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -34,6 +33,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -219,22 +219,16 @@ class SystemVerilog(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="$bitstoreal(64'h7FF0000000000000)")
+        neg_inf = enum.nonmember(value="$bitstoreal(64'hFFF0000000000000)")
+        nan = enum.nonmember(value="$bitstoreal(64'h7FF8000000000000)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "$bitstoreal(64'hFFF0000000000000)"
-                return "$bitstoreal(64'h7FF0000000000000)"
-            if math.isnan(value):
-                return "$bitstoreal(64'h7FF8000000000000)"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -204,8 +204,8 @@ class Toml(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="inf")
-        NEG_INF = enum.nonmember(value="-inf")
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
         NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -41,13 +41,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -201,25 +201,14 @@ class Toml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 import re
 from typing import TYPE_CHECKING
 
@@ -42,6 +41,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -201,20 +201,16 @@ class Toml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="inf")
+        neg_inf = enum.nonmember(value="-inf")
+        nan = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-inf" if value < 0 else "inf"
-            if math.isnan(value):
-                return "nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -204,9 +204,9 @@ class Toml(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="inf")
-        neg_inf = enum.nonmember(value="-inf")
-        nan = enum.nonmember(value="nan")
+        POS_INF = enum.nonmember(value="inf")
+        NEG_INF = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -201,12 +201,14 @@ class Toml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="inf",
+        negative_infinity="-inf",
+        nan="nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
-        NAN = enum.nonmember(value="nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -41,13 +41,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -201,14 +201,25 @@ class Toml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="inf",
-        negative_infinity="-inf",
-        nan="nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-inf")
+        NAN = enum.nonmember(value="nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -275,12 +275,14 @@ class TypeScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -49,13 +49,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -275,25 +275,14 @@ class TypeScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Infinity",
+        negative_infinity="-Infinity",
+        nan="NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
-        NAN = enum.nonmember(value="NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -278,9 +278,9 @@ class TypeScript(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Infinity")
-        neg_inf = enum.nonmember(value="-Infinity")
-        nan = enum.nonmember(value="NaN")
+        POS_INF = enum.nonmember(value="Infinity")
+        NEG_INF = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -278,8 +278,8 @@ class TypeScript(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Infinity")
-        NEG_INF = enum.nonmember(value="-Infinity")
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
         NAN = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -50,6 +49,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -275,20 +275,16 @@ class TypeScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Infinity")
+        neg_inf = enum.nonmember(value="-Infinity")
+        nan = enum.nonmember(value="NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-Infinity" if value < 0 else "Infinity"
-            if math.isnan(value):
-                return "NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -49,13 +49,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -275,14 +275,25 @@ class TypeScript(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Infinity",
-        negative_infinity="-Infinity",
-        nan="NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Infinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="-Infinity")
+        NAN = enum.nonmember(value="NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -259,12 +259,14 @@ class VisualBasic(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.PositiveInfinity",
+        negative_infinity="Double.NegativeInfinity",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
-        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -39,13 +39,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -259,14 +259,25 @@ class VisualBasic(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="Double.PositiveInfinity",
-        negative_infinity="Double.NegativeInfinity",
-        nan="Double.NaN",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
+        NAN = enum.nonmember(value="Double.NaN")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -262,8 +262,8 @@ class VisualBasic(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="Double.PositiveInfinity")
-        NEG_INF = enum.nonmember(value="Double.NegativeInfinity")
+        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
+        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
         NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -262,9 +262,9 @@ class VisualBasic(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="Double.PositiveInfinity")
-        neg_inf = enum.nonmember(value="Double.NegativeInfinity")
-        nan = enum.nonmember(value="Double.NaN")
+        POS_INF = enum.nonmember(value="Double.PositiveInfinity")
+        NEG_INF = enum.nonmember(value="Double.NegativeInfinity")
+        NAN = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -2,7 +2,6 @@
 
 import datetime
 import enum
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -40,6 +39,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -259,22 +259,16 @@ class VisualBasic(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="Double.PositiveInfinity")
+        neg_inf = enum.nonmember(value="Double.NegativeInfinity")
+        nan = enum.nonmember(value="Double.NaN")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "Double.NegativeInfinity"
-                return "Double.PositiveInfinity"
-            if math.isnan(value):
-                return "Double.NaN"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -39,13 +39,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -259,25 +259,14 @@ class VisualBasic(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Double.PositiveInfinity",
+        negative_infinity="Double.NegativeInfinity",
+        nan="Double.NaN",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="Double.PositiveInfinity")
-        NEGATIVE_INFINITY = enum.nonmember(value="Double.NegativeInfinity")
-        NAN = enum.nonmember(value="Double.NaN")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -182,12 +182,14 @@ class Yaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity=".inf",
+        negative_infinity="-.inf",
+        nan=".nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value=".inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-.inf")
-        NAN = enum.nonmember(value=".nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -185,8 +185,8 @@ class Yaml(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value=".inf")
-        NEG_INF = enum.nonmember(value="-.inf")
+        POSITIVE_INFINITY = enum.nonmember(value=".inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-.inf")
         NAN = enum.nonmember(value=".nan")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -40,13 +40,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -182,14 +182,25 @@ class Yaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity=".inf",
-        negative_infinity="-.inf",
-        nan=".nan",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value=".inf")
+        NEGATIVE_INFINITY = enum.nonmember(value="-.inf")
+        NAN = enum.nonmember(value=".nan")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -41,6 +40,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -182,20 +182,16 @@ class Yaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value=".inf")
+        neg_inf = enum.nonmember(value="-.inf")
+        nan = enum.nonmember(value=".nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                return "-.inf" if value < 0 else ".inf"
-            if math.isnan(value):
-                return ".nan"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -40,13 +40,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 
@@ -182,25 +182,14 @@ class Yaml(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity=".inf",
+        negative_infinity="-.inf",
+        nan=".nan",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value=".inf")
-        NEGATIVE_INFINITY = enum.nonmember(value="-.inf")
-        NAN = enum.nonmember(value=".nan")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -185,9 +185,9 @@ class Yaml(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value=".inf")
-        neg_inf = enum.nonmember(value="-.inf")
-        nan = enum.nonmember(value=".nan")
+        POS_INF = enum.nonmember(value=".inf")
+        NEG_INF = enum.nonmember(value="-.inf")
+        NAN = enum.nonmember(value=".nan")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -242,8 +242,8 @@ class Zig(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        POS_INF = enum.nonmember(value="std.math.inf(f64)")
-        NEG_INF = enum.nonmember(value="-std.math.inf(f64)")
+        POSITIVE_INFINITY = enum.nonmember(value="std.math.inf(f64)")
+        NEGATIVE_INFINITY = enum.nonmember(value="-std.math.inf(f64)")
         NAN = enum.nonmember(value="std.math.nan(f64)")
 
         REPR = enum.member(value=format_float_repr)

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -3,7 +3,6 @@
 import datetime
 import enum
 import functools
-import math
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -45,6 +44,7 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -239,22 +239,16 @@ class Zig(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
+
+        pos_inf = enum.nonmember(value="std.math.inf(f64)")
+        neg_inf = enum.nonmember(value="-std.math.inf(f64)")
+        nan = enum.nonmember(value="std.math.nan(f64)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)
         FIXED = enum.member(value=format_float_fixed)
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            if math.isinf(value):
-                if value < 0:
-                    return "-std.math.inf(f64)"
-                return "std.math.inf(f64)"
-            if math.isnan(value):
-                return "std.math.nan(f64)"
-            return self.value(value=value)
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -44,13 +44,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
+    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -239,25 +239,14 @@ class Zig(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="std.math.inf(f64)",
+        negative_infinity="-std.math.inf(f64)",
+        nan="std.math.nan(f64)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="std.math.inf(f64)")
-        NEGATIVE_INFINITY = enum.nonmember(value="-std.math.inf(f64)")
-        NAN = enum.nonmember(value="std.math.nan(f64)")
-
-        def __call__(self, value: float, /) -> str:
-            """Format a float."""
-            special = format_special_float(
-                value=value,
-                positive_infinity=self.POSITIVE_INFINITY,
-                negative_infinity=self.NEGATIVE_INFINITY,
-                nan=self.NAN,
-            )
-            if special is not None:
-                return special
-            formatter: Callable[[float], str] = self.value
-            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -242,9 +242,9 @@ class Zig(metaclass=LanguageCls):
     class FloatFormats(FloatSpecialsMixin, enum.Enum):
         """Float format options."""
 
-        pos_inf = enum.nonmember(value="std.math.inf(f64)")
-        neg_inf = enum.nonmember(value="-std.math.inf(f64)")
-        nan = enum.nonmember(value="std.math.nan(f64)")
+        POS_INF = enum.nonmember(value="std.math.inf(f64)")
+        NEG_INF = enum.nonmember(value="-std.math.inf(f64)")
+        NAN = enum.nonmember(value="std.math.nan(f64)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -44,13 +44,13 @@ from literalizer._language import (
     DatetimeFormatConfig,
     DeclarationStyleConfig,
     DictFormatConfig,
-    FloatSpecialsMixin,
     LanguageCls,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    format_special_float,
     no_type_hint_preamble,
 )
 from literalizer._types import Value
@@ -239,14 +239,25 @@ class Zig(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(
-        FloatSpecialsMixin,
-        enum.Enum,
-        positive_infinity="std.math.inf(f64)",
-        negative_infinity="-std.math.inf(f64)",
-        nan="std.math.nan(f64)",
-    ):
+    class FloatFormats(enum.Enum):
         """Float format options."""
+
+        POSITIVE_INFINITY = enum.nonmember(value="std.math.inf(f64)")
+        NEGATIVE_INFINITY = enum.nonmember(value="-std.math.inf(f64)")
+        NAN = enum.nonmember(value="std.math.nan(f64)")
+
+        def __call__(self, value: float, /) -> str:
+            """Format a float."""
+            special = format_special_float(
+                value=value,
+                positive_infinity=self.POSITIVE_INFINITY,
+                negative_infinity=self.NEGATIVE_INFINITY,
+                nan=self.NAN,
+            )
+            if special is not None:
+                return special
+            formatter: Callable[[float], str] = self.value
+            return formatter(value)
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -239,12 +239,14 @@ class Zig(metaclass=LanguageCls):
 
         ALLOW = enum.auto()
 
-    class FloatFormats(FloatSpecialsMixin, enum.Enum):
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="std.math.inf(f64)",
+        negative_infinity="-std.math.inf(f64)",
+        nan="std.math.nan(f64)",
+    ):
         """Float format options."""
-
-        POSITIVE_INFINITY = enum.nonmember(value="std.math.inf(f64)")
-        NEGATIVE_INFINITY = enum.nonmember(value="-std.math.inf(f64)")
-        NAN = enum.nonmember(value="std.math.nan(f64)")
 
         REPR = enum.member(value=format_float_repr)
         SCIENTIFIC = enum.member(value=format_float_scientific)


### PR DESCRIPTION
## Summary
- Adds `FloatSpecialsMixin` in `_language.py` that provides a shared `__call__` for `FloatFormats` enums, dispatching `isinf`/`isnan` checks and delegating finite values to the formatter
- Each language's `FloatFormats` now inherits from the mixin and declares `pos_inf`, `neg_inf`, `nan` as `enum.nonmember()` class attributes instead of reimplementing the same 4-line dispatch in `__call__`
- Covers all 57 languages including gleam/elm/purescript (which previously used wrapper functions for special floats)
- Net reduction of ~220 lines across 58 files

## Test plan
- [x] All 10606 existing tests pass
- [x] All pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly, vulture, interrogate)
- [x] Runtime verified for representative languages (Rust, Python, Elm, Gleam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches float formatting across many language backends by centralizing `inf`/`nan` handling; a small mistake could change emitted literals for special float values in multiple targets.
> 
> **Overview**
> Introduces a shared `FloatSpecialsMixin` in `_language.py` that implements `FloatFormats.__call__` with centralized `isinf`/`isnan` dispatch and delegates finite values to each enum member’s formatter.
> 
> Updates each language’s `FloatFormats` enum to inherit from this mixin and define per-language literals for `+inf`, `-inf`, and `nan`, removing repeated per-language `__call__` implementations (and cleaning up now-unneeded `math` imports). Also updates the spellcheck dictionary for the new mixin and `isinf`/`isnan` identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11e6b682684c2603b8115bd95a9561a78b67bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->