### PR TITLE
Merge Rust compile and run into one lint step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -327,23 +327,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.rs
-      - name: Check Rust syntax
-        if: steps.find-files.outputs.found == 'true'
-        run: |-
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          cargo init "$tmpdir/chrono-check"
-          cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
-          cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
-          deps="$tmpdir/chrono-check/target/debug/deps"
-          chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
-          while IFS= read -r -d '' f; do
-            rustc --edition 2021 \
-              -L "dependency=$deps" \
-              --extern "chrono=$chrono_rlib" \
-              "$f" -o "$tmpdir/out" 2>&1 || exit 1
-          done < /tmp/files-to-lint
-      - name: Run Rust binaries
+      # Compile and run in one step because the compiled binary lives in a
+      # temp directory that is cleaned up when the step exits.
+      - name: Check Rust syntax and run binaries
         if: steps.find-files.outputs.found == 'true'
         run: |-
           tmpdir=$(mktemp -d)


### PR DESCRIPTION
## Summary

- Merged the duplicate "Check Rust syntax" and "Run Rust binaries" steps into a single step in `lint-rust`. The run step was duplicating the entire cargo/chrono setup just to add one line. Since the compiled binary lives in a temp directory cleaned up when the step exits, both must happen in the same step.

## Test plan

- [ ] Verify `lint-rust` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that consolidates the Rust lint job steps; main impact is potential workflow behavior/diagnostics differences if the combined step fails earlier/later than before.
> 
> **Overview**
> Simplifies the `lint-rust` GitHub Actions job by merging the separate Rust compile-only and execution steps into a single step that **compiles each `.rs` integration case and immediately runs the produced binary** from the same temp directory.
> 
> This removes duplicated `cargo`/`chrono` setup and adds a brief comment explaining why compile+run must happen within one step (temp directory cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2fe83d703431743857d64c74bc4fef2fdbeb8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->