### PR TITLE
Add Standard ML (SML) language support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1077,6 +1077,23 @@ jobs:
             odin check "$f" -file || exit 1
           done < /tmp/files-to-lint
 
+  lint-sml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/find-lint-files
+        id: find-files
+        with:
+          lang_patterns: tests/integration/cases/**/*.sml
+      - name: Install MLton
+        if: steps.find-files.outputs.found == 'true'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq mlton
+      - name: Check SML syntax
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 mlton -stop tc < /tmp/files-to-lint
+
   lint-scheme:
     runs-on: ubuntu-latest
     steps:
@@ -1357,6 +1374,7 @@ jobs:
       - lint-odin
       - lint-raku
       - lint-scheme
+      - lint-sml
       - lint-zig
       - lint-toml
       - lint-v

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -87,6 +87,17 @@ Php
 PureScript
 Pygments
 Raku
+SBool
+SDate
+SDatetime
+SInt
+SList
+SMap
+SNull
+SReal
+SSet
+SStr
+Sml
 SystemVerilog
 Tcl
 Toml
@@ -185,6 +196,7 @@ ruamel
 scala
 scalac
 sigil
+sml
 stdin
 str
 struct

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -92,6 +92,7 @@ SDate
 SDatetime
 SInt
 SList
+SML's
 SMap
 SNull
 SReal

--- a/src/literalizer/languages/__init__.py
+++ b/src/literalizer/languages/__init__.py
@@ -51,6 +51,7 @@ from .ruby import Ruby
 from .rust import Rust
 from .scala import Scala
 from .scheme import Scheme
+from .sml import Sml
 from .swift import Swift
 from .systemverilog import SystemVerilog
 from .tcl import Tcl
@@ -113,6 +114,7 @@ ALL_LANGUAGES: frozenset[LanguageCls] = frozenset(
         Rust,
         Scala,
         Scheme,
+        Sml,
         Swift,
         Tcl,
         Toml,
@@ -177,6 +179,7 @@ __all__ = [
     "Rust",
     "Scala",
     "Scheme",
+    "Sml",
     "Swift",
     "SystemVerilog",
     "Tcl",

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -174,7 +174,7 @@ def _build_sml_body_preamble(
 ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
     """Build a ``compute_body_preamble`` for SML.
 
-    Delegates to :func:`body_preamble_from_scalars` for deduplication,
+    Delegates to :func:`body_preamble_from_scalars` for de-duplication,
     then fixes the first constructor line to omit the leading ``|``
     required by SML's ``datatype`` syntax.
     """

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -145,9 +145,6 @@ def _build_sml_entry_formatter(
     return _format
 
 
-_format_sml_entry = _build_sml_entry_formatter(prefix="S")
-
-
 @beartype
 def _build_sml_declaration(
     *,

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -1,0 +1,644 @@
+"""Standard ML language specification."""
+
+import dataclasses
+import datetime
+import enum
+from collections.abc import Callable
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from beartype import beartype
+from ruamel.yaml.compat import ordereddict
+
+from literalizer._formatters.collection_openers import (
+    fixed_dict_open,
+    fixed_sequence_open,
+    fixed_set_open,
+)
+from literalizer._formatters.format_dates import (
+    date_ymd_formatter,
+    datetime_ymdhms_formatter,
+    format_date_iso,
+    format_datetime_iso,
+)
+from literalizer._formatters.format_entries import (
+    format_bytes_base64,
+    format_bytes_hex,
+    passthrough_sequence_entry,
+    tuple_dict_entry,
+    variable_formatter,
+)
+from literalizer._formatters.format_floats import (
+    format_float_fixed,
+    format_float_repr,
+    format_float_scientific,
+)
+from literalizer._formatters.format_integers import (
+    format_integer_hex,
+)
+from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._language import (
+    CommentConfig,
+    DateFormatConfig,
+    DatetimeFormatConfig,
+    DeclarationStyleConfig,
+    DictFormatConfig,
+    FloatSpecialsMixin,
+    LanguageCls,
+    OrderedMapFormatConfig,
+    SequenceFormatConfig,
+    SetFormatConfig,
+    TrailingCommaConfig,
+    no_type_hint_preamble,
+    prepend_body_preamble,
+)
+from literalizer._types import Value
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _sml_negate_int(
+    formatter: Callable[[int], str],
+) -> Callable[[int], str]:
+    """Wrap an integer formatter to use SML's ``~`` for negation."""
+
+    @beartype
+    def _format(value: int) -> str:
+        """Format an integer, replacing ``-`` with ``~``."""
+        result = formatter(value)
+        if result.startswith("-"):
+            return "~" + result[1:]
+        return result
+
+    return _format
+
+
+def _sml_negate_float(
+    formatter: Callable[[float], str],
+) -> Callable[[float], str]:
+    """Wrap a float formatter to use SML's ``~`` for negation."""
+
+    @beartype
+    def _format(value: float) -> str:
+        """Format a float, replacing ``-`` with ``~``."""
+        result = formatter(value)
+        if result.startswith("-"):
+            return "~" + result[1:]
+        return result
+
+    return _format
+
+
+@beartype
+def _sml_scientific(value: float) -> str:
+    """Format a float in SML scientific notation.
+
+    SML uses ``E`` (not ``e``) and ``~`` for negative exponents.
+    """
+    result = format_float_scientific(value)
+    if result.startswith("-"):
+        result = "~" + result[1:]
+    # Convert Python's 'e' to SML's 'E', with ~ for negative exponents.
+    return result.replace("e-", "E~").replace("e", "E")
+
+
+def _build_sml_entry_formatter(
+    prefix: str,
+) -> Callable[[Value, str], str]:
+    """Build an entry formatter that wraps values in SML ``datatype``
+    constructors using the given *prefix*.
+    """
+
+    @beartype
+    def _format(original: Value, formatted: str) -> str:
+        """Wrap a formatted entry in the appropriate SML ``datatype``
+        constructor.
+        """
+        match original:
+            case bool():
+                return formatted
+            case int():
+                negative = formatted.startswith("~")
+                return (
+                    f"{prefix}Int ({formatted})"
+                    if negative
+                    else f"{prefix}Int {formatted}"
+                )
+            case float():
+                negative = formatted.startswith(("~", "("))
+                return (
+                    f"{prefix}Real ({formatted})"
+                    if negative
+                    else f"{prefix}Real {formatted}"
+                )
+            case str() | bytes():
+                return f"{prefix}Str {formatted}"
+            case datetime.date() if formatted.startswith('"'):
+                return f"{prefix}Str {formatted}"
+            case _:
+                return formatted
+
+    return _format
+
+
+_format_sml_entry = _build_sml_entry_formatter(prefix="S")
+
+
+@beartype
+def _build_sml_declaration(
+    *,
+    sequence_declared_type: str,
+    scalar_declared_type: str,
+    entry_formatter: Callable[[Value, str], str],
+) -> Callable[[str, str, Value], str]:
+    """Build an SML variable declaration formatter."""
+
+    @beartype
+    def _format(name: str, value: str, data: Value) -> str:
+        """Format a variable declaration."""
+        decl_type = (
+            sequence_declared_type
+            if isinstance(data, list)
+            else scalar_declared_type
+        )
+        wrapped = entry_formatter(data, value)
+        return f"val {name} : {decl_type} = {wrapped}"
+
+    return _format
+
+
+def _build_sml_body_preamble(
+    scalar_body_preamble: dict[type, tuple[str, ...]],
+) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
+    """Build a ``compute_body_preamble`` for SML.
+
+    SML's ``datatype`` syntax requires the first constructor after ``=``
+    to have no leading ``|``, while subsequent constructors do.
+    """
+
+    def _compute(types: frozenset[type], data: Value, /) -> tuple[str, ...]:
+        """Return unique body-preamble lines for *types*."""
+        del data
+        seen: set[str] = set()
+        result: list[str] = []
+        for scalar_type, lines in scalar_body_preamble.items():
+            if scalar_type in types:
+                for line in lines:
+                    if line not in seen:
+                        seen.add(line)
+                        result.append(line)
+        # SML: first variant after 'datatype' line must not have '|'
+        for i in range(1, len(result)):
+            if result[i].startswith("  | "):
+                result[i] = "    " + result[i][4:]
+                break
+        return tuple(result)
+
+    return _compute
+
+
+@beartype
+class Sml(metaclass=LanguageCls):
+    """Standard ML language specification.
+
+    Args:
+        date_format: How to format :class:`datetime.date` values.
+
+            * ``date_formats.SML`` — tuple literal,
+              e.g. ``(2024, 1, 15)``.
+            * ``date_formats.ISO`` — ISO 8601 quoted string,
+              e.g. ``"2024-01-15"``.
+
+        datetime_format: How to format :class:`datetime.datetime` values.
+
+            * ``datetime_formats.SML`` — pair of tuples,
+              e.g. ``((2024, 1, 15), (12, 30, 0))``.
+            * ``datetime_formats.ISO`` — ISO 8601 quoted string,
+              e.g. ``"2024-01-15T12:30:00"``.
+
+        type_name: Name of the generated custom type.  Defaults to
+            ``"val_t"``.
+
+        constructor_prefix: Prefix for generated constructor names.
+            Defaults to ``"S"``, producing constructors like ``SNull``,
+            ``SBool``, ``SInt``, etc.
+    """
+
+    extension = ".sml"
+    pygments_name = "sml"
+    supports_default_set_element_type = False
+    supports_default_sequence_element_type = False
+    supports_default_dict_value_type = False
+    supports_default_dict_key_type = False
+    supports_default_ordered_map_value_type = False
+    supports_non_printable_ascii_dict_keys = True
+    supports_variable_names = True
+
+    class DateFormats(enum.Enum):
+        """Date format options for Standard ML."""
+
+        SML = DateFormatConfig(
+            formatter=date_ymd_formatter(
+                template="SDate ({year}, {month}, {day})",
+            ),
+        )
+        ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
+
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value.formatter(date_value)
+
+    class DatetimeFormats(enum.Enum):
+        """Datetime format options for Standard ML."""
+
+        SML = DatetimeFormatConfig(
+            formatter=datetime_ymdhms_formatter(
+                template="SDatetime (({year}, {month}, {day}), "
+                "({hour}, {minute}, {second}))",
+            ),
+        )
+        ISO = DatetimeFormatConfig(
+            formatter=format_datetime_iso,
+            type_produced=str,
+        )
+
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value.formatter(dt_value)
+
+    class BytesFormats(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+        BASE64 = enum.member(value=format_bytes_base64)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
+    class SequenceFormats(enum.Enum):
+        """Sequence type options for Standard ML."""
+
+        LIST = SequenceFormatConfig(
+            sequence_open=fixed_sequence_open(open_str="SList ["),
+            close="]",
+            supports_heterogeneity=True,
+            single_element_trailing_comma=False,
+            supports_trailing_comma=False,
+            empty_sequence=None,
+            preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
+            typed_opener_fallback=None,
+            uses_typed_literal_for_scalars=False,
+            requires_uniform_record_shapes=False,
+            declared_type="val_t",
+        )
+
+        @property
+        def supports_heterogeneity(self) -> bool:
+            """Whether this sequence format supports mixed-type
+            elements.
+            """
+            return self.value.supports_heterogeneity
+
+    class SetFormats(enum.Enum):
+        """Set type options for Standard ML."""
+
+        SET = SetFormatConfig(
+            set_open=fixed_set_open(open_str="SSet ["),
+            close="]",
+            empty_set=None,
+            preamble_lines=(),
+            set_opener_template="",
+            coerce_mixed_to_str=False,
+        )
+
+    class CommentFormats(enum.Enum):
+        """Comment style options."""
+
+        PAREN_STAR = CommentConfig(
+            prefix="(*",
+            suffix=" *)",
+        )
+
+    class DeclarationStyles(enum.Enum):
+        """Declaration style options."""
+
+        VAL = DeclarationStyleConfig(
+            formatter=variable_formatter(
+                template="val {name} = {value}",
+            ),
+            supports_redefinition=False,
+        )
+
+    class DictEntryStyles(enum.Enum):
+        """Dict entry style options."""
+
+        DEFAULT = enum.auto()
+
+    class DictFormats(enum.Enum):
+        """Dict/map format options."""
+
+        DEFAULT = enum.auto()
+
+    class EmptyDictKey(enum.Enum):
+        """Empty dict key options."""
+
+        ALLOW = enum.auto()
+
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="(1.0 / 0.0)",
+        negative_infinity="(~1.0 / 0.0)",
+        nan="(0.0 / 0.0)",
+    ):
+        """Float format options."""
+
+        REPR = enum.member(value=_sml_negate_float(format_float_repr))
+        SCIENTIFIC = enum.member(value=_sml_scientific)
+        FIXED = enum.member(value=_sml_negate_float(format_float_fixed))
+
+    class IntegerFormats(enum.Enum):
+        """Integer format options."""
+
+        DECIMAL = MappingProxyType(
+            mapping={
+                "NONE": _sml_negate_int(str),
+            }
+        )
+        HEX = MappingProxyType(
+            mapping={
+                "NONE": _sml_negate_int(format_integer_hex),
+            }
+        )
+
+        def get_formatter(
+            self,
+            numeric_separator: enum.Enum,
+        ) -> Callable[[int], str]:
+            """Return the integer formatter for the given separator."""
+            formatter: Callable[[int], str] = self.value[
+                numeric_separator.name
+            ]
+            return formatter
+
+    class NumericLiteralSuffixes(enum.Enum):
+        """Numeric literal suffix options."""
+
+        NONE = enum.auto()
+
+    class NumericSeparators(enum.Enum):
+        """Numeric separator options."""
+
+        NONE = enum.auto()
+
+    class StringFormats(enum.Enum):
+        """String format options."""
+
+        DOUBLE = "double"
+
+    class TrailingCommas(enum.Enum):
+        """Trailing comma options."""
+
+        NO = TrailingCommaConfig(multiline_trailing_comma=False)
+
+    date_formats = DateFormats
+    datetime_formats = DatetimeFormats
+    bytes_formats = BytesFormats
+    sequence_formats = SequenceFormats
+    set_formats = SetFormats
+    comment_formats = CommentFormats
+
+    class VariableTypeHints(enum.Enum):
+        """Variable type hint options."""
+
+        AUTO = enum.auto()
+
+    variable_type_hints_formats = VariableTypeHints
+    declaration_styles = DeclarationStyles
+    dict_entry_styles = DictEntryStyles
+    dict_formats = DictFormats
+    empty_dict_keys = EmptyDictKey
+    float_formats = FloatFormats
+    integer_formats = IntegerFormats
+    numeric_literal_suffixes = NumericLiteralSuffixes
+    numeric_separators = NumericSeparators
+    string_formats = StringFormats
+    trailing_commas = TrailingCommas
+
+    class LineEndings(enum.Enum):
+        """Line ending options."""
+
+        SEMICOLON = "semicolon"
+
+    line_endings = LineEndings
+
+    @staticmethod
+    def wrap_in_file(
+        content: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap an SML val declaration in a structure."""
+        del variable_name
+        content = prepend_body_preamble(
+            content=content,
+            body_preamble=body_preamble,
+        )
+        return "structure Check = struct\n\n" + content + "\n\nend"
+
+    @staticmethod
+    def wrap_combined_in_file(
+        declaration: str,
+        assignment: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap SML declaration + assignment in a structure."""
+        return Sml.wrap_in_file(
+            content=declaration + "\n" + assignment,
+            variable_name=variable_name,
+            body_preamble=body_preamble,
+        )
+
+    def __init__(  # noqa: PLR0915
+        self,
+        *,
+        date_format: DateFormats = DateFormats.SML,
+        datetime_format: DatetimeFormats = DatetimeFormats.SML,
+        bytes_format: BytesFormats = BytesFormats.HEX,
+        sequence_format: SequenceFormats = SequenceFormats.LIST,
+        set_format: SetFormats = SetFormats.SET,
+        variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO,
+        comment_format: CommentFormats = CommentFormats.PAREN_STAR,
+        declaration_style: DeclarationStyles = DeclarationStyles.VAL,
+        dict_entry_style: DictEntryStyles = DictEntryStyles.DEFAULT,
+        dict_format: DictFormats = DictFormats.DEFAULT,
+        float_format: FloatFormats = FloatFormats.REPR,
+        integer_format: IntegerFormats = IntegerFormats.DECIMAL,
+        numeric_literal_suffix: NumericLiteralSuffixes = (
+            NumericLiteralSuffixes.NONE
+        ),
+        numeric_separator: NumericSeparators = NumericSeparators.NONE,
+        string_format: StringFormats = StringFormats.DOUBLE,
+        trailing_comma: TrailingCommas = TrailingCommas.NO,
+        line_ending: LineEndings = LineEndings.SEMICOLON,
+        indent: str = "    ",
+        type_name: str = "val_t",
+        constructor_prefix: str = "S",
+    ) -> None:
+        """Initialize Standard ML language specification."""
+        self.variable_type_hints = variable_type_hints
+        self.sequence_format = sequence_format
+        self.null_literal: str = f"{constructor_prefix}Null"
+        self.true_literal: str = f"{constructor_prefix}Bool true"
+        self.false_literal: str = f"{constructor_prefix}Bool false"
+        _entry_formatter = _build_sml_entry_formatter(
+            prefix=constructor_prefix,
+        )
+        fmt = sequence_format.value
+        _seq_open = fixed_sequence_open(
+            open_str=f"{constructor_prefix}List [",
+        )
+        self.sequence_format_config: SequenceFormatConfig = (
+            dataclasses.replace(fmt, sequence_open=_seq_open)
+        )
+        self.sequence_open: Callable[[list[Value]], str] = _seq_open
+        self.set_format = set_format
+        self.set_format_config: SetFormatConfig = dataclasses.replace(
+            set_format.value,
+            set_open=fixed_set_open(
+                open_str=f"{constructor_prefix}Set [",
+            ),
+        )
+
+        self.dict_format_config: DictFormatConfig = DictFormatConfig(
+            dict_open=fixed_dict_open(
+                open_str=f"{constructor_prefix}Map [",
+            ),
+            close="]",
+            format_entry=tuple_dict_entry(
+                format_value=_entry_formatter,
+            ),
+            empty_dict=None,
+            preamble_lines=(),
+            narrowed_open=None,
+        )
+        self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
+        self.format_bytes: Callable[[bytes], str] = bytes_format
+        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_datetime: Callable[[datetime.datetime], str] = (
+            datetime_format
+        )
+        if date_format.name == "SML":
+            self.format_date = date_ymd_formatter(
+                template=(
+                    f"{constructor_prefix}Date ({{year}}, {{month}}, {{day}})"
+                ),
+            )
+        if datetime_format.name == "SML":
+            self.format_datetime = datetime_ymdhms_formatter(
+                template=(
+                    f"{constructor_prefix}Datetime "
+                    f"(({{year}}, {{month}}, {{day}}), "
+                    f"({{hour}}, {{minute}}, {{second}}))"
+                ),
+            )
+        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_float: Callable[[float], str] = float_format
+        self.format_integer: Callable[[int], str] = (
+            integer_format.get_formatter(
+                numeric_separator=numeric_separator,
+            )
+        )
+        self.format_set_entry: Callable[[Value, str], str] = _entry_formatter
+        self.comment_format = comment_format
+        self.declaration_style = declaration_style
+        self.dict_entry_style = dict_entry_style
+        self.dict_format = dict_format
+        self.float_format = float_format
+        self.integer_format = integer_format
+        self.numeric_literal_suffix = numeric_literal_suffix
+        self.numeric_separator = numeric_separator
+        self.string_format = string_format
+        self.trailing_comma = trailing_comma
+        self.line_ending = line_ending
+        self.comment_config: CommentConfig = comment_format.value
+        self.ordered_map_format_config: OrderedMapFormatConfig = (
+            OrderedMapFormatConfig(
+                open_str=f"{constructor_prefix}Map [",
+                close="]",
+                preamble_lines=(),
+            )
+        )
+        self.format_ordered_map_entry: Callable[[str, Value, str], str] = (
+            tuple_dict_entry(format_value=_entry_formatter)
+        )
+        self.indent = indent
+        self.indent_closing_delimiter = False
+        self.skip_null_dict_values = False
+        self.supports_collection_comments = True
+        self.supports_scalar_before_comments = True
+        self.supports_scalar_inline_comments = True
+        _raw_declared = sequence_format.value.declared_type
+        _sequence_declared_type = (
+            _raw_declared.replace("val_t", type_name)
+            if _raw_declared is not None
+            else type_name
+        )
+        _sml_decl = _build_sml_declaration(
+            sequence_declared_type=_sequence_declared_type,
+            scalar_declared_type=type_name,
+            entry_formatter=_entry_formatter,
+        )
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
+            _sml_decl
+        )
+        self.format_variable_assignment: Callable[[str, str, Value], str] = (
+            _sml_decl
+        )
+        self.element_separator = ", "
+        self.format_sequence_entry: Callable[[Value, str], str] = (
+            _entry_formatter
+        )
+        self.static_preamble: Sequence[str] = ()
+        self.static_body_preamble: Sequence[str] = ()
+        self.scalar_preamble: dict[type, tuple[str, ...]] = {}
+        p = constructor_prefix
+        _h = f"datatype {type_name} ="
+        _date_constructor = (
+            f"  | {p}Str of string"
+            if date_format.value.type_produced is str
+            else f"  | {p}Date of (int * int * int)"
+        )
+        _datetime_constructor = (
+            f"  | {p}Str of string"
+            if datetime_format.value.type_produced is str
+            else f"  | {p}Datetime of ((int * int * int) * (int * int * int))"
+        )
+        self.scalar_body_preamble: dict[
+            type,
+            tuple[str, ...],
+        ] = {
+            type(None): (_h, f"  | {p}Null"),
+            bool: (_h, f"  | {p}Bool of bool"),
+            int: (_h, f"  | {p}Int of int"),
+            float: (_h, f"  | {p}Real of real"),
+            str: (_h, f"  | {p}Str of string"),
+            bytes: (_h, f"  | {p}Str of string"),
+            datetime.date: (_h, _date_constructor),
+            datetime.datetime: (_h, _datetime_constructor),
+            list: (_h, f"  | {p}List of {type_name} list"),
+            dict: (_h, f"  | {p}Map of (string * {type_name}) list"),
+            ordereddict: (_h, f"  | {p}Map of (string * {type_name}) list"),
+            set: (_h, f"  | {p}Set of {type_name} list"),
+        }
+        self.compute_body_preamble: Callable[
+            [frozenset[type], Value], tuple[str, ...]
+        ] = _build_sml_body_preamble(
+            scalar_body_preamble=self.scalar_body_preamble,
+        )
+        self.type_hint_collection_preamble_lines = no_type_hint_preamble
+        self.special_float_preamble: tuple[str, ...] = ()

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     SequenceFormatConfig,
     SetFormatConfig,
     TrailingCommaConfig,
+    body_preamble_from_scalars,
     no_type_hint_preamble,
     prepend_body_preamble,
 )
@@ -173,27 +174,22 @@ def _build_sml_body_preamble(
 ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
     """Build a ``compute_body_preamble`` for SML.
 
-    SML's ``datatype`` syntax requires the first constructor after ``=``
-    to have no leading ``|``, while subsequent constructors do.
+    Delegates to :func:`body_preamble_from_scalars` for deduplication,
+    then fixes the first constructor line to omit the leading ``|``
+    required by SML's ``datatype`` syntax.
     """
+    _base = body_preamble_from_scalars(
+        scalar_body_preamble=scalar_body_preamble,
+    )
 
     def _compute(types: frozenset[type], data: Value, /) -> tuple[str, ...]:
         """Return unique body-preamble lines for *types*."""
-        del data
-        seen: set[str] = set()
-        result: list[str] = []
-        for scalar_type, lines in scalar_body_preamble.items():
-            if scalar_type in types:
-                for line in lines:
-                    if line not in seen:
-                        seen.add(line)
-                        result.append(line)
+        lines = _base(types, data)
         # SML: first variant after 'datatype' line must not have '|'.
         # All constructor lines start with '  | ' by construction, so
         # index 1 is always the first constructor.  The caller always
-        # passes at least one type, so result has >= 2 elements.
-        result[1] = "    " + result[1][4:]
-        return tuple(result)
+        # passes at least one type, so lines has >= 2 elements.
+        return (lines[0], "    " + lines[1][4:], *lines[2:])
 
     return _compute
 

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -96,7 +96,7 @@ def _sml_scientific(value: float) -> str:
 
     SML uses ``E`` (not ``e``) and ``~`` for negative exponents.
     """
-    result = format_float_scientific(value)
+    result = format_float_scientific(value=value)
     if result.startswith("-"):
         result = "~" + result[1:]
     # Convert Python's 'e' to SML's 'E', with ~ for negative exponents.
@@ -356,21 +356,25 @@ class Sml(metaclass=LanguageCls):
     ):
         """Float format options."""
 
-        REPR = enum.member(value=_sml_negate_float(format_float_repr))
+        REPR = enum.member(
+            value=_sml_negate_float(formatter=format_float_repr),
+        )
         SCIENTIFIC = enum.member(value=_sml_scientific)
-        FIXED = enum.member(value=_sml_negate_float(format_float_fixed))
+        FIXED = enum.member(
+            value=_sml_negate_float(formatter=format_float_fixed),
+        )
 
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
         DECIMAL = MappingProxyType(
             mapping={
-                "NONE": _sml_negate_int(str),
+                "NONE": _sml_negate_int(formatter=str),
             }
         )
         HEX = MappingProxyType(
             mapping={
-                "NONE": _sml_negate_int(format_integer_hex),
+                "NONE": _sml_negate_int(formatter=format_integer_hex),
             }
         )
 

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime
 import enum
+import functools
 from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -36,7 +37,9 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_integers import (
     format_integer_hex,
 )
-from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._formatters.format_strings import (
+    format_string_backslash_control,
+)
 from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
@@ -190,9 +193,9 @@ def _build_sml_body_preamble(
                         result.append(line)
         # SML: first variant after 'datatype' line must not have '|'.
         # All constructor lines start with '  | ' by construction, so
-        # index 1 is always the first constructor.
-        if len(result) > 1:
-            result[1] = "    " + result[1][4:]
+        # index 1 is always the first constructor.  The caller always
+        # passes at least one type, so result has >= 2 elements.
+        result[1] = "    " + result[1][4:]
         return tuple(result)
 
     return _compute
@@ -550,7 +553,10 @@ class Sml(metaclass=LanguageCls):
                     f"({{hour}}, {{minute}}, {{second}}))"
                 ),
             )
-        self.format_string: Callable[[str], str] = format_string_backslash
+        self.format_string: Callable[[str], str] = functools.partial(
+            format_string_backslash_control,
+            control_char_fmt="\\{:03d}",
+        )
         self.format_float: Callable[[float], str] = float_format
         self.format_integer: Callable[[int], str] = (
             integer_format.get_formatter(

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -188,11 +188,11 @@ def _build_sml_body_preamble(
                     if line not in seen:
                         seen.add(line)
                         result.append(line)
-        # SML: first variant after 'datatype' line must not have '|'
-        for i in range(1, len(result)):
-            if result[i].startswith("  | "):
-                result[i] = "    " + result[i][4:]
-                break
+        # SML: first variant after 'datatype' line must not have '|'.
+        # All constructor lines start with '  | ' by construction, so
+        # index 1 is always the first constructor.
+        if len(result) > 1:
+            result[1] = "    " + result[1][4:]
         return tuple(result)
 
     return _compute

--- a/tests/integration/cases/binary/Sml.sml
+++ b/tests/integration/cases/binary/Sml.sml
@@ -1,0 +1,10 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "48656c6c6f"
+]
+
+end

--- a/tests/integration/cases/binary/Sml_bytes_format_base64.sml
+++ b/tests/integration/cases/binary/Sml_bytes_format_base64.sml
@@ -1,0 +1,10 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "SGVsbG8="
+]
+
+end

--- a/tests/integration/cases/bool_list/Sml.sml
+++ b/tests/integration/cases/bool_list/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SList of val_t list
+val my_data : val_t = SList [
+    SBool true,
+    SBool false,
+    SBool true
+]
+
+end

--- a/tests/integration/cases/comment_block_scalar_not_comment/Sml.sml
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("description", SStr "# not a comment\n"),
+    ("name", SStr "foo")
+]
+
+end

--- a/tests/integration/cases/comment_scalar/Sml.sml
+++ b/tests/integration/cases/comment_scalar/Sml.sml
@@ -1,0 +1,8 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+val my_data : val_t = SInt (* note *)
+42
+
+end

--- a/tests/integration/cases/comment_scalar_document_markers/Sml.sml
+++ b/tests/integration/cases/comment_scalar_document_markers/Sml.sml
@@ -1,0 +1,8 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+val my_data : val_t = SInt (* note *)
+42
+
+end

--- a/tests/integration/cases/comment_scalar_inline/Sml.sml
+++ b/tests/integration/cases/comment_scalar_inline/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+val my_data : val_t = SInt 42  (* note *)
+
+end

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Sml.sml
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+val my_data : val_t = SStr "hello # world"  (* note *)
+
+end

--- a/tests/integration/cases/comments/Sml.sml
+++ b/tests/integration/cases/comments/Sml.sml
@@ -1,0 +1,16 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SInt of int
+  | SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    (* Server configuration *)
+    ("host", SStr "localhost"),  (* default host *)
+    ("port", SInt 8080),
+    (* Enable debug mode *)
+    ("debug", SBool true)
+]
+
+end

--- a/tests/integration/cases/comments_bang_in_double_quote/Sml.sml
+++ b/tests/integration/cases/comments_bang_in_double_quote/Sml.sml
@@ -1,0 +1,10 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("key", SStr "\"bang!\"")  (* real *)
+]
+
+end

--- a/tests/integration/cases/comments_double_hash/Sml.sml
+++ b/tests/integration/cases/comments_double_hash/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    (* # section *)
+    SStr "a"
+]
+
+end

--- a/tests/integration/cases/comments_empty_line/Sml.sml
+++ b/tests/integration/cases/comments_empty_line/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "a",
+    (* *)
+    SStr "b"
+]
+
+end

--- a/tests/integration/cases/comments_escaped_quote/Sml.sml
+++ b/tests/integration/cases/comments_escaped_quote/Sml.sml
@@ -1,0 +1,10 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("key", SStr "value \" # not a comment")  (* real *)
+]
+
+end

--- a/tests/integration/cases/comments_escaped_single_quote/Sml.sml
+++ b/tests/integration/cases/comments_escaped_single_quote/Sml.sml
@@ -1,0 +1,10 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("key", SStr "it's here")  (* a comment *)
+]
+
+end

--- a/tests/integration/cases/comments_multi_line/Sml.sml
+++ b/tests/integration/cases/comments_multi_line/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    (* line 1 *)
+    (* line 2 *)
+    SStr "a"
+]
+
+end

--- a/tests/integration/cases/comments_nested_mapping/Sml.sml
+++ b/tests/integration/cases/comments_nested_mapping/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("a", SMap [("x", SInt 1)]),
+    ("b", SInt 2)
+]
+
+end

--- a/tests/integration/cases/comments_sequence_before/Sml.sml
+++ b/tests/integration/cases/comments_sequence_before/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    (* first *)
+    SStr "a",
+    (* second *)
+    SStr "b"
+]
+
+end

--- a/tests/integration/cases/comments_sequence_inline/Sml.sml
+++ b/tests/integration/cases/comments_sequence_inline/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "a",  (* note a *)
+    SStr "b"  (* note b *)
+]
+
+end

--- a/tests/integration/cases/comments_trailing/Sml.sml
+++ b/tests/integration/cases/comments_trailing/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "a"
+    (* trailing *)
+]
+
+end

--- a/tests/integration/cases/comments_vb_before_dim/Sml.sml
+++ b/tests/integration/cases/comments_vb_before_dim/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    (* Configuration *)
+    ("name", SStr "app"),
+    (* Port setting *)
+    ("port", SInt 3000)
+]
+
+end

--- a/tests/integration/cases/date_list/Sml.sml
+++ b/tests/integration/cases/date_list/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SDate of (int * int * int)
+  | SList of val_t list
+val my_data : val_t = SList [
+    SDate (2024, 1, 15),
+    SDate (2024, 2, 20)
+]
+
+end

--- a/tests/integration/cases/date_list/Sml_date_iso.sml
+++ b/tests/integration/cases/date_list/Sml_date_iso.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "2024-01-15",
+    SStr "2024-02-20"
+]
+
+end

--- a/tests/integration/cases/date_list/Sml_date_sml.sml
+++ b/tests/integration/cases/date_list/Sml_date_sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SDate of (int * int * int)
+  | SList of val_t list
+val my_data : val_t = SList [
+    SDate (2024, 1, 15),
+    SDate (2024, 2, 20)
+]
+
+end

--- a/tests/integration/cases/date_set/Sml.sml
+++ b/tests/integration/cases/date_set/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SDate of (int * int * int)
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    SDate (2024, 1, 15),
+    SDate (2024, 6, 1)
+]
+
+end

--- a/tests/integration/cases/date_set/Sml_date_iso.sml
+++ b/tests/integration/cases/date_set/Sml_date_iso.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    SStr "2024-01-15",
+    SStr "2024-06-01"
+]
+
+end

--- a/tests/integration/cases/date_set/Sml_date_sml.sml
+++ b/tests/integration/cases/date_set/Sml_date_sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SDate of (int * int * int)
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    SDate (2024, 1, 15),
+    SDate (2024, 6, 1)
+]
+
+end

--- a/tests/integration/cases/dates/Sml.sml
+++ b/tests/integration/cases/dates/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SDate of (int * int * int)
+  | SDatetime of ((int * int * int) * (int * int * int))
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("date", SDate (2024, 1, 15)),
+    ("datetime", SDatetime ((2024, 1, 15), (12, 30, 0)))
+]
+
+end

--- a/tests/integration/cases/datetime_list/Sml.sml
+++ b/tests/integration/cases/datetime_list/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+  | SList of val_t list
+val my_data : val_t = SList [
+    SDatetime ((2024, 1, 15), (12, 30, 0)),
+    SDatetime ((2024, 6, 1), (8, 0, 0))
+]
+
+end

--- a/tests/integration/cases/deep_nesting/Sml.sml
+++ b/tests/integration/cases/deep_nesting/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("level1", SMap [("level2", SMap [("level3", SMap [("level4", SMap [("value", SStr "deep"), ("items", SList [SStr "a", SStr "b"])])]), ("sibling", SInt 42)]), ("tags", SList [SMap [("name", SStr "tag1"), ("meta", SMap [("priority", SInt 1), ("labels", SList [SStr "x", SStr "y"])])]])])
+]
+
+end

--- a/tests/integration/cases/dict_with_control_char_keys/Sml.sml
+++ b/tests/integration/cases/dict_with_control_char_keys/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("key\nwith\nnewlines", SStr "value1"),
+    ("key\twith\ttabs", SStr "value2"),
+    ("", SStr "value3")
+]
+
+end

--- a/tests/integration/cases/dict_with_hyphen_keys/Sml.sml
+++ b/tests/integration/cases/dict_with_hyphen_keys/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("my-key", SStr "value1"),
+    ("another-key", SStr "value2"),
+    ("normal_key", SStr "value3")
+]
+
+end

--- a/tests/integration/cases/dict_with_list_value/Sml.sml
+++ b/tests/integration/cases/dict_with_list_value/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("name", SStr "Alice"),
+    ("scores", SList [SInt 10, SInt 20, SInt 30])
+]
+
+end

--- a/tests/integration/cases/dict_with_nulls/Sml.sml
+++ b/tests/integration/cases/dict_with_nulls/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SNull
+  | SInt of int
+  | SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("name", SStr "Alice"),
+    ("score", SNull),
+    ("age", SInt 30)
+]
+
+end

--- a/tests/integration/cases/empty_dict/Sml.sml
+++ b/tests/integration/cases/empty_dict/Sml.sml
@@ -1,0 +1,8 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap []
+
+end

--- a/tests/integration/cases/empty_dicts_in_sequence/Sml.sml
+++ b/tests/integration/cases/empty_dicts_in_sequence/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SMap [],
+    SMap []
+]
+
+end

--- a/tests/integration/cases/empty_list/Sml.sml
+++ b/tests/integration/cases/empty_list/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SList of val_t list
+val my_data : val_t = SList []
+
+end

--- a/tests/integration/cases/empty_sequence/Sml.sml
+++ b/tests/integration/cases/empty_sequence/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SList [],
+    SMap []
+]
+
+end

--- a/tests/integration/cases/empty_set/Sml.sml
+++ b/tests/integration/cases/empty_set/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SSet of val_t list
+val my_data : val_t = SSet []
+
+end

--- a/tests/integration/cases/float_list/Sml.sml
+++ b/tests/integration/cases/float_list/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal 1.1,
+    SReal (~2.2),
+    SReal 3.3
+]
+
+end

--- a/tests/integration/cases/float_list/Sml_float_format_fixed.sml
+++ b/tests/integration/cases/float_list/Sml_float_format_fixed.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal 1.100000,
+    SReal (~2.200000),
+    SReal 3.300000
+]
+
+end

--- a/tests/integration/cases/float_list/Sml_float_format_scientific.sml
+++ b/tests/integration/cases/float_list/Sml_float_format_scientific.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal 1.1,
+    SReal (~2.2),
+    SReal 3.3
+]
+
+end

--- a/tests/integration/cases/float_negative_zero/Sml.sml
+++ b/tests/integration/cases/float_negative_zero/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal (~0.0),
+    SReal 1.5
+]
+
+end

--- a/tests/integration/cases/float_scientific_notation/Sml.sml
+++ b/tests/integration/cases/float_scientific_notation/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal 0.0,
+    SReal 1.0,
+    SReal 1500.0,
+    SReal 0.001
+]
+
+end

--- a/tests/integration/cases/float_scientific_notation/Sml_float_format_fixed_s.sml
+++ b/tests/integration/cases/float_scientific_notation/Sml_float_format_fixed_s.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal 0.000000,
+    SReal 1.000000,
+    SReal 1500.000000,
+    SReal 0.001000
+]
+
+end

--- a/tests/integration/cases/float_scientific_notation/Sml_float_format_scientific_s.sml
+++ b/tests/integration/cases/float_scientific_notation/Sml_float_format_scientific_s.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal 0.0,
+    SReal 1.0,
+    SReal 1.5E3,
+    SReal 1.0E~3
+]
+
+end

--- a/tests/integration/cases/float_special_values/Sml.sml
+++ b/tests/integration/cases/float_special_values/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal ((1.0 / 0.0)),
+    SReal ((~1.0 / 0.0)),
+    SReal ((0.0 / 0.0))
+]
+
+end

--- a/tests/integration/cases/float_special_values/Sml_float_format_fixed_v.sml
+++ b/tests/integration/cases/float_special_values/Sml_float_format_fixed_v.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal ((1.0 / 0.0)),
+    SReal ((~1.0 / 0.0)),
+    SReal ((0.0 / 0.0))
+]
+
+end

--- a/tests/integration/cases/float_special_values/Sml_float_format_scientific_v.sml
+++ b/tests/integration/cases/float_special_values/Sml_float_format_scientific_v.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SReal ((1.0 / 0.0)),
+    SReal ((~1.0 / 0.0)),
+    SReal ((0.0 / 0.0))
+]
+
+end

--- a/tests/integration/cases/int_key_dict/Sml.sml
+++ b/tests/integration/cases/int_key_dict/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("1", SStr "one"),
+    ("2", SStr "two"),
+    ("42", SStr "answer")
+]
+
+end

--- a/tests/integration/cases/int_list/Sml.sml
+++ b/tests/integration/cases/int_list/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 1,
+    SInt 2,
+    SInt 3
+]
+
+end

--- a/tests/integration/cases/int_list/Sml_integer_format_hex.sml
+++ b/tests/integration/cases/int_list/Sml_integer_format_hex.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 0x1,
+    SInt 0x2,
+    SInt 0x3
+]
+
+end

--- a/tests/integration/cases/int_list_large/Sml.sml
+++ b/tests/integration/cases/int_list_large/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 1000000,
+    SInt (~1234),
+    SInt 255,
+    SInt (~10)
+]
+
+end

--- a/tests/integration/cases/int_list_large/Sml_integer_format_hex_large.sml
+++ b/tests/integration/cases/int_list_large/Sml_integer_format_hex_large.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 0xf4240,
+    SInt (~0x4d2),
+    SInt 0xff,
+    SInt (~0xa)
+]
+
+end

--- a/tests/integration/cases/int_list_with_zero/Sml.sml
+++ b/tests/integration/cases/int_list_with_zero/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 0,
+    SInt 1,
+    SInt (~1)
+]
+
+end

--- a/tests/integration/cases/int_list_with_zero/Sml_integer_format_hex_zero.sml
+++ b/tests/integration/cases/int_list_with_zero/Sml_integer_format_hex_zero.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 0x0,
+    SInt 0x1,
+    SInt (~0x1)
+]
+
+end

--- a/tests/integration/cases/int_set/Sml.sml
+++ b/tests/integration/cases/int_set/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    SInt 1,
+    SInt 2,
+    SInt 3
+]
+
+end

--- a/tests/integration/cases/mixed_number_dict/Sml.sml
+++ b/tests/integration/cases/mixed_number_dict/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SReal of real
+  | SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("a", SInt 1),
+    ("b", SReal 2.5),
+    ("c", SInt 3)
+]
+
+end

--- a/tests/integration/cases/mixed_number_list/Sml.sml
+++ b/tests/integration/cases/mixed_number_list/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 1,
+    SReal 2.5,
+    SInt 3
+]
+
+end

--- a/tests/integration/cases/mixed_set/Sml.sml
+++ b/tests/integration/cases/mixed_set/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SInt of int
+  | SStr of string
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    SBool true,
+    SInt 42,
+    SStr "apple"
+]
+
+end

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Sml.sml
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SMap [("type", SStr "create"), ("pr_id", SStr "pr_1"), ("draft", SBool true)],
+    SMap [("type", SStr "create"), ("pr_id", SStr "pr_2")]
+]
+
+end

--- a/tests/integration/cases/nested/Sml.sml
+++ b/tests/integration/cases/nested/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("users", SList [SMap [("name", SStr "Bob"), ("tags", SList [SStr "admin", SStr "user"])], SMap [("name", SStr "Carol"), ("tags", SList [SStr "guest"])]])
+]
+
+end

--- a/tests/integration/cases/nested_bool_list/Sml.sml
+++ b/tests/integration/cases/nested_bool_list/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SBool true, SBool false],
+    SList [SBool true, SBool true]
+]
+
+end

--- a/tests/integration/cases/nested_collection_multi_space_string/Sml.sml
+++ b/tests/integration/cases/nested_collection_multi_space_string/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SMap [("key", SStr "hello   world"), ("value", SInt 1)]
+]
+
+end

--- a/tests/integration/cases/nested_deep_empty/Sml.sml
+++ b/tests/integration/cases/nested_deep_empty/Sml.sml
@@ -1,0 +1,9 @@
+structure Check = struct
+
+datatype val_t =
+    SList of val_t list
+val my_data : val_t = SList [
+    SList [SList [], SList []]
+]
+
+end

--- a/tests/integration/cases/nested_deep_mixed/Sml.sml
+++ b/tests/integration/cases/nested_deep_mixed/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SList [SInt 1, SInt 2], SList [SStr "a", SStr "b"]]
+]
+
+end

--- a/tests/integration/cases/nested_empty_inner/Sml.sml
+++ b/tests/integration/cases/nested_empty_inner/Sml.sml
@@ -1,0 +1,10 @@
+structure Check = struct
+
+datatype val_t =
+    SList of val_t list
+val my_data : val_t = SList [
+    SList [],
+    SList []
+]
+
+end

--- a/tests/integration/cases/nested_float_list/Sml.sml
+++ b/tests/integration/cases/nested_float_list/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SReal 1.5, SReal 2.5],
+    SList [SReal 3.5, SReal 4.5]
+]
+
+end

--- a/tests/integration/cases/nested_float_list/Sml_float_format_fixed_n.sml
+++ b/tests/integration/cases/nested_float_list/Sml_float_format_fixed_n.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SReal 1.500000, SReal 2.500000],
+    SList [SReal 3.500000, SReal 4.500000]
+]
+
+end

--- a/tests/integration/cases/nested_float_list/Sml_float_format_scientific_n.sml
+++ b/tests/integration/cases/nested_float_list/Sml_float_format_scientific_n.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SReal of real
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SReal 1.5, SReal 2.5],
+    SList [SReal 3.5, SReal 4.5]
+]
+
+end

--- a/tests/integration/cases/nested_list_of_dicts/Sml.sml
+++ b/tests/integration/cases/nested_list_of_dicts/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SList [SMap [("name", SStr "Alice")], SMap [("name", SStr "Bob")]],
+    SList [SMap [("name", SStr "Charlie")], SMap [("name", SStr "Dave")]]
+]
+
+end

--- a/tests/integration/cases/nested_mixed_inner/Sml.sml
+++ b/tests/integration/cases/nested_mixed_inner/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SInt 1, SStr "a"],
+    SList [SInt 2, SStr "b"]
+]
+
+end

--- a/tests/integration/cases/nested_mixed_set/Sml.sml
+++ b/tests/integration/cases/nested_mixed_set/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SInt of int
+  | SStr of string
+  | SMap of (string * val_t) list
+  | SSet of val_t list
+val my_data : val_t = SMap [
+    ("name", SStr "Alice"),
+    ("tags", SSet [SBool true, SInt 42, SStr "apple"])
+]
+
+end

--- a/tests/integration/cases/nested_mixed_types/Sml.sml
+++ b/tests/integration/cases/nested_mixed_types/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SInt 1, SInt 2],
+    SList [SStr "a", SStr "b"]
+]
+
+end

--- a/tests/integration/cases/nested_sequence/Sml.sml
+++ b/tests/integration/cases/nested_sequence/Sml.sml
@@ -1,0 +1,16 @@
+structure Check = struct
+
+datatype val_t =
+    SNull
+  | SBool of bool
+  | SInt of int
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SBool true,
+    SStr "hi",
+    SList [SInt 1, SInt 2],
+    SNull
+]
+
+end

--- a/tests/integration/cases/nested_sequences/Sml.sml
+++ b/tests/integration/cases/nested_sequences/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SList of val_t list
+val my_data : val_t = SList [
+    SList [SList [SInt 1, SInt 2], SList [SInt 3, SInt 4]],
+    SList [SList [SInt 5]]
+]
+
+end

--- a/tests/integration/cases/no_comment/Sml.sml
+++ b/tests/integration/cases/no_comment/Sml.sml
@@ -1,0 +1,10 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("message", SStr "no comment here")
+]
+
+end

--- a/tests/integration/cases/ordered_map/Sml.sml
+++ b/tests/integration/cases/ordered_map/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SInt of int
+  | SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("name", SStr "Alice"),
+    ("age", SInt 30),
+    ("active", SBool true)
+]
+
+end

--- a/tests/integration/cases/ordered_map_int_keys/Sml.sml
+++ b/tests/integration/cases/ordered_map_int_keys/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("1", SStr "one"),
+    ("2", SStr "two"),
+    ("42", SStr "answer")
+]
+
+end

--- a/tests/integration/cases/ordered_map_nested_values/Sml.sml
+++ b/tests/integration/cases/ordered_map_nested_values/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("name", SStr "Alice"),
+    ("scores", SMap [("1", SStr "first"), ("2", SStr "second")])
+]
+
+end

--- a/tests/integration/cases/pair_sequence/Sml.sml
+++ b/tests/integration/cases/pair_sequence/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 1,
+    SStr "hello"
+]
+
+end

--- a/tests/integration/cases/scalar_date/Sml.sml
+++ b/tests/integration/cases/scalar_date/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDate of (int * int * int)
+val my_data : val_t = SDate (2024, 1, 15)
+
+end

--- a/tests/integration/cases/scalar_date/Sml_date_iso.sml
+++ b/tests/integration/cases/scalar_date/Sml_date_iso.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+val my_data : val_t = SStr "2024-01-15"
+
+end

--- a/tests/integration/cases/scalar_date/Sml_date_sml.sml
+++ b/tests/integration/cases/scalar_date/Sml_date_sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDate of (int * int * int)
+val my_data : val_t = SDate (2024, 1, 15)
+
+end

--- a/tests/integration/cases/scalar_datetime/Sml.sml
+++ b/tests/integration/cases/scalar_datetime/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (12, 30, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime/Sml_datetime_iso.sml
+++ b/tests/integration/cases/scalar_datetime/Sml_datetime_iso.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+val my_data : val_t = SStr "2024-01-15T12:30:00+00:00"
+
+end

--- a/tests/integration/cases/scalar_datetime/Sml_datetime_sml.sml
+++ b/tests/integration/cases/scalar_datetime/Sml_datetime_sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (12, 30, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime_microsecond/Sml.sml
+++ b/tests/integration/cases/scalar_datetime_microsecond/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (12, 30, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime_midnight/Sml.sml
+++ b/tests/integration/cases/scalar_datetime_midnight/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (0, 0, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime_naive/Sml.sml
+++ b/tests/integration/cases/scalar_datetime_naive/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (12, 30, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime_naive/Sml_datetime_iso_naive.sml
+++ b/tests/integration/cases/scalar_datetime_naive/Sml_datetime_iso_naive.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+val my_data : val_t = SStr "2024-01-15T12:30:00"
+
+end

--- a/tests/integration/cases/scalar_datetime_naive/Sml_datetime_sml_naive.sml
+++ b/tests/integration/cases/scalar_datetime_naive/Sml_datetime_sml_naive.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (12, 30, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime_non_utc/Sml.sml
+++ b/tests/integration/cases/scalar_datetime_non_utc/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (18, 0, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime_non_utc/Sml_datetime_iso_non_utc.sml
+++ b/tests/integration/cases/scalar_datetime_non_utc/Sml_datetime_iso_non_utc.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+val my_data : val_t = SStr "2024-01-15T18:00:00+05:30"
+
+end

--- a/tests/integration/cases/scalar_datetime_non_utc/Sml_datetime_sml_non_utc.sml
+++ b/tests/integration/cases/scalar_datetime_non_utc/Sml_datetime_sml_non_utc.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (18, 0, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Sml.sml
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SDatetime of ((int * int * int) * (int * int * int))
+val my_data : val_t = SDatetime ((2024, 1, 15), (12, 30, 45))
+
+end

--- a/tests/integration/cases/scalars/Sml.sml
+++ b/tests/integration/cases/scalars/Sml.sml
@@ -1,0 +1,17 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SInt of int
+  | SReal of real
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 42,
+    SReal 3.14,
+    SBool true,
+    SBool false,
+    SStr "hello \"world\""
+]
+
+end

--- a/tests/integration/cases/sequence_of_dicts/Sml.sml
+++ b/tests/integration/cases/sequence_of_dicts/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SMap [("name", SStr "Alice"), ("age", SInt 30)],
+    SMap [("name", SStr "Bob"), ("age", SInt 25)]
+]
+
+end

--- a/tests/integration/cases/set/Sml.sml
+++ b/tests/integration/cases/set/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    SStr "apple",
+    SStr "banana",
+    SStr "cherry"
+]
+
+end

--- a/tests/integration/cases/set_comments/Sml.sml
+++ b/tests/integration/cases/set_comments/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    SStr "apple",  (* inline comment *)
+    (* before banana *)
+    SStr "banana"
+    (* trailing *)
+]
+
+end

--- a/tests/integration/cases/set_comments_unsorted_order/Sml.sml
+++ b/tests/integration/cases/set_comments_unsorted_order/Sml.sml
@@ -1,0 +1,13 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SSet of val_t list
+val my_data : val_t = SSet [
+    (* before apple *)
+    SStr "apple",
+    SStr "banana"  (* banana inline *)
+    (* trailing *)
+]
+
+end

--- a/tests/integration/cases/simple_dict/Sml.sml
+++ b/tests/integration/cases/simple_dict/Sml.sml
@@ -1,0 +1,16 @@
+structure Check = struct
+
+datatype val_t =
+    SNull
+  | SBool of bool
+  | SInt of int
+  | SStr of string
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("name", SStr "Alice"),
+    ("age", SInt 30),
+    ("active", SBool true),
+    ("score", SNull)
+]
+
+end

--- a/tests/integration/cases/simple_sequence/Sml.sml
+++ b/tests/integration/cases/simple_sequence/Sml.sml
@@ -1,0 +1,16 @@
+structure Check = struct
+
+datatype val_t =
+    SNull
+  | SBool of bool
+  | SInt of int
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 1,
+    SStr "hello",
+    SBool true,
+    SNull
+]
+
+end

--- a/tests/integration/cases/string_control_chars/Sml.sml
+++ b/tests/integration/cases/string_control_chars/Sml.sml
@@ -6,7 +6,7 @@ datatype val_t =
 val my_data : val_t = SList [
     SStr "line1\r\nline2",
     SStr "line1\rline2",
-    SStr ""
+    SStr "\001"
 ]
 
 end

--- a/tests/integration/cases/string_control_chars/Sml.sml
+++ b/tests/integration/cases/string_control_chars/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "line1\r\nline2",
+    SStr "line1\rline2",
+    SStr ""
+]
+
+end

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Sml.sml
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Sml.sml
@@ -1,0 +1,7 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+val my_data : val_t = SStr "hello \"world\" -- not a comment"
+
+end

--- a/tests/integration/cases/string_list/Sml.sml
+++ b/tests/integration/cases/string_list/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "foo",
+    SStr "bar",
+    SStr "baz"
+]
+
+end

--- a/tests/integration/cases/string_with_backslash/Sml.sml
+++ b/tests/integration/cases/string_with_backslash/Sml.sml
@@ -1,0 +1,16 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "C:\\path\\to\\file",
+    SStr "back\\\\slash",
+    SStr "hello \\\"world\\\"",
+    SStr "path\\to \"# file",
+    SStr "trailing\\",
+    SStr "both \"quotes''' here",
+    SStr "line1\\nline2\nwith newline"
+]
+
+end

--- a/tests/integration/cases/string_with_dollar/Sml.sml
+++ b/tests/integration/cases/string_with_dollar/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "price $10",
+    SStr "$HOME"
+]
+
+end

--- a/tests/integration/cases/string_with_dollar_brace/Sml.sml
+++ b/tests/integration/cases/string_with_dollar_brace/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "prefix ${HOME} suffix",
+    SStr "${interpolated}"
+]
+
+end

--- a/tests/integration/cases/string_with_hash/Sml.sml
+++ b/tests/integration/cases/string_with_hash/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "issue #{42}",
+    SStr "color #red"
+]
+
+end

--- a/tests/integration/cases/string_with_percent/Sml.sml
+++ b/tests/integration/cases/string_with_percent/Sml.sml
@@ -1,0 +1,11 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SStr "100% done",
+    SStr "%(name) is here"
+]
+
+end

--- a/tests/integration/cases/triple_sequence/Sml.sml
+++ b/tests/integration/cases/triple_sequence/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SBool of bool
+  | SInt of int
+  | SStr of string
+  | SList of val_t list
+val my_data : val_t = SList [
+    SInt 1,
+    SStr "hello",
+    SBool true
+]
+
+end

--- a/tests/integration/cases/type_hints/Sml.sml
+++ b/tests/integration/cases/type_hints/Sml.sml
@@ -1,0 +1,21 @@
+structure Check = struct
+
+datatype val_t =
+    SNull
+  | SBool of bool
+  | SInt of int
+  | SStr of string
+  | SDate of (int * int * int)
+  | SDatetime of ((int * int * int) * (int * int * int))
+  | SMap of (string * val_t) list
+val my_data : val_t = SMap [
+    ("name", SStr "Alice"),
+    ("age", SInt 30),
+    ("active", SBool true),
+    ("score", SNull),
+    ("joined", SDate (2024, 1, 15)),
+    ("last_login", SDatetime ((2024, 1, 15), (12, 30, 0))),
+    ("avatar", SStr "48656c6c6f")
+]
+
+end

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Sml.sml
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Sml.sml
@@ -1,0 +1,14 @@
+structure Check = struct
+
+datatype val_t =
+    SInt of int
+  | SReal of real
+  | SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SMap [("x", SInt 1), ("y", SReal 2.5)],
+    SMap [("x", SInt 3), ("y", SReal 4.0)]
+]
+
+end

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Sml.sml
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Sml.sml
@@ -1,0 +1,12 @@
+structure Check = struct
+
+datatype val_t =
+    SStr of string
+  | SList of val_t list
+  | SMap of (string * val_t) list
+val my_data : val_t = SList [
+    SMap [("first", SStr "Alice"), ("last", SStr "Smith")],
+    SMap [("first", SStr "Bob"), ("last", SStr "Jones")]
+]
+
+end


### PR DESCRIPTION
## Summary
- Adds Standard ML as a new supported language with ADT-based output using `datatype val_t` declarations, SML's tilde (`~`) negation syntax for integers and floats, `structure Check = struct ... end` file wrapping, and comma-separated list elements
- Includes CI lint job using MLton (`mlton -stop tc`) for type checking generated `.sml` files
- Adds 114 golden test files covering all integration test cases and format variants (date, datetime, float, integer, bytes, etc.)

## Test plan
- [x] All 11002 integration tests pass
- [x] Pre-commit hooks pass (ruff, interrogate, mypy, pyright, ty, pyrefly)
- [ ] CI `lint-sml` job validates generated SML files compile with MLton

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new language backend and a new CI compiler/typecheck job; main risk is formatting/edge-case correctness in the new SML emitter and increased CI surface area (MLton install/time).
> 
> **Overview**
> Adds **Standard ML (SML)** as a first-class `literalizer` language target, generating `datatype`-based values (e.g., `SInt`, `SMap`, `SList`), SML-specific numeric negation (`~`), and wrapping output in `structure Check = struct ... end`.
> 
> Integrates SML into the language registry (`languages/__init__.py`), updates the private spelling dictionary for SML identifiers, and adds a `lint-sml` GitHub Actions job that installs MLton and typechecks generated `*.sml` fixtures.
> 
> Adds a large set of new SML golden files under `tests/integration/cases/**` covering scalars, collections, comments, bytes/date/datetime formats, and numeric formatting variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc7a4161d9543349e27a71003e8342c000a2c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->