### PR TITLE
Fix preamble mismatch in per-element call path

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -1360,17 +1360,22 @@ def literalize_call(
     parsed = _parse_input(source=source, input_format=input_format)
     data = parsed.data
     formatted_target = language.format_call_target(target_function)
+    coerced_data = apply_coercions(
+        data=data,
+        spec=language,
+        error_on_coercion=False,
+    )
 
     if per_element:
-        if not isinstance(data, list):
+        if not isinstance(coerced_data, list):
             msg = (
                 "per_element=True requires a top-level list, "
-                f"got {type(data).__name__}"
+                f"got {type(coerced_data).__name__}"
             )
             raise TypeError(msg)
 
         lines: list[str] = []
-        for element in data:
+        for element in coerced_data:
             arg_values = element if isinstance(element, list) else [element]
             args_str = _format_call_args(
                 values=cast("list[Value]", arg_values),
@@ -1392,7 +1397,7 @@ def literalize_call(
                 language_name=type(language).__name__,
             )
         lit = _literalize(
-            data=data,
+            data=coerced_data,
             language=language,
             line_prefix="",
             include_delimiters=True,
@@ -1405,12 +1410,6 @@ def literalize_call(
             call_transform=call_transform,
             statement_terminator=language.statement_terminator,
         )
-
-    coerced_data = apply_coercions(
-        data=data,
-        spec=language,
-        error_on_coercion=False,
-    )
     computed = _compute_preamble(
         data=coerced_data,
         language=language,

--- a/tests/integration/cases/call_deep_dotted_method/Rust_call.rs
+++ b/tests/integration/cases/call_deep_dotted_method/Rust_call.rs
@@ -5,6 +5,6 @@ fn main() {
     struct ObjType_ { api: ApiType_ }
     let obj = ObjType_ { api: ApiType_ { client: ClientType_ } };
     obj.api.client.post("hello");
-    obj.api.client.post(42);
-    obj.api.client.post(true);
+    obj.api.client.post("42");
+    obj.api.client.post("True");
 }

--- a/tests/integration/cases/call_deep_dotted_transformed/Rust_call.rs
+++ b/tests/integration/cases/call_deep_dotted_transformed/Rust_call.rs
@@ -5,6 +5,6 @@ fn main() {
     let app = AppType_ { client: ClientType_ };
     fn emit<A>(__arg: A) {}
     emit(app.client.fetch("hello"));
-    emit(app.client.fetch(42));
-    emit(app.client.fetch(true));
+    emit(app.client.fetch("42"));
+    emit(app.client.fetch("True"));
 }

--- a/tests/integration/cases/call_dotted_method/Rust_call.rs
+++ b/tests/integration/cases/call_dotted_method/Rust_call.rs
@@ -4,6 +4,6 @@ fn main() {
     struct AppType_ { client: ClientType_ }
     let app = AppType_ { client: ClientType_ };
     app.client.fetch("hello");
-    app.client.fetch(42);
-    app.client.fetch(true);
+    app.client.fetch("42");
+    app.client.fetch("True");
 }

--- a/tests/integration/cases/call_keyword_args/Rust_call.rs
+++ b/tests/integration/cases/call_keyword_args/Rust_call.rs
@@ -3,6 +3,6 @@ fn main() {
     impl ThrottlerType_ { fn check<A, B>(&self, _user_id: A, _ts: B) {} }
     let throttler = ThrottlerType_;
     fn emit<A>(__arg: A) {}
-    emit(throttler.check("user_1", 1000.0));
-    emit(throttler.check("user_2", 2000.5));
+    emit(throttler.check("user_1", "1000.0"));
+    emit(throttler.check("user_2", "2000.5"));
 }

--- a/tests/integration/cases/call_scalar_args/Rust_call.rs
+++ b/tests/integration/cases/call_scalar_args/Rust_call.rs
@@ -1,6 +1,6 @@
 fn main() {
     fn process<A>(_value: A) {}
     process("hello");
-    process(42);
-    process(true);
+    process("42");
+    process("True");
 }


### PR DESCRIPTION
## Summary

- Fixes a bug where `literalize_call` with `per_element=True` formatted output from uncoerced data but computed the preamble from coerced data, which could silently omit required imports (e.g. `use chrono::NaiveDate;` in Rust)
- Moves `apply_coercions` before the per-element/single-arg branch so both output and preamble use the same coerced data
- Updates 5 Rust golden files where heterogeneous scalar arguments are now correctly coerced to strings

Addresses https://github.com/adamtheturtle/literalizer/pull/1266#discussion_r3094258472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to call-generation ordering plus golden test updates; low risk aside from potential behavior changes for callers relying on the previous (inconsistent) uncoerced argument formatting.
> 
> **Overview**
> Fixes `literalize_call` so coercion via `apply_coercions` happens before the `per_element`/single-arg branch, ensuring the generated call expressions and computed preamble are based on the same coerced data (avoiding missing language-specific imports).
> 
> Updates Rust integration golden files where heterogeneous scalar arguments in call generation are now coerced to strings (e.g. `42`/`true` becoming `"42"`/`"True"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9af678a74188a49f80d38be1b8cc987cc8d718d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->