### PR TITLE
Fix Forth paren comment suffix and deduplicate float formatter

### DIFF
--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -15,6 +15,7 @@ from literalizer._formatters.collection_openers import (
 from literalizer._formatters.format_entries import (
     passthrough_sequence_entry,
 )
+from literalizer._formatters.format_floats import format_float_scientific
 from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
@@ -64,13 +65,10 @@ def _format_float_forth(value: float) -> str:
 
     Example: ``1.5`` -> ``1.5e0``.
     """
-    raw = f"{value:e}"
-    mantissa, exponent_part = raw.split(sep="e")
-    mantissa = mantissa.rstrip("0")
-    if mantissa.endswith("."):
-        mantissa += "0"
-    exponent_value = int(exponent_part)
-    return f"{mantissa}e{exponent_value}"
+    result = format_float_scientific(value=value)
+    if "e" not in result:
+        return f"{result}e0"
+    return result
 
 
 @beartype
@@ -235,7 +233,7 @@ class Forth(metaclass=LanguageCls):
         )
         PAREN = CommentConfig(
             prefix="(",
-            suffix=")",
+            suffix=" )",
         )
 
     class DeclarationStyles(enum.Enum):

--- a/tests/integration/cases/comments/Forth_comment_paren.fth
+++ b/tests/integration/cases/comments/Forth_comment_paren.fth
@@ -1,6 +1,6 @@
-( Server configuration)
-( default host)
-( Enable debug mode)
+( Server configuration )
+( default host )
+( Enable debug mode )
 : my_data
     s\" host" s\" localhost"
     s\" port" 8080


### PR DESCRIPTION
## Summary
- Fix PAREN comment suffix from `)` to ` )` so empty comments produce valid Forth `( )` instead of the undefined token `()`. In Forth, `(` is a word requiring whitespace separation.
- Replace duplicated scientific notation logic in `_format_float_forth` with a call to the existing `format_float_scientific` utility, adding only the Forth-specific `e0` suffix when needed.

Addresses bugbot comments from #1086.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly adjusts Forth literal string formatting and updates an integration fixture; main impact is potential snapshot/output changes for Forth comments and floats.
> 
> **Overview**
> Fixes Forth `PAREN` comment rendering by changing the suffix from `)` to ` )`, ensuring comments are whitespace-delimited and avoiding invalid `()` tokens; updates the corresponding integration `.fth` fixture.
> 
> Refactors `_format_float_forth` to delegate scientific notation formatting to `format_float_scientific`, adding only a Forth-specific `e0` when the shared formatter omits an exponent for `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef0be480a2059309d17041676ba8ff95eb46e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->