### PR TITLE
Remove redundant list() on sorted() in _format_set_value

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -342,14 +342,14 @@ def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
     ):
         value = {coerce_scalar_to_str(value=v) for v in value}
     sorted_items = sorted(value, key=lambda v: (type(v).__name__, repr(v)))
-    items_as_values: list[Value] = list(sorted_items)
     formatted = [_format_scalar(value=v, spec=spec) for v in sorted_items]
     entries = [
         spec.format_set_entry(v, item)
         for v, item in zip(sorted_items, formatted, strict=True)
     ]
     joined = spec.element_separator.join(entries)
-    return set_cfg.set_open(items_as_values) + joined + set_cfg.close
+    open_str = set_cfg.set_open(cast("list[Value]", sorted_items))
+    return open_str + joined + set_cfg.close
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Removed the redundant `list()` call wrapping the `sorted()` result in `_format_set_value`
- Replaced with `cast(list[Value], sorted_items)` since the `list()` was only serving as a type-widening mechanism (list invariance: `list[Scalar]` -> `list[Value]`), not doing useful runtime work

Closes #1188

## Test plan
- [x] pyright strict passes
- [x] mypy passes
- [x] Pre-commit hooks pass
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged; this is a small type/cleanup in set literal formatting that should only affect static typing and a tiny amount of runtime overhead.
> 
> **Overview**
> Removes a redundant `list()` conversion when formatting set literals in `_format_set_value`, keeping the `sorted()` result as-is.
> 
> Updates the call to `set_open` to use an explicit `cast("list[Value]", sorted_items)` for type-widening, avoiding unnecessary runtime allocation while preserving the same output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e71775cd1f23ccefc0d96355777889948dbe66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->