### PR TITLE
Disable cppcoreguidelines-missing-std-forward check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >
   -bugprone-narrowing-conversions,
   -clang-analyzer-deadcode.DeadStores,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-missing-std-forward,
   -cppcoreguidelines-narrowing-conversions,
   -fuchsia-default-arguments-calls,
   -google-explicit-constructor,


### PR DESCRIPTION
## Summary
- The `lint-cpp` CI job is failing on `main` because `cppcoreguidelines-missing-std-forward` flags the generated `Any` struct's constructor (`template<class T> Any(T&&) noexcept {}`) which intentionally uses a forwarding reference as a sink without forwarding.
- Adds `-cppcoreguidelines-missing-std-forward` to `.clang-tidy` exclusion list.

## Test plan
- [ ] Verify `lint-cpp` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the clang-tidy configuration to stop enforcing a single guideline check, with no runtime behavior changes.
> 
> **Overview**
> Disables the `cppcoreguidelines-missing-std-forward` clang-tidy rule by adding it to the `.clang-tidy` exclusion list.
> 
> This unblocks `lint-cpp` by preventing warnings from this check (e.g., on forwarding-reference constructors used intentionally as sinks) from being treated as errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d0bca2b43cad6e4c30e4638d065e223f4e7663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->