### PR TITLE
Add type_name parameter to customize generated type names

### DIFF
--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -139,14 +139,15 @@ def _elm_dict_entry(key: str, _val: Value, value: str) -> str:
 
 
 @beartype
-def _build_elm_body_preamble() -> Callable[
-    [frozenset[type], Value], tuple[str, ...]
-]:
+def _build_elm_body_preamble(
+    *,
+    type_name: str,
+) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
     """Build a callable that computes body-preamble lines for Elm.
 
     The callable receives the set of types present in the data and returns
-    the ``type Val`` declaration with only the constructors that are
-    actually needed.
+    the type declaration with only the constructors that are actually
+    needed.
     """
 
     def _compute(types: frozenset[type], data: Value, /) -> tuple[str, ...]:
@@ -165,16 +166,16 @@ def _build_elm_body_preamble() -> Callable[
                     ),
                     "EStr String",
                 ),
-                (frozenset({list}), "EList (List Val)"),
+                (frozenset({list}), f"EList (List {type_name})"),
                 (
                     frozenset({dict, ordereddict}),
-                    "EDict (List ( String, Val ))",
+                    f"EDict (List ( String, {type_name} ))",
                 ),
-                (frozenset({set}), "ESet (List Val)"),
+                (frozenset({set}), f"ESet (List {type_name})"),
             )
             if types & type_set
         ]
-        first_line = f"type Val\n    = {constructors[0]}"
+        first_line = f"type {type_name}\n    = {constructors[0]}"
         rest_lines = [f"    | {c}" for c in constructors[1:]]
         return ("\n".join([first_line, *rest_lines]),)
 
@@ -215,6 +216,9 @@ class Elm(metaclass=LanguageCls):
 
             * ``datetime_formats.ISO`` — ISO 8601 string,
               e.g. ``EStr "2024-01-15T12:30:00"``.
+
+        type_name: Name of the generated custom type.  Defaults to
+            ``"Val"``.
     """
 
     extension = ".elm"
@@ -430,6 +434,7 @@ class Elm(metaclass=LanguageCls):
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
         indent: str = "    ",
+        type_name: str = "Val",
     ) -> None:
         """Initialize Elm language specification."""
         self.variable_type_hints = variable_type_hints
@@ -495,7 +500,12 @@ class Elm(metaclass=LanguageCls):
         self.supports_scalar_before_comments = False
         self.supports_scalar_inline_comments = True
         _base_declaration = declaration_style.value.formatter
-        _sequence_declared_type = sequence_format.value.declared_type
+        _raw_declared = sequence_format.value.declared_type
+        _sequence_declared_type = (
+            _raw_declared.replace("Val", type_name)
+            if _raw_declared is not None
+            else None
+        )
 
         @beartype
         def _elm_declaration(
@@ -506,7 +516,9 @@ class Elm(metaclass=LanguageCls):
             """Format a variable declaration with type annotation."""
             base = _base_declaration(name, value, data)
             decl_type = (
-                _sequence_declared_type if isinstance(data, list) else "Val"
+                _sequence_declared_type
+                if isinstance(data, list)
+                else type_name
             )
             return f"{name} : {decl_type}\n{base}"
 
@@ -522,6 +534,6 @@ class Elm(metaclass=LanguageCls):
         self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
         self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
-        ] = _build_elm_body_preamble()
+        ] = _build_elm_body_preamble(type_name=type_name)
         self.type_hint_collection_preamble_lines = no_type_hint_preamble
         self.special_float_preamble: tuple[str, ...] = ()

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -87,13 +87,18 @@ def _build_fsharp_declaration(
     *,
     template: str,
     sequence_declared_type: str,
+    scalar_declared_type: str,
 ) -> Callable[[str, str, Value], str]:
     """Build an F# variable declaration/assignment formatter."""
 
     @beartype
     def _format(name: str, value: str, data: Value) -> str:
         """Format a variable declaration or assignment."""
-        decl_type = sequence_declared_type if isinstance(data, list) else "Val"
+        decl_type = (
+            sequence_declared_type
+            if isinstance(data, list)
+            else scalar_declared_type
+        )
         wrapped = _format_fsharp_entry(original=data, formatted=value)
         return template.format(
             name=name,
@@ -118,6 +123,9 @@ class FSharp(metaclass=LanguageCls):
 
             * ``datetime_formats.FSHARP`` — ``System.DateTime(...)`` call,
               e.g. ``System.DateTime(2024, 1, 15, 12, 30, 0)``.
+
+        type_name: Name of the generated custom type.  Defaults to
+            ``"Val"``.
     """
 
     extension = ".fs"
@@ -365,6 +373,7 @@ class FSharp(metaclass=LanguageCls):
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
         indent: str = "    ",
+        type_name: str = "Val",
     ) -> None:
         """Initialize FSharp language specification."""
         self.variable_type_hints = variable_type_hints
@@ -427,7 +436,12 @@ class FSharp(metaclass=LanguageCls):
         self.supports_collection_comments = True
         self.supports_scalar_before_comments = False
         self.supports_scalar_inline_comments = False
-        _sequence_declared_type = sequence_format.value.declared_type or "Val"
+        _raw_declared = sequence_format.value.declared_type
+        _sequence_declared_type = (
+            _raw_declared.replace("Val", type_name)
+            if _raw_declared is not None
+            else type_name
+        )
         _keyword = (
             "let mutable"
             if declaration_style.value.supports_redefinition
@@ -439,12 +453,14 @@ class FSharp(metaclass=LanguageCls):
                     f"{_keyword} {{name}}: {{declared_type}} = {{wrapped}}"
                 ),
                 sequence_declared_type=_sequence_declared_type,
+                scalar_declared_type=type_name,
             )
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             _build_fsharp_declaration(
                 template="let {name}: {declared_type} = {wrapped}",
                 sequence_declared_type=_sequence_declared_type,
+                scalar_declared_type=type_name,
             )
         )
         self.element_separator = "; "
@@ -454,7 +470,7 @@ class FSharp(metaclass=LanguageCls):
         self.static_preamble: Sequence[str] = ()
         self.static_body_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}
-        _header = "type Val ="
+        _header = f"type {type_name} ="
         _f_str = "    | FStr of string"
         self.scalar_body_preamble: dict[
             type,
@@ -466,10 +482,13 @@ class FSharp(metaclass=LanguageCls):
             float: (_header, "    | FFloat of float"),
             str: (_header, _f_str),
             bytes: (_header, _f_str),
-            list: (_header, "    | FList of Val list"),
-            dict: (_header, "    | FMap of (string * Val) list"),
-            ordereddict: (_header, "    | FMap of (string * Val) list"),
-            set: (_header, "    | FSet of Val list"),
+            list: (_header, f"    | FList of {type_name} list"),
+            dict: (_header, f"    | FMap of (string * {type_name}) list"),
+            ordereddict: (
+                _header,
+                f"    | FMap of (string * {type_name}) list",
+            ),
+            set: (_header, f"    | FSet of {type_name} list"),
             datetime.date: (
                 _header,
                 _f_str,

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -196,6 +196,9 @@ class Gleam(metaclass=LanguageCls):
               e.g. ``GList([GInt(1), GInt(2), GInt(3)])``.
             * ``sequence_formats.TUPLE`` — tuple literal,
               e.g. ``#(GInt(1), GInt(2), GInt(3))``.
+
+        type_name: Name of the generated custom type.  Defaults to
+            ``"GVal"``.
     """
 
     extension = ".gleam"
@@ -468,6 +471,7 @@ class Gleam(metaclass=LanguageCls):
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.NONE,
         indent: str = "  ",
+        type_name: str = "GVal",
     ) -> None:
         """Initialize Gleam language specification."""
         self.variable_type_hints = variable_type_hints
@@ -559,15 +563,15 @@ class Gleam(metaclass=LanguageCls):
                 set,
             ),
             (
-                "pub type GVal {\n"
+                f"pub type {type_name} {{\n"
                 "  GNull\n"
                 "  GBool(Bool)\n"
                 "  GInt(Int)\n"
                 "  GFloat(Float)\n"
                 "  GStr(String)\n"
-                "  GList(List(GVal))\n"
-                "  GDict(List(#(String, GVal)))\n"
-                "  GSet(List(GVal))\n"
+                f"  GList(List({type_name}))\n"
+                f"  GDict(List(#(String, {type_name})))\n"
+                f"  GSet(List({type_name}))\n"
                 "}",
             ),
         )

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -83,8 +83,13 @@ def _format_datetime_haskell(value: datetime.datetime) -> str:
     )
 
 
-def _num_instance(*, has_int: bool, has_float: bool) -> str:
-    """Build the ``Num Val`` instance with only relevant constructors."""
+def _num_instance(
+    *,
+    has_int: bool,
+    has_float: bool,
+    type_name: str,
+) -> str:
+    """Build the ``Num`` instance with only relevant constructors."""
     if has_int:
         from_integer = "    fromInteger = HInt"
     else:
@@ -97,7 +102,7 @@ def _num_instance(*, has_int: bool, has_float: bool) -> str:
     negate_parts.append('    negate _ = error "not implemented"')
     return "\n".join(
         [
-            "instance Num Val where",
+            f"instance Num {type_name} where",
             from_integer,
             '    a + b = error "not implemented"',
             '    a * b = error "not implemented"',
@@ -146,14 +151,15 @@ def _build_scalar_body_preamble(
     datetime_format: enum.Enum,
     is_string_import: str,
     is_string_instance: str,
+    type_name: str,
 ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
     """Build a callable that computes body-preamble lines for Haskell.
 
     The callable receives the set of types present in the data and the
-    original data value, and returns only the imports, ``data Val``
-    constructors, and typeclass instances that are actually needed.
+    original data value, and returns only the imports, the type
+    declaration, and typeclass instances that are actually needed.
 
-    The returned lines are ordered: imports first, then ``data Val``,
+    The returned lines are ordered: imports first, then the data type,
     then typeclass instances.
     """
     include_hdate = date_format.value.type_produced is datetime.date
@@ -173,9 +179,12 @@ def _build_scalar_body_preamble(
                 (frozenset({int}), "HInt Integer"),
                 (frozenset({float}), "HFloat Double"),
                 (frozenset({str, bytes}), "HStr String"),
-                (frozenset({list}), "HList [Val]"),
-                (frozenset({dict, ordereddict}), "HMap [(String, Val)]"),
-                (frozenset({set}), "HSet [Val]"),
+                (frozenset({list}), f"HList [{type_name}]"),
+                (
+                    frozenset({dict, ordereddict}),
+                    f"HMap [(String, {type_name})]",
+                ),
+                (frozenset({set}), f"HSet [{type_name}]"),
             )
             if types & type_set
         ]
@@ -217,17 +226,21 @@ def _build_scalar_body_preamble(
         has_int = int in types
         if has_float or has_int:
             instances.append(
-                _num_instance(has_int=has_int, has_float=has_float),
+                _num_instance(
+                    has_int=has_int,
+                    has_float=has_float,
+                    type_name=type_name,
+                ),
             )
         if has_float:
             instances.append(
-                "instance Fractional Val where\n"
+                f"instance Fractional {type_name} where\n"
                 "    fromRational r = HFloat (realToFrac r)\n"
                 '    a / b = error "not implemented"'
             )
 
         lines: list[str] = imports
-        lines.append("data Val = " + " | ".join(data_val_parts))
+        lines.append(f"data {type_name} = " + " | ".join(data_val_parts))
         lines.extend(instances)
         return tuple(lines)
 
@@ -293,6 +306,9 @@ class Haskell(metaclass=LanguageCls):
               Requires the ``time`` package.
             * ``datetime_formats.ISO`` — ISO 8601 quoted string,
               e.g. ``"2024-01-15T12:30:00"``.
+
+        type_name: Name of the generated custom type.  Defaults to
+            ``"Val"``.
     """
 
     extension = ".hs"
@@ -532,6 +548,7 @@ class Haskell(metaclass=LanguageCls):
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
         indent: str = "    ",
+        type_name: str = "Val",
     ) -> None:
         """Initialize Haskell language specification."""
         self.variable_type_hints = variable_type_hints
@@ -602,7 +619,12 @@ class Haskell(metaclass=LanguageCls):
         self.supports_scalar_before_comments = False
         self.supports_scalar_inline_comments = True
         _base_declaration = declaration_style.value.formatter
-        _sequence_declared_type = sequence_format.value.declared_type
+        _raw_declared = sequence_format.value.declared_type
+        _sequence_declared_type = (
+            _raw_declared.replace("Val", type_name)
+            if _raw_declared is not None
+            else None
+        )
 
         @beartype
         def _haskell_declaration(name: str, value: str, data: Value) -> str:
@@ -612,7 +634,7 @@ class Haskell(metaclass=LanguageCls):
                 if _sequence_declared_type is None:
                     return base
                 return f"{name} :: {_sequence_declared_type}\n{base}"
-            return f"{name} :: Val\n{base}"
+            return f"{name} :: {type_name}\n{base}"
 
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _haskell_declaration
@@ -642,8 +664,9 @@ class Haskell(metaclass=LanguageCls):
             datetime_format=datetime_format,
             is_string_import="import Data.String (IsString(fromString))",
             is_string_instance=(
-                "instance IsString Val where\n    fromString = HStr"
+                f"instance IsString {type_name} where\n    fromString = HStr"
             ),
+            type_name=type_name,
         )
         self.type_hint_collection_preamble_lines = no_type_hint_preamble
         self.special_float_preamble: tuple[str, ...] = ()

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -88,6 +88,7 @@ def _format_ocaml_entry(original: Value, formatted: str) -> str:
 def _build_ocaml_declaration(
     *,
     sequence_declared_type: str,
+    scalar_declared_type: str,
 ) -> Callable[[str, str, Value], str]:
     """Build an OCaml variable declaration formatter."""
 
@@ -95,7 +96,9 @@ def _build_ocaml_declaration(
     def _format(name: str, value: str, data: Value) -> str:
         """Format a variable declaration."""
         decl_type = (
-            sequence_declared_type if isinstance(data, list) else "val_t"
+            sequence_declared_type
+            if isinstance(data, list)
+            else scalar_declared_type
         )
         wrapped = _format_ocaml_entry(original=data, formatted=value)
         return f"let {name} : {decl_type} = {wrapped}"
@@ -121,6 +124,9 @@ class OCaml(metaclass=LanguageCls):
               e.g. ``((2024, 1, 15), (12, 30, 0))``.
             * ``datetime_formats.ISO`` — ISO 8601 quoted string,
               e.g. ``"2024-01-15T12:30:00"``.
+
+        type_name: Name of the generated custom type.  Defaults to
+            ``"val_t"``.
     """
 
     extension = ".ml"
@@ -384,6 +390,7 @@ class OCaml(metaclass=LanguageCls):
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
         indent: str = "    ",
+        type_name: str = "val_t",
     ) -> None:
         """Initialize OCaml language specification."""
         self.variable_type_hints = variable_type_hints
@@ -450,10 +457,15 @@ class OCaml(metaclass=LanguageCls):
         self.supports_collection_comments = True
         self.supports_scalar_before_comments = True
         self.supports_scalar_inline_comments = True
+        _raw_declared = sequence_format.value.declared_type
+        _sequence_declared_type = (
+            _raw_declared.replace("val_t", type_name)
+            if _raw_declared is not None
+            else type_name
+        )
         _ocaml_decl = _build_ocaml_declaration(
-            sequence_declared_type=(
-                sequence_format.value.declared_type or "val_t"
-            ),
+            sequence_declared_type=_sequence_declared_type,
+            scalar_declared_type=type_name,
         )
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
             _ocaml_decl
@@ -468,7 +480,7 @@ class OCaml(metaclass=LanguageCls):
         self.static_preamble: Sequence[str] = ()
         self.static_body_preamble: Sequence[str] = ()
         self.scalar_preamble: dict[type, tuple[str, ...]] = {}
-        _h = "type val_t ="
+        _h = f"type {type_name} ="
         _date_constructor = (
             "  | OStr of string"
             if date_format.value.type_produced is str
@@ -491,10 +503,10 @@ class OCaml(metaclass=LanguageCls):
             bytes: (_h, "  | OStr of string"),
             datetime.date: (_h, _date_constructor),
             datetime.datetime: (_h, _datetime_constructor),
-            list: (_h, "  | OList of val_t list"),
-            dict: (_h, "  | OMap of (string * val_t) list"),
-            ordereddict: (_h, "  | OMap of (string * val_t) list"),
-            set: (_h, "  | OSet of val_t list"),
+            list: (_h, f"  | OList of {type_name} list"),
+            dict: (_h, f"  | OMap of (string * {type_name}) list"),
+            ordereddict: (_h, f"  | OMap of (string * {type_name}) list"),
+            set: (_h, f"  | OSet of {type_name} list"),
         }
         self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -145,14 +145,15 @@ def _purescript_dict_entry(key: str, _val: Value, value: str) -> str:
 
 
 @beartype
-def _build_purescript_body_preamble() -> Callable[
-    [frozenset[type], Value], tuple[str, ...]
-]:
+def _build_purescript_body_preamble(
+    *,
+    type_name: str,
+) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
     """Build a callable that computes body-preamble lines for PureScript.
 
     The callable receives the set of types present in the data and returns
-    the ``data Val`` declaration with only the constructors that are
-    actually needed, plus any necessary imports.
+    the type declaration with only the constructors that are actually
+    needed, plus any necessary imports.
     """
 
     def _needs_prelude(val: Value) -> bool:
@@ -197,12 +198,12 @@ def _build_purescript_body_preamble() -> Callable[
                     ),
                     "PStr String",
                 ),
-                (frozenset({list}), "PList (Array Val)"),
+                (frozenset({list}), f"PList (Array {type_name})"),
                 (
                     frozenset({dict, ordereddict}),
-                    "PDict (Array (Tuple String Val))",
+                    f"PDict (Array (Tuple String {type_name}))",
                 ),
-                (frozenset({set}), "PSet (Array Val)"),
+                (frozenset({set}), f"PSet (Array {type_name})"),
             )
             if types & type_set
         ]
@@ -210,7 +211,7 @@ def _build_purescript_body_preamble() -> Callable[
         lines: list[str] = ["import Prelude"] if needs_prelude else []
         if needs_tuple:
             lines.append("data Tuple a b = Tuple a b")
-        first_line = f"data Val\n    = {constructors[0]}"
+        first_line = f"data {type_name}\n    = {constructors[0]}"
         rest_lines = [f"    | {c}" for c in constructors[1:]]
         lines.append("\n".join([first_line, *rest_lines]))
         return tuple(lines)
@@ -256,6 +257,9 @@ class PureScript(metaclass=LanguageCls):
 
             * ``datetime_formats.ISO`` — ISO 8601 string,
               e.g. ``PStr "2024-01-15T12:30:00"``.
+
+        type_name: Name of the generated custom type.  Defaults to
+            ``"Val"``.
     """
 
     extension = ".purs"
@@ -471,6 +475,7 @@ class PureScript(metaclass=LanguageCls):
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
         indent: str = "    ",
+        type_name: str = "Val",
     ) -> None:
         """Initialize PureScript language specification."""
         self.variable_type_hints = variable_type_hints
@@ -536,7 +541,12 @@ class PureScript(metaclass=LanguageCls):
         self.supports_scalar_before_comments = False
         self.supports_scalar_inline_comments = True
         _base_declaration = declaration_style.value.formatter
-        _sequence_declared_type = sequence_format.value.declared_type
+        _raw_declared = sequence_format.value.declared_type
+        _sequence_declared_type = (
+            _raw_declared.replace("Val", type_name)
+            if _raw_declared is not None
+            else None
+        )
 
         @beartype
         def _purescript_declaration(
@@ -547,7 +557,9 @@ class PureScript(metaclass=LanguageCls):
             """Format a variable declaration with type annotation."""
             base = _base_declaration(name, value, data)
             decl_type = (
-                _sequence_declared_type if isinstance(data, list) else "Val"
+                _sequence_declared_type
+                if isinstance(data, list)
+                else type_name
             )
             return f"{name} :: {decl_type}\n{base}"
 
@@ -563,6 +575,6 @@ class PureScript(metaclass=LanguageCls):
         self.scalar_body_preamble: dict[type, tuple[str, ...]] = {}
         self.compute_body_preamble: Callable[
             [frozenset[type], Value], tuple[str, ...]
-        ] = _build_purescript_body_preamble()
+        ] = _build_purescript_body_preamble(type_name=type_name)
         self.type_hint_collection_preamble_lines = no_type_hint_preamble
         self.special_float_preamble: tuple[str, ...] = ()

--- a/tests/integration/cases/simple_dict/Elm_type_name_JsonVal.elm
+++ b/tests/integration/cases/simple_dict/Elm_type_name_JsonVal.elm
@@ -1,0 +1,18 @@
+module Check exposing (..)
+
+
+type JsonVal
+    = ENull
+    | EBool Bool
+    | EInt Int
+    | EStr String
+    | EDict (List ( String, JsonVal ))
+
+
+my_data : JsonVal
+my_data = EDict [
+    ("name", EStr "Alice"),
+    ("age", EInt 30),
+    ("active", EBool True),
+    ("score", ENull)
+    ]

--- a/tests/integration/cases/simple_dict/FSharp_type_name_JsonVal.fs
+++ b/tests/integration/cases/simple_dict/FSharp_type_name_JsonVal.fs
@@ -1,0 +1,14 @@
+module Check
+
+type JsonVal =
+    | FNull
+    | FBool of bool
+    | FInt of int64
+    | FStr of string
+    | FMap of (string * JsonVal) list
+let my_data: JsonVal = FMap [
+    ("name", FStr "Alice");
+    ("age", FInt 30L);
+    ("active", FBool true);
+    ("score", FNull)
+]

--- a/tests/integration/cases/simple_dict/Gleam_type_name_JsonVal.gleam
+++ b/tests/integration/cases/simple_dict/Gleam_type_name_JsonVal.gleam
@@ -1,0 +1,20 @@
+pub type JsonVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(JsonVal))
+  GDict(List(#(String, JsonVal)))
+  GSet(List(JsonVal))
+}
+
+pub fn main() {
+  let my_data = GDict([
+    #("name", GStr("Alice")),
+    #("age", GInt(30)),
+    #("active", GBool(True)),
+    #("score", GNull),
+  ])
+  let _ = my_data
+}

--- a/tests/integration/cases/simple_dict/Haskell_type_name_JsonVal.hs
+++ b/tests/integration/cases/simple_dict/Haskell_type_name_JsonVal.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Check where
+import Data.String (IsString(fromString))
+data JsonVal = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, JsonVal)]
+instance IsString JsonVal where
+    fromString = HStr
+instance Num JsonVal where
+    fromInteger = HInt
+    a + b = error "not implemented"
+    a * b = error "not implemented"
+    abs a = error "not implemented"
+    signum a = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate _ = error "not implemented"
+my_data :: JsonVal
+my_data = HMap [
+    ("name", "Alice"),
+    ("age", 30),
+    ("active", HBool True),
+    ("score", HNull)
+    ]

--- a/tests/integration/cases/simple_dict/OCaml_type_name_json_t.ml
+++ b/tests/integration/cases/simple_dict/OCaml_type_name_json_t.ml
@@ -1,0 +1,16 @@
+module Check = struct
+
+type json_t =
+  | ONull
+  | OBool of bool
+  | OInt of int
+  | OStr of string
+  | OMap of (string * json_t) list
+let my_data : json_t = OMap [
+    ("name", OStr "Alice");
+    ("age", OInt 30);
+    ("active", OBool true);
+    ("score", ONull)
+]
+
+end

--- a/tests/integration/cases/simple_dict/PureScript_type_name_JsonVal.purs
+++ b/tests/integration/cases/simple_dict/PureScript_type_name_JsonVal.purs
@@ -1,0 +1,19 @@
+module Check where
+
+
+data Tuple a b = Tuple a b
+data JsonVal
+    = PNull
+    | PBool Boolean
+    | PInt Int
+    | PStr String
+    | PDict (Array (Tuple String JsonVal))
+
+
+my_data :: JsonVal
+my_data = PDict [
+    (Tuple "name" (PStr "Alice")),
+    (Tuple "age" (PInt 30)),
+    (Tuple "active" (PBool true)),
+    (Tuple "score" (PNull))
+    ]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1924,7 +1924,7 @@ def _build_type_name_variants() -> Iterable[_Variant]:
 
     These languages emit a custom algebraic data type in their body
     preamble (e.g. ``data Val = …`` in Haskell).  The ``type_name``
-    constructor parameter lets users customise that name.
+    constructor parameter lets users customize that name.
     """
     custom_names: dict[str, str] = {
         "Elm": "JsonVal",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1918,6 +1918,36 @@ def test_golden_file_combined_variable_forms(
 
 
 @beartype
+@beartype
+def _build_type_name_variants() -> Iterable[_Variant]:
+    """Build type-name variants for languages that generate a named type.
+
+    These languages emit a custom algebraic data type in their body
+    preamble (e.g. ``data Val = …`` in Haskell).  The ``type_name``
+    constructor parameter lets users customise that name.
+    """
+    custom_names: dict[str, str] = {
+        "Elm": "JsonVal",
+        "FSharp": "JsonVal",
+        "Gleam": "JsonVal",
+        "Haskell": "JsonVal",
+        "OCaml": "json_t",
+        "PureScript": "JsonVal",
+    }
+    variants: list[_Variant] = []
+    for lang_name, custom_name in custom_names.items():
+        lang_config = _LANGUAGES[lang_name]
+        variants.append(
+            _Variant(
+                name=f"{lang_name}_type_name_{custom_name}",
+                spec=lang_config.lang_cls(type_name=custom_name),
+                wrap=lang_config.wrap,
+                wrap_variable_name=lang_config.wrap_variable_name,
+            )
+        )
+    return variants
+
+
 def _build_variant_cases() -> list[_VariantCase]:
     """Collect all format-variant golden-file test cases."""
     cases: list[_VariantCase] = []
@@ -2004,6 +2034,7 @@ def _build_variant_cases() -> list[_VariantCase]:
         (_build_line_ending_variants(), "simple_sequence", ""),
         (_build_line_ending_variants(), "simple_dict", "_dict"),
         (_build_line_ending_decl_variants(), "simple_sequence", ""),
+        (_build_type_name_variants(), "simple_dict", ""),
     ]
     for variants, case_dir_name, suffix in variant_sources:
         cases.extend(


### PR DESCRIPTION
## Summary
- Languages that emit a custom algebraic data type (Elm, F#, Gleam, Haskell, OCaml, PureScript) now accept a `type_name` constructor parameter
- Users can customize the generated type name instead of using the hardcoded default (`Val`, `val_t`, `GVal`)
- The custom name propagates to the type declaration, self-referential type references, variable type annotations, and typeclass instances (Haskell)

Closes #1050

## Test plan
- [x] All 10612 existing tests pass (defaults produce identical output)
- [x] 6 new golden-file integration tests verify custom type names for each language
- [x] Pre-commit hooks (ruff, mypy, pyright, ty, pyrefly) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches code generation for six languages and adds a new public constructor parameter; while defaults aim to preserve existing output, incorrect substitution could change type annotations or self-referential types in generated code.
> 
> **Overview**
> Adds a `type_name` constructor parameter to Elm, F#, Gleam, Haskell, OCaml, and PureScript generators so callers can rename the emitted custom algebraic data type (previously hardcoded as `Val`/`val_t`/`GVal`). The new name is propagated through type declarations, recursive container references, variable type annotations, and (for Haskell) generated `IsString`/`Num`/`Fractional` instances.
> 
> Extends integration golden tests with new `simple_dict` fixtures and a `_build_type_name_variants()` suite to validate custom type names per language.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd66061f2cab3baacda76568bf09ad65fd69b5d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->