### PR TITLE
Add call rendering to Lua

### DIFF
--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Sequence
 
 from beartype import beartype
 
@@ -45,6 +45,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     no_call_stub,
@@ -53,9 +54,6 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
 
 
 @beartype
@@ -94,6 +92,25 @@ def _format_lua_set_entry(_original: Value, item: str) -> str:
     Example: ``'"apple"'`` → ``'["apple"] = true'``.
     """
     return f"[{item}] = true"
+
+
+@beartype
+def _lua_call_stub(
+    name: str,
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Lua stub declarations for a call name."""
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"function {parts[0]}(...) end",)
+    root = parts[0]
+    fields = parts[1:]
+    nested = "function(...) end"
+    for field in reversed(fields):
+        nested = f"{{{field} = {nested}}}"
+    return (f"{root} = {nested}",)
 
 
 @beartype
@@ -445,5 +462,5 @@ class Lua(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
+        self.format_call_stub = _lua_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/tests/integration/cases/call_deep_dotted_method/Lua_call.lua
+++ b/tests/integration/cases/call_deep_dotted_method/Lua_call.lua
@@ -1,3 +1,4 @@
+obj = {api = {client = {post = function(...) end}}}
 obj.api.client.post("hello")
 obj.api.client.post(42)
 obj.api.client.post(true)

--- a/tests/integration/cases/call_deep_dotted_transformed/Lua_call.lua
+++ b/tests/integration/cases/call_deep_dotted_transformed/Lua_call.lua
@@ -1,3 +1,5 @@
+app = {client = {fetch = function(...) end}}
+function emit(...) end
 emit(app.client.fetch("hello"))
 emit(app.client.fetch(42))
 emit(app.client.fetch(true))

--- a/tests/integration/cases/call_dotted_method/Lua_call.lua
+++ b/tests/integration/cases/call_dotted_method/Lua_call.lua
@@ -1,3 +1,4 @@
+app = {client = {fetch = function(...) end}}
 app.client.fetch("hello")
 app.client.fetch(42)
 app.client.fetch(true)

--- a/tests/integration/cases/call_keyword_args/Lua_call.lua
+++ b/tests/integration/cases/call_keyword_args/Lua_call.lua
@@ -1,2 +1,4 @@
+throttler = {check = function(...) end}
+function emit(...) end
 emit(throttler.check("user_1", 1000.0))
 emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_scalar_args/Lua_call.lua
+++ b/tests/integration/cases/call_scalar_args/Lua_call.lua
@@ -1,3 +1,4 @@
+function process(...) end
 process("hello")
 process(42)
 process(true)


### PR DESCRIPTION
## Summary
- Implement `_lua_call_stub` for the Lua language module, replacing `no_call_stub`
- Simple functions generate `function name(...) end`
- Dotted methods generate nested table literals: `obj = {api = {method = function(...) end}}`
- Update golden test files to include stub declarations

Closes #1128

## Test plan
- [x] All 5 Lua call golden-file tests pass
- [x] All 208 Lua tests pass
- [x] All pre-commit hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to Lua output generation and updates golden integration fixtures; main impact is changed emitted Lua preamble for call expressions.
> 
> **Overview**
> Lua call rendering now emits **stub declarations** instead of relying on `no_call_stub`. Simple calls generate `function name(...) end`, while dotted call targets generate nested table literals (e.g. `obj = {api = {client = {post = function(...) end}}}`).
> 
> Integration golden files for Lua call cases are updated to include these stubs ahead of the call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e077e47c735d0c2a9f28c6931f6f5cfc0e920232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->