### PR TITLE
Rename `call_function` to `callee` and `call_params` to `parameter_names`

### DIFF
--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -43,8 +43,8 @@ parameters (``user_id`` and ``ts``) and wrap each call in ``print()``:
            set_format=Python.set_formats.SET,
            variable_type_hints=Python.variable_type_hints_formats.AUTO,
        ),
-       call_function="throttler.check",
-       call_params=["user_id", "ts"],
+       callee="throttler.check",
+       parameter_names=["user_id", "ts"],
        call_transform=lambda c: f"print({c})",
    )
 

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -43,7 +43,7 @@ parameters (``user_id`` and ``ts``) and wrap each call in ``print()``:
            set_format=Python.set_formats.SET,
            variable_type_hints=Python.variable_type_hints_formats.AUTO,
        ),
-       callee="throttler.check",
+       target_function="throttler.check",
        parameter_names=["user_id", "ts"],
        call_transform=lambda c: f"print({c})",
    )

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -111,7 +111,6 @@ backticks
 beartype
 bool
 booleans
-callee
 chrono
 coercions
 commonjs

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -111,6 +111,7 @@ backticks
 beartype
 bool
 booleans
+callee
 chrono
 coercions
 commonjs

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1170,13 +1170,13 @@ def _format_call_args(
 @beartype
 def _assemble_call(
     *,
-    call_function: str,
+    callee: str,
     args_str: str,
     call_transform: Callable[[str], str] | None,
     statement_terminator: str,
 ) -> str:
     """Build one complete call statement, optionally transformed."""
-    call_expr = f"{call_function}{args_str}"
+    call_expr = f"{callee}{args_str}"
     if call_transform is not None:
         call_expr = call_transform(call_expr)
     return f"{call_expr}{statement_terminator}"
@@ -1188,8 +1188,8 @@ def literalize_call(
     source: str,
     input_format: InputFormat,
     language: Language,
-    call_function: str,
-    call_params: Sequence[str],
+    callee: str,
+    parameter_names: Sequence[str],
     call_transform: Callable[[str], str] | None = None,
     per_element: bool = True,
 ) -> LiteralizeResult:
@@ -1204,9 +1204,9 @@ def literalize_call(
         input_format: The serialization format of *source*.
         language: A :class:`Language` instance describing how to format
             literals.
-        call_function: The function expression to call
+        callee: The function expression to call
             (e.g. ``"throttler.should_send_notification"``).
-        call_params: Parameter names, positionally mapped to each
+        parameter_names: Parameter names, positionally mapped to each
             element in each row.  For :attr:`CallStyleKind.POSITIONAL`
             languages these are unused in the output but still
             determine how many values to expect per row.
@@ -1240,12 +1240,12 @@ def literalize_call(
             arg_values = element if isinstance(element, list) else [element]
             args_str = _format_call_args(
                 values=cast("list[Value]", arg_values),
-                params=call_params,
+                params=parameter_names,
                 language=language,
             )
             lines.append(
                 _assemble_call(
-                    call_function=call_function,
+                    callee=callee,
                     args_str=args_str,
                     call_transform=call_transform,
                     statement_terminator=language.statement_terminator,
@@ -1262,7 +1262,7 @@ def literalize_call(
         )
         args_str = f"({lit})"
         result = _assemble_call(
-            call_function=call_function,
+            callee=callee,
             args_str=args_str,
             call_transform=call_transform,
             statement_terminator=language.statement_terminator,

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1170,13 +1170,13 @@ def _format_call_args(
 @beartype
 def _assemble_call(
     *,
-    callee: str,
+    target_function: str,
     args_str: str,
     call_transform: Callable[[str], str] | None,
     statement_terminator: str,
 ) -> str:
     """Build one complete call statement, optionally transformed."""
-    call_expr = f"{callee}{args_str}"
+    call_expr = f"{target_function}{args_str}"
     if call_transform is not None:
         call_expr = call_transform(call_expr)
     return f"{call_expr}{statement_terminator}"
@@ -1188,7 +1188,7 @@ def literalize_call(
     source: str,
     input_format: InputFormat,
     language: Language,
-    callee: str,
+    target_function: str,
     parameter_names: Sequence[str],
     call_transform: Callable[[str], str] | None = None,
     per_element: bool = True,
@@ -1204,7 +1204,7 @@ def literalize_call(
         input_format: The serialization format of *source*.
         language: A :class:`Language` instance describing how to format
             literals.
-        callee: The function expression to call
+        target_function: The function expression to call
             (e.g. ``"throttler.should_send_notification"``).
         parameter_names: Parameter names, positionally mapped to each
             element in each row.  For :attr:`CallStyleKind.POSITIONAL`
@@ -1245,7 +1245,7 @@ def literalize_call(
             )
             lines.append(
                 _assemble_call(
-                    callee=callee,
+                    target_function=target_function,
                     args_str=args_str,
                     call_transform=call_transform,
                     statement_terminator=language.statement_terminator,
@@ -1262,7 +1262,7 @@ def literalize_call(
         )
         args_str = f"({lit})"
         result = _assemble_call(
-            callee=callee,
+            target_function=target_function,
             args_str=args_str,
             call_transform=call_transform,
             statement_terminator=language.statement_terminator,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -405,7 +405,7 @@ class _CallCaseConfig:
     """Configuration for a ``literalize_call`` golden-file test case."""
 
     case_dir_name: str
-    callee: str
+    target_function: str
     parameter_names: list[str]
     call_transform: Callable[[str], str] | None
     transform_stub_names: list[str]
@@ -415,7 +415,7 @@ class _CallCaseConfig:
 _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
     _CallCaseConfig(
         case_dir_name="call_keyword_args",
-        callee="throttler.check",
+        target_function="throttler.check",
         parameter_names=["user_id", "ts"],
         call_transform=lambda c: f"emit({c})",
         transform_stub_names=["emit"],
@@ -423,7 +423,7 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
     ),
     _CallCaseConfig(
         case_dir_name="call_scalar_args",
-        callee="process",
+        target_function="process",
         parameter_names=["value"],
         call_transform=None,
         transform_stub_names=[],
@@ -1357,7 +1357,7 @@ def test_call_golden_file(
         source=yaml_string,
         input_format=literalizer.InputFormat.YAML,
         language=spec,
-        callee=config.callee,
+        target_function=config.target_function,
         parameter_names=config.parameter_names,
         call_transform=config.call_transform,
         per_element=config.per_element,
@@ -1367,10 +1367,13 @@ def test_call_golden_file(
     preamble_stubs: list[str] = []
     # Stubs for the call function (with full parameter names).
     body_stubs.extend(
-        spec.format_call_stub(config.callee, config.parameter_names),
+        spec.format_call_stub(config.target_function, config.parameter_names),
     )
     preamble_stubs.extend(
-        spec.format_call_preamble_stub(config.callee, config.parameter_names),
+        spec.format_call_preamble_stub(
+            config.target_function,
+            config.parameter_names,
+        ),
     )
     # Stubs for transform function names (single argument).
     for wrapper_name in config.transform_stub_names:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -405,8 +405,8 @@ class _CallCaseConfig:
     """Configuration for a ``literalize_call`` golden-file test case."""
 
     case_dir_name: str
-    call_function: str
-    call_params: list[str]
+    callee: str
+    parameter_names: list[str]
     call_transform: Callable[[str], str] | None
     transform_stub_names: list[str]
     per_element: bool
@@ -415,16 +415,16 @@ class _CallCaseConfig:
 _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
     _CallCaseConfig(
         case_dir_name="call_keyword_args",
-        call_function="throttler.check",
-        call_params=["user_id", "ts"],
+        callee="throttler.check",
+        parameter_names=["user_id", "ts"],
         call_transform=lambda c: f"emit({c})",
         transform_stub_names=["emit"],
         per_element=True,
     ),
     _CallCaseConfig(
         case_dir_name="call_scalar_args",
-        call_function="process",
-        call_params=["value"],
+        callee="process",
+        parameter_names=["value"],
         call_transform=None,
         transform_stub_names=[],
         per_element=True,
@@ -1357,8 +1357,8 @@ def test_call_golden_file(
         source=yaml_string,
         input_format=literalizer.InputFormat.YAML,
         language=spec,
-        call_function=config.call_function,
-        call_params=config.call_params,
+        callee=config.callee,
+        parameter_names=config.parameter_names,
         call_transform=config.call_transform,
         per_element=config.per_element,
     )
@@ -1367,12 +1367,10 @@ def test_call_golden_file(
     preamble_stubs: list[str] = []
     # Stubs for the call function (with full parameter names).
     body_stubs.extend(
-        spec.format_call_stub(config.call_function, config.call_params),
+        spec.format_call_stub(config.callee, config.parameter_names),
     )
     preamble_stubs.extend(
-        spec.format_call_preamble_stub(
-            config.call_function, config.call_params
-        ),
+        spec.format_call_preamble_stub(config.callee, config.parameter_names),
     )
     # Stubs for transform function names (single argument).
     for wrapper_name in config.transform_stub_names:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -836,8 +836,8 @@ def test_literalize_call_per_element_false() -> None:
         source="[1, 2, 3]",
         input_format=InputFormat.JSON,
         language=Python(),
-        call_function="process",
-        call_params=["data"],
+        callee="process",
+        parameter_names=["data"],
         per_element=False,
     )
     assert "process(" in result.code
@@ -864,8 +864,8 @@ def test_literalize_call_missing_keyword_separator_raises() -> None:
             source="- [1]",
             input_format=InputFormat.YAML,
             language=lang,
-            call_function="f",
-            call_params=["x"],
+            callee="f",
+            parameter_names=["x"],
         )
 
 
@@ -876,8 +876,8 @@ def test_literalize_call_per_element_non_list_raises() -> None:
             source='"hello"',
             input_format=InputFormat.JSON,
             language=Python(),
-            call_function="process",
-            call_params=["value"],
+            callee="process",
+            parameter_names=["value"],
             per_element=True,
         )
 
@@ -894,8 +894,8 @@ def test_literalize_call_unsupported_language_raises() -> None:
             source="[[1, 2]]",
             input_format=InputFormat.JSON,
             language=Yaml(),
-            call_function="f",
-            call_params=["a", "b"],
+            callee="f",
+            parameter_names=["a", "b"],
         )
 
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -836,7 +836,7 @@ def test_literalize_call_per_element_false() -> None:
         source="[1, 2, 3]",
         input_format=InputFormat.JSON,
         language=Python(),
-        callee="process",
+        target_function="process",
         parameter_names=["data"],
         per_element=False,
     )
@@ -864,7 +864,7 @@ def test_literalize_call_missing_keyword_separator_raises() -> None:
             source="- [1]",
             input_format=InputFormat.YAML,
             language=lang,
-            callee="f",
+            target_function="f",
             parameter_names=["x"],
         )
 
@@ -876,7 +876,7 @@ def test_literalize_call_per_element_non_list_raises() -> None:
             source='"hello"',
             input_format=InputFormat.JSON,
             language=Python(),
-            callee="process",
+            target_function="process",
             parameter_names=["value"],
             per_element=True,
         )
@@ -894,7 +894,7 @@ def test_literalize_call_unsupported_language_raises() -> None:
             source="[[1, 2]]",
             input_format=InputFormat.JSON,
             language=Yaml(),
-            callee="f",
+            target_function="f",
             parameter_names=["a", "b"],
         )
 


### PR DESCRIPTION
## Summary

- Rename the `call_function` parameter to `callee` — reads as a noun describing which function is called, rather than an instruction.
- Rename the `call_params` parameter to `parameter_names` — unambiguously conveys that these are names, not values.
- Updated across source, tests, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure API/terminology rename across implementation, docs, and tests with no behavioral changes; main risk is downstream breakage for callers using the old argument names.
> 
> **Overview**
> Renames `literalize_call`’s public API parameters from `call_function` -> `target_function` and `call_params` -> `parameter_names`, updating internal helpers (e.g. `_assemble_call`) accordingly.
> 
> Updates documentation examples and all tests/golden-case configs to use the new argument names, including call stub/preamble generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc021f9b547f85da63a7c6f82308229ca9a2e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->