### PR TITLE
Remove UnsupportedCallStyleError from top-level __all__

### DIFF
--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -29,7 +29,6 @@ from literalizer._language import (
     SetFormatConfig,
     TrailingCommaConfig,
 )
-from literalizer.exceptions import UnsupportedCallStyleError
 
 __all__ = [
     "BothVariableForms",
@@ -49,7 +48,6 @@ __all__ = [
     "SequenceFormatConfig",
     "SetFormatConfig",
     "TrailingCommaConfig",
-    "UnsupportedCallStyleError",
     "VariableForm",
     "fixed_dict_open",
     "fixed_sequence_open",


### PR DESCRIPTION
## Summary

- Removes `UnsupportedCallStyleError` from `literalizer.__init__.__all__` and its import
- Exceptions should be imported from `literalizer.exceptions` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low implementation risk, but it is a potentially breaking API change for users importing `UnsupportedCallStyleError` from the top-level package.
> 
> **Overview**
> Stops re-exporting `UnsupportedCallStyleError` from `literalizer.__init__` by removing its import and entry in `__all__`.
> 
> This makes `UnsupportedCallStyleError` available only via `literalizer.exceptions`, which is a small but potentially breaking public API change for callers importing it from `literalizer` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53687c3de170e6f3ab666226b9a743b10d0e8a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->