### PR TITLE
Fix None interpolation in make_element_to_type dict resolver

### DIFF
--- a/src/literalizer/_formatters/collection_openers.py
+++ b/src/literalizer/_formatters/collection_openers.py
@@ -133,6 +133,8 @@ def make_element_to_type(
                     element_type=element_type.value_type,
                 )
             inner = resolved if resolved is not None else fallback_value_type
+            if inner is None:
+                return None
             return dict_type_template.format(inner=inner)
         if isinstance(element_type, ListType):
             inner = element_to_type(element_type=element_type.inner)

--- a/tests/test_make_element_to_type.py
+++ b/tests/test_make_element_to_type.py
@@ -1,0 +1,83 @@
+"""Regression test for ``fallback_value_type=None`` in
+:func:`make_element_to_type`.
+
+A custom Go variant with ``fallback_value_type=None`` exercises the
+code path that would otherwise interpolate the string ``"None"`` into
+a type template like ``map[string]{inner}``.
+"""
+
+import json
+import textwrap
+
+import literalizer
+from literalizer._formatters.collection_openers import (
+    make_element_to_type,
+    make_type_to_opener,
+    typed_dict_open,
+)
+from literalizer._language import DictFormatConfig
+from literalizer.languages import Go
+
+
+def test_none_fallback_value_type_uses_dict_open_fallback() -> None:
+    """When ``fallback_value_type`` is ``None`` and dict values have
+    mixed types, the dict opener must use its fallback — not interpolate
+    the string ``"None"`` into the type template.
+    """
+    source = json.dumps(
+        {
+            "group_a": {"x": 1, "y": "hello"},
+            "group_b": {"p": True, "q": 42},
+        }
+    )
+
+    spec = Go()
+    resolver = make_element_to_type(
+        str_type="string",
+        bool_type="bool",
+        int_type="int",
+        float_type="float64",
+        mixed_numeric_type="float64",
+        bytes_type="string",
+        date_type=None,
+        datetime_type=None,
+        list_template="[]{inner}",
+        dict_type_template="map[string]{inner}",
+        fallback_value_type=None,
+    )
+    fallback = "map[string]any{"
+    spec.dict_format_config = DictFormatConfig(
+        dict_open=typed_dict_open(
+            type_to_opener=make_type_to_opener(
+                element_to_type=resolver,
+                opener_template="map[string]{type_name}{{",
+            ),
+            fallback=fallback,
+        ),
+        close="}",
+        format_entry=spec.dict_format_config.format_entry,
+        empty_dict=spec.dict_format_config.empty_dict,
+        preamble_lines=spec.dict_format_config.preamble_lines,
+        narrowed_open=spec.dict_format_config.narrowed_open,
+    )
+    result = literalizer.literalize(
+        source=source,
+        input_format=literalizer.InputFormat.JSON,
+        language=spec,
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=literalizer.NewVariable(name="my_data"),
+        error_on_coercion=False,
+        wrap_in_file=True,
+    )
+    expected = textwrap.dedent("""\
+        package main
+
+        func main() {
+        my_data := map[string]any{
+        \t"group_a": map[string]any{"x": 1, "y": "hello"},
+        \t"group_b": map[string]any{"p": true, "q": 42},
+        }
+        _ = my_data
+        }""")
+    assert result.code == expected

--- a/tests/test_make_element_to_type.py
+++ b/tests/test_make_element_to_type.py
@@ -25,7 +25,7 @@ def test_none_fallback_value_type_uses_dict_open_fallback() -> None:
     the string ``"None"`` into the type template.
     """
     source = json.dumps(
-        {
+        obj={
             "group_a": {"x": 1, "y": "hello"},
             "group_b": {"p": True, "q": 42},
         }
@@ -70,7 +70,8 @@ def test_none_fallback_value_type_uses_dict_open_fallback() -> None:
         error_on_coercion=False,
         wrap_in_file=True,
     )
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        text="""\
         package main
 
         func main() {
@@ -79,5 +80,6 @@ def test_none_fallback_value_type_uses_dict_open_fallback() -> None:
         \t"group_b": map[string]any{"p": true, "q": 42},
         }
         _ = my_data
-        }""")
+        }"""
+    )
     assert result.code == expected


### PR DESCRIPTION
## Summary
- When `fallback_value_type=None` and a dict's value type cannot be resolved, `make_element_to_type` now returns `None` instead of interpolating the string `"None"` into the type template (e.g. producing `Map<string, None>`)
- Adds a regression test using a custom Go variant with `fallback_value_type=None` to exercise the guarded code path

Fixes #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized formatter change plus a regression test; minimal behavioral impact beyond preventing invalid type generation in an edge case.
> 
> **Overview**
> Fixes `make_element_to_type` so when a dict’s value type can’t be resolved and `fallback_value_type` is `None`, it returns `None` instead of formatting templates with the string `"None"`.
> 
> Adds a regression test that configures a custom Go `dict_open` fallback and asserts mixed-value dicts use the fallback opener rather than generating an invalid typed `map[string]None`-style output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ccf0f2db63c896ab9b33a57179bf421e9f62a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->