### PR TITLE
Remove `spec = language` alias in _core.py

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -803,10 +803,9 @@ def _literalize(
             instead of silently coercing heterogeneous scalar
             collections to strings.
     """
-    spec = language
     data = apply_coercions(
         data=data,
-        spec=spec,
+        spec=language,
         error_on_coercion=error_on_coercion,
     )
 
@@ -823,7 +822,7 @@ def _literalize(
         datetime.date,
     )
     if isinstance(data, scalar_types) or data is None:
-        return f"{line_prefix}{_format_scalar(value=data, spec=spec)}"
+        return f"{line_prefix}{_format_scalar(value=data, spec=language)}"
 
     # Empty collections have no elements to lay out line-by-line, so
     # delegate to _format_value which already returns the correct
@@ -831,7 +830,7 @@ def _literalize(
     if not data and include_delimiters:
         formatted = _format_value(
             value=data,
-            spec=spec,
+            spec=language,
             dict_open_override=None,
         )
         return f"{line_prefix}{formatted}"
@@ -842,16 +841,16 @@ def _literalize(
 
     if (
         isinstance(data, set)
-        and spec.set_format_config.coerce_mixed_to_str
+        and language.set_format_config.coerce_mixed_to_str
         and all_scalars_heterogeneous(values=list(data))
     ):
         data = {coerce_scalar_to_str(value=v) for v in data}
 
     is_ordered_map = isinstance(data, ordereddict)
-    trailing_comma = spec.trailing_comma_config.multiline_trailing_comma
+    trailing_comma = language.trailing_comma_config.multiline_trailing_comma
     lines_or_early = _format_collection_lines(
         data=data,
-        spec=spec,
+        spec=language,
         body_prefix=body_prefix,
         trailing_comma=trailing_comma,
         is_ordered_map=is_ordered_map,
@@ -870,7 +869,7 @@ def _literalize(
         body=body,
         is_ordered_map=is_ordered_map,
         data=data,
-        spec=spec,
+        spec=language,
         line_prefix=line_prefix,
     )
 


### PR DESCRIPTION
## Summary
- Remove the `spec = language` alias in `format_literal` and use the `language` parameter directly throughout the function body

Closes #1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `_literalize` that only renames an internal variable alias; behavior should remain unchanged aside from the possibility of a missed reference during replacement.
> 
> **Overview**
> Removes the local `spec = language` alias in `_literalize` and updates all references to use the `language` parameter directly (including coercion, scalar/collection formatting, trailing-comma config, and `_wrap_body` calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c243cad9749142cd4818d1a8d4a998cffc4562ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->