### PR TITLE
Add function call rendering to Java

### DIFF
--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -69,6 +69,22 @@ from literalizer._types import Value
 from literalizer.exceptions import NullInCollectionError
 
 
+def _java_call_stub(name: str, _params: Sequence[str], /) -> tuple[str, ...]:
+    """Return Java stub declarations for a call name."""
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (
+            f"static Object {parts[0]}(Object... args) {{ return null; }}",
+        )
+    root, method = parts[0], parts[1]
+    type_name = f"{root.title()}Type_"
+    return (
+        f"static class {type_name} {{"
+        f" Object {method}(Object... args) {{ return null; }} }}",
+        f"static {type_name} {root} = new {type_name}();",
+    )
+
+
 @beartype
 def _format_datetime_java_zoned(value: datetime.datetime) -> str:
     """Format a datetime as a Java ``ZonedDateTime.of(...)`` call."""
@@ -651,12 +667,22 @@ class Java(metaclass=LanguageCls):
     ) -> str:
         """Wrap a Java declaration in a static method."""
         del variable_name
+        # Lines starting with "static " are class-level declarations
+        # (call stubs); everything else goes inside the method body.
+        class_lines = [
+            line for line in body_preamble if line.startswith("static ")
+        ]
+        method_lines = tuple(
+            line for line in body_preamble if not line.startswith("static ")
+        )
         content = prepend_body_preamble(
             content=content,
-            body_preamble=body_preamble,
+            body_preamble=method_lines,
         )
+        class_block = "\n".join(class_lines) + "\n" if class_lines else ""
         return (
             "class Check {\n"
+            f"{class_block}"
             "    public static void check() {\n"
             f"{content}\n"
             "    }\n"
@@ -840,5 +866,5 @@ class Java(metaclass=LanguageCls):
             kind=CallStyleKind.POSITIONAL,
         )
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
+        self.format_call_stub = _java_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/tests/integration/cases/call_keyword_args/Java_call.java
+++ b/tests/integration/cases/call_keyword_args/Java_call.java
@@ -1,0 +1,9 @@
+class Check {
+static class ThrottlerType_ { Object check(Object... args) { return null; } }
+static ThrottlerType_ throttler = new ThrottlerType_();
+static Object print(Object... args) { return null; }
+    public static void check() {
+print(throttler.check("user_1", 1000.0));
+print(throttler.check("user_2", 2000.5));
+    }
+}

--- a/tests/integration/cases/call_scalar_args/Java_call.java
+++ b/tests/integration/cases/call_scalar_args/Java_call.java
@@ -1,0 +1,8 @@
+class Check {
+static Object process(Object... args) { return null; }
+    public static void check() {
+process("hello");
+process(42);
+process(true);
+    }
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1325,6 +1325,7 @@ _CALL_LANGUAGES: frozenset[str] = frozenset(
         "FSharp",
         "Go",
         "Groovy",
+        "Java",
         "JavaScript",
         "Julia",
         "Kotlin",


### PR DESCRIPTION
## Summary
- Implement `_java_call_stub` for generating Java-compatible stub declarations for function and method calls
- Modify `Java.wrap_in_file` to place `static` stub declarations at class level (between `class Check {` and the `check()` method) while keeping other body preamble lines inside the method
- Add Java to `_CALL_LANGUAGES` test set and generate golden files for both `call_keyword_args` and `call_scalar_args` cases

Closes #1125

## Test plan
- [x] Both golden files compile with `javac`
- [x] All 556 Java integration tests pass (including 2 new call tests)
- [x] Dead golden files check passes
- [x] Pre-commit hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Java code generation to emit new `static` call stubs and adjusts wrapper structure, which could affect compilation or formatting of Java outputs beyond call tests.
> 
> **Overview**
> Adds Java support for `literalize_call` by implementing `_java_call_stub` to generate `static` stub declarations for both simple function calls and dotted method calls.
> 
> Updates `Java.wrap_in_file` to split `body_preamble` so `static ...` stub lines are emitted at class scope (outside `check()`), while other preamble lines remain inside the method.
> 
> Extends integration coverage by including `Java` in `_CALL_LANGUAGES` and adding new Java golden files for `call_scalar_args` and `call_keyword_args`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7487e62f652f1797f428a44ba1ec8b91658b8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->