### PR TITLE
Fix statement_terminator for VB, PHP, and Perl

### DIFF
--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -487,6 +487,6 @@ class Perl(metaclass=LanguageCls):
         self.call_style_config: CallStyleConfig = CallStyleConfig(
             kind=CallStyleKind.POSITIONAL,
         )
-        self.statement_terminator = ""
+        self.statement_terminator = ";"
         self.format_call_stub = no_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -457,6 +457,6 @@ class Php(metaclass=LanguageCls):
             kind=CallStyleKind.KEYWORD,
             keyword_separator=": ",
         )
-        self.statement_terminator = ""
+        self.statement_terminator = ";"
         self.format_call_stub = no_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -532,6 +532,6 @@ class VisualBasic(metaclass=LanguageCls):
             kind=CallStyleKind.KEYWORD,
             keyword_separator=":=",
         )
-        self.statement_terminator = ";"
+        self.statement_terminator = ""
         self.format_call_stub = no_call_stub
         self.format_call_preamble_stub = no_call_stub


### PR DESCRIPTION
## Summary
- Fix VB.NET `statement_terminator` from `";"` to `""` (VB uses newlines, not semicolons)
- Fix PHP `statement_terminator` from `""` to `";"` (PHP requires semicolons)
- Fix Perl `statement_terminator` from `""` to `";"` (Perl requires semicolons)

Closes #1095

## Test plan
- [x] All existing tests pass (535 VB/PHP/Perl tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized configuration tweaks that only affect emitted statement endings for three language backends.
> 
> **Overview**
> Fixes code generation for Perl and PHP by appending `;` to emitted call statements via `statement_terminator`.
> 
> Fixes VB.NET generation by removing the incorrect `;` terminator so statements rely on newlines instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4d71b1f7e0a2503d7f822ee0c3e1effd58bef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->