### PR TITLE
Rename val/value to raw_value/formatted_value in dict entry formatters

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -324,10 +324,14 @@ def _format_scalar(*, value: Scalar, spec: Language) -> str:
 
 @beartype
 def _build_dict_entry(
-    *, key_str: str, val: Value, val_str: str, spec: Language
+    *, key_str: str, raw_value: Value, formatted_value: str, spec: Language
 ) -> str:
     """Format a single dict key-value entry using the language spec."""
-    return spec.dict_format_config.format_entry(key_str, val, val_str)
+    return spec.dict_format_config.format_entry(
+        key_str,
+        raw_value,
+        formatted_value,
+    )
 
 
 @beartype
@@ -410,8 +414,8 @@ def _format_dict_value(
                 spec=spec,
                 dict_open_override=None,
             ),
-            val=v,
-            val_str=_format_value(
+            raw_value=v,
+            formatted_value=_format_value(
                 value=v,
                 spec=spec,
                 dict_open_override=None,
@@ -697,8 +701,8 @@ def _format_collection_lines(
                     if is_ordered_map
                     else _build_dict_entry(
                         key_str=formatted_key,
-                        val=v,
-                        val_str=formatted_val,
+                        raw_value=v,
+                        formatted_value=formatted_val,
                         spec=spec,
                     )
                 )

--- a/src/literalizer/_formatters/format_entries.py
+++ b/src/literalizer/_formatters/format_entries.py
@@ -63,9 +63,9 @@ def tuple_dict_entry(
     """
 
     @beartype
-    def _format(key: str, val: Value, value: str) -> str:
+    def _format(key: str, raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry as a tuple."""
-        return f"({key}, {format_value(val, value)})"
+        return f"({key}, {format_value(raw_value, formatted_value)})"
 
     return _format
 
@@ -86,9 +86,9 @@ def braced_dict_entry(
     """
 
     @beartype
-    def _format(key: str, val: Value, value: str) -> str:
+    def _format(key: str, raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry with braces."""
-        return f"{{{key}, {format_value(val, value)}}}"
+        return f"{{{key}, {format_value(raw_value, formatted_value)}}}"
 
     return _format
 
@@ -149,9 +149,9 @@ def dict_entry_with_separator(
     """
 
     @beartype
-    def _format(key: str, val: Value, value: str) -> str:
+    def _format(key: str, raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry by joining key and value with separator."""
-        return f"{key}{separator}{format_value(val, value)}"
+        return f"{key}{separator}{format_value(raw_value, formatted_value)}"
 
     return _format
 
@@ -175,9 +175,10 @@ def dict_entry_symbol_style(
     """
 
     @beartype
-    def _format(key: str, val: Value, value: str) -> str:
+    def _format(key: str, raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry in symbol style."""
-        return f"{strip_key_quotes(key=key)}: {format_value(val, value)}"
+        formatted = format_value(raw_value, formatted_value)
+        return f"{strip_key_quotes(key=key)}: {formatted}"
 
     return _format
 
@@ -199,8 +200,9 @@ def dict_entry_with_template(
     """
 
     @beartype
-    def _format(key: str, val: Value, value: str) -> str:
+    def _format(key: str, raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry using the template."""
-        return template.format(key=key, value=format_value(val, value))
+        formatted = format_value(raw_value, formatted_value)
+        return template.format(key=key, value=formatted)
 
     return _format

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -90,9 +90,13 @@ def _format_bash_sequence_entry(original: Value, item: str) -> str:
 
 
 @beartype
-def _format_bash_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_bash_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a Bash associative-array entry as ``[key]=value``."""
-    return f"[{key}]={_to_bash_value(item=value)}"
+    return f"[{key}]={_to_bash_value(item=formatted_value)}"
 
 
 @beartype

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -167,7 +167,11 @@ def _key_to_cobol_name(key_str: str) -> str:
 
 
 @beartype
-def _format_cobol_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_cobol_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a COBOL DATA DIVISION entry for a dict key-value pair.
 
     The key string is converted to a valid COBOL data name.  Scalar
@@ -175,14 +179,14 @@ def _format_cobol_dict_entry(key: str, _val: Value, value: str) -> str:
     items with bumped level numbers.
     """
     name = _key_to_cobol_name(key_str=key)
-    if "\n" in value:
-        bumped = _bump_levels(content=value)
+    if "\n" in formatted_value:
+        bumped = _bump_levels(content=formatted_value)
         return f"05 {name}.\n{bumped}"
-    if _is_data_entry(s=value.strip()):
-        bumped = _bump_levels(content=value.strip())
+    if _is_data_entry(s=formatted_value.strip()):
+        bumped = _bump_levels(content=formatted_value.strip())
         return f"05 {name}.\n{bumped}"
-    picture_clause = _pic_from_value(value=value)
-    return f"05 {name} {picture_clause} VALUE {value}."
+    picture_clause = _pic_from_value(value=formatted_value)
+    return f"05 {name} {picture_clause} VALUE {formatted_value}."
 
 
 @beartype

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -54,9 +54,13 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_cons_entry(key: str, _val: Value, value: str) -> str:
+def _format_cons_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a Common Lisp association-list entry as a ``cons`` pair."""
-    return f"(cons {key} {value})"
+    return f"(cons {key} {formatted_value})"
 
 
 _CL_INF = "sb-ext:double-float-positive-infinity"

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -122,7 +122,11 @@ def _format_dhall_string(value: str) -> str:
 
 
 @beartype
-def _format_dhall_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_dhall_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a Dhall record entry as ``key = value``.
 
     If the key is a valid Dhall simple label (letter or underscore
@@ -133,7 +137,7 @@ def _format_dhall_dict_entry(key: str, _val: Value, value: str) -> str:
     """
     inner = key[1:-1]
     if _IDENTIFIER_RE.match(string=inner):
-        return f"{inner} = {value}"
+        return f"{inner} = {formatted_value}"
     raw = _unescape_dhall_string(value=inner)
     if not raw or not _BACKTICK_LABEL_RE.match(string=raw):
         msg = (
@@ -142,7 +146,7 @@ def _format_dhall_dict_entry(key: str, _val: Value, value: str) -> str:
             "printable ASCII (no backticks or control characters)."
         )
         raise InvalidDictKeyError(msg)
-    return f"`{raw}` = {value}"
+    return f"`{raw}` = {formatted_value}"
 
 
 @beartype

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -183,14 +183,14 @@ def _build_elm_dict_entry(
     _str_prefix = f"{prefix}Str "
 
     @beartype
-    def _format(key: str, _val: Value, value: str) -> str:
+    def _format(key: str, _raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry as a tuple with a plain-string key.
 
         Dict keys are ``String``, not ``Val``, so the ``{prefix}Str``
         constructor must be stripped from the formatted key.
         """
         key = key.removeprefix(_str_prefix)
-        return f"({key}, {value})"
+        return f"({key}, {formatted_value})"
 
     return _format
 

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -133,12 +133,16 @@ def _format_forth_declaration(name: str, value: str, _data: Value) -> str:
 
 
 @beartype
-def _format_forth_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_forth_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     r"""Format a dict entry as ``key value``.
 
     Example: ``s\" name" s\" Alice"``.
     """
-    return f"{key} {value}"
+    return f"{key} {formatted_value}"
 
 
 @beartype

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -199,14 +199,14 @@ def _build_gleam_dict_entry(
     _str_prefix = f"{prefix}Str("
 
     @beartype
-    def _format(key: str, _val: Value, value: str) -> str:
+    def _format(key: str, _raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry as a hash tuple with a plain-string key.
 
         Dict keys are ``String``, not ``GVal``, so the ``{prefix}Str(...)``
         constructor must be stripped from the formatted key.
         """
         key = key.removeprefix(_str_prefix).removesuffix(")")
-        return f"#({key}, {value})"
+        return f"#({key}, {formatted_value})"
 
     return _format
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -205,10 +205,14 @@ def _build_explicit_string_formatters(
         return f"{string_constructor}{base_format_bytes(data)}"
 
     @beartype
-    def _format_dict_entry(key: str, _val: Value, value: str) -> str:
+    def _format_dict_entry(
+        key: str,
+        _raw_value: Value,
+        formatted_value: str,
+    ) -> str:
         """Format a dict entry, stripping the constructor from the key."""
         clean_key = key.removeprefix(string_constructor)
-        return f"({clean_key}, {value})"
+        return f"({clean_key}, {formatted_value})"
 
     return _ExplicitStringFormatters(
         format_string=_format_string,

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -59,7 +59,11 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_json5_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_json5_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a JSON5 dict entry as ``key: value``.
 
     If the key is a double-quoted string that is also a valid ECMAScript
@@ -71,8 +75,8 @@ def _format_json5_dict_entry(key: str, _val: Value, value: str) -> str:
         pattern=r"^[A-Za-z_$][A-Za-z0-9_$]*$",
     )
     if identifier_pattern.match(string=inner):
-        return f"{inner}: {value}"
-    return f"{key}: {value}"
+        return f"{inner}: {formatted_value}"
+    return f"{key}: {formatted_value}"
 
 
 @beartype

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -61,7 +61,11 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_jsonnet_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_jsonnet_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a Jsonnet dict entry as ``key: value``.
 
     If the key is a double-quoted string that is also a valid Jsonnet
@@ -72,8 +76,8 @@ def _format_jsonnet_dict_entry(key: str, _val: Value, value: str) -> str:
     inner = key[1:-1]
     identifier_pattern = re.compile(pattern=r"^[A-Za-z_][A-Za-z0-9_]*$")
     if identifier_pattern.match(string=inner):
-        return f"{inner}: {value}"
-    return f"{key}: {value}"
+        return f"{inner}: {formatted_value}"
+    return f"{key}: {formatted_value}"
 
 
 def _jsonnet_call_stub(

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -103,7 +103,11 @@ def _matlab_char_key(s: str) -> str:
 
 
 @beartype
-def _format_matlab_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_matlab_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a MATLAB ``struct`` field as a ``'key', value`` pair.
 
     MATLAB ``struct`` accepts alternating character-vector keys and values.
@@ -119,9 +123,9 @@ def _format_matlab_dict_entry(key: str, _val: Value, value: str) -> str:
     """
     inner = _decode_matlab_string_expr(expr=key)
     key_expr = _matlab_char_key(s=inner)
-    if value.startswith("{") and value.endswith("}"):
-        value = f"{{{value}}}"
-    return f"{key_expr}, {value}"
+    if formatted_value.startswith("{") and formatted_value.endswith("}"):
+        formatted_value = f"{{{formatted_value}}}"
+    return f"{key_expr}, {formatted_value}"
 
 
 @beartype
@@ -145,11 +149,15 @@ def _containers_map_open(data: dict[str, Value]) -> str:
 
 
 @beartype
-def _format_containers_map_entry(_key: str, _val: Value, value: str) -> str:
+def _format_containers_map_entry(
+    _key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a ``containers.Map`` value entry (key already in opener)."""
-    if value.startswith("{") and value.endswith("}"):
-        value = f"{{{value}}}"
-    return value
+    if formatted_value.startswith("{") and formatted_value.endswith("}"):
+        formatted_value = f"{{{formatted_value}}}"
+    return formatted_value
 
 
 @beartype

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -59,9 +59,13 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_mojo_ordered_map_entry(key: str, _val: Value, value: str) -> str:
+def _format_mojo_ordered_map_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format one Mojo ordered-map entry as a ``Tuple(key, value)``."""
-    return f"Tuple({key}, {value})"
+    return f"Tuple({key}, {formatted_value})"
 
 
 @beartype

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -100,7 +100,11 @@ def _format_nix_string(value: str) -> str:
 
 
 @beartype
-def _format_nix_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_nix_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a Nix attribute set entry as ``key = value;``.
 
     If the key is a valid Nix identifier and not a keyword, the quotes
@@ -109,7 +113,7 @@ def _format_nix_dict_entry(key: str, _val: Value, value: str) -> str:
     """
     inner = key[1:-1]
     if _IDENTIFIER_RE.match(string=inner) and inner not in _NIX_KEYWORDS:
-        return f"{inner} = {value};"
+        return f"{inner} = {formatted_value};"
     if not inner or any(ord(ch) < _CONTROL_CHAR_UPPER_BOUND for ch in inner):
         msg = (
             f"Nix does not support the dict key {key}. "
@@ -117,7 +121,7 @@ def _format_nix_dict_entry(key: str, _val: Value, value: str) -> str:
             "control characters."
         )
         raise InvalidDictKeyError(msg)
-    return f"{key} = {value};"
+    return f"{key} = {formatted_value};"
 
 
 @beartype

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -183,14 +183,14 @@ def _build_purescript_dict_entry(
     _str_prefix = f"{prefix}Str "
 
     @beartype
-    def _format(key: str, _val: Value, value: str) -> str:
+    def _format(key: str, _raw_value: Value, formatted_value: str) -> str:
         """Format a dict entry as a ``Tuple`` with a plain-string key.
 
         Dict keys are ``String``, not ``Val``, so the ``{prefix}Str``
         constructor must be stripped from the formatted key.
         """
         key = key.removeprefix(_str_prefix)
-        return f"(Tuple {key} ({value}))"
+        return f"(Tuple {key} ({formatted_value}))"
 
     return _format
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -183,7 +183,11 @@ class R(metaclass=LanguageCls):
             /,
         ) -> str:
             """Format a dict entry."""
-            return self.value(key, raw_value, formatted_value)
+            return self.value(
+                key=key,
+                _raw_value=raw_value,
+                formatted_value=formatted_value,
+            )
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -60,7 +60,11 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_r_dict_entry_positional(key: str, _val: Value, value: str) -> str:
+def _format_r_dict_entry_positional(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format an R named list entry.
 
     R list syntax does not allow zero-length names (``"" = value`` is a
@@ -68,12 +72,16 @@ def _format_r_dict_entry_positional(key: str, _val: Value, value: str) -> str:
     elements.
     """
     if key == '""':
-        return value
-    return f"{key} = {value}"
+        return formatted_value
+    return f"{key} = {formatted_value}"
 
 
 @beartype
-def _format_r_dict_entry_error(key: str, _val: Value, value: str) -> str:
+def _format_r_dict_entry_error(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format an R named list entry, raising on empty-string keys."""
     if key == '""':
         msg = (
@@ -82,7 +90,7 @@ def _format_r_dict_entry_error(key: str, _val: Value, value: str) -> str:
             "as unnamed list elements instead."
         )
         raise InvalidDictKeyError(msg)
-    return f"{key} = {value}"
+    return f"{key} = {formatted_value}"
 
 
 @beartype
@@ -167,9 +175,15 @@ class R(metaclass=LanguageCls):
         POSITIONAL = enum.member(value=_format_r_dict_entry_positional)
         ERROR = enum.member(value=_format_r_dict_entry_error)
 
-        def __call__(self, key: str, val: Value, value: str, /) -> str:
+        def __call__(
+            self,
+            key: str,
+            raw_value: Value,
+            formatted_value: str,
+            /,
+        ) -> str:
             """Format a dict entry."""
-            return self.value(key=key, _val=val, value=value)
+            return self.value(key, raw_value, formatted_value)
 
     class BytesFormats(enum.Enum):
         """Bytes formatting options."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -94,9 +94,13 @@ def _format_tcl_set_entry(_original: Value, item: str) -> str:
 
 
 @beartype
-def _format_tcl_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_tcl_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a dict entry as ``key value``."""
-    return f"{key} {value}"
+    return f"{key} {formatted_value}"
 
 
 @beartype

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -61,7 +61,11 @@ if TYPE_CHECKING:
 
 
 @beartype
-def _format_toml_dict_entry(key: str, _val: Value, value: str) -> str:
+def _format_toml_dict_entry(
+    key: str,
+    _raw_value: Value,
+    formatted_value: str,
+) -> str:
     """Format a TOML dict entry as ``key = value``.
 
     If the key is a double-quoted string that is also a valid bare key
@@ -71,8 +75,8 @@ def _format_toml_dict_entry(key: str, _val: Value, value: str) -> str:
     inner = strip_key_quotes(key=key)
     bare_key_pattern = re.compile(pattern=r"^[A-Za-z0-9_-]+$")
     if bare_key_pattern.match(string=inner):
-        return f"{inner} = {value}"
-    return f"{key} = {value}"
+        return f"{inner} = {formatted_value}"
+    return f"{key} = {formatted_value}"
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Rename confusing `val`/`value` parameters to `raw_value`/`formatted_value` in all dict entry formatter functions across `format_entries.py`, `_core.py`, and 17 language files
- `raw_value` is the Python value, `formatted_value` is the string representation

Closes #1190

## Test plan
- [x] All 12451 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor/rename of dict-entry formatter parameters across core and language specs; behavior should be unchanged but the breadth of touch points could hide a missed call-site update.
> 
> **Overview**
> Renames dict-entry formatter parameters from ambiguous `val`/`value` to **`raw_value` (original Python value)** and **`formatted_value` (string literal)** across `_core.py`, `format_entries.py`, and multiple language implementations.
> 
> Updates all call sites to pass both the raw value and its formatted representation explicitly, keeping formatting logic the same while making `format_entry` implementations easier to reason about.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70174d80bf69994f58c7e143aaa5ac9672ab38a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->