### PR TITLE
Inline _CALL_LANGUAGES check in test discovery

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1354,7 +1354,7 @@ def _discover_call_cases() -> list[_CallCase]:
     cases: list[_CallCase] = []
     for config in _CALL_CASE_CONFIGS:
         for lang_cls in _SORTED_LANGUAGES:
-            if not lang_cls.CallStyles:
+            if len(lang_cls.CallStyles) == 0:
                 continue
             if config.call_style_name is not None:
                 # Only include languages that have this as a

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1348,20 +1348,13 @@ class _CallCase:
     lang_cls: literalizer.LanguageCls
 
 
-_CALL_LANGUAGES: frozenset[str] = frozenset(
-    lang_cls.__name__
-    for lang_cls in _SORTED_LANGUAGES
-    if len(lang_cls.CallStyles) > 0
-)
-
-
 @beartype
 def _discover_call_cases() -> list[_CallCase]:
     """Return call test cases for all languages."""
     cases: list[_CallCase] = []
     for config in _CALL_CASE_CONFIGS:
         for lang_cls in _SORTED_LANGUAGES:
-            if lang_cls.__name__ not in _CALL_LANGUAGES:
+            if not lang_cls.CallStyles:
                 continue
             if config.call_style_name is not None:
                 # Only include languages that have this as a


### PR DESCRIPTION
Remove the `_CALL_LANGUAGES` module-level frozenset and replace its usage with a direct `if not lang_cls.CallStyles` check in `_discover_call_cases`. This is simpler and avoids the indirection of building a set of language names just to filter by whether call styles exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that preserves behavior by replacing a precomputed language-name set with a direct `CallStyles` emptiness check.
> 
> **Overview**
> Simplifies `literalize_call` golden test discovery by removing the module-level `_CALL_LANGUAGES` frozenset and inlining the filter directly in `_discover_call_cases()` via `if len(lang_cls.CallStyles) == 0: continue`.
> 
> This reduces indirection in test case selection without changing production code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825045cc126f76a5d6da92b69a9cdd44ff4baf04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->