### PR TITLE
Mention literalize_call in use cases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Use cases
 
 * Generate test fixtures from JSON, JSON5, YAML, or TOML samples.
 * Generate multi-language request/response examples for API docs (see `guide <https://adamtheturtle.github.io/literalizer/json-api-use-case.html>`__).
+* Generate multi-language function call examples from data (see `guide <https://adamtheturtle.github.io/literalizer/function-call-use-case.html>`__).
 * Create type-safe literal data from JSON, JSON5, YAML, or TOML config files.
 
 CLI

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,7 @@ Use cases
 
 * Generate test fixtures from JSON, JSON5, YAML, or TOML samples.
 * Convert API responses to language-native data structures for documentation.
+* Generate multi-language function call examples from data — see :doc:`function-call-use-case`.
 * Create type-safe literal data from JSON, JSON5, YAML, or TOML config files.
 
 CLI


### PR DESCRIPTION
## Summary

- Add `literalize_call` to the "Use cases" sections in README.rst and docs/source/index.rst, linking to the existing function-call-use-case guide.

The detailed guide already existed but wasn't referenced from the main entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds an additional use-case link; no runtime or API behavior is affected.
> 
> **Overview**
> Highlights `literalize_call` as an additional supported use case by adding a function-call example entry to the *Use cases* lists in `README.rst` and `docs/source/index.rst`, linking to the existing `function-call-use-case` guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50cbfe504538d656bb352425732c952af233515d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->