### PR TITLE
Remove unreachable key-is-None guard in extract_toml_comments

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -191,7 +191,7 @@ def extract_toml_comments(
     pending_before: list[str] = []
     elements: list[ElementComments] = []
 
-    for key, item in toml_doc.body:
+    for _key, item in toml_doc.body:
         if isinstance(item, (Whitespace, Comment)):
             if isinstance(item, Comment):
                 raw: str = item.trivia.comment
@@ -201,8 +201,6 @@ def extract_toml_comments(
                     if line.strip().startswith("#")
                 )
             continue
-        if key is None:
-            continue  # pragma: no cover
         inline = ""
         if not isinstance(item, Table):
             raw_inline: str = item.trivia.comment


### PR DESCRIPTION
## Summary

- Removes the unreachable `if key is None: continue` guard in `extract_toml_comments`. tomlkit never produces a body entry with `key=None` for non-Whitespace/non-Comment items, so this code path was dead and carried a `pragma: no cover`.

## Test plan

- [x] All 12411 existing tests pass
- [x] All 35 TOML-specific tests pass
- [x] Pre-commit hooks (mypy, pyright, ruff, etc.) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes dead/unreachable branching in `extract_toml_comments` without changing the comment parsing logic or external interfaces.
> 
> **Overview**
> Simplifies TOML comment extraction by removing an unreachable `key is None` guard in `extract_toml_comments` and marking the loop key as unused (`_key`).
> 
> This is a small cleanup that drops a dead code path (previously excluded from coverage) while keeping the comment collection behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1773f49d096a45e92bcd57f2a70eea8d49518985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->