### PR TITLE
Rename DictFormatConfig.open_fn to dict_open

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -978,7 +978,7 @@ def _format_dict_value(
     opener = (
         open_override
         if open_override is not None
-        else dict_cfg.open_fn(dict_items)
+        else dict_cfg.dict_open(dict_items)
     )
     return opener + joined + dict_cfg.close
 
@@ -992,7 +992,7 @@ def _compute_dict_open_override(
     """Return a widened dict opener when dicts in a list infer
     different value types, or ``None`` when no widening is needed.
     """
-    open_fn = spec.dict_format_config.open_fn
+    dict_open = spec.dict_format_config.dict_open
     dicts: list[dict[str, Value]] = [
         item
         for item in items
@@ -1013,7 +1013,7 @@ def _compute_dict_open_override(
         for d in dicts
     ]
 
-    openers = {open_fn(d) for d in filtered_dicts}
+    openers = {dict_open(d) for d in filtered_dicts}
     if len(openers) <= 1:
         return None
 
@@ -1024,7 +1024,7 @@ def _compute_dict_open_override(
         for v in d.values():
             combined[f"_k{idx}"] = v
             idx += 1
-    return open_fn(combined)
+    return dict_open(combined)
 
 
 @beartype
@@ -1136,7 +1136,7 @@ def _wrap_body(
     elif isinstance(data, dict):
         dict_cfg = spec.dict_format_config
 
-        opening = f"{line_prefix}{dict_cfg.open_fn(data)}"
+        opening = f"{line_prefix}{dict_cfg.dict_open(data)}"
         closing = f"{close_prefix}{dict_cfg.close}"
     elif isinstance(data, set):
         sorted_set: list[Value] = sorted(

--- a/src/literalizer/_formatters/format_factories.py
+++ b/src/literalizer/_formatters/format_factories.py
@@ -178,7 +178,7 @@ def dict_format_factory(
         """Build a ``DictFormatConfig`` with the given default type."""
         fmt_kwargs = {"type": default_type, "key_type": default_key_type}
         return DictFormatConfig(
-            open_fn=fixed_dict_open(
+            dict_open=fixed_dict_open(
                 open_str=open_template.format(**fmt_kwargs),
             ),
             close=close,

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -127,7 +127,7 @@ class CommentConfig:
 class DictFormatConfig:
     """Configuration for dict formatting."""
 
-    open_fn: Callable[[dict[str, Value]], str]
+    dict_open: Callable[[dict[str, Value]], str]
     close: str
     format_entry: Callable[[str, Value, str], str]
     empty_dict: str | None

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -303,7 +303,7 @@ class Ada(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="AMap'("),
+            dict_open=fixed_dict_open(open_str="AMap'("),
             close=")",
             format_entry=dict_entry_with_template(
                 template="AEntry ({key}, {value})",

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -324,7 +324,7 @@ class Bash(metaclass=LanguageCls):
         self.false_literal = "false"
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="("),
+            dict_open=fixed_dict_open(open_str="("),
             close=")",
             format_entry=_format_bash_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -315,7 +315,7 @@ class C(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="((_CVal){.m = (_CKV[]){"),
+            dict_open=fixed_dict_open(open_str="((_CVal){.m = (_CKV[]){"),
             close="}})",
             format_entry=braced_dict_entry(
                 format_value=_format_c_entry,

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -268,7 +268,7 @@ class Clojure(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" ",

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -443,7 +443,7 @@ class Cobol(metaclass=LanguageCls):
         self.false_literal = '"FALSE"'
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str=""),
+            dict_open=fixed_dict_open(open_str=""),
             close="",
             format_entry=_format_cobol_dict_entry,
             empty_dict="05 FILLER PIC X(1) VALUE SPACES.",

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -287,7 +287,7 @@ class CommonLisp(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="(list "),
+            dict_open=fixed_dict_open(open_str="(list "),
             close=")",
             format_entry=_format_cons_entry,
             empty_dict="nil",

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -212,7 +212,7 @@ def _rebuild_dict_opener(
     base_config: DictFormatConfig = dict_format.value
     return dataclasses.replace(
         base_config,
-        open_fn=typed_dict_open(
+        dict_open=typed_dict_open(
             type_to_opener=make_type_to_opener(
                 element_to_type=element_to_type,
                 opener_template=dict_opener_template,
@@ -369,7 +369,7 @@ class Cpp(metaclass=LanguageCls):
         """Dict/map format options."""
 
         MAP = DictFormatConfig(
-            open_fn=typed_dict_open(
+            dict_open=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=_make_cpp_element_to_type(int_type="int"),
                     opener_template="std::map<std::string, {type_name}>{{",
@@ -385,7 +385,7 @@ class Cpp(metaclass=LanguageCls):
             narrowed_open=None,
         )
         UNORDERED_MAP = DictFormatConfig(
-            open_fn=typed_dict_open(
+            dict_open=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=_make_cpp_element_to_type(int_type="int"),
                     opener_template=(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -449,7 +449,7 @@ class CSharp(metaclass=LanguageCls):
             default_dict_key_type,
         )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=typed_dict_open(
+            dict_open=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=cfg.element_to_type(
                         list_template=None,

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -328,7 +328,7 @@ class D(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="JSONValue(["),
+            dict_open=fixed_dict_open(open_str="JSONValue(["),
             close="])",
             format_entry=dict_entry_with_separator(
                 separator=": ",

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -387,7 +387,7 @@ class Dart(metaclass=LanguageCls):
             else fmt.sequence_open
         )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=typed_dict_open(
+            dict_open=typed_dict_open(
                 type_to_opener=openers.dict,
                 fallback=(
                     f"<{default_dict_key_type}, {default_dict_value_type}>{{"

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -386,7 +386,7 @@ class Dhall(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=_format_dhall_dict_entry,
             empty_dict="{=}",

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -374,7 +374,7 @@ class Elixir(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="%{"),
+            dict_open=fixed_dict_open(open_str="%{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -443,7 +443,7 @@ class Elm(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="EDict ["),
+            dict_open=fixed_dict_open(open_str="EDict ["),
             close="]",
             format_entry=_elm_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -347,7 +347,7 @@ class Erlang(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="#{"),
+            dict_open=fixed_dict_open(open_str="#{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -360,7 +360,7 @@ class Fortran(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="fmap([fval_t :: "),
+            dict_open=fixed_dict_open(open_str="fmap([fval_t :: "),
             close="])",
             format_entry=dict_entry_with_template(
                 template="fentry({key}, {value})",

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -378,7 +378,7 @@ class FSharp(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="FMap ["),
+            dict_open=fixed_dict_open(open_str="FMap ["),
             close="]",
             format_entry=tuple_dict_entry(
                 format_value=_format_fsharp_entry,

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -481,7 +481,7 @@ class Gleam(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="GDict(["),
+            dict_open=fixed_dict_open(open_str="GDict(["),
             close="])",
             format_entry=_gleam_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -455,7 +455,7 @@ class Go(metaclass=LanguageCls):
             )
         )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=typed_dict_open(
+            dict_open=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=init_element_to_type,
                     opener_template=f"map[{default_dict_key_type}]{{type_name}}{{{{",

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -285,7 +285,7 @@ class Groovy(metaclass=LanguageCls):
         )
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="["),
+            dict_open=fixed_dict_open(open_str="["),
             close="]",
             format_entry=dict_entry_with_separator(
                 separator=": ",

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -545,7 +545,7 @@ class Haskell(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="HMap ["),
+            dict_open=fixed_dict_open(open_str="HMap ["),
             close="]",
             format_entry=tuple_dict_entry(
                 format_value=passthrough_sequence_entry

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -272,7 +272,7 @@ class Hcl(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" = ",

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -308,7 +308,7 @@ class Java(metaclass=LanguageCls):
         """Dict/map format options."""
 
         MAP_OF_ENTRIES = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="Map.ofEntries("),
+            dict_open=fixed_dict_open(open_str="Map.ofEntries("),
             close=")",
             format_entry=dict_entry_with_template(
                 template="Map.entry({key}, {value})",
@@ -319,7 +319,7 @@ class Java(metaclass=LanguageCls):
             narrowed_open=None,
         )
         HASH_MAP = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="new HashMap<>(Map.ofEntries("),
+            dict_open=fixed_dict_open(open_str="new HashMap<>(Map.ofEntries("),
             close="))",
             format_entry=dict_entry_with_template(
                 template="Map.entry({key}, {value})",

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -224,7 +224,7 @@ class JavaScript(metaclass=LanguageCls):
         """Dict/map format options."""
 
         OBJECT = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -235,7 +235,7 @@ class JavaScript(metaclass=LanguageCls):
             narrowed_open=None,
         )
         MAP = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="new Map(["),
+            dict_open=fixed_dict_open(open_str="new Map(["),
             close="])",
             format_entry=dict_entry_with_template(
                 template="[{key}, {value}]",

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -300,7 +300,7 @@ class Json5(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=_format_json5_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -302,7 +302,7 @@ class Jsonnet(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=_format_jsonnet_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -224,7 +224,7 @@ class Julia(metaclass=LanguageCls):
         """Dict/map format options."""
 
         DICT = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="Dict("),
+            dict_open=fixed_dict_open(open_str="Dict("),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" => ",
@@ -235,7 +235,7 @@ class Julia(metaclass=LanguageCls):
             narrowed_open=None,
         )
         ORDERED = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="OrderedDict("),
+            dict_open=fixed_dict_open(open_str="OrderedDict("),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" => ",

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -555,7 +555,7 @@ class Kotlin(metaclass=LanguageCls):
             default_dict_key_type,
         )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=typed_dict_open(
+            dict_open=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=cfg.element_to_type(
                         list_template=None,

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -330,7 +330,7 @@ class Lua(metaclass=LanguageCls):
             format_value=passthrough_sequence_entry,
         )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=lua_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -264,7 +264,7 @@ class Matlab(metaclass=LanguageCls):
         """Dict/map format options."""
 
         STRUCT = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="struct("),
+            dict_open=fixed_dict_open(open_str="struct("),
             close=")",
             format_entry=_format_matlab_dict_entry,
             empty_dict="struct()",
@@ -272,7 +272,7 @@ class Matlab(metaclass=LanguageCls):
             narrowed_open=None,
         )
         CONTAINERS_MAP = DictFormatConfig(
-            open_fn=_containers_map_open,
+            dict_open=_containers_map_open,
             narrowed_open=None,
             close="})",
             format_entry=_format_containers_map_entry,

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -434,7 +434,7 @@ class Nim(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -280,7 +280,7 @@ class Norg(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -340,7 +340,7 @@ class ObjectiveC(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="@{"),
+            dict_open=fixed_dict_open(open_str="@{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -397,7 +397,7 @@ class OCaml(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="OMap ["),
+            dict_open=fixed_dict_open(open_str="OMap ["),
             close="]",
             format_entry=tuple_dict_entry(
                 format_value=_format_ocaml_entry,

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -290,7 +290,7 @@ class Occam(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(
+            dict_open=fixed_dict_open(
                 open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
             ),
             close="])",

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -355,7 +355,7 @@ class Odin(metaclass=LanguageCls):
         )
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(
+            dict_open=fixed_dict_open(
                 open_str="map[string]any{",
             ),
             close="}",

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -366,7 +366,7 @@ class Perl(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -340,7 +340,7 @@ class Php(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="["),
+            dict_open=fixed_dict_open(open_str="["),
             close="]",
             format_entry=dict_entry_with_separator(
                 separator=" => ",

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -297,7 +297,7 @@ class PowerShell(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="@{"),
+            dict_open=fixed_dict_open(open_str="@{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" = ",

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -484,7 +484,7 @@ class PureScript(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="PDict ["),
+            dict_open=fixed_dict_open(open_str="PDict ["),
             close="]",
             format_entry=_purescript_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -812,7 +812,7 @@ class Python(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -350,7 +350,7 @@ class R(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="list("),
+            dict_open=fixed_dict_open(open_str="list("),
             close=")",
             format_entry=empty_dict_key,
             empty_dict=None,

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -272,7 +272,7 @@ class Racket(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="(hash "),
+            dict_open=fixed_dict_open(open_str="(hash "),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" ",

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -367,7 +367,7 @@ class Raku(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -373,7 +373,7 @@ class Ruby(metaclass=LanguageCls):
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         (format_entry,) = dict_entry_style.value
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=format_entry,
             empty_dict=None,

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -477,7 +477,7 @@ class Scala(metaclass=LanguageCls):
         )
         dict_spec: _ScalaDictSpec = dict_format.value
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=typed_dict_open(
+            dict_open=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=self._opener_config.element_to_type(
                         list_template=None,

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -272,7 +272,7 @@ class Scheme(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="(list "),
+            dict_open=fixed_dict_open(open_str="(list "),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" ",

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -334,7 +334,7 @@ class SystemVerilog(metaclass=LanguageCls):
             format_value=_format_sv_entry,
         )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="'{"),
+            dict_open=fixed_dict_open(open_str="'{"),
             close="}",
             format_entry=vkv_entry,
             empty_dict="'{}",

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -306,7 +306,7 @@ class Toml(metaclass=LanguageCls):
         self.false_literal = "false"
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=_format_toml_dict_entry,
             empty_dict=None,

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -248,7 +248,7 @@ class TypeScript(metaclass=LanguageCls):
         """Dict/map format options."""
 
         OBJECT = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -259,7 +259,7 @@ class TypeScript(metaclass=LanguageCls):
             narrowed_open=None,
         )
         MAP = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="new Map<string, unknown>(["),
+            dict_open=fixed_dict_open(open_str="new Map<string, unknown>(["),
             close="])",
             format_entry=dict_entry_with_template(
                 template="[{key}, {value}]",

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -287,7 +287,7 @@ class Yaml(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str="{"),
+            dict_open=fixed_dict_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -379,7 +379,7 @@ class Zig(metaclass=LanguageCls):
         self.set_format_config: SetFormatConfig = set_format.value
         self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            open_fn=fixed_dict_open(open_str=".{ .map = &.{"),
+            dict_open=fixed_dict_open(open_str=".{ .map = &.{"),
             close="}}",
             format_entry=dict_entry_with_template(
                 template=".{{ .key = {key}, .val = {value} }}",


### PR DESCRIPTION
## Summary
- Renames `DictFormatConfig.open_fn` to `dict_open` to match the `X_open` naming pattern used by `SequenceFormatConfig.sequence_open` and `SetFormatConfig.set_open`
- Updates all 54 files that reference this field

Fixes #1008

## Test plan
- [x] All pre-commit hooks pass (mypy, pyright, ty, pyrefly, ruff, vulture, etc.)
- [x] Verified `DictFormatConfig` field is correctly renamed
- [x] Verified no remaining references to `open_fn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical rename across language specs and core formatting paths; primary risk is missed references causing runtime/typing errors.
> 
> **Overview**
> Renames `DictFormatConfig.open_fn` to `dict_open` to align dict formatting with the existing `sequence_open`/`set_open` naming pattern.
> 
> Updates core formatting logic (`_core.py`), the dict format factory, typed opener wiring, and all language definitions to use `dict_open` when computing dict openers (including widening/narrowing overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8281052390ac7af3462b2c6892faea9b11c4d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->