### PR TITLE
Use .clang-tidy config file instead of inline flags

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: -*,bugprone-reserved-identifier
+WarningsAsErrors: '*'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -260,8 +260,7 @@ jobs:
         run: xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-to-lint
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --checks='-*,bugprone-reserved-identifier'
-          --warnings-as-errors='*' --extra-arg=-std=c11 < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c11 < /tmp/files-to-lint
 
   lint-cobol:
     runs-on: ubuntu-latest
@@ -296,8 +295,7 @@ jobs:
         run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --checks='-*,bugprone-reserved-identifier'
-          --warnings-as-errors='*' --extra-arg=-std=c++20 < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
 
   lint-kotlin:
     runs-on: ubuntu-latest
@@ -1255,8 +1253,7 @@ jobs:
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only < /tmp/files-to-lint
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy --checks='-*,bugprone-reserved-identifier'
-          --warnings-as-errors='*' < /tmp/files-to-lint
+        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy < /tmp/files-to-lint
 
   lint-wren:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,6 +274,7 @@ ignore = [
     "check_csharp_syntax.py",
     ".clj-kondo",
     ".clj-kondo/**",
+    ".clang-tidy",
 ]
 
 [tool.deptry]

--- a/tests/integration/cases/string_with_percent/Tcl.tcl
+++ b/tests/integration/cases/string_with_percent/Tcl.tcl
@@ -1,0 +1,4 @@
+set my_data [list \
+    "100% done" \
+    "%(name) is here" \
+]

--- a/tests/integration/cases/string_with_percent/Tcl_combined.tcl
+++ b/tests/integration/cases/string_with_percent/Tcl_combined.tcl
@@ -1,0 +1,8 @@
+set my_data [list \
+    "100% done" \
+    "%(name) is here" \
+]
+set my_data [list \
+    "100% done" \
+    "%(name) is here" \
+]


### PR DESCRIPTION
## Summary
- Add a `.clang-tidy` config file to centralize the `--checks` and `--warnings-as-errors` settings that were duplicated across three CI jobs (C, C++, Objective-C).
- Simplify the clang-tidy invocations in `lint.yml` by removing the now-redundant inline flags.
- Exclude `.clang-tidy` from the sdist check in `pyproject.toml`.

## Test plan
- [ ] CI clang-tidy jobs pass for C, C++, and Objective-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/test-only change: switches CI `clang-tidy` invocations to rely on repo config, which could slightly alter lint behavior if the file isn’t picked up in all environments.
> 
> **Overview**
> Centralizes `clang-tidy` settings by adding a repo-level `.clang-tidy` (enforcing `bugprone-reserved-identifier` and treating warnings as errors) and simplifying the C/C++/Objective-C CI lint jobs to drop duplicated inline `--checks/--warnings-as-errors` flags.
> 
> Updates packaging manifest checks to ignore `.clang-tidy`, and adds new Tcl integration fixtures covering strings containing `%` patterns (`Tcl.tcl` and `Tcl_combined.tcl`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a19705a2fc1ec194eb4025113c8b0f421e6fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->