### PR TITLE
Reuse _token_comment_lines in TOML comment extraction

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -196,9 +196,7 @@ def extract_toml_comments(
             if isinstance(item, Comment):
                 raw: str = item.trivia.comment
                 pending_before.extend(
-                    _strip_comment_marker(text=line)
-                    for line in raw.split(sep="\n")
-                    if line.strip().startswith("#")
+                    _token_comment_lines(value=raw),
                 )
             continue
         inline = ""


### PR DESCRIPTION
## Summary
- Replaces duplicated comment-line extraction logic in `extract_toml_comments` with a call to the existing `_token_comment_lines` helper

Closes #1191

## Test plan
- [x] All 12464 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to comment parsing, replacing duplicated line-splitting logic with an existing helper. Behavior should remain equivalent aside from any subtle edge-case alignment with the helper’s rules.
> 
> **Overview**
> Refactors `extract_toml_comments` to use the existing `_token_comment_lines` helper when extracting standalone TOML comments, removing duplicated logic for splitting multi-line `#` comments and stripping markers.
> 
> No functional changes beyond aligning TOML comment-line tokenization with the shared helper implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9783452ead13b6802c68cae86ecd75009ce0e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->