### PR TITLE
Add function call rendering to Jsonnet

### DIFF
--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -34,6 +34,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyleConfig,
+    CallStyleKind,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -274,6 +275,11 @@ class Jsonnet(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Jsonnet call style options."""
 
+        KEYWORD = CallStyleConfig(
+            kind=CallStyleKind.KEYWORD,
+            keyword_separator="=",
+        )
+
     call_styles = CallStyles
 
     @staticmethod
@@ -326,6 +332,7 @@ class Jsonnet(metaclass=LanguageCls):
         string_format: StringFormats = StringFormats.DOUBLE,
         trailing_comma: TrailingCommas = TrailingCommas.YES,
         line_ending: LineEndings = LineEndings.SEMICOLON,
+        call_style: CallStyles = CallStyles.KEYWORD,
         indent: str = "    ",
     ) -> None:
         """Initialize Jsonnet language specification."""
@@ -413,7 +420,8 @@ class Jsonnet(metaclass=LanguageCls):
 
         self.type_hint_collection_preamble_lines = no_type_hint_preamble
         self.special_float_preamble: tuple[str, ...] = ()
-        self.call_style_config: CallStyleConfig | None = None
+        self.call_style = call_style
+        self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
         self.format_call_stub = no_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -4,6 +4,7 @@ import datetime
 import enum
 import functools
 import re
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -45,6 +46,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     no_call_stub,
@@ -55,7 +57,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable
 
 
 @beartype
@@ -72,6 +74,26 @@ def _format_jsonnet_dict_entry(key: str, _val: Value, value: str) -> str:
     if identifier_pattern.match(string=inner):
         return f"{inner}: {value}"
     return f"{key}: {value}"
+
+
+def _jsonnet_call_stub(
+    name: str,
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Jsonnet ``local`` stub declarations for a call name."""
+    param_list = ", ".join(params)
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"local {parts[0]}({param_list}) = null;",)
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    inner = f"{method}({param_list}):: null"
+    for field in reversed(fields):
+        inner = f"{field}: {{ {inner} }}"
+    return (f"local {root} = {{ {inner} }};",)
 
 
 @beartype
@@ -288,12 +310,21 @@ class Jsonnet(metaclass=LanguageCls):
         variable_name: str,
         body_preamble: tuple[str, ...],
     ) -> str:
-        """Wrap code in a valid file (no-op)."""
-        return wrap_in_file_noop(
-            content=content,
-            variable_name=variable_name,
-            body_preamble=body_preamble,
-        )
+        """Wrap code in a valid Jsonnet file.
+
+        When *variable_name* is empty (call mode), wrap the content
+        lines in an array so the file evaluates to a single expression.
+        """
+        if not body_preamble:
+            return wrap_in_file_noop(
+                content=content,
+                variable_name=variable_name,
+                body_preamble=body_preamble,
+            )
+        preamble_str = "\n".join(body_preamble) + "\n"
+        lines = content.split("\n")
+        elements = [f"    {line}," for line in lines if line]
+        return preamble_str + "[\n" + "\n".join(elements) + "\n]"
 
     @staticmethod
     def wrap_combined_in_file(
@@ -423,5 +454,5 @@ class Jsonnet(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
+        self.format_call_stub = _jsonnet_call_stub
         self.format_call_preamble_stub = no_call_stub

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -322,7 +322,7 @@ class Jsonnet(metaclass=LanguageCls):
                 body_preamble=body_preamble,
             )
         preamble_str = "\n".join(body_preamble) + "\n"
-        lines = content.split("\n")
+        lines = content.split(sep="\n")
         elements = [f"    {line}," for line in lines if line]
         return preamble_str + "[\n" + "\n".join(elements) + "\n]"
 

--- a/tests/integration/cases/call_deep_dotted_method/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_deep_dotted_method/Jsonnet_call.jsonnet
@@ -1,0 +1,3 @@
+obj.api.client.post(data="hello")
+obj.api.client.post(data=42)
+obj.api.client.post(data=true)

--- a/tests/integration/cases/call_deep_dotted_method/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_deep_dotted_method/Jsonnet_call.jsonnet
@@ -1,3 +1,6 @@
-obj.api.client.post(data="hello")
-obj.api.client.post(data=42)
-obj.api.client.post(data=true)
+local obj = { api: { client: { post(data):: null } } };
+[
+    obj.api.client.post(data="hello"),
+    obj.api.client.post(data=42),
+    obj.api.client.post(data=true),
+]

--- a/tests/integration/cases/call_deep_dotted_transformed/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_deep_dotted_transformed/Jsonnet_call.jsonnet
@@ -1,0 +1,3 @@
+emit(app.client.fetch(payload="hello"))
+emit(app.client.fetch(payload=42))
+emit(app.client.fetch(payload=true))

--- a/tests/integration/cases/call_deep_dotted_transformed/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_deep_dotted_transformed/Jsonnet_call.jsonnet
@@ -1,3 +1,7 @@
-emit(app.client.fetch(payload="hello"))
-emit(app.client.fetch(payload=42))
-emit(app.client.fetch(payload=true))
+local app = { client: { fetch(payload):: null } };
+local emit(_arg) = null;
+[
+    emit(app.client.fetch(payload="hello")),
+    emit(app.client.fetch(payload=42)),
+    emit(app.client.fetch(payload=true)),
+]

--- a/tests/integration/cases/call_dotted_method/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_dotted_method/Jsonnet_call.jsonnet
@@ -1,0 +1,3 @@
+app.client.fetch(payload="hello")
+app.client.fetch(payload=42)
+app.client.fetch(payload=true)

--- a/tests/integration/cases/call_dotted_method/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_dotted_method/Jsonnet_call.jsonnet
@@ -1,3 +1,6 @@
-app.client.fetch(payload="hello")
-app.client.fetch(payload=42)
-app.client.fetch(payload=true)
+local app = { client: { fetch(payload):: null } };
+[
+    app.client.fetch(payload="hello"),
+    app.client.fetch(payload=42),
+    app.client.fetch(payload=true),
+]

--- a/tests/integration/cases/call_keyword_args/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_keyword_args/Jsonnet_call.jsonnet
@@ -1,2 +1,6 @@
-emit(throttler.check(user_id="user_1", ts=1000.0))
-emit(throttler.check(user_id="user_2", ts=2000.5))
+local throttler = { check(user_id, ts):: null };
+local emit(_arg) = null;
+[
+    emit(throttler.check(user_id="user_1", ts=1000.0)),
+    emit(throttler.check(user_id="user_2", ts=2000.5)),
+]

--- a/tests/integration/cases/call_keyword_args/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_keyword_args/Jsonnet_call.jsonnet
@@ -1,0 +1,2 @@
+emit(throttler.check(user_id="user_1", ts=1000.0))
+emit(throttler.check(user_id="user_2", ts=2000.5))

--- a/tests/integration/cases/call_scalar_args/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_scalar_args/Jsonnet_call.jsonnet
@@ -1,3 +1,6 @@
-process(value="hello")
-process(value=42)
-process(value=true)
+local process(value) = null;
+[
+    process(value="hello"),
+    process(value=42),
+    process(value=true),
+]

--- a/tests/integration/cases/call_scalar_args/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_scalar_args/Jsonnet_call.jsonnet
@@ -1,0 +1,3 @@
+process(value="hello")
+process(value=42)
+process(value=true)


### PR DESCRIPTION
## Summary
- Add KEYWORD call style with `=` separator to the Jsonnet language module, enabling `literalize_call` support
- Jsonnet uses `func(param=value)` syntax for named arguments
- Add 5 golden test files for call rendering scenarios

Closes #1126

## Test plan
- [x] All 5 new Jsonnet call golden file tests pass
- [x] Full test suite passes (12,417 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Jsonnet output generation for `literalize_call`, including new call stub preambles and a new `wrap_in_file` behavior that could affect emitted Jsonnet files for call-mode scenarios.
> 
> **Overview**
> Adds Jsonnet support for `literalize_call` by introducing a `KEYWORD` call style (with `=` separators) and implementing `_jsonnet_call_stub` to emit `local` stub declarations for plain and dotted call targets.
> 
> Updates `Jsonnet.wrap_in_file` to produce a valid single-expression Jsonnet file in call mode by prepending stubs and wrapping rendered call lines into an array expression.
> 
> Adds golden integration fixtures for scalar args, keyword args, dotted methods, and deep dotted/transformed call scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268d8c7dd6c550f7717ff16fc50b8bb24276c7ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->