### PR TITLE
Use match statement for ruamel type dispatch

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -128,14 +128,16 @@ def extract_yaml_comments(
 
     # Sequences and sets store after-element tokens at index 0,
     # mappings at index 2.
-    token_idx = 2 if isinstance(ruamel_data, CommentedMap) else 0
-
-    if isinstance(ruamel_data, CommentedSeq):
-        keys: list[object] = list(range(len(ruamel_data)))
-    elif isinstance(ruamel_data, CommentedSet):
-        keys = list(ruamel_data)
-    else:
-        keys = list(ruamel_data.keys())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    match ruamel_data:
+        case CommentedSeq():
+            token_idx = 0
+            keys: list[object] = list(range(len(ruamel_data)))
+        case CommentedSet():
+            token_idx = 0
+            keys = list(ruamel_data)
+        case CommentedMap():
+            token_idx = 2
+            keys = list(ruamel_data.keys())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 
     # Iterate in insertion order so that pending_before propagation is
     # correct (a "before element N" comment is stored in the after-token

--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -135,7 +135,7 @@ def extract_yaml_comments(
         case CommentedSet():
             token_idx = 0
             keys = list(ruamel_data)
-        case CommentedMap():
+        case _:
             token_idx = 2
             keys = list(ruamel_data.keys())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 


### PR DESCRIPTION
## Summary
- Replace `isinstance` chain with a `match` statement for dispatching on `ruamel_data` type (`CommentedSeq`, `CommentedMap`, `CommentedSet`) in `_comments.py`
- Each case now sets both `token_idx` and `keys` together, making the per-type logic clearer

Closes #1226

## Test plan
- [x] All 530 existing tests pass
- [x] Pre-commit and pre-push hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of `extract_yaml_comments` type dispatch; behavior should be unchanged aside from potential edge cases if non-`CommentedMap/Seq/Set` inputs slip through.
> 
> **Overview**
> Refactors `extract_yaml_comments` in `_comments.py` to replace the `isinstance` chain with a `match` statement that dispatches on `CommentedSeq`, `CommentedSet`, and the default (mapping) case.
> 
> Each branch now sets `token_idx` and the iteration `keys` together, making the per-collection handling clearer while keeping the comment extraction flow the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508d7a157315c40d4f09aade728fbfd847a9ae3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->