### PR TITLE
Simplify Crystal NONE integer formatter to use str directly

### DIFF
--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -278,7 +278,7 @@ class Crystal(metaclass=LanguageCls):
 
         DECIMAL = MappingProxyType(
             mapping={
-                "NONE": lambda value: str(object=value),
+                "NONE": str,
                 "UNDERSCORE": format_integer_underscore,
             }
         )

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -4,7 +4,7 @@ import datetime
 import enum
 from collections.abc import Callable, Sequence
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from beartype import beartype
 
@@ -288,10 +288,10 @@ class Crystal(metaclass=LanguageCls):
             numeric_separator: enum.Enum,
         ) -> Callable[[int], str]:
             """Return the integer formatter for the given separator."""
-            formatter: Callable[[int], str] = self.value[
-                numeric_separator.name
-            ]
-            return formatter
+            return cast(
+                "Callable[[int], str]",
+                self.value[numeric_separator.name],
+            )
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -288,7 +288,10 @@ class Crystal(metaclass=LanguageCls):
             numeric_separator: enum.Enum,
         ) -> Callable[[int], str]:
             """Return the integer formatter for the given separator."""
-            return self.value[numeric_separator.name]
+            formatter: Callable[[int], str] = self.value[
+                numeric_separator.name
+            ]
+            return formatter
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""


### PR DESCRIPTION
## Summary
- Replace verbose `lambda value: str(object=value)` with `str` in Crystal's integer formatter, matching all other language files
- Add `cast()` in `get_formatter` to satisfy mypy, since Crystal is the only language with a single MappingProxyType enum variant

Closes #1204

## Test plan
- [x] All pre-commit hooks pass (mypy, pyright, ty, pyrefly, ruff)
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is effectively unchanged (uses `str` directly) and the only other change is a type-only `cast` to satisfy static checkers.
> 
> **Overview**
> Simplifies Crystal integer formatting by replacing the `NONE` decimal formatter from a lambda wrapper to `str` directly.
> 
> Updates `IntegerFormats.get_formatter` to `cast` the `MappingProxyType` lookup result to `Callable[[int], str]`, aligning typing with other language specs and quieting mypy for this enum shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59569bd31dbf7ca7cec641588840823167110c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->