### PR TITLE
Remove unit tests already covered by integration tests

### DIFF
--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -293,25 +293,6 @@ def test_variable_declaration_json(
 
 
 @pytest.mark.parametrize(
-    argnames=("language", "expected"), argvalues=_DECLARATION_PARAMS
-)
-def test_variable_declaration_yaml(
-    *, language: Language, expected: str
-) -> None:
-    """Each language produces correct variable declaration syntax for YAML."""
-    result = literalize(
-        source="42\n",
-        input_format=InputFormat.YAML,
-        language=language,
-        pre_indent_level=0,
-        include_delimiters=False,
-        variable_form=NewVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    assert result.code == expected
-
-
-@pytest.mark.parametrize(
     argnames=("language", "expected"), argvalues=_ASSIGNMENT_PARAMS
 )
 def test_existing_variable_assignment_json(
@@ -323,27 +304,6 @@ def test_existing_variable_assignment_json(
     result = literalize(
         source="42",
         input_format=InputFormat.JSON,
-        language=language,
-        pre_indent_level=0,
-        include_delimiters=False,
-        variable_form=ExistingVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    assert result.code == expected
-
-
-@pytest.mark.parametrize(
-    argnames=("language", "expected"), argvalues=_ASSIGNMENT_PARAMS
-)
-def test_existing_variable_assignment_yaml(
-    *, language: Language, expected: str
-) -> None:
-    """Each language produces correct existing-variable assignment syntax
-    for YAML.
-    """
-    result = literalize(
-        source="42\n",
-        input_format=InputFormat.YAML,
         language=language,
         pre_indent_level=0,
         include_delimiters=False,
@@ -382,78 +342,6 @@ def test_python_always_type_hints_scalars(
     assert result.code == expected
 
 
-def test_python_always_type_hints_dict() -> None:
-    """Python ALWAYS hints infer dict type for wrapped dicts."""
-    result = literalize(
-        source='{"a": 1}',
-        input_format=InputFormat.JSON,
-        language=PYTHON_ALWAYS_HINTS,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        my_var: dict[str, int] = {
-            "a": 1,
-        }"""
-    )
-    assert result.code == expected
-
-
-def test_python_always_type_hints_tuple() -> None:
-    """Python ALWAYS hints infer tuple type for wrapped sequences."""
-    result = literalize(
-        source="[1, 2]",
-        input_format=InputFormat.JSON,
-        language=PYTHON_ALWAYS_HINTS,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        my_var: tuple[int, ...] = (
-            1,
-            2,
-        )"""
-    )
-    assert result.code == expected
-
-
-def test_python_always_type_hints_list() -> None:
-    """Python ALWAYS hints infer list type when sequence_format is
-    LIST.
-    """
-    lang = Python(
-        date_format=Python.date_formats.PYTHON,
-        datetime_format=Python.datetime_formats.PYTHON,
-        bytes_format=Python.bytes_formats.HEX,
-        sequence_format=Python.sequence_formats.LIST,
-        set_format=Python.set_formats.SET,
-        variable_type_hints=Python.variable_type_hints_formats.ALWAYS,
-    )
-    result = literalize(
-        source="[1, 2]",
-        input_format=InputFormat.JSON,
-        language=lang,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        my_var: list[int] = [
-            1,
-            2,
-        ]"""
-    )
-    assert result.code == expected
-
-
 def test_python_always_type_hints_assignment_no_hint() -> None:
     """Python ALWAYS hints do not add type hints for assignments."""
     result = literalize(
@@ -484,29 +372,6 @@ def test_python_always_type_hints_set_with_colon_in_string() -> None:
         text="""\
         my_var: set[str] = {
             "a\\": b",
-        }"""
-    )
-    assert result.code == expected
-
-
-def test_python_always_type_hints_set_of_integers() -> None:
-    """A set of integers is correctly identified as set, not dict."""
-    yaml_string = "!!set\n? 1\n? 2\n? 3\n"
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=PYTHON_ALWAYS_HINTS,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        my_var: set[int] = {
-            1,
-            2,
-            3,
         }"""
     )
     assert result.code == expected
@@ -553,20 +418,6 @@ def test_python_always_type_hints_dict_with_list_values() -> None:
         }"""
     )
     assert result.code == expected
-
-
-def test_python_always_type_hints_empty_list() -> None:
-    """Empty collections still use Any since element type is unknown."""
-    result = literalize(
-        source="[]",
-        input_format=InputFormat.JSON,
-        language=PYTHON_ALWAYS_HINTS,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    assert result.code == "my_var: tuple[Any, ...] = ()"
 
 
 def test_python_always_type_hints_ordered_dicts_in_sequence() -> None:

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -7,7 +7,6 @@ import pytest
 
 from literalizer import (
     InputFormat,
-    Language,
     NewVariable,
     literalize,
 )
@@ -21,7 +20,6 @@ from literalizer.languages import (
     Cpp,
     Dhall,
     Go,
-    JavaScript,
     Mojo,
     Nix,
     Python,
@@ -33,12 +31,6 @@ GO = Go(
     datetime_format=Go.datetime_formats.GO,
     bytes_format=Go.bytes_formats.HEX,
     sequence_format=Go.sequence_formats.SLICE,
-)
-JAVASCRIPT = JavaScript(
-    date_format=JavaScript.date_formats.JS,
-    datetime_format=JavaScript.datetime_formats.JS,
-    bytes_format=JavaScript.bytes_formats.HEX,
-    sequence_format=JavaScript.sequence_formats.ARRAY,
 )
 MOJO = Mojo(
     date_format=Mojo.date_formats.ISO,
@@ -122,38 +114,6 @@ def test_literalize_yaml_invalid_is_parse_error() -> None:
             variable_form=None,
             error_on_coercion=False,
         )
-
-
-@pytest.mark.parametrize(
-    argnames=("yaml_string", "language", "expected"),
-    argvalues=[
-        ("42", PYTHON, "42"),
-        ("3.14", PYTHON, "3.14"),
-        ("hello", PYTHON, '"hello"'),
-        ("true", PYTHON, "True"),
-        ("false", PYTHON, "False"),
-        ("null", PYTHON, "None"),
-        ("true", JAVASCRIPT, "true"),
-        ("null", GO, "nil"),
-    ],
-)
-def test_literalize_yaml_scalar(
-    *,
-    yaml_string: str,
-    language: Language,
-    expected: str,
-) -> None:
-    """``literalize_yaml`` handles scalar YAML values."""
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=language,
-        pre_indent_level=0,
-        include_delimiters=False,
-        variable_form=None,
-        error_on_coercion=False,
-    )
-    assert result.code == expected
 
 
 def test_cpp_array_binary_typed() -> None:
@@ -304,34 +264,6 @@ def test_coerce_heterogeneous_bytes_in_collection() -> None:
             "key1": "48656c6c6f",
             "key2": "42",
         }"""
-    )
-    assert result.code == expected
-
-
-def test_coerce_heterogeneous_set() -> None:
-    """Heterogeneous sets are coerced to all strings."""
-    yaml_string = textwrap.dedent(
-        text="""\
-        --- !!set
-        ? 1
-        ? "hello"
-    """,
-    )
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=MOJO,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        Set[String](
-            "1",
-            "hello",
-        )"""
     )
     assert result.code == expected
 
@@ -539,34 +471,6 @@ def test_coerce_mixed_ordered_map_values() -> None:
 
 def test_r_empty_dict_key_positional() -> None:
     """R with POSITIONAL empty_dict_key emits unnamed list elements."""
-    spec = R(
-        date_format=R.date_formats.R,
-        datetime_format=R.datetime_formats.R,
-        empty_dict_key=R.empty_dict_keys.POSITIONAL,
-        bytes_format=R.bytes_formats.HEX,
-        sequence_format=R.sequence_formats.LIST,
-    )
-    yaml_string = '{"": "value"}\n'
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=spec,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-        error_on_coercion=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        list(
-            "value"
-        )"""
-    )
-    assert result.code == expected
-
-
-def test_r_empty_dict_key_positional_is_default() -> None:
-    """R defaults to POSITIONAL for empty_dict_key."""
     spec = R(
         date_format=R.date_formats.R,
         datetime_format=R.datetime_formats.R,


### PR DESCRIPTION
## Summary
- Remove 10 test functions (53 individual test cases) from `test_yaml.py` and `test_variables.py` that are fully covered by integration golden file tests
- Removed tests include: `test_literalize_yaml_scalar`, `test_coerce_heterogeneous_set`, `test_r_empty_dict_key_positional_is_default`, `test_variable_declaration_yaml`, `test_existing_variable_assignment_yaml`, and 5 Python type hint tests (`test_python_always_type_hints_dict`, `_tuple`, `_list`, `_set_of_integers`, `_empty_list`)
- Clean up unused `JAVASCRIPT` constant and `Language` import in `test_yaml.py`

## Test plan
- [x] All 79 remaining tests in `test_yaml.py` and `test_variables.py` pass
- [ ] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to deleting redundant unit tests and related unused imports/constants, with no production code modifications.
> 
> **Overview**
> Removes a set of YAML- and variable-related unit tests (including YAML-based variable declaration/assignment cases and several Python ALWAYS type-hint collection cases) that are now covered elsewhere.
> 
> Cleans up `tests/test_yaml.py` by dropping unused `Language`/`JavaScript` imports and the unused `JAVASCRIPT` test language constant after removing the associated scalar/coercion tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434495ab1aef126fde245375f4f02ba51be07879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->