### PR TITLE
Trigger clang-tidy lint jobs when .clang-tidy config changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -255,6 +255,7 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.c
+          extra_config_patterns: .clang-tidy
       - name: Check C syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-to-lint
@@ -290,6 +291,7 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cpp
+          extra_config_patterns: .clang-tidy
       - name: Check C++ syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint
@@ -1248,6 +1250,7 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/objective_c*.m
+          extra_config_patterns: .clang-tidy
       - name: Check Objective-C syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only < /tmp/files-to-lint


### PR DESCRIPTION
## Summary

- Add `extra_config_patterns: .clang-tidy` to the `find-lint-files` step in the `lint-c`, `lint-cpp`, and `lint-objectivec` jobs
- This ensures that when `.clang-tidy` is modified in a PR, all three clang-tidy lint jobs run a full re-lint of their files rather than skipping unchanged source files

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm that a PR touching only `.clang-tidy` triggers the C, C++, and Objective-C lint jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that expands when the C/C++/Objective-C `clang-tidy` lint jobs run; main impact is potentially longer lint runtimes on PRs that modify `.clang-tidy`.
> 
> **Overview**
> Ensures the `lint-c`, `lint-cpp`, and `lint-objectivec` GitHub Actions jobs rerun `clang-tidy` when the shared `.clang-tidy` configuration changes.
> 
> This wires `.clang-tidy` into the `find-lint-files` change-detection via `extra_config_patterns`, so config-only PRs no longer skip these language lint jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3009416d3654df22ed1b053ad116f6e7b2ae6227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->