### PR TITLE
Document ability to render function calls

### DIFF
--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -1,0 +1,88 @@
+Rendering function calls
+========================
+
+If your documentation or test suite needs to show function calls with
+literal arguments across multiple languages, :func:`literalizer.literalize_call`
+generates those calls from a single YAML, JSON, JSON5, or TOML source.
+
+Each row of a top-level list becomes a separate function call, with
+arguments formatted according to the target language's calling
+convention.
+
+Example
+-------
+
+Suppose you want to generate calls to ``throttler.check`` with two
+parameters (``user_id`` and ``ts``) and wrap each call in ``print()``:
+
+.. code-block:: python
+
+   """Generate per-language function call examples."""
+
+   import textwrap
+
+   from literalizer import InputFormat, literalize_call
+   from literalizer.languages import Python
+
+   yaml_source = """\
+   ---
+   - - user_1
+     - 1000.0
+   - - user_2
+     - 2000.5
+   """
+
+   result = literalize_call(
+       source=yaml_source,
+       input_format=InputFormat.YAML,
+       language=Python(
+           date_format=Python.date_formats.PYTHON,
+           datetime_format=Python.datetime_formats.PYTHON,
+           bytes_format=Python.bytes_formats.HEX,
+           sequence_format=Python.sequence_formats.TUPLE,
+           set_format=Python.set_formats.SET,
+           variable_type_hints=Python.variable_type_hints_formats.AUTO,
+       ),
+       call_function="throttler.check",
+       call_params=["user_id", "ts"],
+       call_wrapper=lambda c: f"print({c})",
+   )
+
+   assert result.code == textwrap.dedent(
+       text="""\
+       print(throttler.check(user_id="user_1", ts=1000.0))
+       print(throttler.check(user_id="user_2", ts=2000.5))""",
+   )
+
+Calling conventions
+-------------------
+
+Each language has a calling convention that determines how arguments are
+formatted.  There are three styles:
+
+**Keyword** (e.g. Python, Swift, Ruby):
+arguments are passed as ``name=value`` pairs.
+
+.. skip doccmd[all]: next
+
+.. code-block:: python
+
+   print(throttler.check(user_id="user_1", ts=1000.0))
+
+**Object** (e.g. JavaScript, TypeScript):
+arguments are wrapped in an object literal.
+
+.. code-block:: javascript
+
+   print(throttler.check({ user_id: "user_1", ts: 1000.0 }));
+
+**Positional** (e.g. Rust, Java, C++):
+arguments are passed by position only — parameter names are not included
+in the output.
+
+.. code-block:: rust
+
+   print(throttler.check("user_1", 1000.0));
+
+You do not need to choose a style — it is determined automatically by
+the language you pass to :func:`~literalizer.literalize_call`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,6 +81,7 @@ Reference
    :maxdepth: 3
 
    json-api-use-case
+   function-call-use-case
    api-reference
    languages
    release-process


### PR DESCRIPTION
## Summary
- Add a new docs page (`function-call-use-case.rst`) explaining `literalize_call()` with a working code example
- Document the three calling conventions: keyword, object, and positional
- Add the page to the docs toctree

Closes #1096

## Test plan
- [x] Code example in docs verified to produce correct output
- [x] Sphinx docs build successfully
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds a new docs page and updates the toctree; no runtime code paths are modified.
> 
> **Overview**
> Adds a new documentation page, `function-call-use-case`, showing how to use `literalizer.literalize_call` with a working example and explaining the three supported calling conventions (**keyword**, **object**, **positional**).
> 
> Updates the docs `index.rst` to include this new page in the reference toctree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25c81f2144e44cdd776f08233867a195d275a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->