### PR TITLE
Use match statement for value-to-str type dispatch

### DIFF
--- a/src/literalizer/_coercions.py
+++ b/src/literalizer/_coercions.py
@@ -446,15 +446,19 @@ def _values_mixed_types(*, values: Sequence[Value]) -> bool:
 @beartype
 def _coerce_value_to_str(*, value: Value) -> str:
     """Convert any value (scalar or collection) to a string."""
-    if isinstance(value, str):
-        return value
-    bucket = scalar_type_bucket(value=value)
-    if bucket is not None:
-        return coerce_scalar_to_str(value=value)
-    if isinstance(value, set):
-        sorted_items = sorted(value, key=lambda v: (type(v).__name__, repr(v)))
-        return json.dumps(obj=sorted_items, default=str)
-    return json.dumps(obj=value, default=str, sort_keys=False)
+    match value:
+        case str():
+            return value
+        case None | bool() | int() | float() | bytes() | datetime.date():
+            return coerce_scalar_to_str(value=value)
+        case set():
+            sorted_items = sorted(
+                value,
+                key=lambda v: (type(v).__name__, repr(v)),
+            )
+            return json.dumps(obj=sorted_items, default=str)
+        case _:
+            return json.dumps(obj=value, default=str, sort_keys=False)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace `isinstance` chain in `_coerce_value_to_str` with a `match` statement, consistent with other dispatch patterns in `_coercions.py`

Closes #1229

## Test plan
- [x] All 530 existing tests pass
- [x] All pre-commit hooks pass (ruff, mypy, pyright, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `_coerce_value_to_str`, but it changes the type-dispatch paths for scalar vs collection stringification and could subtly affect edge-case serialization output.
> 
> **Overview**
> Refactors `_coerce_value_to_str` to use a `match` statement for type dispatch instead of an `isinstance`/bucket chain.
> 
> The new dispatch explicitly routes scalar-like types (`None`, `bool`, `int`, `float`, `bytes`, `datetime.date`) through `coerce_scalar_to_str`, preserves deterministic JSON output for `set` by sorting before dumping, and leaves other values to `json.dumps`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a45eceb5784faa327431329b76042e2ab55c2464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->