### PR TITLE
Add missing @beartype to _build_sequence_decl_variants

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -373,6 +373,7 @@ def _build_line_ending_decl_variants() -> Iterable[_Variant]:
     return variants
 
 
+@beartype
 def _build_sequence_decl_variants() -> Iterable[_Variant]:
     """Build sequence format + declaration style cross-option variants.
 


### PR DESCRIPTION
## Summary
- Adds the `@beartype` decorator to `_build_sequence_decl_variants`, matching every other `_build_*_variants` function in the file
- Addresses review comment from #1265

## Test plan
- [x] All 12056 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds a decorator for runtime type checking; no production logic or data handling is affected.
> 
> **Overview**
> Adds the missing `@beartype` decorator to `_build_sequence_decl_variants()` in `tests/integration/test_integration.py`, aligning it with the other `_build_*_variants` helpers and enabling runtime type-checking for this variant builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b8d9e70a8249607100a15763127c7961ab4178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->