### PR TITLE
Remove redundant test_language_sequence unit test

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -13,7 +13,6 @@ from literalizer import (
     CallStyleConfig,
     CallStyleKind,
     InputFormat,
-    Language,
     NewVariable,
     literalize,
     literalize_call,
@@ -30,14 +29,12 @@ from literalizer.languages import (
     Fortran,
     Go,
     Java,
-    JavaScript,
     Kotlin,
     Matlab,
     Python,
     Ruby,
     Rust,
     Toml,
-    TypeScript,
     Yaml,
 )
 
@@ -77,12 +74,6 @@ JAVA = Java(
     bytes_format=Java.bytes_formats.HEX,
     sequence_format=Java.sequence_formats.ARRAY,
 )
-JAVASCRIPT = JavaScript(
-    date_format=JavaScript.date_formats.JS,
-    datetime_format=JavaScript.datetime_formats.JS,
-    bytes_format=JavaScript.bytes_formats.HEX,
-    sequence_format=JavaScript.sequence_formats.ARRAY,
-)
 KOTLIN = Kotlin(
     date_format=Kotlin.date_formats.KOTLIN,
     datetime_format=Kotlin.datetime_formats.KOTLIN,
@@ -115,41 +106,6 @@ TOML = Toml(
     bytes_format=Toml.bytes_formats.HEX,
     sequence_format=Toml.sequence_formats.ARRAY,
 )
-TYPESCRIPT = TypeScript(
-    date_format=TypeScript.date_formats.JS,
-    datetime_format=TypeScript.datetime_formats.JS,
-    bytes_format=TypeScript.bytes_formats.HEX,
-    sequence_format=TypeScript.sequence_formats.ARRAY,
-)
-
-
-@pytest.mark.parametrize(
-    argnames=("language", "expected"),
-    argvalues=[
-        (PYTHON, '(True, None, "hi", (1, 2)),'),
-        (JAVASCRIPT, '[true, null, "hi", [1, 2]],'),
-        (TYPESCRIPT, '[true, null, "hi", [1, 2]],'),
-        (GO, '[]any{true, nil, "hi", []int{1, 2}},'),
-        (CPP, '{true, nullptr, "hi", std::vector<int>{1, 2}},'),
-        (JAVA, 'new Object[]{true, null, "hi", new int[]{1, 2}}'),
-        (CSHARP, 'new object[] {true, (object?)null, "hi", new int[] {1, 2}}'),
-        (RUBY, '[true, nil, "hi", [1, 2]],'),
-        (KOTLIN, 'listOf<Any?>(true, null, "hi", intArrayOf(1, 2)),'),
-        (RUST, 'vec!["True", "None", "hi", "[1, 2]"],'),
-    ],
-)
-def test_language_sequence(*, language: Language, expected: str) -> None:
-    """Each language produces the correct sequence literal."""
-    result = literalize(
-        source=json.dumps(obj=[[True, None, "hi", [1, 2]]]),
-        input_format=InputFormat.JSON,
-        language=language,
-        pre_indent_level=0,
-        include_delimiters=False,
-        variable_form=None,
-        error_on_coercion=False,
-    )
-    assert result.code == expected
 
 
 def test_ruby_dict() -> None:


### PR DESCRIPTION
## Summary
- Remove `test_language_sequence` from `tests/test_languages.py` since the integration golden-file tests (e.g. `nested_sequence`) already cover sequence output for all 62 languages
- Clean up unused imports (`Language`, `JavaScript`, `TypeScript`) and constants (`JAVASCRIPT`, `TYPESCRIPT`) that were only used by this test

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only test cleanup with no production code changes, but it slightly reduces direct unit coverage for sequence literal rendering.
> 
> **Overview**
> Removes the `test_language_sequence` parametrized test (and its `JavaScript`/`TypeScript` fixtures) from `tests/test_languages.py`, relying on existing golden/integration coverage instead.
> 
> Cleans up now-unused imports (`Language`, `JavaScript`, `TypeScript`) and constants (`JAVASCRIPT`, `TYPESCRIPT`) that were only used by that test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c636cb4b1b9a0db9e598d99fbfd5bd47e75e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->