### PR TITLE
Add run steps for Bash, Ruby, JavaScript, Go, and Rust lint jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check Bash syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 bash -n < /tmp/files-to-lint
+      - name: Run Bash files
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 bash < /tmp/files-to-lint
 
   lint-ruby:
     runs-on: ubuntu-latest
@@ -73,6 +76,9 @@ jobs:
       - name: Check Ruby syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(nproc)" -n1 ruby -c < /tmp/files-to-lint
+      - name: Run Ruby files
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 ruby < /tmp/files-to-lint
 
   lint-gleam:
     runs-on: ubuntu-latest
@@ -117,6 +123,9 @@ jobs:
       - name: Check Go compilation
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(nproc)" -n1 go vet < /tmp/files-to-lint
+      - name: Run Go files
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 go run < /tmp/files-to-lint
 
   lint-groovy:
     runs-on: ubuntu-latest
@@ -154,6 +163,9 @@ jobs:
       - name: Check JavaScript syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(nproc)" -n1 node --check < /tmp/files-to-lint
+      - name: Run JavaScript files
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 node < /tmp/files-to-lint
 
   lint-json5:
     runs-on: ubuntu-latest
@@ -326,6 +338,23 @@ jobs:
               -L "dependency=$deps" \
               --extern "chrono=$chrono_rlib" \
               "$f" -o "$tmpdir/out" 2>&1 || exit 1
+          done < /tmp/files-to-lint
+      - name: Run Rust binaries
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cargo init "$tmpdir/chrono-check"
+          cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
+          cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
+          deps="$tmpdir/chrono-check/target/debug/deps"
+          chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
+          while IFS= read -r -d '' f; do
+            rustc --edition 2021 \
+              -L "dependency=$deps" \
+              --extern "chrono=$chrono_rlib" \
+              "$f" -o "$tmpdir/out" 2>&1 || exit 1
+            "$tmpdir/out" || exit 1
           done < /tmp/files-to-lint
 
   lint-swift:


### PR DESCRIPTION
## Summary
- Adds "Run" steps after existing syntax-check/compile steps for Bash, Ruby, JavaScript, Go, and Rust in the lint workflow
- For interpreted languages (Bash, Ruby, JavaScript), this actually executes the generated data literal files to catch runtime errors that syntax checking alone would miss
- For compiled languages (Go, Rust), this runs the compiled binaries to verify they execute successfully

## Test plan
- [ ] CI passes on all five modified lint jobs
- [ ] Verify no regressions on other lint jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends CI lint jobs to actually run contributed Bash/Ruby/JS/Go/Rust files, increasing the chance of flaky failures and lengthening CI while also executing untrusted code paths during PR checks.
> 
> **Overview**
> Updates the `lint` GitHub Actions workflow to **execute** integration case files after existing syntax/compile checks for **Bash, Ruby, JavaScript, and Go** (via parallel `xargs` runs).
> 
> For **Rust**, adds a follow-up step that reuses the temporary `cargo`/`rustc` setup to build each case into a binary and run it, so runtime errors are caught in CI rather than only compile-time issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aba77b35c29ec977e96ebdd9d6fa5beaea57973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->