### PR TITLE
Remove __call__ from DateFormats/DatetimeFormats enums

### DIFF
--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -110,10 +110,6 @@ class Ada(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Ada."""
 
@@ -121,10 +117,6 @@ class Ada(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -368,9 +360,11 @@ class Ada(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = (
             format_string_concat_control(

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -1,6 +1,5 @@
 """Bash language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -54,6 +53,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -126,10 +126,6 @@ class Bash(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Bash."""
 
@@ -137,10 +133,6 @@ class Bash(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -367,9 +359,11 @@ class Bash(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -105,10 +105,6 @@ class C(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for C."""
 
@@ -116,10 +112,6 @@ class C(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -403,9 +395,11 @@ class C(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -1,6 +1,5 @@
 """Clojure language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -75,10 +75,6 @@ class Clojure(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Clojure."""
 
@@ -86,10 +82,6 @@ class Clojure(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -314,9 +306,11 @@ class Clojure(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -1,6 +1,5 @@
 """COBOL language specification (GnuCOBOL free-format)."""
 
-import datetime
 import enum
 import re
 from typing import TYPE_CHECKING
@@ -49,6 +48,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -249,10 +249,6 @@ class Cobol(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Cobol."""
 
@@ -260,10 +256,6 @@ class Cobol(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -500,9 +492,11 @@ class Cobol(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = _format_string_cobol
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -1,6 +1,5 @@
 """Common Lisp language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -88,10 +88,6 @@ class CommonLisp(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for CommonLisp."""
 
@@ -99,10 +95,6 @@ class CommonLisp(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -330,9 +322,11 @@ class CommonLisp(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_double_minimal
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -292,10 +292,6 @@ class Cpp(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for C++."""
 
@@ -308,10 +304,6 @@ class Cpp(metaclass=LanguageCls):
             preamble_lines=("#include <string>",),
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -618,9 +610,11 @@ class Cpp(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -1,6 +1,5 @@
 """Crystal language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable
 from types import MappingProxyType
@@ -54,6 +53,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Sequence
 
     from literalizer._types import Value
@@ -87,10 +87,6 @@ class Crystal(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Crystal."""
 
@@ -98,10 +94,6 @@ class Crystal(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -383,9 +375,11 @@ class Crystal(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash_hash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -1,7 +1,6 @@
 """C# language specification."""
 
 import dataclasses
-import datetime
 import enum
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
@@ -71,6 +70,8 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
+
     from literalizer._types import Value
 
 
@@ -148,10 +149,6 @@ class CSharp(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for C#."""
 
@@ -166,10 +163,6 @@ class CSharp(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -516,9 +509,11 @@ class CSharp(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = string_format

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -1,6 +1,5 @@
 """D language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable
 from types import MappingProxyType
@@ -57,6 +56,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Sequence
 
 
@@ -101,10 +101,6 @@ class D(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for D."""
 
@@ -112,10 +108,6 @@ class D(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -373,9 +365,11 @@ class D(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -1,6 +1,5 @@
 """Dart language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -59,6 +58,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -121,10 +121,6 @@ class Dart(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for Dart."""
 
@@ -137,10 +133,6 @@ class Dart(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -438,9 +430,11 @@ class Dart(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -1,6 +1,5 @@
 """Dhall language specification."""
 
-import datetime
 import enum
 import re
 from typing import TYPE_CHECKING
@@ -55,6 +54,7 @@ from literalizer._types import Value
 from literalizer.exceptions import InvalidDictKeyError
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 _IDENTIFIER_RE = re.compile(pattern=r"^[A-Za-z_][A-Za-z0-9_/\-]*$")
@@ -186,10 +186,6 @@ class Dhall(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Dhall."""
 
@@ -197,10 +193,6 @@ class Dhall(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -429,9 +421,11 @@ class Dhall(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = _format_dhall_string
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -131,10 +131,6 @@ class Elixir(metaclass=LanguageCls):
             formatter=date_iso_formatter(template="~D[{iso}]"),
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Elixir."""
 
@@ -143,10 +139,6 @@ class Elixir(metaclass=LanguageCls):
             type_produced=str,
         )
         ELIXIR = DatetimeFormatConfig(formatter=_format_datetime_elixir)
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -427,9 +419,11 @@ class Elixir(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash_hash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -352,10 +352,6 @@ class Elm(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Elm."""
 
@@ -363,10 +359,6 @@ class Elm(metaclass=LanguageCls):
             formatter=_format_elm_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -611,9 +603,11 @@ class Elm(metaclass=LanguageCls):
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         if constructor_prefix == "E":
             self.format_bytes: Callable[[bytes], str] = bytes_format
-            self.format_date: Callable[[datetime.date], str] = date_format
+            self.format_date: Callable[[datetime.date], str] = (
+                date_format.value.formatter
+            )
             self.format_datetime: Callable[[datetime.datetime], str] = (
-                datetime_format
+                datetime_format.value.formatter
             )
             self.format_string: Callable[[str], str] = _format_elm_string
             self.format_integer: Callable[[int], str] = integer_format

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -132,10 +132,6 @@ class Erlang(metaclass=LanguageCls):
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
         ERLANG = DateFormatConfig(formatter=_format_date_erlang)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Erlang."""
 
@@ -144,10 +140,6 @@ class Erlang(metaclass=LanguageCls):
             type_produced=str,
         )
         ERLANG = DatetimeFormatConfig(formatter=_format_datetime_erlang)
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -400,9 +392,11 @@ class Erlang(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -164,10 +164,6 @@ class Forth(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options."""
 
@@ -175,10 +171,6 @@ class Forth(metaclass=LanguageCls):
             formatter=_format_datetime_forth,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -406,9 +398,11 @@ class Forth(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -191,10 +191,6 @@ class Fortran(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Fortran."""
 
@@ -202,10 +198,6 @@ class Fortran(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -515,9 +507,11 @@ class Fortran(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = (
             format_string_concat_control(

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -187,10 +187,6 @@ class FSharp(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for FSharp."""
 
@@ -204,10 +200,6 @@ class FSharp(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -500,9 +492,11 @@ class FSharp(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -322,10 +322,6 @@ class Gleam(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Gleam."""
 
@@ -333,10 +329,6 @@ class Gleam(metaclass=LanguageCls):
             formatter=_format_gleam_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -664,9 +656,11 @@ class Gleam(metaclass=LanguageCls):
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         if constructor_prefix == "G":
             self.format_bytes: Callable[[bytes], str] = bytes_format
-            self.format_date: Callable[[datetime.date], str] = date_format
+            self.format_date: Callable[[datetime.date], str] = (
+                date_format.value.formatter
+            )
             self.format_datetime: Callable[[datetime.datetime], str] = (
-                datetime_format
+                datetime_format.value.formatter
             )
             self.format_string: Callable[[str], str] = _format_gleam_string
             self.format_integer: Callable[[int], str] = (

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -159,10 +159,6 @@ class Go(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Go."""
 
@@ -174,10 +170,6 @@ class Go(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -505,9 +497,11 @@ class Go(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = format_string_backslash

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -1,6 +1,5 @@
 """Groovy language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -53,6 +52,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -77,10 +77,6 @@ class Groovy(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Groovy."""
 
@@ -88,10 +84,6 @@ class Groovy(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -331,9 +323,11 @@ class Groovy(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -367,10 +367,6 @@ class Haskell(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Haskell."""
 
@@ -380,10 +376,6 @@ class Haskell(metaclass=LanguageCls):
             preamble_lines=("{-# LANGUAGE OverloadedStrings #-}",),
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -659,7 +651,7 @@ class Haskell(metaclass=LanguageCls):
                 )
             )
         else:
-            self.format_date = date_format
+            self.format_date = date_format.value.formatter
         if datetime_format.name == "HASKELL":
             self.format_datetime: Callable[[datetime.datetime], str] = (
                 _build_haskell_datetime_formatter(
@@ -667,7 +659,7 @@ class Haskell(metaclass=LanguageCls):
                 )
             )
         else:
-            self.format_datetime = datetime_format
+            self.format_datetime = datetime_format.value.formatter
         self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,
             control_char_fmt="\\x{:02x}",

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -1,6 +1,5 @@
 """HCL (HashiCorp Configuration Language) language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -75,10 +75,6 @@ class Hcl(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Hcl."""
 
@@ -86,10 +82,6 @@ class Hcl(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -318,9 +310,11 @@ class Hcl(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash_hcl
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -181,10 +181,6 @@ class Java(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for Java."""
 
@@ -205,10 +201,6 @@ class Java(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -543,9 +535,11 @@ class Java(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = dict_format.value
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -1,9 +1,9 @@
 """JavaScript language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 from beartype import beartype
 
@@ -64,6 +64,9 @@ from literalizer._language import (
 )
 from literalizer._types import Value
 
+if TYPE_CHECKING:
+    import datetime
+
 
 def _js_call_stub(name: str, _params: Sequence[str], /) -> tuple[str, ...]:
     """Return JavaScript stub declarations for a call name."""
@@ -113,10 +116,6 @@ class JavaScript(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for JavaScript."""
 
@@ -129,10 +128,6 @@ class JavaScript(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -430,9 +425,11 @@ class JavaScript(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = dict_format.value
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = string_format

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -1,6 +1,5 @@
 """JSON5 language specification."""
 
-import datetime
 import enum
 import functools
 import re
@@ -56,6 +55,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -107,10 +107,6 @@ class Json5(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Json5."""
 
@@ -118,10 +114,6 @@ class Json5(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -343,9 +335,11 @@ class Json5(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -1,6 +1,5 @@
 """Jsonnet language specification."""
 
-import datetime
 import enum
 import functools
 import re
@@ -55,6 +54,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -105,10 +105,6 @@ class Jsonnet(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Jsonnet."""
 
@@ -116,10 +112,6 @@ class Jsonnet(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -345,9 +337,11 @@ class Jsonnet(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -1,6 +1,5 @@
 """Julia language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable
 from types import MappingProxyType
@@ -64,6 +63,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Sequence
 
     from literalizer._types import Value
@@ -117,10 +117,6 @@ class Julia(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for Julia."""
 
@@ -135,10 +131,6 @@ class Julia(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -427,9 +419,11 @@ class Julia(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = dict_format.value
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -236,10 +236,6 @@ class Kotlin(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Kotlin."""
 
@@ -254,10 +250,6 @@ class Kotlin(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -625,9 +617,11 @@ class Kotlin(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = (

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -116,10 +116,6 @@ class Lua(metaclass=LanguageCls):
         LUA = DateFormatConfig(formatter=_format_date_lua)
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Lua."""
 
@@ -128,10 +124,6 @@ class Lua(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -373,9 +365,11 @@ class Lua(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -177,10 +177,6 @@ class Matlab(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Matlab."""
 
@@ -189,10 +185,6 @@ class Matlab(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -426,9 +418,11 @@ class Matlab(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = dict_format.value
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = (
             format_string_concat_control(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -1,6 +1,5 @@
 """Mojo language specification."""
 
-import datetime
 import enum
 import textwrap
 from typing import TYPE_CHECKING
@@ -56,6 +55,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -95,10 +95,6 @@ class Mojo(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Mojo."""
 
@@ -106,10 +102,6 @@ class Mojo(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -392,9 +384,11 @@ class Mojo(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -171,10 +171,6 @@ class Nim(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Nim."""
 
@@ -191,10 +187,6 @@ class Nim(metaclass=LanguageCls):
             preamble_lines=("import json",),
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -480,9 +472,11 @@ class Nim(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -1,6 +1,5 @@
 """Norg language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -85,10 +85,6 @@ class Norg(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Norg."""
 
@@ -96,10 +92,6 @@ class Norg(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -326,9 +318,11 @@ class Norg(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -1,7 +1,6 @@
 """Objective-C language specification."""
 
 import base64
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -52,6 +51,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -131,10 +131,6 @@ class ObjectiveC(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for ObjectiveC."""
 
@@ -145,10 +141,6 @@ class ObjectiveC(metaclass=LanguageCls):
             formatter=datetime_iso_formatter(template='@"{iso}"'),
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -386,9 +378,11 @@ class ObjectiveC(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = _format_objc_string
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -177,10 +177,6 @@ class OCaml(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for OCaml."""
 
@@ -194,10 +190,6 @@ class OCaml(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -493,9 +485,11 @@ class OCaml(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         if date_format.name == "OCAML":
             self.format_date = date_ymd_formatter(

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -91,10 +91,6 @@ class Occam(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Occam."""
 
@@ -102,10 +98,6 @@ class Occam(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -346,9 +338,11 @@ class Occam(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -1,6 +1,5 @@
 """Odin language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable
 from types import MappingProxyType
@@ -60,6 +59,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Sequence
 
 
@@ -91,10 +91,6 @@ class Odin(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Odin."""
 
@@ -102,10 +98,6 @@ class Odin(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -401,9 +393,11 @@ class Odin(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -129,10 +129,6 @@ class Perl(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Perl."""
 
@@ -144,10 +140,6 @@ class Perl(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -412,9 +404,11 @@ class Perl(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -1,6 +1,5 @@
 """PHP language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable
 from types import MappingProxyType
@@ -65,6 +64,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Sequence
 
     from literalizer._types import Value
@@ -92,10 +92,6 @@ class Php(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Php."""
 
@@ -108,10 +104,6 @@ class Php(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -386,9 +378,11 @@ class Php(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -1,6 +1,5 @@
 """PowerShell language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -100,10 +100,6 @@ class PowerShell(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for PowerShell."""
 
@@ -111,10 +107,6 @@ class PowerShell(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -343,9 +335,11 @@ class PowerShell(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = _format_string
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -387,10 +387,6 @@ class PureScript(metaclass=LanguageCls):
             type_produced=str,
         )
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for PureScript."""
 
@@ -398,10 +394,6 @@ class PureScript(metaclass=LanguageCls):
             formatter=_format_purescript_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -648,9 +640,11 @@ class PureScript(metaclass=LanguageCls):
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         if constructor_prefix == "P":
             self.format_bytes: Callable[[bytes], str] = bytes_format
-            self.format_date: Callable[[datetime.date], str] = date_format
+            self.format_date: Callable[[datetime.date], str] = (
+                date_format.value.formatter
+            )
             self.format_datetime: Callable[[datetime.datetime], str] = (
-                datetime_format
+                datetime_format.value.formatter
             )
             self.format_string: Callable[[str], str] = (
                 _format_purescript_string

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -477,10 +477,6 @@ class Python(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
         @property
         def type_hint(self) -> str:
             """The Python type hint for this date format."""
@@ -496,10 +492,6 @@ class Python(metaclass=LanguageCls):
             preamble_lines=("import datetime",),
         )
         EPOCH = DatetimeFormatConfig(formatter=_format_datetime_epoch)
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
         @property
         def type_hint(self) -> str:
@@ -859,9 +851,11 @@ class Python(metaclass=LanguageCls):
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
 
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = string_format

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -1,6 +1,5 @@
 """R language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -56,6 +55,7 @@ from literalizer._types import Value
 from literalizer.exceptions import InvalidDictKeyError
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -135,10 +135,6 @@ class R(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for R."""
 
@@ -151,10 +147,6 @@ class R(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class EmptyDictKey(enum.Enum):
         """How to handle empty-string dict keys in R.
@@ -393,9 +385,11 @@ class R(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -1,6 +1,5 @@
 """Racket language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -75,10 +75,6 @@ class Racket(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Racket."""
 
@@ -86,10 +82,6 @@ class Racket(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -318,9 +310,11 @@ class Racket(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -130,10 +130,6 @@ class Raku(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Raku."""
 
@@ -145,10 +141,6 @@ class Raku(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -413,9 +405,11 @@ class Raku(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -1,6 +1,5 @@
 """Ruby language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
@@ -66,6 +65,8 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
+
     from literalizer._types import Value
 
 
@@ -130,10 +131,6 @@ class Ruby(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Ruby."""
 
@@ -147,10 +144,6 @@ class Ruby(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -427,9 +420,11 @@ class Ruby(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = string_format

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -179,10 +179,6 @@ class Rust(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Rust."""
 
@@ -198,10 +194,6 @@ class Rust(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -555,9 +547,11 @@ class Rust(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = string_format

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -188,10 +188,6 @@ class Scala(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Scala."""
 
@@ -206,10 +202,6 @@ class Scala(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -547,9 +539,11 @@ class Scala(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -1,6 +1,5 @@
 """Scheme language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -75,10 +75,6 @@ class Scheme(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Scheme."""
 
@@ -86,10 +82,6 @@ class Scheme(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -318,9 +310,11 @@ class Scheme(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -244,10 +244,6 @@ class Sml(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Standard ML."""
 
@@ -261,10 +257,6 @@ class Sml(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -531,9 +523,11 @@ class Sml(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         if date_format.name == "SML":
             self.format_date = date_ymd_formatter(

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -134,10 +134,6 @@ class Swift(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Swift."""
 
@@ -149,10 +145,6 @@ class Swift(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -466,9 +458,11 @@ class Swift(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -126,10 +126,6 @@ class SystemVerilog(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for SystemVerilog."""
 
@@ -137,10 +133,6 @@ class SystemVerilog(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -376,9 +368,11 @@ class SystemVerilog(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = format_string_backslash
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -1,6 +1,5 @@
 """Tcl language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -51,6 +50,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -119,10 +119,6 @@ class Tcl(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options."""
 
@@ -130,10 +126,6 @@ class Tcl(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -359,9 +351,11 @@ class Tcl(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -1,6 +1,5 @@
 """TOML language specification."""
 
-import datetime
 import enum
 import functools
 import re
@@ -58,6 +57,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -110,10 +110,6 @@ class Toml(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Toml."""
 
@@ -124,10 +120,6 @@ class Toml(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -349,9 +341,11 @@ class Toml(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -1,9 +1,9 @@
 """TypeScript language specification."""
 
-import datetime
 import enum
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 from beartype import beartype
 
@@ -63,6 +63,9 @@ from literalizer._language import (
 )
 from literalizer._types import Value
 
+if TYPE_CHECKING:
+    import datetime
+
 
 def _ts_call_stub(name: str, _params: Sequence[str], /) -> tuple[str, ...]:
     """Return TypeScript stub declarations for a call name."""
@@ -116,10 +119,6 @@ class TypeScript(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime formatting options for TypeScript."""
 
@@ -132,10 +131,6 @@ class TypeScript(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -451,9 +446,11 @@ class TypeScript(metaclass=LanguageCls):
         self.dict_format_config: DictFormatConfig = dict_format.value
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
 
         self.format_string: Callable[[str], str] = string_format

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -1,6 +1,5 @@
 """V language specification."""
 
-import datetime
 import enum
 import textwrap
 from collections.abc import Callable
@@ -60,6 +59,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Sequence
 
     from literalizer._types import Value
@@ -93,10 +93,6 @@ class V(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for V."""
 
@@ -104,10 +100,6 @@ class V(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -375,9 +367,11 @@ class V(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = (
             format_string_backslash_dollar_single

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -1,6 +1,5 @@
 """Visual Basic (.NET) language specification."""
 
-import datetime
 import enum
 import textwrap
 from typing import TYPE_CHECKING
@@ -56,6 +55,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -153,10 +153,6 @@ class VisualBasic(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for VisualBasic."""
 
@@ -164,10 +160,6 @@ class VisualBasic(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -463,9 +455,11 @@ class VisualBasic(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = _format_string_vb
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -1,6 +1,5 @@
 """Wren language specification."""
 
-import datetime
 import enum
 from typing import TYPE_CHECKING
 
@@ -54,6 +53,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
 
@@ -85,10 +85,6 @@ class Wren(metaclass=LanguageCls):
 
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Wren."""
 
@@ -96,10 +92,6 @@ class Wren(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -340,9 +332,11 @@ class Wren(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = string_format
         self.format_float: Callable[[float], str] = float_format

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -1,6 +1,5 @@
 """YAML language specification."""
 
-import datetime
 import enum
 import functools
 from typing import TYPE_CHECKING
@@ -56,6 +55,7 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Sequence
 
     from literalizer._types import Value
@@ -91,10 +91,6 @@ class Yaml(metaclass=LanguageCls):
         )
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Yaml."""
 
@@ -105,10 +101,6 @@ class Yaml(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -333,9 +325,11 @@ class Yaml(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -146,10 +146,6 @@ class Zig(metaclass=LanguageCls):
         ZIG = DateFormatConfig(formatter=_format_date_zig)
         ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
 
-        def __call__(self, date_value: datetime.date, /) -> str:
-            """Format a date."""
-            return self.value.formatter(date_value)
-
     class DatetimeFormats(enum.Enum):
         """Datetime format options for Zig."""
 
@@ -158,10 +154,6 @@ class Zig(metaclass=LanguageCls):
             formatter=format_datetime_iso,
             type_produced=str,
         )
-
-        def __call__(self, dt_value: datetime.datetime, /) -> str:
-            """Format a datetime."""
-            return self.value.formatter(dt_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""
@@ -429,9 +421,11 @@ class Zig(metaclass=LanguageCls):
         )
         self.trailing_comma_config: TrailingCommaConfig = trailing_comma.value
         self.format_bytes: Callable[[bytes], str] = bytes_format
-        self.format_date: Callable[[datetime.date], str] = date_format
+        self.format_date: Callable[[datetime.date], str] = (
+            date_format.value.formatter
+        )
         self.format_datetime: Callable[[datetime.datetime], str] = (
-            datetime_format
+            datetime_format.value.formatter
         )
         self.format_string: Callable[[str], str] = functools.partial(
             format_string_backslash_control,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -762,13 +762,27 @@ def _build_type_hints_cross_variants() -> list[_Variant]:
         ),
         (
             "date",
-            lambda s: s.format_date,
+            lambda s: next(
+                (
+                    m
+                    for m in s.date_formats
+                    if m.value.formatter is s.format_date
+                ),
+                None,
+            ),
             lambda s: s.date_formats,
             "date_format",
         ),
         (
             "dt",
-            lambda s: s.format_datetime,
+            lambda s: next(
+                (
+                    m
+                    for m in s.datetime_formats
+                    if m.value.formatter is s.format_datetime
+                ),
+                None,
+            ),
             lambda s: s.datetime_formats,
             "datetime_format",
         ),
@@ -822,13 +836,23 @@ def _build_variant_cases() -> list[_VariantCase]:
     nv = _build_non_default_variants
     date = nv(
         category="date",
-        get_default=lambda s: s.format_date,
+        get_default=lambda s: next(
+            (m for m in s.date_formats if m.value.formatter is s.format_date),
+            None,
+        ),
         get_formats=lambda s: s.date_formats,
         make_spec=lambda cls, fmt: cls(date_format=fmt),
     )
     datetime_ = nv(
         category="datetime",
-        get_default=lambda s: s.format_datetime,
+        get_default=lambda s: next(
+            (
+                m
+                for m in s.datetime_formats
+                if m.value.formatter is s.format_datetime
+            ),
+            None,
+        ),
         get_formats=lambda s: s.datetime_formats,
         make_spec=lambda cls, fmt: cls(datetime_format=fmt),
     )


### PR DESCRIPTION
## Summary
- Remove identical `__call__` methods from `DateFormats` and `DatetimeFormats` enums across all 61 language files
- Store `date_format.value.formatter` / `datetime_format.value.formatter` (the underlying callable) directly instead of the enum member
- Update test helpers to find the default format enum member by matching `.value.formatter` identity, since `format_date`/`format_datetime` are now plain callables rather than enum members
- Move `import datetime` into `TYPE_CHECKING` blocks in 32 files where it's no longer needed at runtime

## Test plan
- [x] All 522 unit tests pass
- [x] All 11239 integration tests pass (2 skipped)
- [x] Pre-commit hooks pass (ruff, mypy, pyright, pyright-verifytypes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches date/datetime formatting initialization across many language specs, so any mismatch in selecting/storing the formatter could subtly change emitted literals or preambles. No new functionality, but the wide sweep increases regression risk.
> 
> **Overview**
> **Removes duplicated `__call__` implementations** from `DateFormats`/`DatetimeFormats` enums across language specs and stops treating enum members as callables.
> 
> Language initializers now **store the underlying formatter function** (`date_format.value.formatter` / `datetime_format.value.formatter`) in `format_date` and `format_datetime`, and several modules move runtime `import datetime` into `TYPE_CHECKING` where only used for annotations.
> 
> Integration test variant builders are updated to **infer the default date/datetime enum member by identity-matching** the stored `format_*` callable against each enum member’s `.value.formatter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2fa06cdee4f4e6ea970eac548241351dba8bc3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->