### PR TITLE
Use textwrap.indent instead of manual indentation

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -413,7 +413,7 @@ def _wrap_mojo(
     # Consume the variable so ``--Werror`` does not flag the
     # "assignment was never used" warning.
     content = content + f"\n_ = {variable_name}"
-    indented = "\n".join(f"    {line}" for line in content.splitlines())
+    indented = textwrap.indent(text=content, prefix="    ")
     return f"def main():\n{indented}"
 
 


### PR DESCRIPTION
## Summary

- Replace manual `"\n".join(f"    {line}" for line in content.splitlines())` with `textwrap.indent(text=content, prefix="    ")` in `_wrap_mojo` test helper.

## Test plan

- [x] All 10158 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that swaps indentation implementation without changing test coverage or production logic; any impact would be limited to Mojo golden-file formatting in integration tests.
> 
> **Overview**
> Replaces manual line-by-line indentation in the Mojo integration-test wrapper (`_wrap_mojo`) with `textwrap.indent(...)` to standardize and simplify how generated Mojo code is indented before writing golden files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566506e6e739bf5545f13ab7b3080e8104d0d6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->