### PR TITLE
Rename ObjC wrapper `_check` to `check_` and add clang-tidy lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1217,6 +1217,10 @@ jobs:
       - name: Check Objective-C syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only < /tmp/files-to-lint
+      - name: Run clang-tidy
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy --checks='-*,bugprone-reserved-identifier'
+          --warnings-as-errors='*' < /tmp/files-to-lint
 
   completion-lint:
     needs:

--- a/tests/integration/cases/binary/ObjectiveC.m
+++ b/tests/integration/cases/binary/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"48656c6c6f",
 ];

--- a/tests/integration/cases/binary/ObjectiveC_bytes_format_base64.m
+++ b/tests/integration/cases/binary/ObjectiveC_bytes_format_base64.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"SGVsbG8=",
 ];

--- a/tests/integration/cases/binary/ObjectiveC_combined.m
+++ b/tests/integration/cases/binary/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"48656c6c6f",
 ];

--- a/tests/integration/cases/bool_list/ObjectiveC.m
+++ b/tests/integration/cases/bool_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @YES,
     @NO,

--- a/tests/integration/cases/bool_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/bool_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @YES,
     @NO,

--- a/tests/integration/cases/comment_block_scalar_not_comment/ObjectiveC.m
+++ b/tests/integration/cases/comment_block_scalar_not_comment/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"description": @"# not a comment\n",
     @"name": @"foo",

--- a/tests/integration/cases/comment_block_scalar_not_comment/ObjectiveC_combined.m
+++ b/tests/integration/cases/comment_block_scalar_not_comment/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"description": @"# not a comment\n",
     @"name": @"foo",

--- a/tests/integration/cases/comment_scalar/ObjectiveC.m
+++ b/tests/integration/cases/comment_scalar/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = // note
 42;
     (void)my_data;

--- a/tests/integration/cases/comment_scalar/ObjectiveC_combined.m
+++ b/tests/integration/cases/comment_scalar/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = // note
 42;
 my_data = // note

--- a/tests/integration/cases/comment_scalar_document_markers/ObjectiveC.m
+++ b/tests/integration/cases/comment_scalar_document_markers/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = // note
 42;
     (void)my_data;

--- a/tests/integration/cases/comment_scalar_document_markers/ObjectiveC_combined.m
+++ b/tests/integration/cases/comment_scalar_document_markers/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = // note
 42;
 my_data = // note

--- a/tests/integration/cases/comment_scalar_inline/ObjectiveC.m
+++ b/tests/integration/cases/comment_scalar_inline/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = 42  // note;
     (void)my_data;
 }

--- a/tests/integration/cases/comment_scalar_inline/ObjectiveC_combined.m
+++ b/tests/integration/cases/comment_scalar_inline/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = 42  // note;
 my_data = 42  // note;
     (void)my_data;

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/ObjectiveC.m
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"hello # world"  // note;
     (void)my_data;
 }

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/ObjectiveC_combined.m
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"hello # world"  // note;
 my_data = @"hello # world"  // note;
     (void)my_data;

--- a/tests/integration/cases/comments/ObjectiveC.m
+++ b/tests/integration/cases/comments/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     // Server configuration
     @"host": @"localhost",  // default host

--- a/tests/integration/cases/comments/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     // Server configuration
     @"host": @"localhost",  // default host

--- a/tests/integration/cases/comments/ObjectiveC_comment_block.m
+++ b/tests/integration/cases/comments/ObjectiveC_comment_block.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     /* Server configuration */
     @"host": @"localhost",  /* default host */

--- a/tests/integration/cases/comments_bang_in_double_quote/ObjectiveC.m
+++ b/tests/integration/cases/comments_bang_in_double_quote/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key": @"\"bang!\"",  // real
 };

--- a/tests/integration/cases/comments_bang_in_double_quote/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_bang_in_double_quote/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key": @"\"bang!\"",  // real
 };

--- a/tests/integration/cases/comments_double_hash/ObjectiveC.m
+++ b/tests/integration/cases/comments_double_hash/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     // # section
     @"a",

--- a/tests/integration/cases/comments_double_hash/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_double_hash/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     // # section
     @"a",

--- a/tests/integration/cases/comments_empty_line/ObjectiveC.m
+++ b/tests/integration/cases/comments_empty_line/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"a",
     //

--- a/tests/integration/cases/comments_empty_line/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_empty_line/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"a",
     //

--- a/tests/integration/cases/comments_escaped_quote/ObjectiveC.m
+++ b/tests/integration/cases/comments_escaped_quote/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key": @"value \" # not a comment",  // real
 };

--- a/tests/integration/cases/comments_escaped_quote/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_escaped_quote/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key": @"value \" # not a comment",  // real
 };

--- a/tests/integration/cases/comments_escaped_single_quote/ObjectiveC.m
+++ b/tests/integration/cases/comments_escaped_single_quote/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key": @"it's here",  // a comment
 };

--- a/tests/integration/cases/comments_escaped_single_quote/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_escaped_single_quote/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key": @"it's here",  // a comment
 };

--- a/tests/integration/cases/comments_multi_line/ObjectiveC.m
+++ b/tests/integration/cases/comments_multi_line/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     // line 1
     // line 2

--- a/tests/integration/cases/comments_multi_line/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_multi_line/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     // line 1
     // line 2

--- a/tests/integration/cases/comments_nested_mapping/ObjectiveC.m
+++ b/tests/integration/cases/comments_nested_mapping/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"a": @{@"x": @(1)},
     @"b": @(2),

--- a/tests/integration/cases/comments_nested_mapping/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_nested_mapping/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"a": @{@"x": @(1)},
     @"b": @(2),

--- a/tests/integration/cases/comments_sequence_before/ObjectiveC.m
+++ b/tests/integration/cases/comments_sequence_before/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     // first
     @"a",

--- a/tests/integration/cases/comments_sequence_before/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_sequence_before/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     // first
     @"a",

--- a/tests/integration/cases/comments_sequence_inline/ObjectiveC.m
+++ b/tests/integration/cases/comments_sequence_inline/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"a",  // note a
     @"b",  // note b

--- a/tests/integration/cases/comments_sequence_inline/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_sequence_inline/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"a",  // note a
     @"b",  // note b

--- a/tests/integration/cases/comments_trailing/ObjectiveC.m
+++ b/tests/integration/cases/comments_trailing/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"a",
     // trailing

--- a/tests/integration/cases/comments_trailing/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_trailing/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"a",
     // trailing

--- a/tests/integration/cases/comments_vb_before_dim/ObjectiveC.m
+++ b/tests/integration/cases/comments_vb_before_dim/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     // Configuration
     @"name": @"app",

--- a/tests/integration/cases/comments_vb_before_dim/ObjectiveC_combined.m
+++ b/tests/integration/cases/comments_vb_before_dim/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     // Configuration
     @"name": @"app",

--- a/tests/integration/cases/date_list/ObjectiveC.m
+++ b/tests/integration/cases/date_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"2024-01-15",
     @"2024-02-20",

--- a/tests/integration/cases/date_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/date_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"2024-01-15",
     @"2024-02-20",

--- a/tests/integration/cases/date_list/ObjectiveC_date_iso.m
+++ b/tests/integration/cases/date_list/ObjectiveC_date_iso.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"2024-01-15",
     @"2024-02-20",

--- a/tests/integration/cases/date_set/ObjectiveC.m
+++ b/tests/integration/cases/date_set/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @"2024-01-15",
     @"2024-06-01",

--- a/tests/integration/cases/date_set/ObjectiveC_combined.m
+++ b/tests/integration/cases/date_set/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @"2024-01-15",
     @"2024-06-01",

--- a/tests/integration/cases/date_set/ObjectiveC_date_iso.m
+++ b/tests/integration/cases/date_set/ObjectiveC_date_iso.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @"2024-01-15",
     @"2024-06-01",

--- a/tests/integration/cases/dates/ObjectiveC.m
+++ b/tests/integration/cases/dates/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"date": @"2024-01-15",
     @"datetime": @"2024-01-15T12:30:00+00:00",

--- a/tests/integration/cases/dates/ObjectiveC_combined.m
+++ b/tests/integration/cases/dates/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"date": @"2024-01-15",
     @"datetime": @"2024-01-15T12:30:00+00:00",

--- a/tests/integration/cases/datetime_list/ObjectiveC.m
+++ b/tests/integration/cases/datetime_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"2024-01-15T12:30:00.123456+00:00",
     @"2024-06-01T08:00:00+00:00",

--- a/tests/integration/cases/datetime_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/datetime_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"2024-01-15T12:30:00.123456+00:00",
     @"2024-06-01T08:00:00+00:00",

--- a/tests/integration/cases/deep_nesting/ObjectiveC.m
+++ b/tests/integration/cases/deep_nesting/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"level1": @{@"level2": @{@"level3": @{@"level4": @{@"value": @"deep", @"items": @[@"a", @"b"]}}, @"sibling": @(42)}, @"tags": @[@{@"name": @"tag1", @"meta": @{@"priority": @(1), @"labels": @[@"x", @"y"]}}]},
 };

--- a/tests/integration/cases/deep_nesting/ObjectiveC_combined.m
+++ b/tests/integration/cases/deep_nesting/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"level1": @{@"level2": @{@"level3": @{@"level4": @{@"value": @"deep", @"items": @[@"a", @"b"]}}, @"sibling": @(42)}, @"tags": @[@{@"name": @"tag1", @"meta": @{@"priority": @(1), @"labels": @[@"x", @"y"]}}]},
 };

--- a/tests/integration/cases/dict_with_control_char_keys/ObjectiveC.m
+++ b/tests/integration/cases/dict_with_control_char_keys/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key\nwith\nnewlines": @"value1",
     @"key\twith\ttabs": @"value2",

--- a/tests/integration/cases/dict_with_control_char_keys/ObjectiveC_combined.m
+++ b/tests/integration/cases/dict_with_control_char_keys/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"key\nwith\nnewlines": @"value1",
     @"key\twith\ttabs": @"value2",

--- a/tests/integration/cases/dict_with_hyphen_keys/ObjectiveC.m
+++ b/tests/integration/cases/dict_with_hyphen_keys/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"my-key": @"value1",
     @"another-key": @"value2",

--- a/tests/integration/cases/dict_with_hyphen_keys/ObjectiveC_combined.m
+++ b/tests/integration/cases/dict_with_hyphen_keys/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"my-key": @"value1",
     @"another-key": @"value2",

--- a/tests/integration/cases/dict_with_list_value/ObjectiveC.m
+++ b/tests/integration/cases/dict_with_list_value/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"scores": @[@(10), @(20), @(30)],

--- a/tests/integration/cases/dict_with_list_value/ObjectiveC_combined.m
+++ b/tests/integration/cases/dict_with_list_value/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"scores": @[@(10), @(20), @(30)],

--- a/tests/integration/cases/dict_with_nulls/ObjectiveC.m
+++ b/tests/integration/cases/dict_with_nulls/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"score": [NSNull null],

--- a/tests/integration/cases/dict_with_nulls/ObjectiveC_combined.m
+++ b/tests/integration/cases/dict_with_nulls/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"score": [NSNull null],

--- a/tests/integration/cases/empty_dict/ObjectiveC.m
+++ b/tests/integration/cases/empty_dict/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{};
     (void)my_data;
 }

--- a/tests/integration/cases/empty_dict/ObjectiveC_combined.m
+++ b/tests/integration/cases/empty_dict/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{};
 my_data = @{};
     (void)my_data;

--- a/tests/integration/cases/empty_dicts_in_sequence/ObjectiveC.m
+++ b/tests/integration/cases/empty_dicts_in_sequence/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{},
     @{},

--- a/tests/integration/cases/empty_dicts_in_sequence/ObjectiveC_combined.m
+++ b/tests/integration/cases/empty_dicts_in_sequence/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{},
     @{},

--- a/tests/integration/cases/empty_list/ObjectiveC.m
+++ b/tests/integration/cases/empty_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[];
     (void)my_data;
 }

--- a/tests/integration/cases/empty_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/empty_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[];
 my_data = @[];
     (void)my_data;

--- a/tests/integration/cases/empty_sequence/ObjectiveC.m
+++ b/tests/integration/cases/empty_sequence/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[],
     @{},

--- a/tests/integration/cases/empty_sequence/ObjectiveC_combined.m
+++ b/tests/integration/cases/empty_sequence/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[],
     @{},

--- a/tests/integration/cases/empty_set/ObjectiveC.m
+++ b/tests/integration/cases/empty_set/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet set];
     (void)my_data;
 }

--- a/tests/integration/cases/empty_set/ObjectiveC_combined.m
+++ b/tests/integration/cases/empty_set/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet set];
 my_data = [NSSet set];
     (void)my_data;

--- a/tests/integration/cases/float_list/ObjectiveC.m
+++ b/tests/integration/cases/float_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1.1),
     @(-2.2),

--- a/tests/integration/cases/float_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/float_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1.1),
     @(-2.2),

--- a/tests/integration/cases/float_list/ObjectiveC_float_format_fixed.m
+++ b/tests/integration/cases/float_list/ObjectiveC_float_format_fixed.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1.100000),
     @(-2.200000),

--- a/tests/integration/cases/float_list/ObjectiveC_float_format_scientific.m
+++ b/tests/integration/cases/float_list/ObjectiveC_float_format_scientific.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1.1),
     @(-2.2),

--- a/tests/integration/cases/float_negative_zero/ObjectiveC.m
+++ b/tests/integration/cases/float_negative_zero/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(-0.0),
     @(1.5),

--- a/tests/integration/cases/float_negative_zero/ObjectiveC_combined.m
+++ b/tests/integration/cases/float_negative_zero/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(-0.0),
     @(1.5),

--- a/tests/integration/cases/float_scientific_notation/ObjectiveC.m
+++ b/tests/integration/cases/float_scientific_notation/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0.0),
     @(1.0),

--- a/tests/integration/cases/float_scientific_notation/ObjectiveC_combined.m
+++ b/tests/integration/cases/float_scientific_notation/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0.0),
     @(1.0),

--- a/tests/integration/cases/float_scientific_notation/ObjectiveC_float_format_fixed_s.m
+++ b/tests/integration/cases/float_scientific_notation/ObjectiveC_float_format_fixed_s.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0.000000),
     @(1.000000),

--- a/tests/integration/cases/float_scientific_notation/ObjectiveC_float_format_scientific_s.m
+++ b/tests/integration/cases/float_scientific_notation/ObjectiveC_float_format_scientific_s.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0.0),
     @(1.0),

--- a/tests/integration/cases/float_special_values/ObjectiveC.m
+++ b/tests/integration/cases/float_special_values/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(INFINITY),
     @(-INFINITY),

--- a/tests/integration/cases/float_special_values/ObjectiveC_combined.m
+++ b/tests/integration/cases/float_special_values/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(INFINITY),
     @(-INFINITY),

--- a/tests/integration/cases/float_special_values/ObjectiveC_float_format_fixed_v.m
+++ b/tests/integration/cases/float_special_values/ObjectiveC_float_format_fixed_v.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(INFINITY),
     @(-INFINITY),

--- a/tests/integration/cases/float_special_values/ObjectiveC_float_format_scientific_v.m
+++ b/tests/integration/cases/float_special_values/ObjectiveC_float_format_scientific_v.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(INFINITY),
     @(-INFINITY),

--- a/tests/integration/cases/int_key_dict/ObjectiveC.m
+++ b/tests/integration/cases/int_key_dict/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"1": @"one",
     @"2": @"two",

--- a/tests/integration/cases/int_key_dict/ObjectiveC_combined.m
+++ b/tests/integration/cases/int_key_dict/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"1": @"one",
     @"2": @"two",

--- a/tests/integration/cases/int_list/ObjectiveC.m
+++ b/tests/integration/cases/int_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @(2),

--- a/tests/integration/cases/int_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/int_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @(2),

--- a/tests/integration/cases/int_list/ObjectiveC_integer_format_hex.m
+++ b/tests/integration/cases/int_list/ObjectiveC_integer_format_hex.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0x1),
     @(0x2),

--- a/tests/integration/cases/int_list/ObjectiveC_integer_format_octal.m
+++ b/tests/integration/cases/int_list/ObjectiveC_integer_format_octal.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(01),
     @(02),

--- a/tests/integration/cases/int_list_large/ObjectiveC.m
+++ b/tests/integration/cases/int_list_large/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1000000),
     @(-1234),

--- a/tests/integration/cases/int_list_large/ObjectiveC_combined.m
+++ b/tests/integration/cases/int_list_large/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1000000),
     @(-1234),

--- a/tests/integration/cases/int_list_large/ObjectiveC_integer_format_hex_large.m
+++ b/tests/integration/cases/int_list_large/ObjectiveC_integer_format_hex_large.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0xf4240),
     @(-0x4d2),

--- a/tests/integration/cases/int_list_large/ObjectiveC_integer_format_octal_large.m
+++ b/tests/integration/cases/int_list_large/ObjectiveC_integer_format_octal_large.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(03641100),
     @(-02322),

--- a/tests/integration/cases/int_list_with_zero/ObjectiveC.m
+++ b/tests/integration/cases/int_list_with_zero/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0),
     @(1),

--- a/tests/integration/cases/int_list_with_zero/ObjectiveC_combined.m
+++ b/tests/integration/cases/int_list_with_zero/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0),
     @(1),

--- a/tests/integration/cases/int_list_with_zero/ObjectiveC_integer_format_hex_zero.m
+++ b/tests/integration/cases/int_list_with_zero/ObjectiveC_integer_format_hex_zero.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0x0),
     @(0x1),

--- a/tests/integration/cases/int_list_with_zero/ObjectiveC_integer_format_octal_zero.m
+++ b/tests/integration/cases/int_list_with_zero/ObjectiveC_integer_format_octal_zero.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(0),
     @(01),

--- a/tests/integration/cases/int_set/ObjectiveC.m
+++ b/tests/integration/cases/int_set/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @(1),
     @(2),

--- a/tests/integration/cases/int_set/ObjectiveC_combined.m
+++ b/tests/integration/cases/int_set/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @(1),
     @(2),

--- a/tests/integration/cases/mixed_number_dict/ObjectiveC.m
+++ b/tests/integration/cases/mixed_number_dict/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"a": @(1),
     @"b": @(2.5),

--- a/tests/integration/cases/mixed_number_dict/ObjectiveC_combined.m
+++ b/tests/integration/cases/mixed_number_dict/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"a": @(1),
     @"b": @(2.5),

--- a/tests/integration/cases/mixed_number_list/ObjectiveC.m
+++ b/tests/integration/cases/mixed_number_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @(2.5),

--- a/tests/integration/cases/mixed_number_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/mixed_number_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @(2.5),

--- a/tests/integration/cases/mixed_set/ObjectiveC.m
+++ b/tests/integration/cases/mixed_set/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @YES,
     @(42),

--- a/tests/integration/cases/mixed_set/ObjectiveC_combined.m
+++ b/tests/integration/cases/mixed_set/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @YES,
     @(42),

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/ObjectiveC.m
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"type": @"create", @"pr_id": @"pr_1", @"draft": @YES},
     @{@"type": @"create", @"pr_id": @"pr_2"},

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/ObjectiveC_combined.m
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"type": @"create", @"pr_id": @"pr_1", @"draft": @YES},
     @{@"type": @"create", @"pr_id": @"pr_2"},

--- a/tests/integration/cases/nested/ObjectiveC.m
+++ b/tests/integration/cases/nested/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"users": @[@{@"name": @"Bob", @"tags": @[@"admin", @"user"]}, @{@"name": @"Carol", @"tags": @[@"guest"]}],
 };

--- a/tests/integration/cases/nested/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"users": @[@{@"name": @"Bob", @"tags": @[@"admin", @"user"]}, @{@"name": @"Carol", @"tags": @[@"guest"]}],
 };

--- a/tests/integration/cases/nested_bool_list/ObjectiveC.m
+++ b/tests/integration/cases/nested_bool_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@YES, @NO],
     @[@YES, @YES],

--- a/tests/integration/cases/nested_bool_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_bool_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@YES, @NO],
     @[@YES, @YES],

--- a/tests/integration/cases/nested_collection_multi_space_string/ObjectiveC.m
+++ b/tests/integration/cases/nested_collection_multi_space_string/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"key": @"hello   world", @"value": @(1)},
 ];

--- a/tests/integration/cases/nested_collection_multi_space_string/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_collection_multi_space_string/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"key": @"hello   world", @"value": @(1)},
 ];

--- a/tests/integration/cases/nested_deep_empty/ObjectiveC.m
+++ b/tests/integration/cases/nested_deep_empty/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@[], @[]],
 ];

--- a/tests/integration/cases/nested_deep_empty/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_deep_empty/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@[], @[]],
 ];

--- a/tests/integration/cases/nested_deep_mixed/ObjectiveC.m
+++ b/tests/integration/cases/nested_deep_mixed/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@[@(1), @(2)], @[@"a", @"b"]],
 ];

--- a/tests/integration/cases/nested_deep_mixed/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_deep_mixed/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@[@(1), @(2)], @[@"a", @"b"]],
 ];

--- a/tests/integration/cases/nested_empty_inner/ObjectiveC.m
+++ b/tests/integration/cases/nested_empty_inner/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[],
     @[],

--- a/tests/integration/cases/nested_empty_inner/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_empty_inner/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[],
     @[],

--- a/tests/integration/cases/nested_float_list/ObjectiveC.m
+++ b/tests/integration/cases/nested_float_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1.5), @(2.5)],
     @[@(3.5), @(4.5)],

--- a/tests/integration/cases/nested_float_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_float_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1.5), @(2.5)],
     @[@(3.5), @(4.5)],

--- a/tests/integration/cases/nested_float_list/ObjectiveC_float_format_fixed_n.m
+++ b/tests/integration/cases/nested_float_list/ObjectiveC_float_format_fixed_n.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1.500000), @(2.500000)],
     @[@(3.500000), @(4.500000)],

--- a/tests/integration/cases/nested_float_list/ObjectiveC_float_format_scientific_n.m
+++ b/tests/integration/cases/nested_float_list/ObjectiveC_float_format_scientific_n.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1.5), @(2.5)],
     @[@(3.5), @(4.5)],

--- a/tests/integration/cases/nested_list_of_dicts/ObjectiveC.m
+++ b/tests/integration/cases/nested_list_of_dicts/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@{@"name": @"Alice"}, @{@"name": @"Bob"}],
     @[@{@"name": @"Charlie"}, @{@"name": @"Dave"}],

--- a/tests/integration/cases/nested_list_of_dicts/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_list_of_dicts/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@{@"name": @"Alice"}, @{@"name": @"Bob"}],
     @[@{@"name": @"Charlie"}, @{@"name": @"Dave"}],

--- a/tests/integration/cases/nested_mixed_inner/ObjectiveC.m
+++ b/tests/integration/cases/nested_mixed_inner/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1), @"a"],
     @[@(2), @"b"],

--- a/tests/integration/cases/nested_mixed_inner/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_mixed_inner/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1), @"a"],
     @[@(2), @"b"],

--- a/tests/integration/cases/nested_mixed_set/ObjectiveC.m
+++ b/tests/integration/cases/nested_mixed_set/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"tags": [NSSet setWithArray:@[@YES, @(42), @"apple"]],

--- a/tests/integration/cases/nested_mixed_set/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_mixed_set/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"tags": [NSSet setWithArray:@[@YES, @(42), @"apple"]],

--- a/tests/integration/cases/nested_mixed_types/ObjectiveC.m
+++ b/tests/integration/cases/nested_mixed_types/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1), @(2)],
     @[@"a", @"b"],

--- a/tests/integration/cases/nested_mixed_types/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_mixed_types/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@(1), @(2)],
     @[@"a", @"b"],

--- a/tests/integration/cases/nested_sequence/ObjectiveC.m
+++ b/tests/integration/cases/nested_sequence/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @YES,
     @"hi",

--- a/tests/integration/cases/nested_sequence/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_sequence/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @YES,
     @"hi",

--- a/tests/integration/cases/nested_sequences/ObjectiveC.m
+++ b/tests/integration/cases/nested_sequences/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@[@(1), @(2)], @[@(3), @(4)]],
     @[@[@(5)]],

--- a/tests/integration/cases/nested_sequences/ObjectiveC_combined.m
+++ b/tests/integration/cases/nested_sequences/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @[@[@(1), @(2)], @[@(3), @(4)]],
     @[@[@(5)]],

--- a/tests/integration/cases/no_comment/ObjectiveC.m
+++ b/tests/integration/cases/no_comment/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"message": @"no comment here",
 };

--- a/tests/integration/cases/no_comment/ObjectiveC_combined.m
+++ b/tests/integration/cases/no_comment/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"message": @"no comment here",
 };

--- a/tests/integration/cases/ordered_map/ObjectiveC.m
+++ b/tests/integration/cases/ordered_map/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"age": @(30),

--- a/tests/integration/cases/ordered_map/ObjectiveC_combined.m
+++ b/tests/integration/cases/ordered_map/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"age": @(30),

--- a/tests/integration/cases/ordered_map_int_keys/ObjectiveC.m
+++ b/tests/integration/cases/ordered_map_int_keys/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"1": @"one",
     @"2": @"two",

--- a/tests/integration/cases/ordered_map_int_keys/ObjectiveC_combined.m
+++ b/tests/integration/cases/ordered_map_int_keys/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"1": @"one",
     @"2": @"two",

--- a/tests/integration/cases/ordered_map_nested_values/ObjectiveC.m
+++ b/tests/integration/cases/ordered_map_nested_values/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"scores": @{@"1": @"first", @"2": @"second"},

--- a/tests/integration/cases/ordered_map_nested_values/ObjectiveC_combined.m
+++ b/tests/integration/cases/ordered_map_nested_values/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"scores": @{@"1": @"first", @"2": @"second"},

--- a/tests/integration/cases/pair_sequence/ObjectiveC.m
+++ b/tests/integration/cases/pair_sequence/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @"hello",

--- a/tests/integration/cases/pair_sequence/ObjectiveC_combined.m
+++ b/tests/integration/cases/pair_sequence/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @"hello",

--- a/tests/integration/cases/scalar_date/ObjectiveC.m
+++ b/tests/integration/cases/scalar_date/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_date/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalar_date/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15";
 my_data = @"2024-01-15";
     (void)my_data;

--- a/tests/integration/cases/scalar_date/ObjectiveC_date_iso.m
+++ b/tests/integration/cases/scalar_date/ObjectiveC_date_iso.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime/ObjectiveC.m
+++ b/tests/integration/cases/scalar_datetime/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00+00:00";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalar_datetime/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00+00:00";
 my_data = @"2024-01-15T12:30:00+00:00";
     (void)my_data;

--- a/tests/integration/cases/scalar_datetime/ObjectiveC_datetime_iso.m
+++ b/tests/integration/cases/scalar_datetime/ObjectiveC_datetime_iso.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00+00:00";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_microsecond/ObjectiveC.m
+++ b/tests/integration/cases/scalar_datetime_microsecond/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00.123456+00:00";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_microsecond/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalar_datetime_microsecond/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00.123456+00:00";
 my_data = @"2024-01-15T12:30:00.123456+00:00";
     (void)my_data;

--- a/tests/integration/cases/scalar_datetime_midnight/ObjectiveC.m
+++ b/tests/integration/cases/scalar_datetime_midnight/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T00:00:00";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_midnight/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalar_datetime_midnight/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T00:00:00";
 my_data = @"2024-01-15T00:00:00";
     (void)my_data;

--- a/tests/integration/cases/scalar_datetime_naive/ObjectiveC.m
+++ b/tests/integration/cases/scalar_datetime_naive/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_naive/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalar_datetime_naive/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00";
 my_data = @"2024-01-15T12:30:00";
     (void)my_data;

--- a/tests/integration/cases/scalar_datetime_naive/ObjectiveC_datetime_iso_naive.m
+++ b/tests/integration/cases/scalar_datetime_naive/ObjectiveC_datetime_iso_naive.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:00";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/ObjectiveC.m
+++ b/tests/integration/cases/scalar_datetime_non_utc/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T18:00:00+05:30";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalar_datetime_non_utc/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T18:00:00+05:30";
 my_data = @"2024-01-15T18:00:00+05:30";
     (void)my_data;

--- a/tests/integration/cases/scalar_datetime_non_utc/ObjectiveC_datetime_iso_non_utc.m
+++ b/tests/integration/cases/scalar_datetime_non_utc/ObjectiveC_datetime_iso_non_utc.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T18:00:00+05:30";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/ObjectiveC.m
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:45.123456";
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"2024-01-15T12:30:45.123456";
 my_data = @"2024-01-15T12:30:45.123456";
     (void)my_data;

--- a/tests/integration/cases/scalars/ObjectiveC.m
+++ b/tests/integration/cases/scalars/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(42),
     @(3.14),

--- a/tests/integration/cases/scalars/ObjectiveC_combined.m
+++ b/tests/integration/cases/scalars/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(42),
     @(3.14),

--- a/tests/integration/cases/sequence_of_dicts/ObjectiveC.m
+++ b/tests/integration/cases/sequence_of_dicts/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"name": @"Alice", @"age": @(30)},
     @{@"name": @"Bob", @"age": @(25)},

--- a/tests/integration/cases/sequence_of_dicts/ObjectiveC_combined.m
+++ b/tests/integration/cases/sequence_of_dicts/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"name": @"Alice", @"age": @(30)},
     @{@"name": @"Bob", @"age": @(25)},

--- a/tests/integration/cases/set/ObjectiveC.m
+++ b/tests/integration/cases/set/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @"apple",
     @"banana",

--- a/tests/integration/cases/set/ObjectiveC_combined.m
+++ b/tests/integration/cases/set/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @"apple",
     @"banana",

--- a/tests/integration/cases/set_comments/ObjectiveC.m
+++ b/tests/integration/cases/set_comments/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @"apple",  // inline comment
     // before banana

--- a/tests/integration/cases/set_comments/ObjectiveC_combined.m
+++ b/tests/integration/cases/set_comments/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     @"apple",  // inline comment
     // before banana

--- a/tests/integration/cases/set_comments_unsorted_order/ObjectiveC.m
+++ b/tests/integration/cases/set_comments_unsorted_order/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     // before apple
     @"apple",

--- a/tests/integration/cases/set_comments_unsorted_order/ObjectiveC_combined.m
+++ b/tests/integration/cases/set_comments_unsorted_order/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = [NSSet setWithArray:@[
     // before apple
     @"apple",

--- a/tests/integration/cases/simple_dict/ObjectiveC.m
+++ b/tests/integration/cases/simple_dict/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"age": @(30),

--- a/tests/integration/cases/simple_dict/ObjectiveC_combined.m
+++ b/tests/integration/cases/simple_dict/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"age": @(30),

--- a/tests/integration/cases/simple_sequence/ObjectiveC.m
+++ b/tests/integration/cases/simple_sequence/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @"hello",

--- a/tests/integration/cases/simple_sequence/ObjectiveC_combined.m
+++ b/tests/integration/cases/simple_sequence/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @"hello",

--- a/tests/integration/cases/simple_sequence/ObjectiveC_trailing_comma_no.m
+++ b/tests/integration/cases/simple_sequence/ObjectiveC_trailing_comma_no.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @"hello",

--- a/tests/integration/cases/string_control_chars/ObjectiveC.m
+++ b/tests/integration/cases/string_control_chars/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"line1\r\nline2",
     @"line1\rline2",

--- a/tests/integration/cases/string_control_chars/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_control_chars/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"line1\r\nline2",
     @"line1\rline2",

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/ObjectiveC.m
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"hello \"world\" -- not a comment";
     (void)my_data;
 }

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @"hello \"world\" -- not a comment";
 my_data = @"hello \"world\" -- not a comment";
     (void)my_data;

--- a/tests/integration/cases/string_list/ObjectiveC.m
+++ b/tests/integration/cases/string_list/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"foo",
     @"bar",

--- a/tests/integration/cases/string_list/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_list/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"foo",
     @"bar",

--- a/tests/integration/cases/string_with_backslash/ObjectiveC.m
+++ b/tests/integration/cases/string_with_backslash/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"C:\\path\\to\\file",
     @"back\\\\slash",

--- a/tests/integration/cases/string_with_backslash/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_with_backslash/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"C:\\path\\to\\file",
     @"back\\\\slash",

--- a/tests/integration/cases/string_with_dollar/ObjectiveC.m
+++ b/tests/integration/cases/string_with_dollar/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"price $10",
     @"$HOME",

--- a/tests/integration/cases/string_with_dollar/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_with_dollar/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"price $10",
     @"$HOME",

--- a/tests/integration/cases/string_with_dollar_brace/ObjectiveC.m
+++ b/tests/integration/cases/string_with_dollar_brace/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"prefix ${HOME} suffix",
     @"${interpolated}",

--- a/tests/integration/cases/string_with_dollar_brace/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_with_dollar_brace/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"prefix ${HOME} suffix",
     @"${interpolated}",

--- a/tests/integration/cases/string_with_hash/ObjectiveC.m
+++ b/tests/integration/cases/string_with_hash/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"issue #{42}",
     @"color #red",

--- a/tests/integration/cases/string_with_hash/ObjectiveC_combined.m
+++ b/tests/integration/cases/string_with_hash/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @"issue #{42}",
     @"color #red",

--- a/tests/integration/cases/triple_sequence/ObjectiveC.m
+++ b/tests/integration/cases/triple_sequence/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @"hello",

--- a/tests/integration/cases/triple_sequence/ObjectiveC_combined.m
+++ b/tests/integration/cases/triple_sequence/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @(1),
     @"hello",

--- a/tests/integration/cases/type_hints/ObjectiveC.m
+++ b/tests/integration/cases/type_hints/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"age": @(30),

--- a/tests/integration/cases/type_hints/ObjectiveC_combined.m
+++ b/tests/integration/cases/type_hints/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @{
     @"name": @"Alice",
     @"age": @(30),

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/ObjectiveC.m
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"x": @(1), @"y": @(2.5)},
     @{@"x": @(3), @"y": @(4.0)},

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/ObjectiveC_combined.m
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"x": @(1), @"y": @(2.5)},
     @{@"x": @(3), @"y": @(4.0)},

--- a/tests/integration/cases/uniform_string_dicts_in_seq/ObjectiveC.m
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/ObjectiveC.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"first": @"Alice", @"last": @"Smith"},
     @{@"first": @"Bob", @"last": @"Jones"},

--- a/tests/integration/cases/uniform_string_dicts_in_seq/ObjectiveC_combined.m
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/ObjectiveC_combined.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-void _check(void) {
+void check_(void) {
 id my_data = @[
     @{@"first": @"Alice", @"last": @"Smith"},
     @{@"first": @"Bob", @"last": @"Jones"},

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -388,7 +388,7 @@ def _wrap_objc(
 ) -> str:
     """Wrap an Objective-C variable declaration in a function."""
     content = _with_body_preamble(content=content, body_preamble=body_preamble)
-    return f"void _check(void) {{\n{content}\n    (void){variable_name};\n}}"
+    return f"void check_(void) {{\n{content}\n    (void){variable_name};\n}}"
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Rename the Objective-C test wrapper function `_check` → `check_` to avoid using a C-reserved identifier (leading underscore at file scope)
- Add a `clang-tidy` `bugprone-reserved-identifier` check to the `lint-objectivec` CI job
- Regenerate all 202 Objective-C golden files

Closes #1041

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `clang-tidy` step with `--warnings-as-errors` to the Objective-C CI lint job, which can introduce new PR/CI failures if any generated `.m` fixtures trigger reserved-identifier warnings. Code changes are otherwise mechanical renames/regenerated golden files limited to integration-test fixtures.
> 
> **Overview**
> Renames the Objective-C integration-test wrapper function from `void _check(void)` to `void check_(void)` to avoid reserved identifiers, updating the generator (`tests/integration/test_integration.py`) accordingly.
> 
> Updates the Objective-C lint workflow (`.github/workflows/lint.yml`) to run `clang-tidy` with `bugprone-reserved-identifier` (warnings treated as errors) and regenerates all affected Objective-C golden `.m` fixtures to match the new wrapper name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeaa5970b191fb3f3a65383e62cbb237282ed9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->