### PR TITLE
Bump ty to 0.0.30 and fix type-check errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
-    "ty==0.0.29",
+    "ty==0.0.30",
     "types-pygments==2.20.0.20260408",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -40,6 +40,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -454,6 +455,10 @@ class Ada(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -43,6 +43,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -448,6 +449,10 @@ class Bash(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -44,6 +44,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -509,6 +510,10 @@ class C(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ("#include <math.h>",)
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -41,6 +41,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -394,6 +395,10 @@ class Clojure(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -39,6 +39,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -583,6 +584,10 @@ class Cobol(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -40,6 +40,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -411,6 +412,10 @@ class CommonLisp(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -754,6 +754,10 @@ class Cpp(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = _cpp_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _cpp_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -510,6 +510,10 @@ class Crystal(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _crystal_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _crystal_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -624,6 +624,10 @@ class CSharp(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _csharp_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _csharp_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -494,6 +494,10 @@ class D(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _d_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _d_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -660,6 +661,10 @@ class Dart(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -43,6 +43,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -510,7 +511,11 @@ class Dhall(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target
         self.type_hint_collection_preamble_lines = no_type_hint_preamble

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -504,6 +505,10 @@ class Elixir(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     identity_call_target,
     no_call_stub,
@@ -746,6 +747,10 @@ class Elm(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -45,6 +45,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -477,6 +478,10 @@ class Erlang(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -28,6 +28,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -487,6 +488,10 @@ class Forth(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -41,6 +41,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -635,6 +636,10 @@ class Fortran(metaclass=LanguageCls):
         )
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -656,6 +656,10 @@ class FSharp(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _fsharp_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _fsharp_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -810,6 +811,10 @@ class Gleam(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -634,6 +634,10 @@ class Go(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = _go_call_preamble_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _go_call_preamble_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -462,6 +462,10 @@ class Groovy(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _groovy_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _groovy_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -42,6 +42,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -419,6 +420,10 @@ class Hcl(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -913,6 +913,10 @@ class Java(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _java_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _java_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -537,6 +537,10 @@ class JavaScript(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _js_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _js_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -45,6 +45,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -427,6 +428,10 @@ class Json5(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -468,6 +468,10 @@ class Jsonnet(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _jsonnet_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _jsonnet_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -565,6 +565,10 @@ class Julia(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _julia_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _julia_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -945,6 +945,10 @@ class Kotlin(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _kotlin_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _kotlin_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -472,6 +472,10 @@ class Lua(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _lua_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _lua_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -42,6 +42,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -519,6 +520,10 @@ class Matlab(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -473,6 +474,10 @@ class Mojo(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ("import std.math",)
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -581,6 +582,10 @@ class Nim(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -42,6 +42,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -478,7 +479,11 @@ class Nix(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target
         self.type_hint_collection_preamble_lines = no_type_hint_preamble

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -41,6 +41,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -408,6 +409,10 @@ class Norg(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -42,6 +42,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -466,6 +467,10 @@ class ObjectiveC(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -624,6 +625,10 @@ class OCaml(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -41,6 +41,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -439,6 +440,10 @@ class Occam(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -486,6 +487,10 @@ class Odin(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ('import "core:math"',)
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
@@ -506,6 +507,10 @@ class Perl(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -479,6 +480,10 @@ class Php(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -40,6 +40,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -423,6 +424,10 @@ class PowerShell(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     identity_call_target,
     no_call_stub,
@@ -785,6 +786,10 @@ class PureScript(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -384,7 +384,7 @@ def _build_type_hint_preamble(
         /,
     ) -> tuple[str, ...]:
         """Return ``from typing import Any`` if needed."""
-        if _any_types & empty_collection_types:
+        if _any_types.intersection(empty_collection_types):
             return ("from typing import Any",)
         return ()
 
@@ -987,7 +987,9 @@ class Python(metaclass=LanguageCls):
                 default_dict_key_type=default_dict_key_type,
             )
         )
-        self.format_variable_declaration = decl_fmt
+        self.format_variable_declaration: Callable[[str, str, Value], str] = (
+            decl_fmt
+        )
         self.format_variable_assignment: Callable[[str, str, Value], str] = (
             variable_formatter(template="{name} = {value}")
         )
@@ -1019,6 +1021,10 @@ class Python(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _python_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _python_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -45,6 +45,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -500,6 +501,10 @@ class R(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -41,6 +41,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -398,6 +399,10 @@ class Racket(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
@@ -502,6 +503,10 @@ class Raku(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -550,6 +550,10 @@ class Ruby(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _ruby_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _ruby_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -678,6 +678,10 @@ class Rust(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _rust_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _rust_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -668,6 +668,10 @@ class Scala(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ""
-        self.format_call_stub = _scala_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _scala_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -41,6 +41,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -398,6 +399,10 @@ class Scheme(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -653,6 +654,10 @@ class Sml(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -741,6 +741,10 @@ class Swift(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _swift_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _swift_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -39,6 +39,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -463,6 +464,10 @@ class SystemVerilog(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -40,6 +40,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -440,6 +441,10 @@ class Tcl(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -433,6 +434,10 @@ class Toml(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -698,6 +698,10 @@ class TypeScript(metaclass=LanguageCls):
         self.call_style = call_style
         self.call_style_config: CallStyleConfig | None = call_style.value
         self.statement_terminator = ";"
-        self.format_call_stub = _ts_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = _ts_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -461,6 +462,10 @@ class V(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ("import math",)
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -545,6 +546,10 @@ class VisualBasic(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -43,6 +43,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -417,6 +418,10 @@ class Wren(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -416,6 +417,10 @@ class Yaml(metaclass=LanguageCls):
         self.special_float_preamble: tuple[str, ...] = ()
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ""
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     OrderedMapFormatConfig,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_target,
@@ -528,6 +529,10 @@ class Zig(metaclass=LanguageCls):
         )
         self.call_style_config: CallStyleConfig | None = None
         self.statement_terminator = ";"
-        self.format_call_stub = no_call_stub
-        self.format_call_preamble_stub = no_call_stub
-        self.format_call_target = identity_call_target
+        self.format_call_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_preamble_stub: Callable[
+            [str, Sequence[str], StubReturn], tuple[str, ...]
+        ] = no_call_stub
+        self.format_call_target: Callable[[str], str] = identity_call_target


### PR DESCRIPTION
## Summary

Bumps ty from 0.0.29 to 0.0.30 (supersedes #1222) and fixes two type-check errors exposed by the upgrade:

- **`unsupported-operator`** on `frozenset &` with narrowed type params — switched to `.intersection()`
- **`invalid-argument-type`** where constructed Language instances (e.g. `Python()`) weren't recognised as satisfying the `Language` Protocol — root cause: ty 0.0.30 doesn't match an unannotated function attribute against a `Callable` Protocol member. Fixed by adding explicit `Callable` annotations to `format_call_stub`, `format_call_preamble_stub`, `format_call_target`, and `format_variable_declaration` across all 62 language classes.

## Test plan

- [x] All 12467 tests pass
- [x] All pre-commit hooks pass
- [x] All pre-push hooks pass (mypy, pyright, ty, pyrefly)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)