### PR TITLE
Remove redundant _COVERED_LANGUAGES assert

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -87,11 +87,6 @@ _LANGUAGES: dict[str, _LanguageConfig] = {
     for lang_cls in sorted(ALL_LANGUAGES, key=lambda cls: cls.__name__)
 }
 
-_COVERED_LANGUAGES = frozenset(cfg.lang_cls for cfg in _LANGUAGES.values())
-assert _COVERED_LANGUAGES == ALL_LANGUAGES, (
-    f"Missing from integration tests: {ALL_LANGUAGES - _COVERED_LANGUAGES}"
-)
-
 
 @dataclasses.dataclass
 class _VariantCase:


### PR DESCRIPTION
The `_COVERED_LANGUAGES` assert verified that `_LANGUAGES` covered all languages, but since `_LANGUAGES` is now built directly from `ALL_LANGUAGES`, this check is tautological and can never fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that removes a redundant assertion without affecting runtime code paths.
> 
> **Overview**
> Removes the `_COVERED_LANGUAGES` integration-test assertion in `tests/integration/test_integration.py`, since `_LANGUAGES` is constructed directly from `ALL_LANGUAGES` and the check is tautological.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c660d39787cdca3843e632bf18d7573a1b845a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->