### PR TITLE
Use `not val` instead of `len(val) == 0` for empty set check

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -165,7 +165,7 @@ def _walk_empty_collections(*, val: Value, result: set[type]) -> None:
                 for v in val.values():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
                     _walk_empty_collections(val=v, result=result)  # pyright: ignore[reportUnknownArgumentType]
         case set():
-            if len(val) == 0:
+            if not val:
                 result.add(set)
         case list():
             if not val:


### PR DESCRIPTION
## Summary
- Use `not val` instead of `len(val) == 0` in `_walk_empty_collections` for the set branch, consistent with dict and list branches.

Fixes #1184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, behavior-preserving refactor that only changes how empty sets are checked while walking values to infer empty collection types.
> 
> **Overview**
> Updates `_walk_empty_collections` to detect empty sets using Python truthiness (`if not val`) instead of `len(val) == 0`, aligning the set branch with the existing dict/list empty-collection checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3bd8d9feee047ca0fe6452cd4434ecfc683322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->