### PR TITLE
Cache Octave apt package in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -902,7 +902,10 @@ jobs:
           lang_patterns: tests/integration/cases/**/Matlab*.m
       - name: Install Octave
         if: steps.find-files.outputs.found == 'true'
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq octave
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: octave
+          version: 1.0
       # Octave is a practical CI substitute, but it does not support
       # every MATLAB builtin.  Skip files that use features Octave lacks:
       #  - datetime(): not yet implemented in Octave


### PR DESCRIPTION
## Summary

- Replace the bare `apt-get update && apt-get install octave` step with `awalsh128/cache-apt-pkgs-action`, which caches installed apt packages between CI runs
- After the first run populates the cache, subsequent runs restore Octave from cache instead of re-downloading and installing, significantly speeding up the lint-matlab job

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that swaps Octave installation to an apt package caching action; low functional risk but could cause CI failures if the third-party action misbehaves.
> 
> **Overview**
> Speeds up the `lint-matlab` GitHub Actions job by replacing the `apt-get install octave` step with `awalsh128/cache-apt-pkgs-action`, caching the Octave package between runs.
> 
> No lint logic changes—only how Octave is provisioned in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4dd9db034fb187ae8ca5fd168dddcd50bd6df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->