### PR TITLE
Speed up SML lint by downloading MLton binary directly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1089,7 +1089,9 @@ jobs:
           lang_patterns: tests/integration/cases/**/*.sml
       - name: Install MLton
         if: steps.find-files.outputs.found == 'true'
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq mlton
+        run: |
+          curl -fsSL https://github.com/MLton/mlton/releases/download/on-20241230-release/mlton-20241230-1.amd64-linux.ubuntu-24.04_static.tgz | tar xz -C /tmp
+          echo "/tmp/mlton-20241230-1.amd64-linux.ubuntu-24.04_static/bin" >> "$GITHUB_PATH"
       - name: Check SML syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(nproc)" -n1 mlton -stop tc < /tmp/files-to-lint


### PR DESCRIPTION
## Summary

Replace `apt-get update && apt-get install mlton` with a direct download of the MLton static binary from GitHub Releases. This avoids the slow `apt-get update` step, which downloads package indexes and resolves dependencies unnecessarily. The static binary has no runtime dependencies and runs directly from the extracted tarball.

## Test plan

- [ ] Verify the `lint-sml` CI job passes with the new install method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just alters how MLton is installed for the `lint-sml` job. Main risk is CI breakage if the pinned GitHub release URL or Ubuntu 24.04 static binary becomes unavailable/incompatible.
> 
> **Overview**
> Speeds up the `lint-sml` GitHub Actions job by replacing `apt-get install mlton` with a pinned download/extract of the MLton *static* binary from GitHub Releases and adding it to `GITHUB_PATH` before running the existing SML typecheck command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444d1d213c9ca4cf0b7928fa324a159adcf4f246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->