### PR TITLE
Add call stub rendering for Julia language module

### DIFF
--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -2,7 +2,7 @@
 
 import datetime
 import enum
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
@@ -54,6 +54,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
@@ -65,9 +66,46 @@ from literalizer._language import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from literalizer._types import Value
+
+_VARIADIC = "args...; kwargs..."
+
+
+def _julia_call_stub(
+    name: str,
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Julia stub declarations for a call name."""
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"{parts[0]}({_VARIADIC}) = nothing",)
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    _anon = f"({_VARIADIC}) -> nothing"
+    if not fields:
+        cls = root.capitalize() + "Type"
+        return (
+            f"struct {cls}; {method}; end",
+            f"{root} = {cls}({_anon})",
+        )
+    lines: list[str] = []
+    inner_cls = fields[-1].capitalize() + "Type"
+    lines.append(f"struct {inner_cls}; {method}; end")
+    for i in range(len(fields) - 2, -1, -1):
+        cls = fields[i].capitalize() + "Type"
+        field = fields[i + 1]
+        lines.append(f"struct {cls}; {field}; end")
+    root_cls = root.capitalize() + "Type"
+    lines.append(f"struct {root_cls}; {fields[0]}; end")
+    inner_inst = f"{inner_cls}({_anon})"
+    for i in range(len(fields) - 2, -1, -1):
+        cls = fields[i].capitalize() + "Type"
+        inner_inst = f"{cls}({inner_inst})"
+    lines.append(f"{root} = {root_cls}({inner_inst})")
+    return tuple(lines)
 
 
 @beartype
@@ -527,6 +565,6 @@ class Julia(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
+        self.format_call_stub = _julia_call_stub
         self.format_call_preamble_stub = no_call_stub
         self.format_call_target = identity_call_target

--- a/tests/integration/cases/call_deep_dotted_method/Julia_call.jl
+++ b/tests/integration/cases/call_deep_dotted_method/Julia_call.jl
@@ -1,3 +1,7 @@
+struct ClientType; post; end
+struct ApiType; client; end
+struct ObjType; api; end
+obj = ObjType(ApiType(ClientType((args...; kwargs...) -> nothing)))
 obj.api.client.post(data="hello")
 obj.api.client.post(data=42)
 obj.api.client.post(data=true)

--- a/tests/integration/cases/call_deep_dotted_transformed/Julia_call.jl
+++ b/tests/integration/cases/call_deep_dotted_transformed/Julia_call.jl
@@ -1,3 +1,7 @@
+struct ClientType; fetch; end
+struct AppType; client; end
+app = AppType(ClientType((args...; kwargs...) -> nothing))
+emit(args...; kwargs...) = nothing
 emit(app.client.fetch(payload="hello"))
 emit(app.client.fetch(payload=42))
 emit(app.client.fetch(payload=true))

--- a/tests/integration/cases/call_dotted_method/Julia_call.jl
+++ b/tests/integration/cases/call_dotted_method/Julia_call.jl
@@ -1,3 +1,6 @@
+struct ClientType; fetch; end
+struct AppType; client; end
+app = AppType(ClientType((args...; kwargs...) -> nothing))
 app.client.fetch(payload="hello")
 app.client.fetch(payload=42)
 app.client.fetch(payload=true)

--- a/tests/integration/cases/call_keyword_args/Julia_call.jl
+++ b/tests/integration/cases/call_keyword_args/Julia_call.jl
@@ -1,2 +1,5 @@
+struct ThrottlerType; check; end
+throttler = ThrottlerType((args...; kwargs...) -> nothing)
+emit(args...; kwargs...) = nothing
 emit(throttler.check(user_id="user_1", ts=1000.0))
 emit(throttler.check(user_id="user_2", ts=2000.5))

--- a/tests/integration/cases/call_positional/Julia_call.jl
+++ b/tests/integration/cases/call_positional/Julia_call.jl
@@ -1,2 +1,5 @@
+struct ThrottlerType; check; end
+throttler = ThrottlerType((args...; kwargs...) -> nothing)
+emit(args...; kwargs...) = nothing
 emit(throttler.check("user_1", 1000.0))
 emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_scalar_args/Julia_call.jl
+++ b/tests/integration/cases/call_scalar_args/Julia_call.jl
@@ -1,3 +1,4 @@
+process(args...; kwargs...) = nothing
 process(value="hello")
 process(value=42)
 process(value=true)


### PR DESCRIPTION
## Summary
- Implements `_julia_call_stub()` in the Julia language module, replacing `no_call_stub` with real call stub generation
- Simple functions get `f(args...; kwargs...) = nothing` stubs
- Dotted method calls (e.g. `throttler.check(...)`) use nested `struct` types with callable fields
- Updates all 6 Julia call golden test files with the new stub output

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Julia call-stub rendering and associated golden test outputs, with no impact on core data formatting or other languages.
> 
> **Overview**
> Adds Julia-specific call stub generation via `_julia_call_stub` and wires it into the `Julia` language config (replacing `no_call_stub`).
> 
> Simple call targets now get a variadic `f(args...; kwargs...) = nothing` stub, while dotted calls emit nested `struct` wrappers with callable fields so expressions like `obj.api.client.post(...)` typecheck.
> 
> Updates the Julia call integration golden files to include these new stub declarations before the call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5042d4b8855f03ad670d0483039254563a56b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->