### PR TITLE
Compute flattened sublist elements once

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -387,15 +387,16 @@ def _coerce_heterogeneous_sibling_lists(*, data: Value) -> Value:
             new_list = [
                 _coerce_heterogeneous_sibling_lists(data=v) for v in data
             ]
-            sublists: list[list[Value]] = [
-                v for v in new_list if isinstance(v, list)
-            ]
+            sublists: list[list[Value]] = []
+            all_elements: list[Value] = []
+            for v in new_list:
+                if isinstance(v, list):
+                    sublists.append(v)
+                    all_elements.extend(v)
             if (
                 len(sublists) == len(new_list)
                 and len(sublists) > 1
-                and _all_scalars_heterogeneous(
-                    values=[e for sub in sublists for e in sub],
-                )
+                and _all_scalars_heterogeneous(values=all_elements)
             ):
                 return [
                     [_coerce_scalar_to_str(value=e) for e in sub]


### PR DESCRIPTION
## Summary
- Extracts the flattened sublist elements into an `all_elements` variable computed once, instead of rebuilding the list comprehension inline in the `_all_scalars_heterogeneous()` call.

Fixes #1018

## Test plan
- [x] All 10606 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small internal refactor that preserves behavior while reducing redundant list flattening in `_coerce_heterogeneous_sibling_lists`. The main risk is subtle differences in element collection order/contents affecting the heterogeneity check, but the logic remains equivalent.
> 
> **Overview**
> Optimizes `_coerce_heterogeneous_sibling_lists` by flattening sibling sublist elements once into `all_elements` and reusing it for the `_all_scalars_heterogeneous` check, instead of rebuilding a nested list comprehension inline.
> 
> This reduces repeated work when scanning lists of lists for heterogeneous scalar types, without changing the coercion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4e7dde940fa5d4a2b5f24bd1ad8f300effb5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->