### PR TITLE
Add Python call stubs to remove type checker exclusions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,14 +293,13 @@ strict = true
 files = [ "." ]
 exclude = [
     "build",
-    "tests/integration/cases/call_",
 ]
 plugins = [ "mypy_strict_kwargs" ]
 follow_untyped_imports = true
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
-project_excludes = [ "tests/integration/cases/call_*/" ]
+project_excludes = []
 
 [tool.pyright]
 enableTypeIgnoreComments = false
@@ -310,13 +309,13 @@ exclude = [
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 executionEnvironments = [
-    { root = "tests/integration/cases", reportUnusedExpression = false, reportUndefinedVariable = false, reportUnknownVariableType = false, reportUnknownMemberType = false, reportUnknownArgumentType = false },
+    { root = "tests/integration/cases", reportUnusedExpression = false, reportUndefinedVariable = false, reportUnknownVariableType = false },
 ]
 
 [tool.ty]
 analysis.respect-type-ignore-comments = false
 terminal.error-on-warning = true
-overrides = [ { include = [ "tests/integration/cases/call_*/*.py" ], rules.unresolved-reference = "ignore" } ]
+overrides = []
 
 [tool.pytest]
 ini_options.xfail_strict = true

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -389,6 +389,24 @@ def _build_type_hint_preamble(
     return _preamble
 
 
+def _python_call_stub(name: str, params: Sequence[str], /) -> tuple[str, ...]:
+    """Return Python stub declarations for a call name."""
+    root = name.split(sep=".", maxsplit=1)[0]
+    if root == "print":
+        return ()
+    parts = name.split(sep=".")
+    param_str = ", ".join(f"{p}: object" for p in params)
+    if len(parts) == 1:
+        return (f"def {name}(*, {param_str}) -> object: ...",)
+    root, method = parts[0], parts[1]
+    cls = f"_{root.capitalize()}Type"
+    return (
+        f"class {cls}:",
+        f"    def {method}(self, *, {param_str}) -> object: ...",
+        f"{root} = {cls}()",
+    )
+
+
 @beartype
 class Python(metaclass=LanguageCls):
     """Python language specification.
@@ -957,5 +975,5 @@ class Python(metaclass=LanguageCls):
             keyword_separator="=",
         )
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
+        self.format_call_stub = _python_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/tests/integration/cases/call_keyword_args/Python_call.py
+++ b/tests/integration/cases/call_keyword_args/Python_call.py
@@ -1,2 +1,5 @@
+class _ThrottlerType:
+    def check(self, *, user_id: object, ts: object) -> object: ...
+throttler = _ThrottlerType()
 print(throttler.check(user_id="user_1", ts=1000.0))
 print(throttler.check(user_id="user_2", ts=2000.5))

--- a/tests/integration/cases/call_scalar_args/Python_call.py
+++ b/tests/integration/cases/call_scalar_args/Python_call.py
@@ -1,3 +1,4 @@
+def process(*, value: object) -> object: ...
 process(value="hello")
 process(value=42)
 process(value=True)


### PR DESCRIPTION
## Summary

- Implement `_python_call_stub` in the Python language so call golden files define typed stubs for undefined names (`throttler`, `process`, etc.)
- Remove type checker exclusions for call golden files from `pyproject.toml` (mypy, pyright, ty, pyrefly)

Closes #1094

## Test plan

- [x] All 11761 tests pass
- [x] All four type checkers (mypy, pyright, ty, pyrefly) pass on the full project with no exclusions for call files
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect generated Python call-fixture output and static type-checker configuration, with no runtime logic or data handling changes.
> 
> **Overview**
> Adds `_python_call_stub` to the Python language backend to emit minimal `def`/`class` stub declarations for unknown call targets (skipping `print`), and wires it in via `format_call_stub`.
> 
> Removes previously-needed exclusions/overrides for `tests/integration/cases/call_*` across mypy, pyright, ty, and pyrefly, and updates the affected golden call fixtures to include the new stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5489036be8e403ad90944472aa6047aca7c20ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->