### PR TITLE
Remove duplicate @beartype decorator

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -910,7 +910,6 @@ def _literalize(
 
 
 @beartype
-@beartype
 def _apply_variable_wrapper(
     *,
     result: str,


### PR DESCRIPTION
## Summary

- Remove accidental duplicate `@beartype` decorator on `_apply_variable_wrapper`

## Test plan

- CI passes (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line cleanup with no logic changes; risk limited to eliminating redundant runtime decoration.
> 
> **Overview**
> Removes an accidental duplicate `@beartype` decorator on `_apply_variable_wrapper` in `src/literalizer/_core.py`, leaving a single runtime type-check wrapper and avoiding redundant decoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea41d8d85b30992fec2aba88aa0da570fd12d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->