### PR TITLE
Remove unnecessary pyrefly ignore comment in test_variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,6 +299,7 @@ follow_untyped_imports = true
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
+errors.unused-ignore = "error"
 project_excludes = []
 
 [tool.pyright]

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -166,7 +166,7 @@ class _VariableSyntax:
 # scalar integer. Both _DECLARATION_PARAMS and _ASSIGNMENT_PARAMS are derived
 # from this single source of truth so that adding a language to one
 # automatically adds it to the other.
-_VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {  # pyrefly: ignore[bad-assignment]
+_VARIABLE_SYNTAX: dict[Language, _VariableSyntax] = {
     PYTHON: _VariableSyntax(
         declaration="my_var = 42", assignment="my_var = 42"
     ),


### PR DESCRIPTION
## Summary
- Remove the `pyrefly: ignore[bad-assignment]` suppression from `_VARIABLE_SYNTAX` in `tests/test_variables.py`, as pyrefly no longer reports this error.

## Test plan
- [x] `pyrefly check tests/test_variables.py` passes with 0 errors
- [x] All 92 tests in `test_variables.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/test cleanup: tightens `pyrefly` checks for unused ignores and removes a now-unnecessary suppression in a test, with no runtime behavior changes.
> 
> **Overview**
> Tightens static analysis by configuring `pyrefly` to treat `errors.unused-ignore` as an error.
> 
> Removes the stale `# pyrefly: ignore[bad-assignment]` suppression from `_VARIABLE_SYNTAX` in `tests/test_variables.py`, relying on current type checking to pass without the workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d28771177717e567a0bb5174f4e2adaeaaa67ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->