### PR TITLE
Fix unused imports in generated code after coercion

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1204,15 +1204,20 @@ def literalize(
     # --- Preamble ---
     variable_name = variable_form.name if variable_form is not None else None
     is_declaration = isinstance(variable_form, NewVariable)
-    computed = _compute_preamble(
+    coerced_data = apply_coercions(
         data=data,
+        spec=language,
+        error_on_coercion=False,
+    )
+    computed = _compute_preamble(
+        data=coerced_data,
         language=language,
         has_variable_declaration=variable_name is not None and is_declaration,
     )
     preamble = (
         tuple(language.static_preamble)
         + computed.header
-        + language.data_dependent_preamble(data)
+        + language.data_dependent_preamble(coerced_data)
     )
 
     pre_decl = resolved.pending_scalar_before if resolved is not None else ()
@@ -1401,15 +1406,20 @@ def literalize_call(
             statement_terminator=language.statement_terminator,
         )
 
-    computed = _compute_preamble(
+    coerced_data = apply_coercions(
         data=data,
+        spec=language,
+        error_on_coercion=False,
+    )
+    computed = _compute_preamble(
+        data=coerced_data,
         language=language,
         has_variable_declaration=False,
     )
     preamble = (
         tuple(language.static_preamble)
         + computed.header
-        + language.data_dependent_preamble(data)
+        + language.data_dependent_preamble(coerced_data)
     )
 
     if wrap_in_file:

--- a/tests/integration/cases/dates/Rust.rs
+++ b/tests/integration/cases/dates/Rust.rs
@@ -1,6 +1,3 @@
-use chrono::NaiveDate;
-use chrono::NaiveDateTime;
-use chrono::NaiveTime;
 use std::collections::HashMap;
 fn main() {
     let my_data = HashMap::from([

--- a/tests/integration/cases/dates/Rust_combined.rs
+++ b/tests/integration/cases/dates/Rust_combined.rs
@@ -1,6 +1,3 @@
-use chrono::NaiveDate;
-use chrono::NaiveDateTime;
-use chrono::NaiveTime;
 use std::collections::HashMap;
 fn main() {
     let mut my_data = HashMap::from([

--- a/tests/integration/cases/empty_sequence/Rust.rs
+++ b/tests/integration/cases/empty_sequence/Rust.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 fn main() {
     let my_data = vec![
         "[]",

--- a/tests/integration/cases/empty_sequence/Rust_combined.rs
+++ b/tests/integration/cases/empty_sequence/Rust_combined.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 fn main() {
     let mut my_data = vec![
         "[]",

--- a/tests/integration/cases/empty_sequence/Rust_default_sequence_element_type_string.rs
+++ b/tests/integration/cases/empty_sequence/Rust_default_sequence_element_type_string.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 fn main() {
     let my_data = vec![
         "[]",

--- a/tests/integration/cases/nested_mixed_set/Mojo.mojo
+++ b/tests/integration/cases/nested_mixed_set/Mojo.mojo
@@ -1,4 +1,3 @@
-from std.collections import Set
 def main():
     var my_data = {
         "name": "Alice",

--- a/tests/integration/cases/nested_mixed_set/Mojo_combined.mojo
+++ b/tests/integration/cases/nested_mixed_set/Mojo_combined.mojo
@@ -1,4 +1,3 @@
-from std.collections import Set
 def main():
     var my_data = {
         "name": "Alice",

--- a/tests/integration/cases/nested_mixed_set/Rust.rs
+++ b/tests/integration/cases/nested_mixed_set/Rust.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::HashSet;
 fn main() {
     let my_data = HashMap::from([
         ("name", "Alice"),

--- a/tests/integration/cases/nested_mixed_set/Rust_combined.rs
+++ b/tests/integration/cases/nested_mixed_set/Rust_combined.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::HashSet;
 fn main() {
     let mut my_data = HashMap::from([
         ("name", "Alice"),

--- a/tests/integration/cases/ordered_map_in_sequence/Rust.rs
+++ b/tests/integration/cases/ordered_map_in_sequence/Rust.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 fn main() {
     let my_data = vec![
         "{\"a\": 1}",

--- a/tests/integration/cases/ordered_map_in_sequence/Rust_combined.rs
+++ b/tests/integration/cases/ordered_map_in_sequence/Rust_combined.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 fn main() {
     let mut my_data = vec![
         "{\"a\": 1}",

--- a/tests/integration/cases/pair_sequence/Cpp_sequence_array_pair.cpp
+++ b/tests/integration/cases/pair_sequence/Cpp_sequence_array_pair.cpp
@@ -1,10 +1,6 @@
 #include <initializer_list>
 #include <string>
 #include <array>
-struct Any {
-    template<class T> Any(T&&) noexcept {}
-    Any(std::initializer_list<Any>) noexcept {}
-};
 void check_() {
 auto my_data = std::array<std::string, 2>{
     "1",

--- a/tests/integration/cases/simple_sequence/Cpp_sequence_array.cpp
+++ b/tests/integration/cases/simple_sequence/Cpp_sequence_array.cpp
@@ -1,11 +1,6 @@
 #include <initializer_list>
 #include <string>
-#include <cstddef>
 #include <array>
-struct Any {
-    template<class T> Any(T&&) noexcept {}
-    Any(std::initializer_list<Any>) noexcept {}
-};
 void check_() {
 auto my_data = std::array<std::string, 4>{
     "1",

--- a/tests/integration/cases/simple_sequence/Cpp_sequence_array_varname.cpp
+++ b/tests/integration/cases/simple_sequence/Cpp_sequence_array_varname.cpp
@@ -1,11 +1,6 @@
 #include <initializer_list>
 #include <string>
-#include <cstddef>
 #include <array>
-struct Any {
-    template<class T> Any(T&&) noexcept {}
-    Any(std::initializer_list<Any>) noexcept {}
-};
 void check_() {
 auto my_data = std::array<std::string, 4>{
     "1",

--- a/tests/integration/cases/triple_sequence/Cpp_sequence_array_triple.cpp
+++ b/tests/integration/cases/triple_sequence/Cpp_sequence_array_triple.cpp
@@ -1,10 +1,6 @@
 #include <initializer_list>
 #include <string>
 #include <array>
-struct Any {
-    template<class T> Any(T&&) noexcept {}
-    Any(std::initializer_list<Any>) noexcept {}
-};
 void check_() {
 auto my_data = std::array<std::string, 3>{
     "1",

--- a/tests/integration/cases/type_hints/Rust.rs
+++ b/tests/integration/cases/type_hints/Rust.rs
@@ -1,6 +1,3 @@
-use chrono::NaiveDate;
-use chrono::NaiveDateTime;
-use chrono::NaiveTime;
 use std::collections::HashMap;
 fn main() {
     let my_data = HashMap::from([

--- a/tests/integration/cases/type_hints/Rust_combined.rs
+++ b/tests/integration/cases/type_hints/Rust_combined.rs
@@ -1,6 +1,3 @@
-use chrono::NaiveDate;
-use chrono::NaiveDateTime;
-use chrono::NaiveTime;
 use std::collections::HashMap;
 fn main() {
     let mut my_data = HashMap::from([


### PR DESCRIPTION
## Summary

- Compute preamble (imports) from coerced data instead of raw parsed data, so imports are only emitted for types actually present in the generated code
- Fixes unused `use std::collections::HashMap` in `ordered_map_in_sequence` Rust golden files (reported in #1264)
- Also fixes unused `use chrono::*` imports in Rust, unused C++ includes, and unused Mojo imports where coercion converts values to strings

## Test plan

- [x] All 12513 tests pass
- [x] Golden files regenerated to reflect correct imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preamble/import computation for both `literalize` and `literalize_call`, which can change generated source output across languages; functional risk is limited but broad in surface area for golden outputs.
> 
> **Overview**
> Computes preamble/import lines from *coerced* data (via `apply_coercions`) rather than the raw parsed input, so only types that actually survive coercion drive header/type-hint preamble generation.
> 
> Regenerates multiple integration golden files to drop now-unused imports/includes (notably Rust `chrono`/`HashMap`, Mojo `Set`, and some C++ helper/include lines) in cases where coercion turns values into strings or otherwise removes the need for those dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91b22a2b40767250005f8bcda6e6ae626dbdf6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->