### PR TITLE
Add constructor name parameters to Fortran

### DIFF
--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -395,9 +395,9 @@ class Fortran(metaclass=LanguageCls):
         )
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self.null_literal = f"{null_name}()"
-        self.true_literal = f"{bool_name}(.true.)"
-        self.false_literal = f"{bool_name}(.false.)"
+        self.null_literal: str = f"{null_name}()"
+        self.true_literal: str = f"{bool_name}(.true.)"
+        self.false_literal: str = f"{bool_name}(.false.)"
         fmt = sequence_format.value
         self.sequence_format_config: SequenceFormatConfig = (
             SequenceFormatConfig(

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -2,6 +2,7 @@
 
 import datetime
 import enum
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -45,25 +46,36 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Sequence
 
 
 @beartype
-def _format_fortran_entry(original: Value, formatted: str) -> str:
-    """Wrap a formatted entry in the appropriate ``fval_t``
+def _build_format_fortran_entry(
+    *,
+    int_name: str,
+    real_name: str,
+    str_name: str,
+) -> Callable[[Value, str], str]:
+    """Build a formatter that wraps values in the appropriate
     constructor.
     """
-    match original:
-        case bool():
-            return formatted
-        case int():
-            return f"fint({formatted})"
-        case float():
-            return f"freal({formatted})"
-        case str() | bytes() | datetime.date():
-            return f"fstr({formatted})"
-        case _:
-            return formatted
+
+    @beartype
+    def _format_fortran_entry(original: Value, formatted: str) -> str:
+        """Wrap a formatted entry in its constructor call."""
+        match original:
+            case bool():
+                return formatted
+            case int():
+                return f"{int_name}({formatted})"
+            case float():
+                return f"{real_name}({formatted})"
+            case str() | bytes() | datetime.date():
+                return f"{str_name}({formatted})"
+            case _:
+                return formatted
+
+    return _format_fortran_entry
 
 
 @beartype
@@ -120,27 +132,39 @@ def _add_continuation(value: str) -> str:
 
 
 @beartype
-def _format_variable_declaration(name: str, value: str, data: Value) -> str:
-    r"""Format a Fortran variable declaration and initialisation.
+def _build_format_variable_declaration(
+    *,
+    format_entry: Callable[[Value, str], str],
+) -> Callable[[str, str, Value], str]:
+    """Build a variable declaration formatter."""
 
-    Example: ``"x"`` and ``"flist([fval_t :: fint(1)])"`` →
-    ``"type(fval_t) :: x\nx = flist([fval_t :: fint(1)])"``
-    """
-    fval = _format_fortran_entry(original=data, formatted=value)
-    continued = _add_continuation(value=fval)
-    return f"type(fval_t) :: {name}\n{name} = {continued}"
+    @beartype
+    def _format_variable_declaration(
+        name: str, value: str, data: Value
+    ) -> str:
+        """Format a variable declaration and initialisation."""
+        fval = format_entry(data, value)
+        continued = _add_continuation(value=fval)
+        return f"type(fval_t) :: {name}\n{name} = {continued}"
+
+    return _format_variable_declaration
 
 
 @beartype
-def _format_variable_assignment(name: str, value: str, data: Value) -> str:
-    """Format a Fortran assignment to an existing ``fval_t`` variable.
+def _build_format_variable_assignment(
+    *,
+    format_entry: Callable[[Value, str], str],
+) -> Callable[[str, str, Value], str]:
+    """Build a variable assignment formatter."""
 
-    Example: ``"x"`` and ``"flist([fval_t :: fint(1)])"`` →
-    ``"x = flist([fval_t :: fint(1)])"``
-    """
-    fval = _format_fortran_entry(original=data, formatted=value)
-    continued = _add_continuation(value=fval)
-    return f"{name} = {continued}"
+    @beartype
+    def _format_variable_assignment(name: str, value: str, data: Value) -> str:
+        """Format an assignment to an existing variable."""
+        fval = format_entry(data, value)
+        continued = _add_continuation(value=fval)
+        return f"{name} = {continued}"
+
+    return _format_variable_assignment
 
 
 @beartype
@@ -236,7 +260,13 @@ class Fortran(metaclass=LanguageCls):
         """Declaration style options."""
 
         TYPED = DeclarationStyleConfig(
-            formatter=_format_variable_declaration,
+            formatter=_build_format_variable_declaration(
+                format_entry=_build_format_fortran_entry(
+                    int_name="fint",
+                    real_name="freal",
+                    str_name="fstr",
+                ),
+            ),
             supports_redefinition=True,
         )
 
@@ -347,24 +377,74 @@ class Fortran(metaclass=LanguageCls):
         trailing_comma: TrailingCommas = TrailingCommas.NO,
         line_ending: LineEndings = LineEndings.SEMICOLON,
         indent: str = "    ",
+        null_name: str = "fnull",
+        bool_name: str = "fbool",
+        int_name: str = "fint",
+        real_name: str = "freal",
+        str_name: str = "fstr",
+        list_name: str = "flist",
+        map_name: str = "fmap",
+        set_name: str = "fset",
+        entry_name: str = "fentry",
     ) -> None:
         """Initialize Fortran language specification."""
+        format_entry = _build_format_fortran_entry(
+            int_name=int_name,
+            real_name=real_name,
+            str_name=str_name,
+        )
         self.variable_type_hints = variable_type_hints
         self.sequence_format = sequence_format
-        self.null_literal = "fnull()"
-        self.true_literal = "fbool(.true.)"
-        self.false_literal = "fbool(.false.)"
+        self.null_literal = f"{null_name}()"
+        self.true_literal = f"{bool_name}(.true.)"
+        self.false_literal = f"{bool_name}(.false.)"
         fmt = sequence_format.value
-        self.sequence_format_config: SequenceFormatConfig = fmt
+        self.sequence_format_config: SequenceFormatConfig = (
+            SequenceFormatConfig(
+                sequence_open=fixed_sequence_open(
+                    open_str=f"{list_name}([fval_t :: ",
+                ),
+                close="])",
+                supports_heterogeneity=fmt.supports_heterogeneity,
+                single_element_trailing_comma=(
+                    fmt.single_element_trailing_comma
+                ),
+                supports_trailing_comma=fmt.supports_trailing_comma,
+                empty_sequence=fmt.empty_sequence,
+                preamble_lines=fmt.preamble_lines,
+                format_entry=fmt.format_entry,
+                typed_opener_fallback=fmt.typed_opener_fallback,
+                uses_typed_literal_for_scalars=(
+                    fmt.uses_typed_literal_for_scalars
+                ),
+                requires_uniform_record_shapes=(
+                    fmt.requires_uniform_record_shapes
+                ),
+                declared_type=fmt.declared_type,
+            )
+        )
         self.set_format = set_format
-        self.set_format_config: SetFormatConfig = set_format.value
-        self.sequence_open: Callable[[list[Value]], str] = fmt.sequence_open
+        self.set_format_config: SetFormatConfig = SetFormatConfig(
+            set_open=fixed_set_open(
+                open_str=f"{set_name}([fval_t :: ",
+            ),
+            close="])",
+            empty_set=set_format.value.empty_set,
+            preamble_lines=set_format.value.preamble_lines,
+            set_opener_template=set_format.value.set_opener_template,
+            coerce_mixed_to_str=set_format.value.coerce_mixed_to_str,
+        )
+        self.sequence_open: Callable[[list[Value]], str] = (
+            self.sequence_format_config.sequence_open
+        )
         self.dict_format_config: DictFormatConfig = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="fmap([fval_t :: "),
+            dict_open=fixed_dict_open(
+                open_str=f"{map_name}([fval_t :: ",
+            ),
             close="])",
             format_entry=dict_entry_with_template(
-                template="fentry({key}, {value})",
-                format_value=_format_fortran_entry,
+                template=f"{entry_name}({{key}}, {{value}})",
+                format_value=format_entry,
             ),
             empty_dict=None,
             preamble_lines=(),
@@ -387,12 +467,8 @@ class Fortran(metaclass=LanguageCls):
         )
         self.format_float: Callable[[float], str] = float_format
         self.format_integer: Callable[[int], str] = str
-        self.format_sequence_entry: Callable[[Value, str], str] = (
-            _format_fortran_entry
-        )
-        self.format_set_entry: Callable[[Value, str], str] = (
-            _format_fortran_entry
-        )
+        self.format_sequence_entry: Callable[[Value, str], str] = format_entry
+        self.format_set_entry: Callable[[Value, str], str] = format_entry
         self.comment_format = comment_format
         self.declaration_style = declaration_style
         self.dict_entry_style = dict_entry_style
@@ -407,15 +483,15 @@ class Fortran(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="fmap([fval_t :: ",
+                open_str=f"{map_name}([fval_t :: ",
                 close="])",
                 preamble_lines=(),
             )
         )
         self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
             dict_entry_with_template(
-                template="fentry({key}, {value})",
-                format_value=_format_fortran_entry,
+                template=f"{entry_name}({{key}}, {{value}})",
+                format_value=format_entry,
             )
         )
         self.indent = indent
@@ -426,10 +502,10 @@ class Fortran(metaclass=LanguageCls):
         self.supports_scalar_before_comments = False
         self.supports_scalar_inline_comments = False
         self.format_variable_declaration: Callable[[str, str, Value], str] = (
-            declaration_style.value.formatter
+            _build_format_variable_declaration(format_entry=format_entry)
         )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
-            _format_variable_assignment
+            _build_format_variable_assignment(format_entry=format_entry)
         )
         self.static_preamble: Sequence[str] = ("module fval_m",)
         self.static_body_preamble: Sequence[str] = (
@@ -438,29 +514,30 @@ class Fortran(metaclass=LanguageCls):
             "    integer :: t = 0",
             "  end type fval_t",
             "contains",
-            "  function fnull() result(v); type(fval_t) :: v; end function",
-            "  function fbool(b) result(v)"
+            f"  function {null_name}() result(v)"
+            "; type(fval_t) :: v; end function",
+            f"  function {bool_name}(b) result(v)"
             "; logical, intent(in) :: b"
             "; type(fval_t) :: v; end function",
-            "  function fint(n) result(v)"
+            f"  function {int_name}(n) result(v)"
             "; integer, intent(in) :: n"
             "; type(fval_t) :: v; end function",
-            "  function freal(x) result(v)"
+            f"  function {real_name}(x) result(v)"
             "; real, intent(in) :: x"
             "; type(fval_t) :: v; end function",
-            "  function fstr(s) result(v)"
+            f"  function {str_name}(s) result(v)"
             "; character(len=*), intent(in) :: s"
             "; type(fval_t) :: v; end function",
-            "  function flist(a) result(v)"
+            f"  function {list_name}(a) result(v)"
             "; type(fval_t), intent(in) :: a(:)"
             "; type(fval_t) :: v; end function",
-            "  function fmap(a) result(v)"
+            f"  function {map_name}(a) result(v)"
             "; type(fval_t), intent(in) :: a(:)"
             "; type(fval_t) :: v; end function",
-            "  function fset(a) result(v)"
+            f"  function {set_name}(a) result(v)"
             "; type(fval_t), intent(in) :: a(:)"
             "; type(fval_t) :: v; end function",
-            "  function fentry(k, u) result(v)"
+            f"  function {entry_name}(k, u) result(v)"
             "; character(len=*), intent(in) :: k"
             "; type(fval_t), intent(in) :: u"
             "; type(fval_t) :: v; end function",

--- a/tests/integration/cases/simple_dict/Fortran_constructor_names_j.f90
+++ b/tests/integration/cases/simple_dict/Fortran_constructor_names_j.f90
@@ -1,0 +1,27 @@
+module fval_m
+  implicit none
+  type :: fval_t
+    integer :: t = 0
+  end type fval_t
+contains
+  function jnull() result(v); type(fval_t) :: v; end function
+  function jbool(b) result(v); logical, intent(in) :: b; type(fval_t) :: v; end function
+  function jint(n) result(v); integer, intent(in) :: n; type(fval_t) :: v; end function
+  function jreal(x) result(v); real, intent(in) :: x; type(fval_t) :: v; end function
+  function jstr(s) result(v); character(len=*), intent(in) :: s; type(fval_t) :: v; end function
+  function jlist(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function jmap(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function jset(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function jentry(k, u) result(v); character(len=*), intent(in) :: k; type(fval_t), intent(in) :: u; type(fval_t) :: v; end function
+end module fval_m
+program check
+  use fval_m
+  implicit none
+  type(fval_t) :: my_data
+  my_data = jmap([fval_t :: &
+      jentry('name', jstr('Alice')), &
+      jentry('age', jint(30)), &
+      jentry('active', jbool(.true.)), &
+      jentry('score', jnull()) &
+  ])
+end program check

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1921,9 +1921,9 @@ def test_golden_file_combined_variable_forms(
 def _build_constructor_name_variants() -> Iterable[_Variant]:
     """Build constructor-name variants for Fortran.
 
-    Fortran emits constructor function calls (``fint``, ``fstr``, etc.)
-    in its output.  The constructor name parameters let users customise
-    those names.
+    Fortran emits constructor function calls (e.g. ``fnull``) in its
+    output.  The constructor name parameters let users customize those
+    names.
     """
     lang_config = _LANGUAGES["Fortran"]
     return [

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1918,6 +1918,35 @@ def test_golden_file_combined_variable_forms(
 
 
 @beartype
+def _build_constructor_name_variants() -> Iterable[_Variant]:
+    """Build constructor-name variants for Fortran.
+
+    Fortran emits constructor function calls (``fint``, ``fstr``, etc.)
+    in its output.  The constructor name parameters let users customise
+    those names.
+    """
+    lang_config = _LANGUAGES["Fortran"]
+    return [
+        _Variant(
+            name="Fortran_constructor_names_j",
+            spec=lang_config.lang_cls(
+                null_name="jnull",
+                bool_name="jbool",
+                int_name="jint",
+                real_name="jreal",
+                str_name="jstr",
+                list_name="jlist",
+                map_name="jmap",
+                set_name="jset",
+                entry_name="jentry",
+            ),
+            wrap=lang_config.wrap,
+            wrap_variable_name=lang_config.wrap_variable_name,
+        ),
+    ]
+
+
+@beartype
 @beartype
 def _build_type_name_variants() -> Iterable[_Variant]:
     """Build type-name variants for languages that generate a named type.
@@ -2035,6 +2064,7 @@ def _build_variant_cases() -> list[_VariantCase]:
         (_build_line_ending_variants(), "simple_dict", "_dict"),
         (_build_line_ending_decl_variants(), "simple_sequence", ""),
         (_build_type_name_variants(), "simple_dict", ""),
+        (_build_constructor_name_variants(), "simple_dict", ""),
     ]
     for variants, case_dir_name, suffix in variant_sources:
         cases.extend(


### PR DESCRIPTION
## Summary
- Fortran constructor function names (`fint`, `fstr`, `flist`, `freal`, `fnull`, `fmap`, `fset`, `fbool`, `fentry`) are now configurable via `__init__` parameters (`int_name`, `str_name`, `list_name`, `real_name`, `null_name`, `map_name`, `set_name`, `bool_name`, `entry_name`)
- All hardcoded usages replaced: entry formatting, collection openers, dict/ordered map entries, variable declaration/assignment, and the static body preamble function definitions
- Defaults preserve existing behavior (`fint`, `fstr`, etc.)

Closes #1054

## Test plan
- [x] All 189 existing Fortran integration tests pass
- [x] New golden file test (`Fortran_constructor_names_j`) verifies custom names propagate through all output locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Fortran code generation and are backward-compatible via defaults, with added integration coverage to catch output regressions.
> 
> **Overview**
> Adds `__init__` parameters to the Fortran language spec to let callers customize all emitted constructor function names (e.g. `null_name`, `bool_name`, `list_name`, `map_name`, `entry_name`, etc.).
> 
> Refactors Fortran formatting to build name-aware formatter closures and threads the custom names through scalar wrappers, collection openers, dict/ordered-map entry templates, variable declaration/assignment formatting, and the generated module preamble.
> 
> Extends integration tests with a new golden case (`Fortran_constructor_names_j`) and a variant generator to verify custom constructor names propagate through the full output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24e7e489e04d4ff92af75d70c861be967779aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->