### PR TITLE
Replace variable_name/new_variable with variable_form parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,7 @@ Usage
        ),
        pre_indent_level=0,
        include_delimiters=True,
-       variable_name=None,
-       new_variable=True,
+       variable_form=None,
    )
    # result:
    # map[string]any{

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,8 +50,7 @@ Use :func:`literalizer.literalize` to convert data to native language literals:
        ),
        pre_indent_level=0,
        include_delimiters=True,
-       variable_name=None,
-       new_variable=True,
+       variable_form=None,
    )
    # result.code:
    # map[string]any{

--- a/docs/source/json-api-use-case.rst
+++ b/docs/source/json-api-use-case.rst
@@ -28,7 +28,7 @@ returns this response:
 
    import textwrap
 
-   from literalizer import InputFormat, literalize
+   from literalizer import InputFormat, NewVariable, literalize
    from literalizer.languages import Python
 
    request_json = '{"name": "Alice", "email": "alice@example.com"}'
@@ -50,9 +50,8 @@ returns this response:
            variable_type_hints=Python.variable_type_hints_formats.AUTO,
        ),
        pre_indent_level=0,
-       variable_name="request_body",
+       variable_form=NewVariable(name="request_body"),
        include_delimiters=True,
-       new_variable=True,
    )
    assert request_literal.code == textwrap.dedent(
        text="""\
@@ -75,9 +74,8 @@ returns this response:
            variable_type_hints=Python.variable_type_hints_formats.AUTO,
        ),
        pre_indent_level=0,
-       variable_name="response",
+       variable_form=NewVariable(name="response"),
        include_delimiters=True,
-       new_variable=True,
    )
    assert response_literal.code == textwrap.dedent(
        text="""\

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -1,8 +1,12 @@
 """Convert data structures to native language literal syntax."""
 
 from literalizer._core import (
+    BothVariableForms,
+    ExistingVariable,
     InputFormat,
     LiteralizeResult,
+    NewVariable,
+    VariableForm,
     literalize,
     literalize_call,
 )
@@ -28,21 +32,25 @@ from literalizer._language import (
 from literalizer.exceptions import UnsupportedCallStyleError
 
 __all__ = [
+    "BothVariableForms",
     "CallStyleConfig",
     "CallStyleKind",
     "CommentConfig",
     "DateFormatConfig",
     "DatetimeFormatConfig",
     "DictFormatConfig",
+    "ExistingVariable",
     "InputFormat",
     "Language",
     "LanguageCls",
     "LiteralizeResult",
+    "NewVariable",
     "OrderedMapFormatConfig",
     "SequenceFormatConfig",
     "SetFormatConfig",
     "TrailingCommaConfig",
     "UnsupportedCallStyleError",
+    "VariableForm",
     "fixed_dict_open",
     "fixed_sequence_open",
     "fixed_set_open",

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1106,6 +1106,8 @@ def literalize(
         HeterogeneousCoercionError: If *error_on_coercion* is ``True``
             and the data contains heterogeneous scalar collections
             that would be coerced.
+        ValueError: If *variable_form* is :class:`BothVariableForms`
+            and *wrap_in_file* is ``False``.
     """
     # --- BothVariableForms: two full literalize() calls ---
     if isinstance(variable_form, BothVariableForms):

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -123,6 +123,33 @@ class LiteralizeResult:
         return self.code[len(prefix) :]
 
 
+@dataclasses.dataclass(frozen=True)
+class NewVariable:
+    """Wrap output in a new variable declaration."""
+
+    name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class ExistingVariable:
+    """Wrap output in an assignment to an existing variable."""
+
+    name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class BothVariableForms:
+    """Produce both a declaration and an assignment, combined.
+
+    Requires ``wrap_in_file=True`` on :func:`literalize`.
+    """
+
+    name: str
+
+
+VariableForm = NewVariable | ExistingVariable | BothVariableForms
+
+
 @beartype
 def _collect_value_types(*, data: Value) -> frozenset[type]:
     """Return the set of Python types present in *data*."""
@@ -884,20 +911,19 @@ def _apply_variable_wrapper(
     result: str,
     language: Language,
     data: Value,
-    variable_name: str | None,
-    new_variable: bool,
+    variable_form: NewVariable | ExistingVariable | None,
 ) -> str:
     """Optionally wrap *result* in a variable declaration or
     assignment.
     """
-    if variable_name is None:
+    if variable_form is None:
         return result
     formatter = (
         language.format_variable_declaration
-        if new_variable
+        if isinstance(variable_form, NewVariable)
         else language.format_variable_assignment
     )
-    return formatter(variable_name, result, data)
+    return formatter(variable_form.name, result, data)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -976,8 +1002,7 @@ def literalize(
     language: Language,
     pre_indent_level: int = 0,
     include_delimiters: bool = True,
-    variable_name: str | None = None,
-    new_variable: bool = True,
+    variable_form: VariableForm | None = None,
     error_on_coercion: bool = False,
     wrap_in_file: bool = False,
 ) -> LiteralizeResult:
@@ -998,15 +1023,15 @@ def literalize(
             indent produces an 8-space margin.  Defaults to ``0``.
         include_delimiters: If True, include the collection delimiters
             (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
-        variable_name: If given, wrap the output in a variable
-            declaration using the language's
-            ``format_variable_declaration`` or
-            ``format_variable_assignment`` callable.
-        new_variable: If ``True`` (the default), use
+        variable_form: Controls how the output is wrapped in a variable.
+            Pass :class:`NewVariable` to use
             ``format_variable_declaration`` (e.g. ``const x =`` in
-            JavaScript).  If ``False``, use
-            ``format_variable_assignment`` (e.g. ``x =``).  Only
-            relevant when *variable_name* is given.
+            JavaScript), :class:`ExistingVariable` to use
+            ``format_variable_assignment`` (e.g. ``x =``),
+            or :class:`BothVariableForms` to produce both a declaration
+            and an assignment combined in one output (requires
+            *wrap_in_file*).  ``None`` (default) means no variable
+            wrapping.
         error_on_coercion: If ``True``, raise
             :exc:`~literalizer.exceptions.HeterogeneousCoercionError`
             instead of silently coercing heterogeneous scalar
@@ -1033,6 +1058,44 @@ def literalize(
             and the data contains heterogeneous scalar collections
             that would be coerced.
     """
+    # --- BothVariableForms: two full literalize() calls ---
+    if isinstance(variable_form, BothVariableForms):
+        declaration = literalize(
+            source=source,
+            input_format=input_format,
+            language=language,
+            pre_indent_level=pre_indent_level,
+            include_delimiters=include_delimiters,
+            variable_form=NewVariable(name=variable_form.name),
+            error_on_coercion=error_on_coercion,
+        )
+        assignment = literalize(
+            source=source,
+            input_format=input_format,
+            language=language,
+            pre_indent_level=pre_indent_level,
+            include_delimiters=include_delimiters,
+            variable_form=ExistingVariable(name=variable_form.name),
+            error_on_coercion=error_on_coercion,
+        )
+        decl_preamble = (
+            *declaration.body_preamble,
+            *declaration.pre_declaration_comments,
+        )
+        wrapped = language.wrap_combined_in_file(
+            declaration=declaration.declaration_code,
+            assignment=assignment.bare_code,
+            variable_name=variable_form.name,
+            body_preamble=decl_preamble,
+        )
+        if declaration.preamble:
+            wrapped = "\n".join(declaration.preamble) + "\n" + wrapped
+        return LiteralizeResult(
+            code=wrapped,
+            preamble=(),
+            body_preamble=(),
+        )
+
     line_prefix = language.indent * pre_indent_level
     parsed = _parse_input(source=source, input_format=input_format)
     data = parsed.data
@@ -1092,8 +1155,7 @@ def literalize(
         result=result,
         language=language,
         data=data,
-        variable_name=variable_name,
-        new_variable=new_variable,
+        variable_form=variable_form,
     )
 
     # --- Pending comments ---
@@ -1111,10 +1173,12 @@ def literalize(
         result = "\n".join(resolved.pending_scalar_before) + "\n" + result
 
     # --- Preamble ---
+    variable_name = variable_form.name if variable_form is not None else None
+    is_declaration = isinstance(variable_form, NewVariable)
     computed = _compute_preamble(
         data=data,
         language=language,
-        has_variable_declaration=variable_name is not None and new_variable,
+        has_variable_declaration=variable_name is not None and is_declaration,
     )
     preamble = tuple(language.static_preamble) + computed.header
 

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -995,6 +995,55 @@ def _parse_input(*, source: str, input_format: InputFormat) -> _ParsedInput:
 
 
 @beartype
+def _literalize_both_forms(
+    *,
+    source: str,
+    input_format: InputFormat,
+    language: Language,
+    pre_indent_level: int,
+    include_delimiters: bool,
+    variable_form: BothVariableForms,
+    error_on_coercion: bool,
+) -> LiteralizeResult:
+    """Produce combined declaration + assignment output."""
+    declaration = literalize(
+        source=source,
+        input_format=input_format,
+        language=language,
+        pre_indent_level=pre_indent_level,
+        include_delimiters=include_delimiters,
+        variable_form=NewVariable(name=variable_form.name),
+        error_on_coercion=error_on_coercion,
+    )
+    assignment = literalize(
+        source=source,
+        input_format=input_format,
+        language=language,
+        pre_indent_level=pre_indent_level,
+        include_delimiters=include_delimiters,
+        variable_form=ExistingVariable(name=variable_form.name),
+        error_on_coercion=error_on_coercion,
+    )
+    decl_preamble = (
+        *declaration.body_preamble,
+        *declaration.pre_declaration_comments,
+    )
+    wrapped = language.wrap_combined_in_file(
+        declaration=declaration.declaration_code,
+        assignment=assignment.bare_code,
+        variable_name=variable_form.name,
+        body_preamble=decl_preamble,
+    )
+    if declaration.preamble:
+        wrapped = "\n".join(declaration.preamble) + "\n" + wrapped
+    return LiteralizeResult(
+        code=wrapped,
+        preamble=(),
+        body_preamble=(),
+    )
+
+
+@beartype
 def literalize(
     *,
     source: str,
@@ -1060,40 +1109,17 @@ def literalize(
     """
     # --- BothVariableForms: two full literalize() calls ---
     if isinstance(variable_form, BothVariableForms):
-        declaration = literalize(
+        if not wrap_in_file:
+            msg = "BothVariableForms requires wrap_in_file=True"
+            raise ValueError(msg)
+        return _literalize_both_forms(
             source=source,
             input_format=input_format,
             language=language,
             pre_indent_level=pre_indent_level,
             include_delimiters=include_delimiters,
-            variable_form=NewVariable(name=variable_form.name),
+            variable_form=variable_form,
             error_on_coercion=error_on_coercion,
-        )
-        assignment = literalize(
-            source=source,
-            input_format=input_format,
-            language=language,
-            pre_indent_level=pre_indent_level,
-            include_delimiters=include_delimiters,
-            variable_form=ExistingVariable(name=variable_form.name),
-            error_on_coercion=error_on_coercion,
-        )
-        decl_preamble = (
-            *declaration.body_preamble,
-            *declaration.pre_declaration_comments,
-        )
-        wrapped = language.wrap_combined_in_file(
-            declaration=declaration.declaration_code,
-            assignment=assignment.bare_code,
-            variable_name=variable_form.name,
-            body_preamble=decl_preamble,
-        )
-        if declaration.preamble:
-            wrapped = "\n".join(declaration.preamble) + "\n" + wrapped
-        return LiteralizeResult(
-            code=wrapped,
-            preamble=(),
-            body_preamble=(),
         )
 
     line_prefix = language.indent * pre_indent_level

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -83,6 +83,18 @@ def _wrap_variable_name(lang_cls: literalizer.LanguageCls) -> str | None:
     return "my_data" if lang_cls.supports_variable_names else None
 
 
+def _wrap_variable_form(
+    lang_cls: literalizer.LanguageCls,
+) -> literalizer.NewVariable | None:
+    """Return a :class:`NewVariable` form for a language class, or
+    None.
+    """
+    name = _wrap_variable_name(lang_cls=lang_cls)
+    if name is None:
+        return None
+    return literalizer.NewVariable(name=name)
+
+
 def _lang_cls_name(cls: literalizer.LanguageCls) -> str:
     """Return the class name for sorting."""
     return cls.__name__
@@ -101,7 +113,7 @@ class _VariantCase:
     variant_name: str
     variant: _Variant
     case_dir_name: str
-    variable_name: str | None
+    variable_form: literalizer.NewVariable | None
 
 
 @beartype
@@ -560,8 +572,7 @@ def test_golden_file(
         language=lang_cls(),
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=_wrap_variable_name(lang_cls=lang_cls),
-        new_variable=True,
+        variable_form=_wrap_variable_form(lang_cls=lang_cls),
         error_on_coercion=False,
         wrap_in_file=True,
     )
@@ -642,9 +653,8 @@ def test_golden_file_combined_variable_forms(
     cases_dir: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
-    """Test that literalize_yaml with new_variable=True (declaration) and
-    new_variable=False (assignment to existing variable) produce expected
-    golden output, combined in one file to show the difference in syntax.
+    """Test that literalize with BothVariableForms produces expected
+    golden output combining declaration and assignment in one file.
     """
     input_path = cases_dir / combined_case.case_name / "input.yaml"
     lang_cls = combined_case.lang_cls
@@ -652,42 +662,18 @@ def test_golden_file_combined_variable_forms(
         declaration_style=combined_case.declaration_style,
     )
     yaml_string = input_path.read_text()
-    declaration = literalizer.literalize(
+    result = literalizer.literalize(
         source=yaml_string,
         input_format=literalizer.InputFormat.YAML,
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_data",
-        new_variable=True,
+        variable_form=literalizer.BothVariableForms(name="my_data"),
         error_on_coercion=False,
-    )
-    assignment = literalizer.literalize(
-        source=yaml_string,
-        input_format=literalizer.InputFormat.YAML,
-        language=spec,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_name="my_data",
-        new_variable=False,
-        error_on_coercion=False,
-    )
-    variable_name = _wrap_variable_name(lang_cls=lang_cls) or ""
-    decl_preamble = (
-        *declaration.body_preamble,
-        *declaration.pre_declaration_comments,
-    )
-    combined = spec.wrap_combined_in_file(
-        declaration=declaration.declaration_code,
-        assignment=assignment.bare_code,
-        variable_name=variable_name,
-        body_preamble=decl_preamble,
-    )
-    combined = _prepend_preamble(
-        wrapped=combined, preamble=declaration.preamble
+        wrap_in_file=True,
     )
     file_regression.check(
-        contents=combined + "\n",
+        contents=result.code + "\n",
         extension=lang_cls.extension,
         newline="",
         fullpath=input_path.parent
@@ -1130,7 +1116,7 @@ def _build_variant_cases() -> list[_VariantCase]:
                 variant_name=f"{variant.name}{suffix}",
                 variant=variant,
                 case_dir_name=case_dir_name,
-                variable_name=_wrap_variable_name(lang_cls=variant.lang_cls),
+                variable_form=_wrap_variable_form(lang_cls=variant.lang_cls),
             )
             for variant in variants
         )
@@ -1163,8 +1149,7 @@ def test_format_variant_golden_file(
             language=variant.spec,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=variant_case.variable_name,
-            new_variable=True,
+            variable_form=variant_case.variable_form,
             error_on_coercion=False,
             wrap_in_file=True,
         )
@@ -1246,41 +1231,18 @@ def test_line_ending_combined_variable_forms(
         line_ending=case.line_ending,
         declaration_style=redef_styles[0],
     )
-    declaration = literalizer.literalize(
+    result = literalizer.literalize(
         source=yaml_string,
         input_format=literalizer.InputFormat.YAML,
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_data",
-        new_variable=True,
+        variable_form=literalizer.BothVariableForms(name="my_data"),
         error_on_coercion=False,
-    )
-    assignment = literalizer.literalize(
-        source=yaml_string,
-        input_format=literalizer.InputFormat.YAML,
-        language=spec,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_name="my_data",
-        new_variable=False,
-        error_on_coercion=False,
-    )
-    decl_preamble = (
-        *declaration.body_preamble,
-        *declaration.pre_declaration_comments,
-    )
-    combined = spec.wrap_combined_in_file(
-        declaration=declaration.declaration_code,
-        assignment=assignment.bare_code,
-        variable_name=_wrap_variable_name(lang_cls=case.lang_cls) or "",
-        body_preamble=decl_preamble,
-    )
-    combined = _prepend_preamble(
-        wrapped=combined, preamble=declaration.preamble
+        wrap_in_file=True,
     )
     file_regression.check(
-        contents=combined + "\n",
+        contents=result.code + "\n",
         extension=spec.extension,
         fullpath=input_path.parent / (case.name + spec.extension),
     )

--- a/tests/test_comment_unit.py
+++ b/tests/test_comment_unit.py
@@ -53,8 +53,7 @@ def test_yaml_comment_scalar_only_comments() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = "# just a comment\nNone"
@@ -70,8 +69,7 @@ def test_yaml_comment_no_include_delimiters() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = '    # comment\n    "a",\n    "b",'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -9,6 +9,7 @@ import pytest
 from literalizer import (
     InputFormat,
     Language,
+    NewVariable,
     literalize,
 )
 from literalizer.exceptions import (
@@ -79,8 +80,6 @@ def test_dict_python() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = '    "user_1": "team_alpha",\n    "user_2": "team_alpha",'
@@ -95,8 +94,6 @@ def test_dict_include_delimiters() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -123,8 +120,6 @@ def test_dict_empty(*, include_delimiters: bool) -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=include_delimiters,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = "{}" if include_delimiters else ""
@@ -139,8 +134,6 @@ def test_integers() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -160,8 +153,6 @@ def test_floats() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -180,8 +171,6 @@ def test_string_escaping() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     lines = result.code.split(sep="\n")
@@ -198,8 +187,6 @@ def test_nested_arrays() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == "((1, 2), (3, 4)),"
@@ -213,8 +200,6 @@ def test_dicts() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == '{"name": "alice", "age": 30},'
@@ -228,8 +213,6 @@ def test_nested_dict_in_sequence() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == '("a", {"x": 1}),'
@@ -243,8 +226,6 @@ def test_nested_sequence_in_dict() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == '{"items": (1, 2)},'
@@ -258,8 +239,6 @@ def test_indent_spaces() -> None:
         language=PYTHON,
         pre_indent_level=2,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == "        True,\n        False,"
@@ -273,8 +252,6 @@ def test_indent_tabs() -> None:
         language=GO,
         pre_indent_level=2,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == "\t\ttrue,\n\t\tfalse,"
@@ -288,8 +265,6 @@ def test_include_delimiters() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -310,8 +285,6 @@ def test_include_delimiters_with_pre_indent_level() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = '    (\n        ("a", 1.0),\n    )'
@@ -334,8 +307,6 @@ def test_indent_override() -> None:
         language=language,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = "(\n\tTrue,\n\tFalse,\n)"
@@ -356,8 +327,6 @@ def test_empty_data(*, include_delimiters: bool) -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=include_delimiters,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = "()" if include_delimiters else ""
@@ -390,8 +359,6 @@ def test_scalar(
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -405,8 +372,6 @@ def test_scalar_with_indent() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == "    42"
@@ -420,8 +385,6 @@ def test_scalar_include_delimiters_ignored() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == "42"
@@ -436,8 +399,6 @@ def test_literalize_json_array() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = '    ("user_1", 1000.0),\n    ("user_2", 2000.0),'
@@ -453,8 +414,6 @@ def test_literalize_json_object() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -476,8 +435,6 @@ def test_literalize_json_invalid() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -496,8 +453,6 @@ def test_part1_sample_python() -> None:
         language=PYTHON,
         pre_indent_level=2,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected_lines = [
@@ -518,8 +473,6 @@ def test_part2_sample_go() -> None:
         language=GO,
         pre_indent_level=2,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     lines = result.code.split(sep="\n")
@@ -536,8 +489,6 @@ def test_literalize_json_invalid_is_parse_error() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -566,8 +517,6 @@ def test_error_on_coercion_json_raises() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -580,8 +529,6 @@ def test_error_on_coercion_json_no_raise_homogeneous() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -611,8 +558,6 @@ def test_error_on_coercion_json_raises_sibling_lists() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -635,8 +580,6 @@ def test_error_on_coercion_json_raises_nested_sibling_lists() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -652,8 +595,6 @@ def test_cpp_array_null_list_fallback_json() -> None:
         language=cpp_array,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -674,8 +615,6 @@ def test_coerce_mixed_dict_values_none_with_list_json() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -698,8 +637,6 @@ def test_coerce_mixed_dict_values_with_list_json() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -727,8 +664,6 @@ def test_r_empty_dict_key_positional_json() -> None:
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -764,8 +699,6 @@ def test_r_empty_dict_key_error_json() -> None:
             language=spec,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -785,8 +718,6 @@ def test_r_empty_dict_key_error_non_empty_key_ok_json() -> None:
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -809,8 +740,6 @@ def test_error_on_coercion_json_raises_for_heterogeneous_dict() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -823,8 +752,6 @@ def test_error_on_coercion_json_no_effect_without_coerce_flag() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -849,8 +776,6 @@ def test_error_on_coercion_json_raises_for_nested_heterogeneous() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -863,8 +788,6 @@ def test_error_on_coercion_json_no_raise_for_homogeneous_dict() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -895,8 +818,6 @@ def test_error_on_coercion_json_raises_for_mixed_dict_values() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -927,8 +848,6 @@ def test_error_on_coercion_json_raises_for_nested_mixed_dict_values() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -955,8 +874,6 @@ def test_error_on_coercion_json_raises_for_nested_mixed_list_values() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -977,8 +894,6 @@ def test_error_on_coercion_json_raises_for_mixed_list_values() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -1007,8 +922,6 @@ def test_error_on_coercion_json_mixed_dict_inside_mixed_list() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -1037,8 +950,6 @@ def test_error_on_coercion_json_raises_for_mixed_dict_shapes() -> None:
             language=Dhall(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -1057,8 +968,6 @@ def test_error_on_coercion_json_no_raise_for_uniform_dict_shapes() -> None:
         language=Dhall(),
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=True,
     )
 
@@ -1081,8 +990,6 @@ def test_error_on_coercion_json_raises_for_mixed_dict_none_list() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -1104,8 +1011,6 @@ def test_dhall_empty_dict_key_error_json() -> None:
             language=Dhall(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -1118,8 +1023,7 @@ def test_dhall_control_char_in_string_json() -> None:
         language=Dhall(),
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_data",
-        new_variable=True,
+        variable_form=NewVariable(name="my_data"),
         error_on_coercion=False,
     )
     expected = 'let my_data = "\\u{0001}" in my_data'
@@ -1143,8 +1047,6 @@ def test_dhall_control_char_key_error_json() -> None:
             language=Dhall(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -1166,8 +1068,6 @@ def test_nix_control_char_key_error_json() -> None:
             language=Nix(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -1180,8 +1080,7 @@ def test_dhall_backtick_label_unescaping_json() -> None:
         language=Dhall(),
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_data",
-        new_variable=True,
+        variable_form=NewVariable(name="my_data"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(

--- a/tests/test_json5.py
+++ b/tests/test_json5.py
@@ -5,8 +5,10 @@ import textwrap
 import pytest
 
 from literalizer import (
+    ExistingVariable,
     InputFormat,
     Language,
+    NewVariable,
     literalize,
 )
 from literalizer.exceptions import (
@@ -52,8 +54,7 @@ def test_dict_python() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = '    "user_1": "team_alpha",\n    "user_2": "team_alpha",'
@@ -69,8 +70,7 @@ def test_dict_include_delimiters() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -92,8 +92,7 @@ def test_array() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -116,8 +115,7 @@ def test_unquoted_keys() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -139,8 +137,7 @@ def test_single_quoted_strings() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -161,8 +158,7 @@ def test_trailing_commas() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -190,8 +186,7 @@ def test_comments_stripped() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -213,8 +208,7 @@ def test_null() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -235,8 +229,7 @@ def test_booleans() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -258,8 +251,7 @@ def test_nested_objects() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -280,8 +272,7 @@ def test_invalid_json5() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -295,8 +286,7 @@ def test_invalid_json5_is_parse_error() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -310,8 +300,7 @@ def test_variable_declaration() -> None:
         language=JAVASCRIPT,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="config",
-        new_variable=True,
+        variable_form=NewVariable(name="config"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -332,8 +321,7 @@ def test_variable_assignment() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="config",
-        new_variable=False,
+        variable_form=ExistingVariable(name="config"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -354,8 +342,7 @@ def test_go_output() -> None:
         language=GO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = 'map[string]any{\n\t"name": "test",\n\t"count": 42,\n}'
@@ -380,8 +367,7 @@ def test_error_on_coercion_raises() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -407,8 +393,7 @@ def test_scalar_types(
         language=language,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -423,8 +408,7 @@ def test_scalar_string() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == '"hello"'
@@ -439,8 +423,7 @@ def test_scalar_number() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == "42"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -13,6 +13,7 @@ from literalizer import (
     CallStyleKind,
     InputFormat,
     Language,
+    NewVariable,
     literalize,
     literalize_call,
 )
@@ -144,8 +145,7 @@ def test_language_sequence(*, language: Language, expected: str) -> None:
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -159,8 +159,7 @@ def test_ruby_dict() -> None:
         language=RUBY,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == '{"key" => nil},'
@@ -174,8 +173,7 @@ def test_dict_ruby() -> None:
         language=RUBY,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == '    "user_1" => "team_alpha",'
@@ -191,8 +189,7 @@ def test_java_dict_include_delimiters_no_multiline_trailing_comma() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -214,8 +211,7 @@ def test_java_dict_skips_null_values() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -236,8 +232,7 @@ def test_java_dict_skips_null_values_no_include_delimiters() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = 'Map.entry("b", 1)'
@@ -254,8 +249,7 @@ def test_java_dict_all_null_values_include_delimiters() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == "Map.ofEntries()"
@@ -269,8 +263,7 @@ def test_java_dict_all_null_values_with_pre_indent_level() -> None:
         language=JAVA,
         pre_indent_level=1,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == "    Map.ofEntries()"
@@ -285,8 +278,7 @@ def test_java_yaml_dict_null_values_with_comments() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -316,8 +308,7 @@ def test_java_yaml_dict_null_value_inline_comment_preserved() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -347,8 +338,7 @@ def test_java_yaml_null_value_inline_comment_as_trailing() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -372,8 +362,7 @@ def test_java_yaml_all_null_dict_with_trailing_comments() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = "Map.ofEntries()\n    // trailing"
@@ -397,8 +386,7 @@ def test_java_yaml_ordered_map_skips_null_values() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     ordered_map_inline = (
@@ -417,8 +405,7 @@ def test_java_sequence_include_delimiters_uses_braces() -> None:
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -480,8 +467,7 @@ def test_java_typed_array_opener(
         language=JAVA,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -516,8 +502,7 @@ def test_matlab_string_escaping(*, yaml_string: str, expected: str) -> None:
         ),
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -541,8 +526,7 @@ def test_matlab_dict_key_with_quote() -> None:
         ),
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == "'hello \"world\"', 1"
@@ -561,8 +545,7 @@ def test_toml_integer_dict_key() -> None:
         language=TOML,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -582,8 +565,7 @@ def test_cobol_string_control_characters() -> None:
         language=COBOL,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == '"line1 line2"'
@@ -597,8 +579,7 @@ def test_cobol_string_tab_characters() -> None:
         language=COBOL,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == '"col1 col2"'
@@ -628,8 +609,7 @@ def test_cobol_level_number_cap() -> None:
         language=COBOL,
         pre_indent_level=1,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = (
@@ -659,8 +639,7 @@ def test_cobol_key_name_trailing_hyphen_after_truncation() -> None:
         language=COBOL,
         pre_indent_level=1,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     for line in result.code.splitlines():
@@ -678,9 +657,8 @@ def test_fortran_continuation_with_escaped_quote_and_comment() -> None:
         input_format=InputFormat.YAML,
         language=FORTRAN,
         pre_indent_level=0,
-        variable_name="cfg",
+        variable_form=NewVariable(name="cfg"),
         include_delimiters=True,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -705,8 +683,7 @@ def test_java_list_format() -> None:
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -740,8 +717,7 @@ def test_java_list_rejects_null_elements() -> None:
             language=spec,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -811,8 +787,7 @@ def test_python_no_any_import_when_all_defaults_overridden() -> None:
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_data",
-        new_variable=True,
+        variable_form=NewVariable(name="my_data"),
         error_on_coercion=False,
     )
     assert result.code == "my_data: dict[str, str] = {}"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -9,6 +9,7 @@ from pygments.lexers import find_lexer_class_by_name
 
 import literalizer.languages
 from literalizer import (
+    BothVariableForms,
     CallStyleConfig,
     CallStyleKind,
     InputFormat,
@@ -836,6 +837,17 @@ def test_literalize_call_per_element_false() -> None:
     )
     assert "process(" in result.code
     assert "1," in result.code
+
+
+def test_both_variable_forms_without_wrap_in_file_raises() -> None:
+    """BothVariableForms without wrap_in_file=True raises ValueError."""
+    with pytest.raises(expected_exception=ValueError, match="wrap_in_file"):
+        literalize(
+            source="42",
+            input_format=InputFormat.JSON,
+            language=Python(),
+            variable_form=BothVariableForms(name="x"),
+        )
 
 
 def test_literalize_call_missing_keyword_separator_raises() -> None:

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -85,8 +85,7 @@ def test_roundtrip_array(data: list[_JSONValue]) -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     parsed = ast.literal_eval(node_or_string=result.code)
@@ -102,8 +101,7 @@ def test_roundtrip_scalar(data: _JSONScalar) -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     parsed = ast.literal_eval(node_or_string=result.code)
@@ -124,8 +122,7 @@ def test_roundtrip_dict(data: dict[str, _JSONValue]) -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     parsed = ast.literal_eval(node_or_string=result.code)
@@ -159,8 +156,7 @@ def test_roundtrip_yaml_binary_python(data: bytes) -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     code = result.code.rstrip(",")
@@ -232,8 +228,7 @@ def test_roundtrip_yaml_binary_hex_languages(
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     code = result.code.rstrip(",")
@@ -251,8 +246,7 @@ def test_roundtrip_yaml_binary_erlang(data: bytes) -> None:
         language=ERLANG_LANG,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     code = result.code.rstrip(",")

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -5,8 +5,10 @@ import textwrap
 import pytest
 
 from literalizer import (
+    ExistingVariable,
     InputFormat,
     Language,
+    NewVariable,
     literalize,
 )
 from literalizer._comments import extract_toml_comments
@@ -55,8 +57,6 @@ def test_dict_python() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = '    "user_1": "team_alpha",\n    "user_2": "team_alpha",'
@@ -72,8 +72,6 @@ def test_dict_include_delimiters() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -94,8 +92,6 @@ def test_empty_table() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == "{}"
@@ -110,8 +106,6 @@ def test_integers() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -132,8 +126,6 @@ def test_floats() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -154,8 +146,6 @@ def test_booleans() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -177,8 +167,6 @@ def test_nested_table() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -199,8 +187,6 @@ def test_array_of_tables() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -221,8 +207,6 @@ def test_date_python() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -243,8 +227,6 @@ def test_datetime_python() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = (
@@ -266,8 +248,6 @@ def test_time_coerced_to_string() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -288,8 +268,6 @@ def test_invalid_toml() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -303,8 +281,6 @@ def test_invalid_toml_is_parse_error() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=False,
         )
 
@@ -318,8 +294,7 @@ def test_variable_declaration() -> None:
         language=JAVASCRIPT,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="config",
-        new_variable=True,
+        variable_form=NewVariable(name="config"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -340,8 +315,7 @@ def test_variable_assignment() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="config",
-        new_variable=False,
+        variable_form=ExistingVariable(name="config"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -362,8 +336,6 @@ def test_go_output() -> None:
         language=GO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = 'map[string]any{\n\t"name": "test",\n\t"count": 42,\n}'
@@ -388,8 +360,6 @@ def test_error_on_coercion_raises() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
             error_on_coercion=True,
         )
 
@@ -403,8 +373,6 @@ def test_error_on_coercion_no_raise_homogeneous() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -436,8 +404,6 @@ def test_scalar_types(
         language=language,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -458,8 +424,6 @@ def test_body_preamble() -> None:
         language=haskell,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected_preamble = "data Val = HStr String | HMap [(String, Val)]"
@@ -490,8 +454,6 @@ def test_body_preamble_double_iso() -> None:
         language=haskell,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -516,8 +478,6 @@ def test_inline_comment_preserved() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -539,8 +499,6 @@ def test_before_comment_preserved() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -563,8 +521,6 @@ def test_trailing_comment_preserved() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -590,8 +546,6 @@ def test_mixed_comments_preserved() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -614,8 +568,6 @@ def test_comments_go_output() -> None:
         language=GO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = (
@@ -637,8 +589,6 @@ def test_no_comments_unchanged() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -660,8 +610,6 @@ def test_comments_without_delimiters() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = '# header\n"host": "localhost",  # inline\n"port": 8080,'
@@ -677,8 +625,7 @@ def test_comments_with_variable_declaration() -> None:
         language=JAVASCRIPT,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="config",
-        new_variable=True,
+        variable_form=NewVariable(name="config"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -708,8 +655,7 @@ def test_comments_language_without_collection_comments() -> None:
         language=VISUAL_BASIC,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="config",
-        new_variable=True,
+        variable_form=NewVariable(name="config"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -739,8 +685,6 @@ def test_comments_with_blank_lines() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -8,8 +8,10 @@ import textwrap
 import pytest
 
 from literalizer import (
+    ExistingVariable,
     InputFormat,
     Language,
+    NewVariable,
     literalize,
 )
 from literalizer.languages import (
@@ -284,8 +286,7 @@ def test_variable_declaration_json(
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -304,8 +305,7 @@ def test_variable_declaration_yaml(
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -326,8 +326,7 @@ def test_existing_variable_assignment_json(
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name="my_var",
-        new_variable=False,
+        variable_form=ExistingVariable(name="my_var"),
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -348,8 +347,7 @@ def test_existing_variable_assignment_yaml(
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name="my_var",
-        new_variable=False,
+        variable_form=ExistingVariable(name="my_var"),
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -378,8 +376,7 @@ def test_python_always_type_hints_scalars(
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -393,8 +390,7 @@ def test_python_always_type_hints_dict() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -414,8 +410,7 @@ def test_python_always_type_hints_tuple() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -446,8 +441,7 @@ def test_python_always_type_hints_list() -> None:
         language=lang,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -468,8 +462,7 @@ def test_python_always_type_hints_assignment_no_hint() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name="my_var",
-        new_variable=False,
+        variable_form=ExistingVariable(name="my_var"),
         error_on_coercion=False,
     )
     assert result.code == "my_var = 42"
@@ -484,8 +477,7 @@ def test_python_always_type_hints_set_with_colon_in_string() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -506,8 +498,7 @@ def test_python_always_type_hints_set_of_integers() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -529,8 +520,7 @@ def test_python_always_type_hints_nested_list_in_list() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -553,8 +543,7 @@ def test_python_always_type_hints_dict_with_list_values() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -574,8 +563,7 @@ def test_python_always_type_hints_empty_list() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     assert result.code == "my_var: tuple[Any, ...] = ()"
@@ -598,8 +586,7 @@ def test_python_always_type_hints_ordered_dicts_in_sequence() -> None:
         language=PYTHON_ALWAYS_HINTS,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_var",
-        new_variable=True,
+        variable_form=NewVariable(name="my_var"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -8,6 +8,7 @@ import pytest
 from literalizer import (
     InputFormat,
     Language,
+    NewVariable,
     literalize,
 )
 from literalizer.exceptions import (
@@ -64,8 +65,7 @@ def test_literalize_yaml_sequence() -> None:
         language=PYTHON,
         pre_indent_level=1,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = '    ("user_1", 1000.0),\n    ("user_2", 2000.0),'
@@ -89,8 +89,7 @@ def test_literalize_yaml_indent_override() -> None:
         language=language,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = '{\n\t"a": 1,\n\t"b": True,\n}'
@@ -106,8 +105,7 @@ def test_literalize_yaml_invalid() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -121,8 +119,7 @@ def test_literalize_yaml_invalid_is_parse_error() -> None:
             language=PYTHON,
             pre_indent_level=0,
             include_delimiters=False,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -153,8 +150,7 @@ def test_literalize_yaml_scalar(
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == expected
@@ -172,8 +168,7 @@ def test_cpp_array_binary_typed() -> None:
         language=cpp_array,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -197,8 +192,7 @@ def test_cpp_array_null_list_fallback() -> None:
         language=cpp_array,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -221,8 +215,7 @@ def test_yaml_set_inline_in_sequence() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == '{"a", "b"},'
@@ -236,8 +229,7 @@ def test_yaml_set_inline_with_format_set_entry() -> None:
         language=GO,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == 'map[string]struct{}{"a": struct{}{}},'
@@ -251,8 +243,7 @@ def test_yaml_empty_set_inline() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=False,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     assert result.code == "set(),"
@@ -277,8 +268,7 @@ def test_ordered_map_nested_in_sequence() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -305,8 +295,7 @@ def test_coerce_heterogeneous_bytes_in_collection() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -334,8 +323,7 @@ def test_coerce_heterogeneous_set() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -362,8 +350,7 @@ def test_coerce_heterogeneous_date_in_collection() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -392,8 +379,7 @@ def test_coerce_heterogeneous_datetime_in_collection() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -421,8 +407,7 @@ def test_coerce_homogeneous_ordered_map_no_coercion() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -450,8 +435,7 @@ def test_coerce_mixed_dict_values_none_with_list() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -479,8 +463,7 @@ def test_coerce_mixed_dict_values_set_with_string() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     # Set is converted to a sorted JSON array before string conversion.
@@ -510,8 +493,7 @@ def test_coerce_mixed_dict_values_with_list() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -541,8 +523,7 @@ def test_coerce_mixed_ordered_map_values() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -572,8 +553,7 @@ def test_r_empty_dict_key_positional() -> None:
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -601,8 +581,7 @@ def test_r_empty_dict_key_positional_is_default() -> None:
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -639,8 +618,7 @@ def test_r_empty_dict_key_error() -> None:
             language=spec,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -661,8 +639,7 @@ def test_r_empty_dict_key_error_non_empty_key_ok() -> None:
         language=spec,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=False,
     )
     expected = textwrap.dedent(
@@ -684,8 +661,7 @@ def test_error_on_coercion_raises_for_heterogeneous_list() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -707,8 +683,7 @@ def test_error_on_coercion_raises_for_heterogeneous_dict() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -722,8 +697,7 @@ def test_error_on_coercion_no_raise_for_homogeneous() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -746,8 +720,7 @@ def test_error_on_coercion_no_effect_without_coerce_flag() -> None:
         language=PYTHON,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -778,8 +751,7 @@ def test_error_on_coercion_raises_for_nested_heterogeneous() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -800,8 +772,7 @@ def test_error_on_coercion_raises_for_heterogeneous_ordered_map() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -822,8 +793,7 @@ def test_error_on_coercion_raises_for_heterogeneous_set() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -842,8 +812,7 @@ def test_error_on_coercion_no_raise_for_homogeneous_dict() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -871,8 +840,7 @@ def test_error_on_coercion_no_raise_for_homogeneous_ordered_map() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -900,8 +868,7 @@ def test_error_on_coercion_no_raise_for_homogeneous_set() -> None:
         language=MOJO,
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=True,
     )
     expected = textwrap.dedent(
@@ -938,8 +905,7 @@ def test_error_on_coercion_raises_for_mixed_dict_values() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -967,8 +933,7 @@ def test_error_on_coercion_raises_for_mixed_list_values() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -999,8 +964,7 @@ def test_error_on_coercion_raises_for_mixed_dict_shapes() -> None:
             language=Dhall(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -1023,8 +987,7 @@ def test_error_on_coercion_no_raise_for_uniform_dict_shapes() -> None:
         language=Dhall(),
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name=None,
-        new_variable=True,
+        variable_form=None,
         error_on_coercion=True,
     )
 
@@ -1052,8 +1015,7 @@ def test_error_on_coercion_raises_for_mixed_dict_none_list() -> None:
             language=MOJO,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=True,
         )
 
@@ -1076,8 +1038,7 @@ def test_dhall_empty_dict_key_error() -> None:
             language=Dhall(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -1091,8 +1052,7 @@ def test_dhall_control_char_in_string() -> None:
         language=Dhall(),
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_data",
-        new_variable=True,
+        variable_form=NewVariable(name="my_data"),
         error_on_coercion=False,
     )
     expected = 'let my_data = "\\u{0001}" in my_data'
@@ -1117,8 +1077,7 @@ def test_dhall_control_char_key_error() -> None:
             language=Dhall(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -1141,8 +1100,7 @@ def test_nix_control_char_key_error() -> None:
             language=Nix(),
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=None,
             error_on_coercion=False,
         )
 
@@ -1156,8 +1114,7 @@ def test_dhall_backtick_label_unescaping() -> None:
         language=Dhall(),
         pre_indent_level=0,
         include_delimiters=True,
-        variable_name="my_data",
-        new_variable=True,
+        variable_form=NewVariable(name="my_data"),
         error_on_coercion=False,
     )
     expected = textwrap.dedent(


### PR DESCRIPTION
## Summary
- Introduces `NewVariable`, `ExistingVariable`, and `BothVariableForms` dataclasses that replace the `variable_name: str | None` and `new_variable: bool` parameters on `literalize()` with a single `variable_form: VariableForm | None` parameter.
- `BothVariableForms` produces combined declaration+assignment output through the public API, making `wrap_combined_in_file` testable via `literalize()` without needing to call it directly on the language instance.
- Integration tests for combined variable forms now use a single `literalize(..., variable_form=BothVariableForms(name="my_data"), wrap_in_file=True)` call instead of two separate `literalize()` calls plus manual `wrap_combined_in_file` and `_prepend_preamble` calls.

## Test plan
- [x] All 12463 existing tests pass with no golden file changes
- [x] Pre-commit hooks pass (vulture, ruff, mypy, pyright, ty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API signature changes from `variable_name`/`new_variable` to `variable_form`, which is a breaking change for callers and touches variable-wrapping/preamble generation paths. Logic is mostly a refactor plus a new combined-output mode, but it could affect code formatting across languages if edge cases slip through.
> 
> **Overview**
> **Reworks variable wrapping in `literalize()`.** The `variable_name` + `new_variable` parameters are replaced by a single `variable_form` union, backed by new dataclasses `NewVariable`, `ExistingVariable`, and `BothVariableForms` (exported in `__init__`).
> 
> **Adds a new combined-output mode.** Passing `BothVariableForms` (with `wrap_in_file=True`) now produces a single file containing both declaration and assignment forms via an internal `_literalize_both_forms` helper, and raises a `ValueError` if used without `wrap_in_file`.
> 
> **Updates docs and tests.** All examples and tests are migrated to the new API, and integration tests for “combined variable forms” are simplified to one `literalize()` call instead of manually combining two results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ca03d17d50317ff7aa6a2c369eb5b7423e3814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->