### PR TITLE
Remove dead module-level _format_c_entry

### DIFF
--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -82,13 +82,6 @@ def _make_format_c_entry(
     return _format_c_entry
 
 
-_format_c_entry = _make_format_c_entry(
-    int_field="i",
-    float_field="f",
-    string_field="s",
-)
-
-
 @beartype
 class C(metaclass=LanguageCls):
     """C language specification."""
@@ -188,9 +181,7 @@ class C(metaclass=LanguageCls):
         """Declaration style options."""
 
         TYPED = DeclarationStyleConfig(
-            formatter=lambda name, value, data: (
-                f"CVal {name} = {_format_c_entry(data, value)};"
-            ),
+            formatter=lambda name, value, _data: f"CVal {name} = {value};",
             supports_redefinition=True,
         )
 


### PR DESCRIPTION
## Summary
- Removes the module-level `_format_c_entry` (hardcoded with default field names `"i"`, `"f"`, `"s"`) which was never used — `__init__` always creates a fresh formatter via `_make_format_c_entry` with the caller's custom field names
- Fixes the `TYPED` enum formatter lambda to not reference the dead binding, preventing a potential silent bug if any future refactor routes through `declaration_style.value.formatter`

Addresses [#1063 review comment](https://github.com/adamtheturtle/literalizer/pull/1063#discussion_r3069272880).

## Test plan
- [x] All 89 C language golden file tests pass
- [x] Custom field name variant tests pass
- [x] Pre-commit hooks (ruff, mypy, pyright, ty) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup in the C literalizer; it removes an unused module-level formatter and avoids a stale reference in `DeclarationStyles.TYPED`, with behavior still driven by the instance-created formatter.
> 
> **Overview**
> Removes the unused module-level `_format_c_entry` default formatter in `languages/c.py`, relying solely on `_make_format_c_entry` created per `C` instance (including custom union field names).
> 
> Updates `DeclarationStyles.TYPED` to stop referencing the removed binding and instead emit `CVal {name} = {value};`, preventing future mis-formatting if the enum formatter is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d1ccfaa3970d9ea0ff16e53a6b2ac1ae69631a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->