### PR TITLE
Use match statement for TOML body item dispatch

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -201,6 +201,8 @@ def extract_toml_comments(
                 continue
             case Whitespace():
                 continue
+            case _:
+                pass
         inline = ""
         if not isinstance(item, Table):
             raw_inline: str = item.trivia.comment

--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -192,13 +192,15 @@ def extract_toml_comments(
     elements: list[ElementComments] = []
 
     for _key, item in toml_doc.body:
-        if isinstance(item, (Whitespace, Comment)):
-            if isinstance(item, Comment):
+        match item:
+            case Comment():
                 raw: str = item.trivia.comment
                 pending_before.extend(
                     _token_comment_lines(value=raw),
                 )
-            continue
+                continue
+            case Whitespace():
+                continue
         inline = ""
         if not isinstance(item, Table):
             raw_inline: str = item.trivia.comment


### PR DESCRIPTION
## Summary
- Replace nested `isinstance` checks with `match`/`case` for `Comment` and `Whitespace` handling in `extract_toml_comments`
- Closes #1227

## Test plan
- [x] All 12464 existing tests pass
- [x] Pre-commit hooks pass (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `extract_toml_comments` control flow with no intended behavior change beyond readability/maintainability.
> 
> **Overview**
> Refactors `extract_toml_comments` to replace nested `isinstance` checks with a `match`/`case` dispatch that explicitly handles `Comment` and `Whitespace` nodes (accumulating pending standalone comments and skipping whitespace) before processing inline comments and emitting `ElementComments`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12f17b289ba1858f7a69d548e77a04c5b49c6e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->