### PR TITLE
Rename reserved C++ identifiers and add clang-tidy to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -278,6 +278,10 @@ jobs:
       - name: Check C++ syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint
+      - name: Run clang-tidy
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --checks='-*,bugprone-reserved-identifier'
+          --warnings-as-errors='*' --extra-arg=-std=c++20 < /tmp/files-to-lint
 
   lint-kotlin:
     runs-on: ubuntu-latest

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -111,7 +111,7 @@ def _make_cpp_element_to_type(
         datetime_type=None,
         list_template="std::vector<{inner}>",
         dict_type_template="std::map<std::string, {inner}>",
-        fallback_value_type="_Any",
+        fallback_value_type="Any",
     )
 
 
@@ -229,7 +229,7 @@ def _format_variable_declaration(
     _data: Value,
 ) -> str:
     """Format a C++ variable declaration."""
-    return f"_Any {name} = {value};"
+    return f"Any {name} = {value};"
 
 
 @beartype
@@ -633,9 +633,9 @@ class Cpp(metaclass=LanguageCls):
         self.supports_scalar_inline_comments = False
         self.static_preamble: Sequence[str] = ("#include <initializer_list>",)
         self.static_body_preamble: Sequence[str] = (
-            "struct _Any {",
-            "    template<class T> _Any(T&&) noexcept {}",
-            "    _Any(std::initializer_list<_Any>) noexcept {}",
+            "struct Any {",
+            "    template<class T> Any(T&&) noexcept {}",
+            "    Any(std::initializer_list<Any>) noexcept {}",
             "};",
         )
         self.format_variable_declaration: Callable[[str, str, Value], str] = (

--- a/tests/integration/cases/binary/Cpp.cpp
+++ b/tests/integration/cases/binary/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "48656c6c6f",
 };
 }

--- a/tests/integration/cases/binary/Cpp_bytes_format_base64.cpp
+++ b/tests/integration/cases/binary/Cpp_bytes_format_base64.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "SGVsbG8=",
 };
 }

--- a/tests/integration/cases/binary/Cpp_combined.cpp
+++ b/tests/integration/cases/binary/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "48656c6c6f",
 };
 my_data = std::vector<std::string>{

--- a/tests/integration/cases/bool_list/Cpp.cpp
+++ b/tests/integration/cases/bool_list/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<bool>{
+void check_() {
+Any my_data = std::vector<bool>{
     true,
     false,
     true,

--- a/tests/integration/cases/bool_list/Cpp_combined.cpp
+++ b/tests/integration/cases/bool_list/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<bool>{
+void check_() {
+Any my_data = std::vector<bool>{
     true,
     false,
     true,

--- a/tests/integration/cases/comment_block_scalar_not_comment/Cpp.cpp
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"description", "# not a comment\n"},
     {"name", "foo"},
 };

--- a/tests/integration/cases/comment_block_scalar_not_comment/Cpp_combined.cpp
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"description", "# not a comment\n"},
     {"name", "foo"},
 };

--- a/tests/integration/cases/comment_scalar/Cpp.cpp
+++ b/tests/integration/cases/comment_scalar/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = // note
+void check_() {
+Any my_data = // note
 42;
 }

--- a/tests/integration/cases/comment_scalar/Cpp_combined.cpp
+++ b/tests/integration/cases/comment_scalar/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = // note
+void check_() {
+Any my_data = // note
 42;
 my_data = // note
 42;

--- a/tests/integration/cases/comment_scalar_document_markers/Cpp.cpp
+++ b/tests/integration/cases/comment_scalar_document_markers/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = // note
+void check_() {
+Any my_data = // note
 42;
 }

--- a/tests/integration/cases/comment_scalar_document_markers/Cpp_combined.cpp
+++ b/tests/integration/cases/comment_scalar_document_markers/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = // note
+void check_() {
+Any my_data = // note
 42;
 my_data = // note
 42;

--- a/tests/integration/cases/comment_scalar_inline/Cpp.cpp
+++ b/tests/integration/cases/comment_scalar_inline/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
+void check_() {
 // note
-_Any my_data = 42;
+Any my_data = 42;
 }

--- a/tests/integration/cases/comment_scalar_inline/Cpp_combined.cpp
+++ b/tests/integration/cases/comment_scalar_inline/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
+void check_() {
 // note
-_Any my_data = 42;
+Any my_data = 42;
 // note
 my_data = 42;
 }

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Cpp.cpp
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Cpp.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
+void check_() {
 // note
-_Any my_data = "hello # world";
+Any my_data = "hello # world";
 }

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Cpp_combined.cpp
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
+void check_() {
 // note
-_Any my_data = "hello # world";
+Any my_data = "hello # world";
 // note
 my_data = "hello # world";
 }

--- a/tests/integration/cases/comments/Cpp.cpp
+++ b/tests/integration/cases/comments/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     // Server configuration
     {"host", "localhost"},  // default host
     {"port", 8080},

--- a/tests/integration/cases/comments/Cpp_combined.cpp
+++ b/tests/integration/cases/comments/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     // Server configuration
     {"host", "localhost"},  // default host
     {"port", 8080},

--- a/tests/integration/cases/comments/Cpp_comment_block.cpp
+++ b/tests/integration/cases/comments/Cpp_comment_block.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     /* Server configuration */
     {"host", "localhost"},  /* default host */
     {"port", 8080},

--- a/tests/integration/cases/comments_bang_in_double_quote/Cpp.cpp
+++ b/tests/integration/cases/comments_bang_in_double_quote/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key", "\"bang!\""},  // real
 };
 }

--- a/tests/integration/cases/comments_bang_in_double_quote/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_bang_in_double_quote/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key", "\"bang!\""},  // real
 };
 my_data = std::map<std::string, std::string>{

--- a/tests/integration/cases/comments_double_hash/Cpp.cpp
+++ b/tests/integration/cases/comments_double_hash/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     // # section
     "a",
 };

--- a/tests/integration/cases/comments_double_hash/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_double_hash/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     // # section
     "a",
 };

--- a/tests/integration/cases/comments_empty_line/Cpp.cpp
+++ b/tests/integration/cases/comments_empty_line/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "a",
     //
     "b",

--- a/tests/integration/cases/comments_empty_line/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_empty_line/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "a",
     //
     "b",

--- a/tests/integration/cases/comments_escaped_quote/Cpp.cpp
+++ b/tests/integration/cases/comments_escaped_quote/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key", "value \" # not a comment"},  // real
 };
 }

--- a/tests/integration/cases/comments_escaped_quote/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_escaped_quote/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key", "value \" # not a comment"},  // real
 };
 my_data = std::map<std::string, std::string>{

--- a/tests/integration/cases/comments_escaped_single_quote/Cpp.cpp
+++ b/tests/integration/cases/comments_escaped_single_quote/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key", "it's here"},  // a comment
 };
 }

--- a/tests/integration/cases/comments_escaped_single_quote/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_escaped_single_quote/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key", "it's here"},  // a comment
 };
 my_data = std::map<std::string, std::string>{

--- a/tests/integration/cases/comments_multi_line/Cpp.cpp
+++ b/tests/integration/cases/comments_multi_line/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     // line 1
     // line 2
     "a",

--- a/tests/integration/cases/comments_multi_line/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_multi_line/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     // line 1
     // line 2
     "a",

--- a/tests/integration/cases/comments_nested_mapping/Cpp.cpp
+++ b/tests/integration/cases/comments_nested_mapping/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"a", std::map<std::string, int>{{"x", 1}}},
     {"b", 2},
 };

--- a/tests/integration/cases/comments_nested_mapping/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_nested_mapping/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"a", std::map<std::string, int>{{"x", 1}}},
     {"b", 2},
 };

--- a/tests/integration/cases/comments_sequence_before/Cpp.cpp
+++ b/tests/integration/cases/comments_sequence_before/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     // first
     "a",
     // second

--- a/tests/integration/cases/comments_sequence_before/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_sequence_before/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     // first
     "a",
     // second

--- a/tests/integration/cases/comments_sequence_inline/Cpp.cpp
+++ b/tests/integration/cases/comments_sequence_inline/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "a",  // note a
     "b",  // note b
 };

--- a/tests/integration/cases/comments_sequence_inline/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_sequence_inline/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "a",  // note a
     "b",  // note b
 };

--- a/tests/integration/cases/comments_trailing/Cpp.cpp
+++ b/tests/integration/cases/comments_trailing/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "a",
     // trailing
 };

--- a/tests/integration/cases/comments_trailing/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_trailing/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "a",
     // trailing
 };

--- a/tests/integration/cases/comments_vb_before_dim/Cpp.cpp
+++ b/tests/integration/cases/comments_vb_before_dim/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     // Configuration
     {"name", "app"},
     // Port setting

--- a/tests/integration/cases/comments_vb_before_dim/Cpp_combined.cpp
+++ b/tests/integration/cases/comments_vb_before_dim/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     // Configuration
     {"name", "app"},
     // Port setting

--- a/tests/integration/cases/date_list/Cpp.cpp
+++ b/tests/integration/cases/date_list/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <chrono>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}},
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{2}, std::chrono::day{20}},
 };

--- a/tests/integration/cases/date_list/Cpp_combined.cpp
+++ b/tests/integration/cases/date_list/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <chrono>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}},
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{2}, std::chrono::day{20}},
 };

--- a/tests/integration/cases/date_list/Cpp_date_iso.cpp
+++ b/tests/integration/cases/date_list/Cpp_date_iso.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     "2024-01-15",
     "2024-02-20",
 };

--- a/tests/integration/cases/date_set/Cpp.cpp
+++ b/tests/integration/cases/date_set/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}},
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{6}, std::chrono::day{1}},
 };

--- a/tests/integration/cases/date_set/Cpp_combined.cpp
+++ b/tests/integration/cases/date_set/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}},
     std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{6}, std::chrono::day{1}},
 };

--- a/tests/integration/cases/date_set/Cpp_date_iso.cpp
+++ b/tests/integration/cases/date_set/Cpp_date_iso.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     "2024-01-15",
     "2024-06-01",
 };

--- a/tests/integration/cases/dates/Cpp.cpp
+++ b/tests/integration/cases/dates/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <chrono>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"date", std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}},
     {"datetime", std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30}},
 };

--- a/tests/integration/cases/dates/Cpp_combined.cpp
+++ b/tests/integration/cases/dates/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <chrono>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"date", std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}},
     {"datetime", std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30}},
 };

--- a/tests/integration/cases/datetime_list/Cpp.cpp
+++ b/tests/integration/cases/datetime_list/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <chrono>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::microseconds{123456},
     std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{6}, std::chrono::day{1}}} + std::chrono::hours{8},
 };

--- a/tests/integration/cases/datetime_list/Cpp_combined.cpp
+++ b/tests/integration/cases/datetime_list/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <chrono>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::microseconds{123456},
     std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{6}, std::chrono::day{1}}} + std::chrono::hours{8},
 };

--- a/tests/integration/cases/deep_nesting/Cpp.cpp
+++ b/tests/integration/cases/deep_nesting/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::map<std::string, _Any>>{
-    {"level1", {{"level2", {{"level3", std::map<std::string, std::map<std::string, _Any>>{{"level4", {{"value", "deep"}, {"items", std::vector<std::string>{"a", "b"}}}}}}, {"sibling", 42}}}, {"tags", std::vector<std::map<std::string, _Any>>{{{"name", "tag1"}, {"meta", {{"priority", 1}, {"labels", std::vector<std::string>{"x", "y"}}}}}}}}},
+void check_() {
+Any my_data = std::map<std::string, std::map<std::string, Any>>{
+    {"level1", {{"level2", {{"level3", std::map<std::string, std::map<std::string, Any>>{{"level4", {{"value", "deep"}, {"items", std::vector<std::string>{"a", "b"}}}}}}, {"sibling", 42}}}, {"tags", std::vector<std::map<std::string, Any>>{{{"name", "tag1"}, {"meta", {{"priority", 1}, {"labels", std::vector<std::string>{"x", "y"}}}}}}}}},
 };
 }

--- a/tests/integration/cases/deep_nesting/Cpp_combined.cpp
+++ b/tests/integration/cases/deep_nesting/Cpp_combined.cpp
@@ -2,15 +2,15 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::map<std::string, _Any>>{
-    {"level1", {{"level2", {{"level3", std::map<std::string, std::map<std::string, _Any>>{{"level4", {{"value", "deep"}, {"items", std::vector<std::string>{"a", "b"}}}}}}, {"sibling", 42}}}, {"tags", std::vector<std::map<std::string, _Any>>{{{"name", "tag1"}, {"meta", {{"priority", 1}, {"labels", std::vector<std::string>{"x", "y"}}}}}}}}},
+void check_() {
+Any my_data = std::map<std::string, std::map<std::string, Any>>{
+    {"level1", {{"level2", {{"level3", std::map<std::string, std::map<std::string, Any>>{{"level4", {{"value", "deep"}, {"items", std::vector<std::string>{"a", "b"}}}}}}, {"sibling", 42}}}, {"tags", std::vector<std::map<std::string, Any>>{{{"name", "tag1"}, {"meta", {{"priority", 1}, {"labels", std::vector<std::string>{"x", "y"}}}}}}}}},
 };
-my_data = std::map<std::string, std::map<std::string, _Any>>{
-    {"level1", {{"level2", {{"level3", std::map<std::string, std::map<std::string, _Any>>{{"level4", {{"value", "deep"}, {"items", std::vector<std::string>{"a", "b"}}}}}}, {"sibling", 42}}}, {"tags", std::vector<std::map<std::string, _Any>>{{{"name", "tag1"}, {"meta", {{"priority", 1}, {"labels", std::vector<std::string>{"x", "y"}}}}}}}}},
+my_data = std::map<std::string, std::map<std::string, Any>>{
+    {"level1", {{"level2", {{"level3", std::map<std::string, std::map<std::string, Any>>{{"level4", {{"value", "deep"}, {"items", std::vector<std::string>{"a", "b"}}}}}}, {"sibling", 42}}}, {"tags", std::vector<std::map<std::string, Any>>{{{"name", "tag1"}, {"meta", {{"priority", 1}, {"labels", std::vector<std::string>{"x", "y"}}}}}}}}},
 };
 }

--- a/tests/integration/cases/dict_with_control_char_keys/Cpp.cpp
+++ b/tests/integration/cases/dict_with_control_char_keys/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key\nwith\nnewlines", "value1"},
     {"key\twith\ttabs", "value2"},
     {"", "value3"},

--- a/tests/integration/cases/dict_with_control_char_keys/Cpp_combined.cpp
+++ b/tests/integration/cases/dict_with_control_char_keys/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"key\nwith\nnewlines", "value1"},
     {"key\twith\ttabs", "value2"},
     {"", "value3"},

--- a/tests/integration/cases/dict_with_hyphen_keys/Cpp.cpp
+++ b/tests/integration/cases/dict_with_hyphen_keys/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"my-key", "value1"},
     {"another-key", "value2"},
     {"normal_key", "value3"},

--- a/tests/integration/cases/dict_with_hyphen_keys/Cpp_combined.cpp
+++ b/tests/integration/cases/dict_with_hyphen_keys/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"my-key", "value1"},
     {"another-key", "value2"},
     {"normal_key", "value3"},

--- a/tests/integration/cases/dict_with_list_value/Cpp.cpp
+++ b/tests/integration/cases/dict_with_list_value/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"scores", std::vector<int>{10, 20, 30}},
 };

--- a/tests/integration/cases/dict_with_list_value/Cpp_combined.cpp
+++ b/tests/integration/cases/dict_with_list_value/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"scores", std::vector<int>{10, 20, 30}},
 };

--- a/tests/integration/cases/dict_with_list_value/Cpp_dict_format_unordered_map_list_val.cpp
+++ b/tests/integration/cases/dict_with_list_value/Cpp_dict_format_unordered_map_list_val.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"scores", std::vector<int>{10, 20, 30}},
 };

--- a/tests/integration/cases/dict_with_nulls/Cpp.cpp
+++ b/tests/integration/cases/dict_with_nulls/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"score", nullptr},
     {"age", 30},

--- a/tests/integration/cases/dict_with_nulls/Cpp_combined.cpp
+++ b/tests/integration/cases/dict_with_nulls/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"score", nullptr},
     {"age", 30},

--- a/tests/integration/cases/empty_dict/Cpp.cpp
+++ b/tests/integration/cases/empty_dict/Cpp.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {};
+void check_() {
+Any my_data = {};
 }

--- a/tests/integration/cases/empty_dict/Cpp_combined.cpp
+++ b/tests/integration/cases/empty_dict/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {};
+void check_() {
+Any my_data = {};
 my_data = {};
 }

--- a/tests/integration/cases/empty_dicts_in_sequence/Cpp.cpp
+++ b/tests/integration/cases/empty_dicts_in_sequence/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {},
     {},
 };

--- a/tests/integration/cases/empty_dicts_in_sequence/Cpp_combined.cpp
+++ b/tests/integration/cases/empty_dicts_in_sequence/Cpp_combined.cpp
@@ -2,16 +2,16 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {},
     {},
 };
-my_data = std::vector<std::map<std::string, _Any>>{
+my_data = std::vector<std::map<std::string, Any>>{
     {},
     {},
 };

--- a/tests/integration/cases/empty_list/Cpp.cpp
+++ b/tests/integration/cases/empty_list/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {};
+void check_() {
+Any my_data = {};
 }

--- a/tests/integration/cases/empty_list/Cpp_combined.cpp
+++ b/tests/integration/cases/empty_list/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {};
+void check_() {
+Any my_data = {};
 my_data = {};
 }

--- a/tests/integration/cases/empty_sequence/Cpp.cpp
+++ b/tests/integration/cases/empty_sequence/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {},
     {},
 };

--- a/tests/integration/cases/empty_sequence/Cpp_combined.cpp
+++ b/tests/integration/cases/empty_sequence/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {},
     {},
 };

--- a/tests/integration/cases/empty_set/Cpp.cpp
+++ b/tests/integration/cases/empty_set/Cpp.cpp
@@ -1,8 +1,8 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {};
+void check_() {
+Any my_data = {};
 }

--- a/tests/integration/cases/empty_set/Cpp_combined.cpp
+++ b/tests/integration/cases/empty_set/Cpp_combined.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {};
+void check_() {
+Any my_data = {};
 my_data = {};
 }

--- a/tests/integration/cases/float_list/Cpp.cpp
+++ b/tests/integration/cases/float_list/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     1.1,
     -2.2,
     3.3,

--- a/tests/integration/cases/float_list/Cpp_combined.cpp
+++ b/tests/integration/cases/float_list/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     1.1,
     -2.2,
     3.3,

--- a/tests/integration/cases/float_list/Cpp_float_format_fixed.cpp
+++ b/tests/integration/cases/float_list/Cpp_float_format_fixed.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     1.100000,
     -2.200000,
     3.300000,

--- a/tests/integration/cases/float_list/Cpp_float_format_scientific.cpp
+++ b/tests/integration/cases/float_list/Cpp_float_format_scientific.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     1.1,
     -2.2,
     3.3,

--- a/tests/integration/cases/float_list/Cpp_sequence_array_float.cpp
+++ b/tests/integration/cases/float_list/Cpp_sequence_array_float.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <array>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::array<double, 3>{
+void check_() {
+Any my_data = std::array<double, 3>{
     1.1,
     -2.2,
     3.3,

--- a/tests/integration/cases/float_negative_zero/Cpp.cpp
+++ b/tests/integration/cases/float_negative_zero/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     -0.0,
     1.5,
 };

--- a/tests/integration/cases/float_negative_zero/Cpp_combined.cpp
+++ b/tests/integration/cases/float_negative_zero/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     -0.0,
     1.5,
 };

--- a/tests/integration/cases/float_scientific_notation/Cpp.cpp
+++ b/tests/integration/cases/float_scientific_notation/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     0.0,
     1.0,
     1500.0,

--- a/tests/integration/cases/float_scientific_notation/Cpp_combined.cpp
+++ b/tests/integration/cases/float_scientific_notation/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     0.0,
     1.0,
     1500.0,

--- a/tests/integration/cases/float_scientific_notation/Cpp_float_format_fixed_s.cpp
+++ b/tests/integration/cases/float_scientific_notation/Cpp_float_format_fixed_s.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     0.000000,
     1.000000,
     1500.000000,

--- a/tests/integration/cases/float_scientific_notation/Cpp_float_format_scientific_s.cpp
+++ b/tests/integration/cases/float_scientific_notation/Cpp_float_format_scientific_s.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     0.0,
     1.0,
     1.5e3,

--- a/tests/integration/cases/float_special_values/Cpp.cpp
+++ b/tests/integration/cases/float_special_values/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <cmath>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     INFINITY,
     -INFINITY,
     NAN,

--- a/tests/integration/cases/float_special_values/Cpp_combined.cpp
+++ b/tests/integration/cases/float_special_values/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <cmath>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     INFINITY,
     -INFINITY,
     NAN,

--- a/tests/integration/cases/float_special_values/Cpp_float_format_fixed_v.cpp
+++ b/tests/integration/cases/float_special_values/Cpp_float_format_fixed_v.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <cmath>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     INFINITY,
     -INFINITY,
     NAN,

--- a/tests/integration/cases/float_special_values/Cpp_float_format_scientific_v.cpp
+++ b/tests/integration/cases/float_special_values/Cpp_float_format_scientific_v.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <cmath>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     INFINITY,
     -INFINITY,
     NAN,

--- a/tests/integration/cases/int_key_dict/Cpp.cpp
+++ b/tests/integration/cases/int_key_dict/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"1", "one"},
     {"2", "two"},
     {"42", "answer"},

--- a/tests/integration/cases/int_key_dict/Cpp_combined.cpp
+++ b/tests/integration/cases/int_key_dict/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"1", "one"},
     {"2", "two"},
     {"42", "answer"},

--- a/tests/integration/cases/int_list/Cpp.cpp
+++ b/tests/integration/cases/int_list/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     1,
     2,
     3,

--- a/tests/integration/cases/int_list/Cpp_combined.cpp
+++ b/tests/integration/cases/int_list/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     1,
     2,
     3,

--- a/tests/integration/cases/int_list/Cpp_integer_format_binary.cpp
+++ b/tests/integration/cases/int_list/Cpp_integer_format_binary.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0b1,
     0b10,
     0b11,

--- a/tests/integration/cases/int_list/Cpp_integer_format_hex.cpp
+++ b/tests/integration/cases/int_list/Cpp_integer_format_hex.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0x1,
     0x2,
     0x3,

--- a/tests/integration/cases/int_list/Cpp_integer_format_octal.cpp
+++ b/tests/integration/cases/int_list/Cpp_integer_format_octal.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     01,
     02,
     03,

--- a/tests/integration/cases/int_list/Cpp_numeric_literal_suffix_auto.cpp
+++ b/tests/integration/cases/int_list/Cpp_numeric_literal_suffix_auto.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<long>{
+void check_() {
+Any my_data = std::vector<long>{
     1L,
     2L,
     3L,

--- a/tests/integration/cases/int_list/Cpp_numeric_separator_underscore.cpp
+++ b/tests/integration/cases/int_list/Cpp_numeric_separator_underscore.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     1,
     2,
     3,

--- a/tests/integration/cases/int_list_large/Cpp.cpp
+++ b/tests/integration/cases/int_list_large/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     1000000,
     -1234,
     255,

--- a/tests/integration/cases/int_list_large/Cpp_combined.cpp
+++ b/tests/integration/cases/int_list_large/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     1000000,
     -1234,
     255,

--- a/tests/integration/cases/int_list_large/Cpp_integer_format_binary_large.cpp
+++ b/tests/integration/cases/int_list_large/Cpp_integer_format_binary_large.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0b11110100001001000000,
     -0b10011010010,
     0b11111111,

--- a/tests/integration/cases/int_list_large/Cpp_integer_format_hex_large.cpp
+++ b/tests/integration/cases/int_list_large/Cpp_integer_format_hex_large.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0xf4240,
     -0x4d2,
     0xff,

--- a/tests/integration/cases/int_list_large/Cpp_integer_format_octal_large.cpp
+++ b/tests/integration/cases/int_list_large/Cpp_integer_format_octal_large.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     03641100,
     -02322,
     0377,

--- a/tests/integration/cases/int_list_large/Cpp_numeric_literal_suffix_auto_large.cpp
+++ b/tests/integration/cases/int_list_large/Cpp_numeric_literal_suffix_auto_large.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<long>{
+void check_() {
+Any my_data = std::vector<long>{
     1000000L,
     -1234L,
     255L,

--- a/tests/integration/cases/int_list_large/Cpp_numeric_separator_underscore_large.cpp
+++ b/tests/integration/cases/int_list_large/Cpp_numeric_separator_underscore_large.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     1'000'000,
     -1'234,
     255,

--- a/tests/integration/cases/int_list_with_zero/Cpp.cpp
+++ b/tests/integration/cases/int_list_with_zero/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0,
     1,
     -1,

--- a/tests/integration/cases/int_list_with_zero/Cpp_combined.cpp
+++ b/tests/integration/cases/int_list_with_zero/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0,
     1,
     -1,

--- a/tests/integration/cases/int_list_with_zero/Cpp_integer_format_binary_zero.cpp
+++ b/tests/integration/cases/int_list_with_zero/Cpp_integer_format_binary_zero.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0b0,
     0b1,
     -0b1,

--- a/tests/integration/cases/int_list_with_zero/Cpp_integer_format_hex_zero.cpp
+++ b/tests/integration/cases/int_list_with_zero/Cpp_integer_format_hex_zero.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0x0,
     0x1,
     -0x1,

--- a/tests/integration/cases/int_list_with_zero/Cpp_integer_format_octal_zero.cpp
+++ b/tests/integration/cases/int_list_with_zero/Cpp_integer_format_octal_zero.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0,
     01,
     -01,

--- a/tests/integration/cases/int_list_with_zero/Cpp_numeric_literal_suffix_auto_zero.cpp
+++ b/tests/integration/cases/int_list_with_zero/Cpp_numeric_literal_suffix_auto_zero.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<long>{
+void check_() {
+Any my_data = std::vector<long>{
     0L,
     1L,
     -1L,

--- a/tests/integration/cases/int_list_with_zero/Cpp_numeric_separator_underscore_zero.cpp
+++ b/tests/integration/cases/int_list_with_zero/Cpp_numeric_separator_underscore_zero.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<int>{
+void check_() {
+Any my_data = std::vector<int>{
     0,
     1,
     -1,

--- a/tests/integration/cases/int_set/Cpp.cpp
+++ b/tests/integration/cases/int_set/Cpp.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     2,
     3,

--- a/tests/integration/cases/int_set/Cpp_combined.cpp
+++ b/tests/integration/cases/int_set/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     2,
     3,

--- a/tests/integration/cases/mixed_number_dict/Cpp.cpp
+++ b/tests/integration/cases/mixed_number_dict/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, double>{
+void check_() {
+Any my_data = std::map<std::string, double>{
     {"a", 1},
     {"b", 2.5},
     {"c", 3},

--- a/tests/integration/cases/mixed_number_dict/Cpp_combined.cpp
+++ b/tests/integration/cases/mixed_number_dict/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, double>{
+void check_() {
+Any my_data = std::map<std::string, double>{
     {"a", 1},
     {"b", 2.5},
     {"c", 3},

--- a/tests/integration/cases/mixed_number_list/Cpp.cpp
+++ b/tests/integration/cases/mixed_number_list/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     1,
     2.5,
     3,

--- a/tests/integration/cases/mixed_number_list/Cpp_combined.cpp
+++ b/tests/integration/cases/mixed_number_list/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<double>{
+void check_() {
+Any my_data = std::vector<double>{
     1,
     2.5,
     3,

--- a/tests/integration/cases/mixed_set/Cpp.cpp
+++ b/tests/integration/cases/mixed_set/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     true,
     42,
     "apple",

--- a/tests/integration/cases/mixed_set/Cpp_combined.cpp
+++ b/tests/integration/cases/mixed_set/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     true,
     42,
     "apple",

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Cpp.cpp
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {{"type", "create"}, {"pr_id", "pr_1"}, {"draft", true}},
     {{"type", "create"}, {"pr_id", "pr_2"}},
 };

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Cpp_combined.cpp
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Cpp_combined.cpp
@@ -2,16 +2,16 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {{"type", "create"}, {"pr_id", "pr_1"}, {"draft", true}},
     {{"type", "create"}, {"pr_id", "pr_2"}},
 };
-my_data = std::vector<std::map<std::string, _Any>>{
+my_data = std::vector<std::map<std::string, Any>>{
     {{"type", "create"}, {"pr_id", "pr_1"}, {"draft", true}},
     {{"type", "create"}, {"pr_id", "pr_2"}},
 };

--- a/tests/integration/cases/nested/Cpp.cpp
+++ b/tests/integration/cases/nested/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::vector<std::map<std::string, _Any>>>{
-    {"users", std::vector<std::map<std::string, _Any>>{{{"name", "Bob"}, {"tags", std::vector<std::string>{"admin", "user"}}}, {{"name", "Carol"}, {"tags", std::vector<std::string>{"guest"}}}}},
+void check_() {
+Any my_data = std::map<std::string, std::vector<std::map<std::string, Any>>>{
+    {"users", std::vector<std::map<std::string, Any>>{{{"name", "Bob"}, {"tags", std::vector<std::string>{"admin", "user"}}}, {{"name", "Carol"}, {"tags", std::vector<std::string>{"guest"}}}}},
 };
 }

--- a/tests/integration/cases/nested/Cpp_combined.cpp
+++ b/tests/integration/cases/nested/Cpp_combined.cpp
@@ -2,15 +2,15 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::vector<std::map<std::string, _Any>>>{
-    {"users", std::vector<std::map<std::string, _Any>>{{{"name", "Bob"}, {"tags", std::vector<std::string>{"admin", "user"}}}, {{"name", "Carol"}, {"tags", std::vector<std::string>{"guest"}}}}},
+void check_() {
+Any my_data = std::map<std::string, std::vector<std::map<std::string, Any>>>{
+    {"users", std::vector<std::map<std::string, Any>>{{{"name", "Bob"}, {"tags", std::vector<std::string>{"admin", "user"}}}, {{"name", "Carol"}, {"tags", std::vector<std::string>{"guest"}}}}},
 };
-my_data = std::map<std::string, std::vector<std::map<std::string, _Any>>>{
-    {"users", std::vector<std::map<std::string, _Any>>{{{"name", "Bob"}, {"tags", std::vector<std::string>{"admin", "user"}}}, {{"name", "Carol"}, {"tags", std::vector<std::string>{"guest"}}}}},
+my_data = std::map<std::string, std::vector<std::map<std::string, Any>>>{
+    {"users", std::vector<std::map<std::string, Any>>{{{"name", "Bob"}, {"tags", std::vector<std::string>{"admin", "user"}}}, {{"name", "Carol"}, {"tags", std::vector<std::string>{"guest"}}}}},
 };
 }

--- a/tests/integration/cases/nested_bool_list/Cpp.cpp
+++ b/tests/integration/cases/nested_bool_list/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<bool>>{
+void check_() {
+Any my_data = std::vector<std::vector<bool>>{
     std::vector<bool>{true, false},
     std::vector<bool>{true, true},
 };

--- a/tests/integration/cases/nested_bool_list/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_bool_list/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<bool>>{
+void check_() {
+Any my_data = std::vector<std::vector<bool>>{
     std::vector<bool>{true, false},
     std::vector<bool>{true, true},
 };

--- a/tests/integration/cases/nested_collection_multi_space_string/Cpp.cpp
+++ b/tests/integration/cases/nested_collection_multi_space_string/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {{"key", "hello   world"}, {"value", 1}},
 };
 }

--- a/tests/integration/cases/nested_collection_multi_space_string/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_collection_multi_space_string/Cpp_combined.cpp
@@ -2,15 +2,15 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {{"key", "hello   world"}, {"value", 1}},
 };
-my_data = std::vector<std::map<std::string, _Any>>{
+my_data = std::vector<std::map<std::string, Any>>{
     {{"key", "hello   world"}, {"value", 1}},
 };
 }

--- a/tests/integration/cases/nested_deep_empty/Cpp.cpp
+++ b/tests/integration/cases/nested_deep_empty/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {{}, {}},
 };
 }

--- a/tests/integration/cases/nested_deep_empty/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_deep_empty/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {{}, {}},
 };
 my_data = {

--- a/tests/integration/cases/nested_deep_mixed/Cpp.cpp
+++ b/tests/integration/cases/nested_deep_mixed/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {std::vector<int>{1, 2}, std::vector<std::string>{"a", "b"}},
 };
 }

--- a/tests/integration/cases/nested_deep_mixed/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_deep_mixed/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {std::vector<int>{1, 2}, std::vector<std::string>{"a", "b"}},
 };
 my_data = {

--- a/tests/integration/cases/nested_empty_inner/Cpp.cpp
+++ b/tests/integration/cases/nested_empty_inner/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {},
     {},
 };

--- a/tests/integration/cases/nested_empty_inner/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_empty_inner/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {},
     {},
 };

--- a/tests/integration/cases/nested_float_list/Cpp.cpp
+++ b/tests/integration/cases/nested_float_list/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<double>>{
+void check_() {
+Any my_data = std::vector<std::vector<double>>{
     std::vector<double>{1.5, 2.5},
     std::vector<double>{3.5, 4.5},
 };

--- a/tests/integration/cases/nested_float_list/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_float_list/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<double>>{
+void check_() {
+Any my_data = std::vector<std::vector<double>>{
     std::vector<double>{1.5, 2.5},
     std::vector<double>{3.5, 4.5},
 };

--- a/tests/integration/cases/nested_float_list/Cpp_float_format_fixed_n.cpp
+++ b/tests/integration/cases/nested_float_list/Cpp_float_format_fixed_n.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<double>>{
+void check_() {
+Any my_data = std::vector<std::vector<double>>{
     std::vector<double>{1.500000, 2.500000},
     std::vector<double>{3.500000, 4.500000},
 };

--- a/tests/integration/cases/nested_float_list/Cpp_float_format_scientific_n.cpp
+++ b/tests/integration/cases/nested_float_list/Cpp_float_format_scientific_n.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<double>>{
+void check_() {
+Any my_data = std::vector<std::vector<double>>{
     std::vector<double>{1.5, 2.5},
     std::vector<double>{3.5, 4.5},
 };

--- a/tests/integration/cases/nested_list_of_dicts/Cpp.cpp
+++ b/tests/integration/cases/nested_list_of_dicts/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<std::map<std::string, std::string>>>{
+void check_() {
+Any my_data = std::vector<std::vector<std::map<std::string, std::string>>>{
     std::vector<std::map<std::string, std::string>>{std::map<std::string, std::string>{{"name", "Alice"}}, std::map<std::string, std::string>{{"name", "Bob"}}},
     std::vector<std::map<std::string, std::string>>{std::map<std::string, std::string>{{"name", "Charlie"}}, std::map<std::string, std::string>{{"name", "Dave"}}},
 };

--- a/tests/integration/cases/nested_list_of_dicts/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_list_of_dicts/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<std::map<std::string, std::string>>>{
+void check_() {
+Any my_data = std::vector<std::vector<std::map<std::string, std::string>>>{
     std::vector<std::map<std::string, std::string>>{std::map<std::string, std::string>{{"name", "Alice"}}, std::map<std::string, std::string>{{"name", "Bob"}}},
     std::vector<std::map<std::string, std::string>>{std::map<std::string, std::string>{{"name", "Charlie"}}, std::map<std::string, std::string>{{"name", "Dave"}}},
 };

--- a/tests/integration/cases/nested_mixed_inner/Cpp.cpp
+++ b/tests/integration/cases/nested_mixed_inner/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {1, "a"},
     {2, "b"},
 };

--- a/tests/integration/cases/nested_mixed_inner/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_mixed_inner/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {1, "a"},
     {2, "b"},
 };

--- a/tests/integration/cases/nested_mixed_set/Cpp.cpp
+++ b/tests/integration/cases/nested_mixed_set/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"tags", {true, 42, "apple"}},
 };

--- a/tests/integration/cases/nested_mixed_set/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_mixed_set/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"tags", {true, 42, "apple"}},
 };

--- a/tests/integration/cases/nested_mixed_types/Cpp.cpp
+++ b/tests/integration/cases/nested_mixed_types/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::vector<int>{1, 2},
     std::vector<std::string>{"a", "b"},
 };

--- a/tests/integration/cases/nested_mixed_types/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_mixed_types/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     std::vector<int>{1, 2},
     std::vector<std::string>{"a", "b"},
 };

--- a/tests/integration/cases/nested_sequence/Cpp.cpp
+++ b/tests/integration/cases/nested_sequence/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     true,
     "hi",
     std::vector<int>{1, 2},

--- a/tests/integration/cases/nested_sequence/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_sequence/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     true,
     "hi",
     std::vector<int>{1, 2},

--- a/tests/integration/cases/nested_sequences/Cpp.cpp
+++ b/tests/integration/cases/nested_sequences/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<std::vector<int>>>{
+void check_() {
+Any my_data = std::vector<std::vector<std::vector<int>>>{
     std::vector<std::vector<int>>{std::vector<int>{1, 2}, std::vector<int>{3, 4}},
     std::vector<std::vector<int>>{std::vector<int>{5}},
 };

--- a/tests/integration/cases/nested_sequences/Cpp_combined.cpp
+++ b/tests/integration/cases/nested_sequences/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::vector<std::vector<int>>>{
+void check_() {
+Any my_data = std::vector<std::vector<std::vector<int>>>{
     std::vector<std::vector<int>>{std::vector<int>{1, 2}, std::vector<int>{3, 4}},
     std::vector<std::vector<int>>{std::vector<int>{5}},
 };

--- a/tests/integration/cases/no_comment/Cpp.cpp
+++ b/tests/integration/cases/no_comment/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"message", "no comment here"},
 };
 }

--- a/tests/integration/cases/no_comment/Cpp_combined.cpp
+++ b/tests/integration/cases/no_comment/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::map<std::string, std::string>{
+void check_() {
+Any my_data = std::map<std::string, std::string>{
     {"message", "no comment here"},
 };
 my_data = std::map<std::string, std::string>{

--- a/tests/integration/cases/ordered_map/Cpp.cpp
+++ b/tests/integration/cases/ordered_map/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"age", 30},
     {"active", true},

--- a/tests/integration/cases/ordered_map/Cpp_combined.cpp
+++ b/tests/integration/cases/ordered_map/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"age", 30},
     {"active", true},

--- a/tests/integration/cases/ordered_map_int_keys/Cpp.cpp
+++ b/tests/integration/cases/ordered_map_int_keys/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"1", "one"},
     {"2", "two"},
     {"42", "answer"},

--- a/tests/integration/cases/ordered_map_int_keys/Cpp_combined.cpp
+++ b/tests/integration/cases/ordered_map_int_keys/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"1", "one"},
     {"2", "two"},
     {"42", "answer"},

--- a/tests/integration/cases/ordered_map_nested_values/Cpp.cpp
+++ b/tests/integration/cases/ordered_map_nested_values/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"scores", std::map<std::string, std::string>{{"1", "first"}, {"2", "second"}}},
 };

--- a/tests/integration/cases/ordered_map_nested_values/Cpp_combined.cpp
+++ b/tests/integration/cases/ordered_map_nested_values/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"scores", std::map<std::string, std::string>{{"1", "first"}, {"2", "second"}}},
 };

--- a/tests/integration/cases/pair_sequence/Cpp.cpp
+++ b/tests/integration/cases/pair_sequence/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     "hello",
 };

--- a/tests/integration/cases/pair_sequence/Cpp_combined.cpp
+++ b/tests/integration/cases/pair_sequence/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     "hello",
 };

--- a/tests/integration/cases/pair_sequence/Cpp_sequence_array_pair.cpp
+++ b/tests/integration/cases/pair_sequence/Cpp_sequence_array_pair.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <array>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::array<std::string, 2>{
+void check_() {
+Any my_data = std::array<std::string, 2>{
     "1",
     "hello",
 };

--- a/tests/integration/cases/scalar_date/Cpp.cpp
+++ b/tests/integration/cases/scalar_date/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}};
+void check_() {
+Any my_data = std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}};
 }

--- a/tests/integration/cases/scalar_date/Cpp_combined.cpp
+++ b/tests/integration/cases/scalar_date/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}};
+void check_() {
+Any my_data = std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}};
 my_data = std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}};
 }

--- a/tests/integration/cases/scalar_date/Cpp_date_iso.cpp
+++ b/tests/integration/cases/scalar_date/Cpp_date_iso.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = "2024-01-15";
+void check_() {
+Any my_data = "2024-01-15";
 }

--- a/tests/integration/cases/scalar_datetime/Cpp.cpp
+++ b/tests/integration/cases/scalar_datetime/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
 }

--- a/tests/integration/cases/scalar_datetime/Cpp_combined.cpp
+++ b/tests/integration/cases/scalar_datetime/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
 my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
 }

--- a/tests/integration/cases/scalar_datetime/Cpp_datetime_iso.cpp
+++ b/tests/integration/cases/scalar_datetime/Cpp_datetime_iso.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = "2024-01-15T12:30:00+00:00";
+void check_() {
+Any my_data = "2024-01-15T12:30:00+00:00";
 }

--- a/tests/integration/cases/scalar_datetime_microsecond/Cpp.cpp
+++ b/tests/integration/cases/scalar_datetime_microsecond/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::microseconds{123456};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::microseconds{123456};
 }

--- a/tests/integration/cases/scalar_datetime_microsecond/Cpp_combined.cpp
+++ b/tests/integration/cases/scalar_datetime_microsecond/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::microseconds{123456};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::microseconds{123456};
 my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::microseconds{123456};
 }

--- a/tests/integration/cases/scalar_datetime_midnight/Cpp.cpp
+++ b/tests/integration/cases/scalar_datetime_midnight/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}};
 }

--- a/tests/integration/cases/scalar_datetime_midnight/Cpp_combined.cpp
+++ b/tests/integration/cases/scalar_datetime_midnight/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}};
 my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}};
 }

--- a/tests/integration/cases/scalar_datetime_naive/Cpp.cpp
+++ b/tests/integration/cases/scalar_datetime_naive/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
 }

--- a/tests/integration/cases/scalar_datetime_naive/Cpp_combined.cpp
+++ b/tests/integration/cases/scalar_datetime_naive/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
 my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30};
 }

--- a/tests/integration/cases/scalar_datetime_naive/Cpp_datetime_iso_naive.cpp
+++ b/tests/integration/cases/scalar_datetime_naive/Cpp_datetime_iso_naive.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = "2024-01-15T12:30:00";
+void check_() {
+Any my_data = "2024-01-15T12:30:00";
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/Cpp.cpp
+++ b/tests/integration/cases/scalar_datetime_non_utc/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{18};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{18};
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/Cpp_combined.cpp
+++ b/tests/integration/cases/scalar_datetime_non_utc/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{18};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{18};
 my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{18};
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/Cpp_datetime_iso_non_utc.cpp
+++ b/tests/integration/cases/scalar_datetime_non_utc/Cpp_datetime_iso_non_utc.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = "2024-01-15T18:00:00+05:30";
+void check_() {
+Any my_data = "2024-01-15T18:00:00+05:30";
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Cpp.cpp
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::seconds{45} + std::chrono::microseconds{123456};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::seconds{45} + std::chrono::microseconds{123456};
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Cpp_combined.cpp
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <chrono>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::seconds{45} + std::chrono::microseconds{123456};
+void check_() {
+Any my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::seconds{45} + std::chrono::microseconds{123456};
 my_data = std::chrono::sys_days{std::chrono::year_month_day{std::chrono::year{2024}, std::chrono::month{1}, std::chrono::day{15}}} + std::chrono::hours{12} + std::chrono::minutes{30} + std::chrono::seconds{45} + std::chrono::microseconds{123456};
 }

--- a/tests/integration/cases/scalars/Cpp.cpp
+++ b/tests/integration/cases/scalars/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     42,
     3.14,
     true,

--- a/tests/integration/cases/scalars/Cpp_combined.cpp
+++ b/tests/integration/cases/scalars/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     42,
     3.14,
     true,

--- a/tests/integration/cases/sequence_of_dicts/Cpp.cpp
+++ b/tests/integration/cases/sequence_of_dicts/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {{"name", "Alice"}, {"age", 30}},
     {{"name", "Bob"}, {"age", 25}},
 };

--- a/tests/integration/cases/sequence_of_dicts/Cpp_combined.cpp
+++ b/tests/integration/cases/sequence_of_dicts/Cpp_combined.cpp
@@ -2,16 +2,16 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, _Any>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, Any>>{
     {{"name", "Alice"}, {"age", 30}},
     {{"name", "Bob"}, {"age", 25}},
 };
-my_data = std::vector<std::map<std::string, _Any>>{
+my_data = std::vector<std::map<std::string, Any>>{
     {{"name", "Alice"}, {"age", 30}},
     {{"name", "Bob"}, {"age", 25}},
 };

--- a/tests/integration/cases/set/Cpp.cpp
+++ b/tests/integration/cases/set/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     "apple",
     "banana",
     "cherry",

--- a/tests/integration/cases/set/Cpp_combined.cpp
+++ b/tests/integration/cases/set/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     "apple",
     "banana",
     "cherry",

--- a/tests/integration/cases/set_comments/Cpp.cpp
+++ b/tests/integration/cases/set_comments/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     "apple",  // inline comment
     // before banana
     "banana",

--- a/tests/integration/cases/set_comments/Cpp_combined.cpp
+++ b/tests/integration/cases/set_comments/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     "apple",  // inline comment
     // before banana
     "banana",

--- a/tests/integration/cases/set_comments_unsorted_order/Cpp.cpp
+++ b/tests/integration/cases/set_comments_unsorted_order/Cpp.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     // before apple
     "apple",
     "banana",  // banana inline

--- a/tests/integration/cases/set_comments_unsorted_order/Cpp_combined.cpp
+++ b/tests/integration/cases/set_comments_unsorted_order/Cpp_combined.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     // before apple
     "apple",
     "banana",  // banana inline

--- a/tests/integration/cases/simple_dict/Cpp.cpp
+++ b/tests/integration/cases/simple_dict/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"age", 30},
     {"active", true},

--- a/tests/integration/cases/simple_dict/Cpp_combined.cpp
+++ b/tests/integration/cases/simple_dict/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"age", 30},
     {"active", true},

--- a/tests/integration/cases/simple_dict/Cpp_dict_format_unordered_map.cpp
+++ b/tests/integration/cases/simple_dict/Cpp_dict_format_unordered_map.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <unordered_map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"age", 30},
     {"active", true},

--- a/tests/integration/cases/simple_sequence/Cpp.cpp
+++ b/tests/integration/cases/simple_sequence/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     "hello",
     true,

--- a/tests/integration/cases/simple_sequence/Cpp_combined.cpp
+++ b/tests/integration/cases/simple_sequence/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     "hello",
     true,

--- a/tests/integration/cases/simple_sequence/Cpp_sequence_array.cpp
+++ b/tests/integration/cases/simple_sequence/Cpp_sequence_array.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <array>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::array<std::string, 4>{
+void check_() {
+Any my_data = std::array<std::string, 4>{
     "1",
     "hello",
     "True",

--- a/tests/integration/cases/simple_sequence/Cpp_sequence_array_varname.cpp
+++ b/tests/integration/cases/simple_sequence/Cpp_sequence_array_varname.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <array>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::array<std::string, 4>{
+void check_() {
+Any my_data = std::array<std::string, 4>{
     "1",
     "hello",
     "True",

--- a/tests/integration/cases/simple_sequence/Cpp_trailing_comma_no.cpp
+++ b/tests/integration/cases/simple_sequence/Cpp_trailing_comma_no.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <cstddef>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     "hello",
     true,

--- a/tests/integration/cases/string_control_chars/Cpp.cpp
+++ b/tests/integration/cases/string_control_chars/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "line1\r\nline2",
     "line1\rline2",
     "",

--- a/tests/integration/cases/string_control_chars/Cpp_combined.cpp
+++ b/tests/integration/cases/string_control_chars/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "line1\r\nline2",
     "line1\rline2",
     "",

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Cpp.cpp
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Cpp.cpp
@@ -1,9 +1,9 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = "hello \"world\" -- not a comment";
+void check_() {
+Any my_data = "hello \"world\" -- not a comment";
 }

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Cpp_combined.cpp
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Cpp_combined.cpp
@@ -1,10 +1,10 @@
 #include <initializer_list>
 #include <string>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = "hello \"world\" -- not a comment";
+void check_() {
+Any my_data = "hello \"world\" -- not a comment";
 my_data = "hello \"world\" -- not a comment";
 }

--- a/tests/integration/cases/string_list/Cpp.cpp
+++ b/tests/integration/cases/string_list/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "foo",
     "bar",
     "baz",

--- a/tests/integration/cases/string_list/Cpp_combined.cpp
+++ b/tests/integration/cases/string_list/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "foo",
     "bar",
     "baz",

--- a/tests/integration/cases/string_with_backslash/Cpp.cpp
+++ b/tests/integration/cases/string_with_backslash/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "C:\\path\\to\\file",
     "back\\\\slash",
     "hello \\\"world\\\"",

--- a/tests/integration/cases/string_with_backslash/Cpp_combined.cpp
+++ b/tests/integration/cases/string_with_backslash/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "C:\\path\\to\\file",
     "back\\\\slash",
     "hello \\\"world\\\"",

--- a/tests/integration/cases/string_with_dollar/Cpp.cpp
+++ b/tests/integration/cases/string_with_dollar/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "price $10",
     "$HOME",
 };

--- a/tests/integration/cases/string_with_dollar/Cpp_combined.cpp
+++ b/tests/integration/cases/string_with_dollar/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "price $10",
     "$HOME",
 };

--- a/tests/integration/cases/string_with_dollar_brace/Cpp.cpp
+++ b/tests/integration/cases/string_with_dollar_brace/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "prefix ${HOME} suffix",
     "${interpolated}",
 };

--- a/tests/integration/cases/string_with_dollar_brace/Cpp_combined.cpp
+++ b/tests/integration/cases/string_with_dollar_brace/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "prefix ${HOME} suffix",
     "${interpolated}",
 };

--- a/tests/integration/cases/string_with_hash/Cpp.cpp
+++ b/tests/integration/cases/string_with_hash/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "issue #{42}",
     "color #red",
 };

--- a/tests/integration/cases/string_with_hash/Cpp_combined.cpp
+++ b/tests/integration/cases/string_with_hash/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::string>{
+void check_() {
+Any my_data = std::vector<std::string>{
     "issue #{42}",
     "color #red",
 };

--- a/tests/integration/cases/triple_sequence/Cpp.cpp
+++ b/tests/integration/cases/triple_sequence/Cpp.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     "hello",
     true,

--- a/tests/integration/cases/triple_sequence/Cpp_combined.cpp
+++ b/tests/integration/cases/triple_sequence/Cpp_combined.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     1,
     "hello",
     true,

--- a/tests/integration/cases/triple_sequence/Cpp_sequence_array_triple.cpp
+++ b/tests/integration/cases/triple_sequence/Cpp_sequence_array_triple.cpp
@@ -1,12 +1,12 @@
 #include <initializer_list>
 #include <string>
 #include <array>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::array<std::string, 3>{
+void check_() {
+Any my_data = std::array<std::string, 3>{
     "1",
     "hello",
     "True",

--- a/tests/integration/cases/type_hints/Cpp.cpp
+++ b/tests/integration/cases/type_hints/Cpp.cpp
@@ -3,12 +3,12 @@
 #include <cstddef>
 #include <chrono>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"age", 30},
     {"active", true},

--- a/tests/integration/cases/type_hints/Cpp_combined.cpp
+++ b/tests/integration/cases/type_hints/Cpp_combined.cpp
@@ -3,12 +3,12 @@
 #include <cstddef>
 #include <chrono>
 #include <map>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = {
+void check_() {
+Any my_data = {
     {"name", "Alice"},
     {"age", 30},
     {"active", true},

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Cpp.cpp
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, double>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, double>>{
     std::map<std::string, double>{{"x", 1}, {"y", 2.5}},
     std::map<std::string, double>{{"x", 3}, {"y", 4.0}},
 };

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Cpp_combined.cpp
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, double>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, double>>{
     std::map<std::string, double>{{"x", 1}, {"y", 2.5}},
     std::map<std::string, double>{{"x", 3}, {"y", 4.0}},
 };

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Cpp.cpp
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Cpp.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, std::string>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, std::string>>{
     std::map<std::string, std::string>{{"first", "Alice"}, {"last", "Smith"}},
     std::map<std::string, std::string>{{"first", "Bob"}, {"last", "Jones"}},
 };

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Cpp_combined.cpp
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Cpp_combined.cpp
@@ -2,12 +2,12 @@
 #include <string>
 #include <map>
 #include <vector>
-struct _Any {
-    template<class T> _Any(T&&) noexcept {}
-    _Any(std::initializer_list<_Any>) noexcept {}
+struct Any {
+    template<class T> Any(T&&) noexcept {}
+    Any(std::initializer_list<Any>) noexcept {}
 };
-void _check() {
-_Any my_data = std::vector<std::map<std::string, std::string>>{
+void check_() {
+Any my_data = std::vector<std::map<std::string, std::string>>{
     std::map<std::string, std::string>{{"first", "Alice"}, {"last", "Smith"}},
     std::map<std::string, std::string>{{"first", "Bob"}, {"last", "Jones"}},
 };

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -226,7 +226,7 @@ def _wrap_cpp(
 ) -> str:
     """Wrap a C++ variable declaration in a function body."""
     content = _with_body_preamble(content=content, body_preamble=body_preamble)
-    return f"void _check() {{\n{content}\n}}"
+    return f"void check_() {{\n{content}\n}}"
 
 
 @beartype

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -182,7 +182,7 @@ _VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {  # pyrefly: ignore[bad-ass
         declaration="var my_var = 42;", assignment="my_var = 42;"
     ),
     CPP: _VariableSyntax(
-        declaration="_Any my_var = 42;", assignment="my_var = 42;"
+        declaration="Any my_var = 42;", assignment="my_var = 42;"
     ),
     JAVA: _VariableSyntax(
         declaration="var my_var = 42;", assignment="my_var = 42;"


### PR DESCRIPTION
## Summary

- Rename `_Any` to `Any` and `_check` to `check_` in C++ output to avoid identifiers reserved by the C++ standard (`_[A-Z]` and `_` at file scope).
- Add a `bugprone-reserved-identifier` clang-tidy step to the `lint-cpp` CI job to catch future violations.
- Regenerate all 218 golden `.cpp` test files.

Closes #1037

## Test plan

- [x] All 10158 integration tests pass after regeneration
- [x] `clang-tidy --checks='-*,bugprone-reserved-identifier'` reports 0 errors on all `.cpp` files
- [ ] CI `lint-cpp` job passes with the new clang-tidy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily renames generated C++ identifiers and updates golden integration outputs, plus adds a CI `clang-tidy` check that may surface new lint failures.
> 
> **Overview**
> Updates C++ code generation to avoid reserved identifiers by renaming the fallback type from `_Any` to `Any` and the wrapper function from `void _check()` to `void check_()`.
> 
> Extends the `lint-cpp` GitHub Actions job to run `clang-tidy` with `bugprone-reserved-identifier` as warnings-as-errors, and regenerates the C++ golden integration fixtures and variable syntax expectations to match the new names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7ec6a2def70e654b0071abd685c56117793b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->