### PR TITLE
Add --quiet flag to clang-tidy in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -261,7 +261,8 @@ jobs:
         run: xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-to-lint
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c11 < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --quiet --extra-arg=-std=c11 <
+          /tmp/files-to-lint
 
   lint-cobol:
     runs-on: ubuntu-latest
@@ -297,7 +298,8 @@ jobs:
         run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --quiet --extra-arg=-std=c++20
+          < /tmp/files-to-lint
 
   lint-kotlin:
     runs-on: ubuntu-latest
@@ -1256,7 +1258,7 @@ jobs:
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only < /tmp/files-to-lint
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy < /tmp/files-to-lint
+        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy --quiet < /tmp/files-to-lint
 
   lint-wren:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `--quiet` to all three clang-tidy invocations (C, C++, Objective-C) to suppress noisy informational output
- This eliminates hundreds of "Error while opening fixed/JSON database: No such file or directory" messages and "N warnings generated / Suppressed N warnings (N in non-user code)" summaries that clutter CI logs
- Actual clang-tidy check failures are still reported (configured as errors via `WarningsAsErrors: '*'`)

## Test plan
- [ ] Verify the lint-c, lint-cpp, and lint-objectivec CI jobs still pass
- [ ] Confirm CI logs are significantly less noisy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that suppresses `clang-tidy` informational output without altering which files are linted or how failures are reported.
> 
> **Overview**
> Reduces CI log noise by adding `--quiet` to the `clang-tidy` invocations in the `lint-c`, `lint-cpp`, and `lint-objectivec` jobs.
> 
> This keeps the existing compile/check behavior (including language standard flags) while suppressing non-actionable `clang-tidy` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f16e3c5576218d9af4c88715ff6edf0a190bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->