### PR TITLE
Deduplicate backslash escaping in format_strings.py

### DIFF
--- a/src/literalizer/_formatters/format_strings.py
+++ b/src/literalizer/_formatters/format_strings.py
@@ -17,6 +17,22 @@ class _StringFormatter(Protocol):
 
 
 @beartype
+def _backslash_escape(value: str, *, quote_char: str) -> str:
+    r"""Apply base backslash escapes to *value*.
+
+    Escapes backslashes, *quote_char*, ``\r``, ``\n``, and ``\t``.
+    Does **not** wrap the result in quotes.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace(quote_char, f"\\{quote_char}")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+
+
+@beartype
 def _build_backslash_formatter(
     *,
     quote_char: str,
@@ -35,13 +51,7 @@ def _build_backslash_formatter(
     @beartype
     def _format(value: str) -> str:
         """Format *value* using backslash escaping."""
-        escaped = (
-            value.replace("\\", "\\\\")
-            .replace(quote_char, f"\\{quote_char}")
-            .replace("\r", "\\r")
-            .replace("\n", "\\n")
-            .replace("\t", "\\t")
-        )
+        escaped = _backslash_escape(value=value, quote_char=quote_char)
         for old, new in extra_replacements:
             escaped = escaped.replace(old, new)
         return f"{quote_char}{escaped}{quote_char}"
@@ -265,13 +275,7 @@ def format_string_backslash_control(
         format_string_backslash_control("\x01hi", control_char_fmt="\\x{:02x}")
         # => '"\\x01hi"'
     """
-    escaped = (
-        value.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("\r", "\\r")
-        .replace("\n", "\\n")
-        .replace("\t", "\\t")
-    )
+    escaped = _backslash_escape(value=value, quote_char='"')
     escaped = escape_control_chars(value=escaped, fmt=control_char_fmt)
     return f'"{escaped}"'
 


### PR DESCRIPTION
## Summary
- Extract `_backslash_escape` helper to share the common backslash/quote/control-char escaping sequence between `_build_backslash_formatter` and `format_string_backslash_control`
- Eliminates the duplicated `.replace()` chain that was hardcoding `"` instead of using the parameterized pattern

Closes #1203

## Test plan
- [x] All pre-commit hooks pass (mypy, pyright, ty, ruff, vulture, etc.)
- [x] Manual smoke test confirms `format_string_backslash` and `format_string_backslash_control` produce identical output to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes string escaping logic; main risk is subtle output differences if the new helper changes escaping order or quote handling.
> 
> **Overview**
> **Refactors string escaping to remove duplication.** Introduces a shared `_backslash_escape()` helper for the common backslash/quote/`\r`/`\n`/`\t` replacement sequence.
> 
> Updates `_build_backslash_formatter()` and `format_string_backslash_control()` to use the helper (instead of inline `.replace()` chains), reducing drift and ensuring the quote character is consistently parameterized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6995404d06e301c462b3033315d055df38719923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->