### PR TITLE
Include ordereddict in isinstance checks for mixed dict shape detection

### DIFF
--- a/src/literalizer/_coercions.py
+++ b/src/literalizer/_coercions.py
@@ -540,7 +540,9 @@ def _coerce_mixed_dict_shapes(*, data: Value) -> Value:
             }
         case list():
             new_list = [_coerce_mixed_dict_shapes(data=v) for v in data]
-            dicts_in_list = [v for v in new_list if isinstance(v, dict)]
+            dicts_in_list = [
+                v for v in new_list if isinstance(v, (dict, ordereddict))
+            ]
             key_sets = {frozenset(d.keys()) for d in dicts_in_list}
             needs_padding = (
                 not all(ks == next(iter(key_sets)) for ks in key_sets)
@@ -558,7 +560,7 @@ def _coerce_mixed_dict_shapes(*, data: Value) -> Value:
                 new_list = [
                     (
                         {k: v.get(k) for k in all_keys}
-                        if isinstance(v, dict)
+                        if isinstance(v, (dict, ordereddict))
                         else v
                     )
                     for v in new_list
@@ -580,7 +582,9 @@ def _has_mixed_dict_shapes(*, data: Value) -> bool:
                 for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
             )
         case list():
-            dicts_in_list = [v for v in data if isinstance(v, dict)]
+            dicts_in_list = [
+                v for v in data if isinstance(v, (dict, ordereddict))
+            ]
             key_sets = {frozenset(d.keys()) for d in dicts_in_list}
             has_mixed = (
                 not all(ks == next(iter(key_sets)) for ks in key_sets)

--- a/src/literalizer/_coercions.py
+++ b/src/literalizer/_coercions.py
@@ -543,7 +543,7 @@ def _coerce_mixed_dict_shapes(*, data: Value) -> Value:
             dicts_in_list = [
                 v for v in new_list if isinstance(v, (dict, ordereddict))
             ]
-            key_sets = {frozenset(d.keys()) for d in dicts_in_list}
+            key_sets = {frozenset(d.keys()) for d in dicts_in_list}  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
             needs_padding = (
                 not all(ks == next(iter(key_sets)) for ks in key_sets)
                 if key_sets
@@ -553,19 +553,19 @@ def _coerce_mixed_dict_shapes(*, data: Value) -> Value:
                 all_keys: list[str] = []
                 seen: set[str] = set()
                 for d in dicts_in_list:
-                    for k in d:
+                    for k in d:  # pyright: ignore[reportUnknownVariableType]
                         if k not in seen:
-                            all_keys.append(k)
-                            seen.add(k)
-                new_list = [
+                            all_keys.append(k)  # pyright: ignore[reportUnknownArgumentType]
+                            seen.add(k)  # pyright: ignore[reportUnknownArgumentType]
+                new_list = [  # pyright: ignore[reportUnknownVariableType]
                     (
-                        {k: v.get(k) for k in all_keys}
+                        {k: v.get(k) for k in all_keys}  # pyright: ignore[reportUnknownMemberType]
                         if isinstance(v, (dict, ordereddict))
                         else v
                     )
                     for v in new_list
                 ]
-            return new_list
+            return new_list  # pyright: ignore[reportUnknownVariableType]
         case _:
             return data
 
@@ -585,7 +585,7 @@ def _has_mixed_dict_shapes(*, data: Value) -> bool:
             dicts_in_list = [
                 v for v in data if isinstance(v, (dict, ordereddict))
             ]
-            key_sets = {frozenset(d.keys()) for d in dicts_in_list}
+            key_sets = {frozenset(d.keys()) for d in dicts_in_list}  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
             has_mixed = (
                 not all(ks == next(iter(key_sets)) for ks in key_sets)
                 if key_sets

--- a/src/literalizer/_coercions.py
+++ b/src/literalizer/_coercions.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import json
 from collections.abc import Sequence
-from typing import Protocol
+from typing import Protocol, cast
 
 from beartype import beartype
 from ruamel.yaml.compat import ordereddict
@@ -565,7 +565,7 @@ def _coerce_mixed_dict_shapes(*, data: Value) -> Value:
                     )
                     for v in new_list
                 ]
-            return new_list  # pyright: ignore[reportUnknownVariableType]
+            return cast("Value", new_list)
         case _:
             return data
 


### PR DESCRIPTION
## Summary
- Changed `isinstance(v, dict)` to `isinstance(v, (dict, ordereddict))` in `_has_mixed_dict_shapes` and `_coerce_mixed_dict_shapes` so that `ordereddict` instances from `ruamel.yaml.compat` are no longer silently skipped when checking for heterogeneous key sets in lists of dicts.

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to mixed-dict-shape detection/coercion that broadens type handling to include `ordereddict`; behavior changes only for YAML-derived ordered mappings in lists.
> 
> **Overview**
> Fixes mixed-record-shape handling so `ruamel.yaml` `ordereddict` entries in lists are treated like normal dicts when detecting differing key sets and padding missing keys.
> 
> Adds a small typing adjustment (`cast`) to keep the list coercion return type aligned after the updated `isinstance(..., (dict, ordereddict))` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30c9cd74ab4769b7372e53b009a614e9f8a69c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->