### PR TITLE
Require FloatSpecialsMixin in LanguageCls.FloatFormats

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -234,7 +234,7 @@ class LanguageCls(type):
     DictEntryStyles: type[enum.Enum]
     DictFormats: type[enum.Enum]
     EmptyDictKey: type[enum.Enum]
-    FloatFormats: type[enum.Enum]
+    FloatFormats: type[FloatSpecialsMixin]
     IntegerFormats: type[enum.Enum]
     NumericLiteralSuffixes: type[enum.Enum]
     NumericSeparators: type[enum.Enum]


### PR DESCRIPTION
## Summary

- Tighten the `FloatFormats` type annotation in `LanguageCls` from `type[enum.Enum]` to `type[FloatSpecialsMixin]`
- Every language already uses `FloatSpecialsMixin` for its `FloatFormats` enum, so this enforces the invariant at the type level

## Test plan

- [x] All 10606 tests pass
- [x] mypy, pyright, ty, and pyrefly all pass (verified via pre-push hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change that tightens `LanguageCls.FloatFormats` to `type[FloatSpecialsMixin]`, potentially surfacing new static type errors for any out-of-tree language implementations that don’t mix in `FloatSpecialsMixin`.
> 
> **Overview**
> Tightens the `LanguageCls` metaclass contract by changing `FloatFormats` from `type[enum.Enum]` to `type[FloatSpecialsMixin]`, enforcing at the type level that language `FloatFormats` enums support special float formatting via the mixin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6aeb403d921a4e853166864cfd1dd7ba3fbabc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->