### PR TITLE
Add function call rendering to Groovy

### DIFF
--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -2,6 +2,7 @@
 
 import datetime
 import enum
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -44,6 +45,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     no_call_stub,
@@ -53,9 +55,47 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable
 
     from literalizer._types import Value
+
+
+def _groovy_call_stub(
+    name: str,
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Groovy stub declarations for a call name."""
+    param_list = ", ".join(params)
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"def {parts[0]}({param_list}) {{ null }}",)
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    if not fields:
+        cls = f"_{root.title()}Type"
+        return (
+            f"class {cls} {{ def {method}({param_list}) {{ null }} }}",
+            f"def {root} = new {cls}()",
+        )
+    lines: list[str] = []
+    inner_cls = f"_{fields[-1].title()}Type"
+    lines.append(
+        f"class {inner_cls} {{ def {method}({param_list}) {{ null }} }}"
+    )
+    prev_cls = inner_cls
+    for i in range(len(fields) - 2, -1, -1):
+        cls = f"_{fields[i].title()}Type"
+        lines.append(
+            f"class {cls} {{ def {fields[i + 1]} = new {prev_cls}() }}"
+        )
+        prev_cls = cls
+    root_cls = f"_{root.title()}Type"
+    lines.append(f"class {root_cls} {{ def {fields[0]} = new {prev_cls}() }}")
+    lines.append(f"def {root} = new {root_cls}()")
+    return tuple(lines)
 
 
 @beartype
@@ -412,5 +452,5 @@ class Groovy(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
+        self.format_call_stub = _groovy_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/tests/integration/cases/call_deep_dotted_method/Groovy_call.groovy
+++ b/tests/integration/cases/call_deep_dotted_method/Groovy_call.groovy
@@ -1,3 +1,7 @@
+class _ClientType { def post(data) { null } }
+class _ApiType { def client = new _ClientType() }
+class _ObjType { def api = new _ApiType() }
+def obj = new _ObjType()
 obj.api.client.post(data: "hello")
 obj.api.client.post(data: 42)
 obj.api.client.post(data: true)

--- a/tests/integration/cases/call_deep_dotted_transformed/Groovy_call.groovy
+++ b/tests/integration/cases/call_deep_dotted_transformed/Groovy_call.groovy
@@ -1,3 +1,7 @@
+class _ClientType { def fetch(payload) { null } }
+class _AppType { def client = new _ClientType() }
+def app = new _AppType()
+def emit(_arg) { null }
 emit(app.client.fetch(payload: "hello"))
 emit(app.client.fetch(payload: 42))
 emit(app.client.fetch(payload: true))

--- a/tests/integration/cases/call_dotted_method/Groovy_call.groovy
+++ b/tests/integration/cases/call_dotted_method/Groovy_call.groovy
@@ -1,3 +1,6 @@
+class _ClientType { def fetch(payload) { null } }
+class _AppType { def client = new _ClientType() }
+def app = new _AppType()
 app.client.fetch(payload: "hello")
 app.client.fetch(payload: 42)
 app.client.fetch(payload: true)

--- a/tests/integration/cases/call_keyword_args/Groovy_call.groovy
+++ b/tests/integration/cases/call_keyword_args/Groovy_call.groovy
@@ -1,2 +1,5 @@
+class _ThrottlerType { def check(user_id, ts) { null } }
+def throttler = new _ThrottlerType()
+def emit(_arg) { null }
 emit(throttler.check(user_id: "user_1", ts: 1000.0))
 emit(throttler.check(user_id: "user_2", ts: 2000.5))

--- a/tests/integration/cases/call_positional_args/Groovy_call.groovy
+++ b/tests/integration/cases/call_positional_args/Groovy_call.groovy
@@ -1,2 +1,5 @@
+class _ThrottlerType { def check(user_id, ts) { null } }
+def throttler = new _ThrottlerType()
+def emit(_arg) { null }
 emit(throttler.check("user_1", 1000.0))
 emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_scalar_args/Groovy_call.groovy
+++ b/tests/integration/cases/call_scalar_args/Groovy_call.groovy
@@ -1,3 +1,4 @@
+def process(value) { null }
 process(value: "hello")
 process(value: 42)
 process(value: true)


### PR DESCRIPTION
## Summary
- Implement `_groovy_call_stub` to generate stub declarations for Groovy call rendering
- Support simple functions, dotted methods (`app.client.fetch`), and deep dotted chains (`obj.api.client.post`)
- Update golden test files with expected stub output

Closes #1122

## Test plan
- [x] All 6 Groovy call golden file tests pass
- [x] All 203 Groovy tests pass
- [x] mypy, ruff, and pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Groovy call-stub generation logic that affects how rendered call snippets compile, including dotted/deep-dotted method chains; mistakes could produce invalid Groovy or name collisions in generated stubs.
> 
> **Overview**
> Groovy call rendering now emits **call stubs** instead of relying on `no_call_stub`, via a new `_groovy_call_stub` hooked up as `Groovy.format_call_stub`.
> 
> The stub generator supports plain functions, single dotted calls (e.g. `app.client.fetch`), and deep dotted chains by emitting minimal `def` functions or synthetic `class _XType` wrappers plus root object instantiation, and integration golden files are updated to expect these prelude declarations for six call scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20357468661e42d848cd9dfead5aa6c0eb8ad212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->