### PR TITLE
Remove unreachable ValueError guard from strip_key_quotes

### DIFF
--- a/src/literalizer/_formatters/format_entries.py
+++ b/src/literalizer/_formatters/format_entries.py
@@ -18,20 +18,12 @@ def strip_key_quotes(key: str) -> str:
 
         strip_key_quotes('"name"')  # => 'name'
 
-    Raises ``ValueError`` for unquoted keys.  All current input
-    formats produce quoted string keys; this guard exists so that
-    adding a new input format with non-string keys surfaces
-    immediately rather than silently slicing the wrong characters.
+    All current input formats produce quoted string keys, so *key*
+    is always surrounded by matching quotes.
     """
-    min_quoted_length = 2
-    if (
-        len(key) >= min_quoted_length
-        and key[0] in {'"', "'"}
-        and key[-1] == key[0]
-    ):
-        return key[1:-1]
-    msg = f"Expected a quoted key, got {key!r}"  # pragma: no cover
-    raise ValueError(msg)  # pragma: no cover
+    # All current input formats produce quoted string keys.
+    # If a new format introduces unquoted keys, this will need updating.
+    return key[1:-1]
 
 
 @beartype

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -574,17 +574,6 @@ def test_toml_integer_dict_key() -> None:
     assert result.code == expected
 
 
-def test_toml_non_quoted_dict_key() -> None:
-    """TOML format_dict_entry rejects a key that is not a quoted
-    string.
-    """
-    with pytest.raises(
-        expected_exception=ValueError,
-        match=r"^Expected a quoted key, got 'plain_key'$",
-    ):
-        TOML.dict_format_config.format_entry("plain_key", "value", '"value"')
-
-
 def test_cobol_string_control_characters() -> None:
     """COBOL string literals replace control characters with spaces."""
     result = literalize(


### PR DESCRIPTION
## Summary
- Removes the unreachable `ValueError` guard and `pragma: no cover` from `strip_key_quotes` in `format_entries.py`
- All current input formats produce quoted string keys, so the error path was dead code
- Replaces the conditional with a direct return and a comment explaining the assumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only removes unreachable error handling and a corresponding test, but it does reduce defensive checking if unquoted keys are ever introduced later.
> 
> **Overview**
> Removes the conditional validation and `ValueError` guard from `strip_key_quotes`, making it an unconditional `key[1:-1]` with updated documentation/comments that assume all formatted dict keys are quoted.
> 
> Deletes the language test that expected TOML dict entry formatting to reject non-quoted keys, aligning the test suite with the new “quoted keys only” assumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23b7b055971dc3dd06213e04aa5d17180892d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->