### PR TITLE
Simplify FloatSpecialsMixin.__init_subclass__ signature

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -192,13 +192,12 @@ class FloatSpecialsMixin:
     def __init_subclass__(
         cls,
         *,
-        positive_infinity: str = "",
-        negative_infinity: str = "",
-        nan: str = "",
-        **kwargs: object,
+        positive_infinity: str,
+        negative_infinity: str,
+        nan: str,
     ) -> None:
         """Store float-special strings as class attributes."""
-        super().__init_subclass__(**kwargs)
+        super().__init_subclass__()
         cls._positive_infinity = positive_infinity
         cls._negative_infinity = negative_infinity
         cls._nan = nan


### PR DESCRIPTION
## Summary
- Remove `**kwargs` from `FloatSpecialsMixin.__init_subclass__` — no subclass passes extra keyword arguments, so forwarding is unnecessary.
- Remove default values for `positive_infinity`, `negative_infinity`, and `nan` so that missing arguments are caught at class-definition time instead of silently defaulting to `""`.

## Test plan
- [x] Smoke-tested float formatting (inf, -inf, nan, finite) across Python, Rust, and Go languages
- [x] All pre-commit hooks pass (mypy, pyright, ty, pyrefly, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API tightening: it only affects classes subclassing `FloatSpecialsMixin`, and the change should surface misconfigured float special literals at class definition time rather than silently defaulting to empty strings.
> 
> **Overview**
> Makes `FloatSpecialsMixin.__init_subclass__` stricter by **requiring** `positive_infinity`, `negative_infinity`, and `nan` keyword arguments and removing the `**kwargs` passthrough.
> 
> This ensures missing special-float literal configuration fails immediately during class creation instead of defaulting to empty strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed137bf2840ad1d85abae26d60e4bc9b9ad8429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->