### PR TITLE
Replace bare TypeError with custom PerElementNotListError

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -42,6 +42,7 @@ from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
     JSON5ParseError,
     JSONParseError,
+    PerElementNotListError,
     TOMLParseError,
     UnsupportedCallStyleError,
     YAMLParseError,
@@ -1372,7 +1373,7 @@ def literalize_call(
                 "per_element=True requires a top-level list, "
                 f"got {type(coerced_data).__name__}"
             )
-            raise TypeError(msg)
+            raise PerElementNotListError(msg)
 
         lines: list[str] = []
         for element in coerced_data:

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -43,6 +43,12 @@ class NullInCollectionError(Exception):
     """
 
 
+class PerElementNotListError(Exception):
+    """Raised when ``per_element=True`` but the parsed data is not a
+    list.
+    """
+
+
 class UnsupportedCallStyleError(Exception):
     """Raised when a language does not support function call rendering."""
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -20,6 +20,7 @@ from literalizer import (
 from literalizer._language import LanguageCls
 from literalizer.exceptions import (
     NullInCollectionError,
+    PerElementNotListError,
     UnsupportedCallStyleError,
 )
 from literalizer.languages import (
@@ -441,9 +442,9 @@ def test_literalize_call_missing_keyword_separator_raises() -> None:
 
 
 def test_literalize_call_per_element_non_list_raises() -> None:
-    """Literalize_call raises TypeError for non-list with per_element."""
+    """Literalize_call raises PerElementNotListError for non-list."""
     with pytest.raises(
-        expected_exception=TypeError,
+        expected_exception=PerElementNotListError,
         match=r"^per_element=True requires a top-level list, got str$",
     ):
         literalize_call(


### PR DESCRIPTION
## Summary
- Adds `PerElementNotListError` to `literalizer.exceptions`, raised when `per_element=True` but the parsed data is not a list.
- Replaces the bare `TypeError` in `literalize_call` with this custom exception.
- Updates the test to assert on `PerElementNotListError`.

## Test plan
- [x] Existing test updated and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but potentially user-visible change: callers catching `TypeError` will no longer intercept this failure mode and may need to update exception handling.
> 
> **Overview**
> `literalize_call()` now raises a dedicated `PerElementNotListError` when `per_element=True` is used on non-list top-level input, instead of throwing a generic `TypeError`.
> 
> Adds the new exception type to `literalizer.exceptions` and updates the language tests to assert on the new error class and message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d284ef88dd2e277885cc46d85f1742fc09e122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->