### PR TITLE
Rename call_wrapper to call_transform

### DIFF
--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -45,7 +45,7 @@ parameters (``user_id`` and ``ts``) and wrap each call in ``print()``:
        ),
        call_function="throttler.check",
        call_params=["user_id", "ts"],
-       call_wrapper=lambda c: f"print({c})",
+       call_transform=lambda c: f"print({c})",
    )
 
    assert result.code == textwrap.dedent(

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1172,13 +1172,13 @@ def _assemble_call(
     *,
     call_function: str,
     args_str: str,
-    call_wrapper: Callable[[str], str] | None,
+    call_transform: Callable[[str], str] | None,
     statement_terminator: str,
 ) -> str:
-    """Build one complete call statement, optionally wrapped."""
+    """Build one complete call statement, optionally transformed."""
     call_expr = f"{call_function}{args_str}"
-    if call_wrapper is not None:
-        call_expr = call_wrapper(call_expr)
+    if call_transform is not None:
+        call_expr = call_transform(call_expr)
     return f"{call_expr}{statement_terminator}"
 
 
@@ -1190,7 +1190,7 @@ def literalize_call(
     language: Language,
     call_function: str,
     call_params: Sequence[str],
-    call_wrapper: Callable[[str], str] | None = None,
+    call_transform: Callable[[str], str] | None = None,
     per_element: bool = True,
 ) -> LiteralizeResult:
     r"""Convert data to function call expressions in the target language.
@@ -1210,8 +1210,8 @@ def literalize_call(
             element in each row.  For :attr:`CallStyleKind.POSITIONAL`
             languages these are unused in the output but still
             determine how many values to expect per row.
-        call_wrapper: Optional callable wrapping each call expression.
-            Receives the bare call string and returns the wrapped
+        call_transform: Optional callable transforming each call expression.
+            Receives the bare call string and returns the transformed
             version (e.g. ``lambda c: f"print({c})"``).
         per_element: If ``True`` (default), each top-level list element
             becomes a separate call.  If ``False``, the whole
@@ -1240,7 +1240,7 @@ def literalize_call(
                 _assemble_call(
                     call_function=call_function,
                     args_str=args_str,
-                    call_wrapper=call_wrapper,
+                    call_transform=call_transform,
                     statement_terminator=language.statement_terminator,
                 )
             )
@@ -1257,7 +1257,7 @@ def literalize_call(
         result = _assemble_call(
             call_function=call_function,
             args_str=args_str,
-            call_wrapper=call_wrapper,
+            call_transform=call_transform,
             statement_terminator=language.statement_terminator,
         )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -407,8 +407,8 @@ class _CallCaseConfig:
     case_dir_name: str
     call_function: str
     call_params: list[str]
-    call_wrapper: Callable[[str], str] | None
-    wrapper_stub_names: list[str]
+    call_transform: Callable[[str], str] | None
+    transform_stub_names: list[str]
     per_element: bool
 
 
@@ -417,16 +417,16 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         case_dir_name="call_keyword_args",
         call_function="throttler.check",
         call_params=["user_id", "ts"],
-        call_wrapper=lambda c: f"print({c})",
-        wrapper_stub_names=["print"],
+        call_transform=lambda c: f"print({c})",
+        transform_stub_names=["print"],
         per_element=True,
     ),
     _CallCaseConfig(
         case_dir_name="call_scalar_args",
         call_function="process",
         call_params=["value"],
-        call_wrapper=None,
-        wrapper_stub_names=[],
+        call_transform=None,
+        transform_stub_names=[],
         per_element=True,
     ),
 ]
@@ -1382,7 +1382,7 @@ def test_call_golden_file(
         language=spec,
         call_function=config.call_function,
         call_params=config.call_params,
-        call_wrapper=config.call_wrapper,
+        call_transform=config.call_transform,
         per_element=config.per_element,
     )
     # Build stub declarations for undefined names.
@@ -1397,8 +1397,8 @@ def test_call_golden_file(
             config.call_function, config.call_params
         ),
     )
-    # Stubs for wrapper function names (single argument).
-    for wrapper_name in config.wrapper_stub_names:
+    # Stubs for transform function names (single argument).
+    for wrapper_name in config.transform_stub_names:
         body_stubs.extend(
             spec.format_call_stub(wrapper_name, ["_arg"]),
         )


### PR DESCRIPTION
## Summary
- Rename `call_wrapper` parameter to `call_transform` in `literalize_call` and `_assemble_call`, since the callable has no requirement to wrap anything — it can perform any transformation on the call expression string.
- Rename `wrapper_stub_names` to `transform_stub_names` in tests for consistency.
- Update docstrings and docs to reflect the new naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API parameter renames (`call_wrapper`→`call_transform`) are breaking for downstream callers and could cause runtime TypeErrors until updated. Functional behavior is unchanged aside from the renamed hook and updated test stubbing.
> 
> **Overview**
> Renames the `literalize_call` customization hook from `call_wrapper` to `call_transform` (and the internal `_assemble_call` parameter) to reflect that the callable can apply any transformation, not just wrapping.
> 
> Updates integration tests and docs accordingly, including renaming `wrapper_stub_names` to `transform_stub_names` and adjusting golden-call case configuration to use the new parameter name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e6db2adc6d541de944b0912d6dfbbdd8b1063c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->