### PR TITLE
Use match statement for datetime subtype dispatch

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -220,11 +220,13 @@ def _preamble_scalar_type(*, value: Value) -> type | None:
     ``datetime.datetime`` from ``datetime.date`` (they need different
     preamble lines).
     """
-    if isinstance(value, datetime.datetime):
-        return datetime.datetime
-    if isinstance(value, datetime.date):
-        return datetime.date
-    return scalar_type_bucket(value=value)
+    match value:
+        case datetime.datetime():
+            return datetime.datetime
+        case datetime.date():
+            return datetime.date
+        case _:
+            return scalar_type_bucket(value=value)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace `isinstance` chain with `match` statement in `_preamble_scalar_type` for datetime subtype dispatch

Closes #1228

## Test plan
- [x] All 530 existing tests pass
- [x] Pre-commit hooks (mypy, pyright, ruff, etc.) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to `_preamble_scalar_type` dispatch logic; behavior should be unchanged aside from relying on Python pattern matching semantics for `datetime`/`date` identification.
> 
> **Overview**
> Switches `_preamble_scalar_type` from an `isinstance` chain to a `match`/`case` statement to select the correct preamble-relevant type for `datetime.datetime` vs `datetime.date`, falling back to `scalar_type_bucket` for all other scalars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4cb725a386e57a128b37d6eba157e8fe8caff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->