### PR TITLE
Replace in/startswith test assertions with exact == comparisons

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -655,8 +655,14 @@ def test_cpp_array_null_list_fallback_json() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert "nullptr" in result.code
-    assert result.code.startswith("{")
+    expected = textwrap.dedent(
+        text="""\
+        {
+            nullptr,
+            nullptr,
+        }""",
+    )
+    assert result.code == expected
 
 
 def test_coerce_mixed_dict_values_none_with_list_json() -> None:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -823,7 +823,7 @@ def test_python_no_any_import_when_all_defaults_overridden() -> None:
         error_on_coercion=False,
     )
     assert result.code == "my_data: dict[str, str] = {}"
-    assert result.preamble == ()
+    assert not result.preamble
 
 
 def test_cobol_bump_levels_rejects_non_level_line() -> None:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -690,8 +690,15 @@ def test_fortran_continuation_with_escaped_quote_and_comment() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert "'it''s here'" in result.code
-    assert "&  !" in result.code
+    expected = textwrap.dedent(
+        text="""\
+        type(fval_t) :: cfg
+        cfg = fmap([fval_t :: &
+            fentry('host', fstr('it''s here')), &  ! a comment
+            fentry('port', fint(80)) &  ! another
+        ])""",
+    )
+    assert result.code == expected
 
 
 def test_java_list_format() -> None:
@@ -816,7 +823,7 @@ def test_python_no_any_import_when_all_defaults_overridden() -> None:
         error_on_coercion=False,
     )
     assert result.code == "my_data: dict[str, str] = {}"
-    assert "Any" not in "".join(result.preamble)
+    assert result.preamble == ()
 
 
 def test_cobol_bump_levels_rejects_non_level_line() -> None:

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -247,9 +247,14 @@ def test_datetime_python() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert '"updated": datetime.datetime(' in result.code
-    assert "year=2024" in result.code
-    assert "minute=30" in result.code
+    expected = (
+        "{\n"
+        '    "updated": datetime.datetime('
+        "year=2024, month=1, day=15, "
+        "hour=10, minute=30, second=0),\n"
+        "}"
+    )
+    assert result.code == expected
 
 
 def test_time_coerced_to_string() -> None:
@@ -457,8 +462,19 @@ def test_body_preamble() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert result.body_preamble
-    assert result.body_preamble[0] in result.code
+    expected_preamble = "import Data.String (IsString(fromString))"
+    assert result.body_preamble[0] == expected_preamble
+    expected = textwrap.dedent(
+        text="""\
+        import Data.String (IsString(fromString))
+        data Val = HStr String | HMap [(String, Val)]
+        instance IsString Val where
+            fromString = HStr
+        HMap [
+            ("name", "alice")
+            ]""",
+    )
+    assert result.code == expected
 
 
 def test_inline_comment_preserved() -> None:
@@ -666,8 +682,15 @@ def test_comments_language_without_collection_comments() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert "' header" in result.code
-    assert "' inline" in result.code
+    expected = textwrap.dedent(
+        text="""\
+        ' header
+        ' inline
+        Dim config = New Dictionary(Of String, Object) From {
+            {"host", "localhost"}
+        }""",
+    )
+    assert result.code == expected
 
 
 def test_extract_toml_comments_non_document() -> None:

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -578,7 +578,7 @@ def test_python_always_type_hints_empty_list() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert "tuple[Any, ...]" in result.code
+    assert result.code == "my_var: tuple[Any, ...] = ()"
 
 
 def test_python_always_type_hints_ordered_dicts_in_sequence() -> None:
@@ -602,4 +602,11 @@ def test_python_always_type_hints_ordered_dicts_in_sequence() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert "tuple[OrderedDict[str, str | bool], ...]" in result.code
+    expected = textwrap.dedent(
+        text="""\
+        my_var: tuple[OrderedDict[str, str | bool], ...] = (
+            OrderedDict([("name", "Alice"), ("draft", True)]),
+            OrderedDict([("name", "Bob")]),
+        )""",
+    )
+    assert result.code == expected

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -175,8 +175,13 @@ def test_cpp_array_binary_typed() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert '"48656c6c6f"' in result.code
-    assert "std::array<std::string, 1>" in result.code
+    expected = textwrap.dedent(
+        text="""\
+        std::array<std::string, 1>{
+            "48656c6c6f",
+        }""",
+    )
+    assert result.code == expected
 
 
 def test_cpp_array_null_list_fallback() -> None:
@@ -195,8 +200,14 @@ def test_cpp_array_null_list_fallback() -> None:
         new_variable=True,
         error_on_coercion=False,
     )
-    assert "nullptr" in result.code
-    assert result.code.startswith("{")
+    expected = textwrap.dedent(
+        text="""\
+        {
+            nullptr,
+            nullptr,
+        }""",
+    )
+    assert result.code == expected
 
 
 def test_yaml_set_inline_in_sequence() -> None:


### PR DESCRIPTION
## Summary
- Replaced all `in` and `startswith` assertions in tests with exact `==` comparisons against the full expected output
- Uses `textwrap.dedent` for multi-line expected strings, matching existing test conventions
- Covers 10 assertions across 5 test files: `test_json.py`, `test_languages.py`, `test_toml.py`, `test_variables.py`, `test_yaml.py`

## Test plan
- [x] All 10 affected tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to test expectations and make assertions stricter without modifying production logic.
> 
> **Overview**
> Updates multiple test cases to assert **exact generated output** (including indentation, delimiters, and comment/preamble lines) instead of using partial `in`/`startswith` checks.
> 
> Also tightens a Python test to assert `result.preamble` is empty and expands several expected literals (C++ null-list fallback, Fortran continuation/comment formatting, TOML datetime + Haskell body preamble, Visual Basic comments, and Python ALWAYS type-hint outputs) to full string matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f67d019b8d6b170e5a0474ce128a41331f2b18ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->