### PR TITLE
Replace ValueError with UnsupportedCallStyleError for call rendering

### DIFF
--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -25,6 +25,7 @@ from literalizer._language import (
     SetFormatConfig,
     TrailingCommaConfig,
 )
+from literalizer.exceptions import UnsupportedCallStyleError
 
 __all__ = [
     "CallStyleConfig",
@@ -41,6 +42,7 @@ __all__ = [
     "SequenceFormatConfig",
     "SetFormatConfig",
     "TrailingCommaConfig",
+    "UnsupportedCallStyleError",
     "fixed_dict_open",
     "fixed_sequence_open",
     "fixed_set_open",

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1137,11 +1137,9 @@ def _format_call_args(
     """
     style = language.call_style_config
     if style is None:
-        msg = (
-            f"{type(language).__name__} does not support "
-            "function call rendering"
+        raise UnsupportedCallStyleError(
+            language_name=type(language).__name__,
         )
-        raise UnsupportedCallStyleError(msg)
     formatted = [
         _format_value(value=v, spec=language, dict_open_override=None)
         for v in values
@@ -1254,11 +1252,9 @@ def literalize_call(
         result = "\n".join(lines)
     else:
         if language.call_style_config is None:
-            msg = (
-                f"{type(language).__name__} does not support "
-                "function call rendering"
+            raise UnsupportedCallStyleError(
+                language_name=type(language).__name__,
             )
-            raise UnsupportedCallStyleError(msg)
         lit = _literalize(
             data=data,
             language=language,

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -43,6 +43,7 @@ from literalizer.exceptions import (
     JSON5ParseError,
     JSONParseError,
     TOMLParseError,
+    UnsupportedCallStyleError,
     YAMLParseError,
 )
 
@@ -1140,7 +1141,7 @@ def _format_call_args(
             f"{type(language).__name__} does not support "
             "function call rendering"
         )
-        raise ValueError(msg)
+        raise UnsupportedCallStyleError(msg)
     formatted = [
         _format_value(value=v, spec=language, dict_open_override=None)
         for v in values
@@ -1257,7 +1258,7 @@ def literalize_call(
                 f"{type(language).__name__} does not support "
                 "function call rendering"
             )
-            raise ValueError(msg)
+            raise UnsupportedCallStyleError(msg)
         lit = _literalize(
             data=data,
             language=language,

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -45,3 +45,10 @@ class NullInCollectionError(Exception):
 
 class UnsupportedCallStyleError(Exception):
     """Raised when a language does not support function call rendering."""
+
+    def __init__(self, *, language_name: str) -> None:
+        """Create an ``UnsupportedCallStyleError``."""
+        super().__init__(
+            f"{language_name} does not support function call rendering"
+        )
+        self.language_name = language_name

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -41,3 +41,7 @@ class NullInCollectionError(Exception):
     """Raised when a collection contains null elements and the chosen
     format does not support them (e.g. Java's ``List.of()``).
     """
+
+
+class UnsupportedCallStyleError(Exception):
+    """Raised when a language does not support function call rendering."""

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -17,7 +17,10 @@ from literalizer import (
     literalize_call,
 )
 from literalizer._language import LanguageCls
-from literalizer.exceptions import NullInCollectionError
+from literalizer.exceptions import (
+    NullInCollectionError,
+    UnsupportedCallStyleError,
+)
 from literalizer.languages import (
     Cobol,
     Cpp,
@@ -883,11 +886,11 @@ def test_literalize_call_per_element_non_list_raises() -> None:
 
 
 def test_literalize_call_unsupported_language_raises() -> None:
-    """Literalize_call raises ValueError for a language without call
-    support.
+    """Literalize_call raises UnsupportedCallStyleError for a language
+    without call support.
     """
     with pytest.raises(
-        expected_exception=ValueError,
+        expected_exception=UnsupportedCallStyleError,
         match="does not support",
     ):
         literalize_call(
@@ -900,11 +903,11 @@ def test_literalize_call_unsupported_language_raises() -> None:
 
 
 def test_literalize_call_unsupported_language_per_element_false() -> None:
-    """Literalize_call raises ValueError for a non-call language with
-    per_element=False.
+    """Literalize_call raises UnsupportedCallStyleError for a non-call
+    language with per_element=False.
     """
     with pytest.raises(
-        expected_exception=ValueError,
+        expected_exception=UnsupportedCallStyleError,
         match="does not support",
     ):
         literalize_call(


### PR DESCRIPTION
## Summary
- Add `UnsupportedCallStyleError` custom exception to `exceptions.py` for when a language does not support function call rendering.
- Replace the two `raise ValueError` sites in `_core.py` (`_format_call_args` and `literalize_call`) with the new exception.
- Export the new exception from the public API via `__init__.py`.
- Update tests to expect `UnsupportedCallStyleError` instead of `ValueError`.

## Test plan
- [x] Existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small, targeted error-type change that only affects the exception raised when `literalize_call` is used with languages lacking call-style support.
> 
> **Overview**
> Introduces a dedicated `UnsupportedCallStyleError` for cases where a `Language` has no `call_style_config`, replacing the previous generic `ValueError` in `_format_call_args` and `literalize_call`.
> 
> Exports the new exception from the public API (`literalizer.__init__`) and updates tests to assert the new exception type and message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f47467bd7a739daa4d906668a6a9d476f9b7412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->