### PR TITLE
Consolidate OrderedMapFormatConfig open into single callable

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -611,10 +611,9 @@ def _wrap_body(
     """Wrap ``body`` in the language's open/close delimiters."""
     ci = spec.indent if spec.indent_closing_delimiter else ""
     close_prefix = f"{line_prefix}{ci}"
-    if is_ordered_map:
+    if is_ordered_map and isinstance(data, dict):
         ordered_map_cfg = spec.ordered_map_format_config
-        ordered_map_data = cast("dict[str, Value]", data)
-        open_str = ordered_map_cfg.ordered_map_open(ordered_map_data)
+        open_str = ordered_map_cfg.ordered_map_open(data)
         opening = f"{line_prefix}{open_str}"
         closing = f"{close_prefix}{ordered_map_cfg.close}"
     elif isinstance(data, dict):

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -419,7 +419,8 @@ def _format_ordered_map_value(
         for k, v in ordered_map_items
     ]
     joined = spec.element_separator.join(pairs)
-    return ordered_map_cfg.open_str + joined + ordered_map_cfg.close
+    opening = ordered_map_cfg.ordered_map_open(value)
+    return opening + joined + ordered_map_cfg.close
 
 
 @beartype
@@ -612,8 +613,9 @@ def _wrap_body(
     close_prefix = f"{line_prefix}{ci}"
     if is_ordered_map:
         ordered_map_cfg = spec.ordered_map_format_config
-
-        opening = f"{line_prefix}{ordered_map_cfg.open_str}"
+        ordered_map_data = cast("dict[str, Value]", data)
+        open_str = ordered_map_cfg.ordered_map_open(ordered_map_data)
+        opening = f"{line_prefix}{open_str}"
         closing = f"{close_prefix}{ordered_map_cfg.close}"
     elif isinstance(data, dict):
         dict_cfg = spec.dict_format_config

--- a/src/literalizer/_formatters/format_factories.py
+++ b/src/literalizer/_formatters/format_factories.py
@@ -217,7 +217,9 @@ def ordered_map_format_factory(
         """Build an ``OrderedMapFormatConfig`` with the given default type."""
         fmt_kwargs = {"type": default_type, "key_type": default_key_type}
         return OrderedMapFormatConfig(
-            open_str=open_template.format(**fmt_kwargs),
+            ordered_map_open=fixed_dict_open(
+                open_str=open_template.format(**fmt_kwargs),
+            ),
             close=close,
             preamble_lines=preamble_lines,
         )

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -139,7 +139,7 @@ class DictFormatConfig:
 class OrderedMapFormatConfig:
     """Configuration for ordered-map formatting."""
 
-    open_str: str
+    ordered_map_open: Callable[[dict[str, Value]], str]
     close: str
     preamble_lines: tuple[str, ...]
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -417,7 +417,7 @@ class Ada(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="AMap'(",
+                ordered_map_open=fixed_dict_open(open_str="AMap'("),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -414,7 +414,7 @@ class Bash(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="(",
+                ordered_map_open=fixed_dict_open(open_str="("),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -449,7 +449,7 @@ class C(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=map_open,
+                ordered_map_open=fixed_dict_open(open_str=map_open),
                 close="}})",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -357,7 +357,7 @@ class Clojure(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -549,7 +549,7 @@ class Cobol(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="",
+                ordered_map_open=fixed_dict_open(open_str=""),
                 close="",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -377,7 +377,7 @@ class CommonLisp(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="(list ",
+                ordered_map_open=fixed_dict_open(open_str="(list "),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -11,6 +11,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
+    fixed_dict_open,
     fixed_set_open,
     make_element_to_type,
     make_type_to_opener,
@@ -826,7 +827,7 @@ class Cpp(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING
 
 from beartype import beartype
 
-from literalizer._formatters.collection_openers import fixed_sequence_open
+from literalizer._formatters.collection_openers import (
+    fixed_dict_open,
+    fixed_sequence_open,
+)
 from literalizer._formatters.format_dates import (
     format_date_iso,
     format_datetime_iso,
@@ -471,7 +474,7 @@ class Crystal(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -455,7 +455,7 @@ class D(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="JSONValue([",
+                ordered_map_open=fixed_dict_open(open_str="JSONValue(["),
                 close="])",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -10,6 +10,7 @@ from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
+    fixed_dict_open,
     fixed_sequence_open,
     typed_collection_open,
     typed_dict_open,
@@ -602,7 +603,7 @@ class Dart(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -476,7 +476,7 @@ class Dhall(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -470,7 +470,7 @@ class Elixir(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[",
+                ordered_map_open=fixed_dict_open(open_str="["),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -690,7 +690,9 @@ class Elm(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"{constructor_prefix}Dict [",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"{constructor_prefix}Dict [",
+                ),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -443,7 +443,7 @@ class Erlang(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[",
+                ordered_map_open=fixed_dict_open(open_str="["),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -453,7 +453,7 @@ class Forth(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="",
+                ordered_map_open=fixed_dict_open(open_str=""),
                 close="",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -562,7 +562,9 @@ class Fortran(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"{map_name}([fval_t :: ",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"{map_name}([fval_t :: ",
+                ),
                 close="])",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -565,7 +565,9 @@ class FSharp(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"{constructor_prefix}Map [",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"{constructor_prefix}Map [",
+                ),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -749,7 +749,9 @@ class Gleam(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"{constructor_prefix}Dict([",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"{constructor_prefix}Dict(["
+                ),
                 close="])",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
+    fixed_dict_open,
     fixed_sequence_open,
     make_element_to_type,
     make_type_to_opener,
@@ -593,7 +594,9 @@ class Go(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"[][2]{default_ordered_map_value_type}{{",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"[][2]{default_ordered_map_value_type}{{"
+                ),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -423,7 +423,7 @@ class Groovy(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[",
+                ordered_map_open=fixed_dict_open(open_str="["),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1143,7 +1143,7 @@ class Haskell(metaclass=LanguageCls):
         )
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=_map_open,
+                ordered_map_open=fixed_dict_open(open_str=_map_open),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -381,7 +381,7 @@ class Hcl(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -849,7 +849,11 @@ class Java(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="new java.util.ArrayList<>(java.util.Arrays.asList(",
+                ordered_map_open=fixed_dict_open(
+                    open_str=(
+                        "new java.util.ArrayList<>(java.util.Arrays.asList("
+                    ),
+                ),
                 close="))",
                 preamble_lines=("import java.util.Map;",),
             )

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -493,7 +493,7 @@ class JavaScript(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -393,7 +393,7 @@ class Json5(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -432,7 +432,7 @@ class Jsonnet(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -521,7 +521,7 @@ class Julia(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[",
+                ordered_map_open=fixed_dict_open(open_str="["),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -14,6 +14,7 @@ from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
+    fixed_dict_open,
     fixed_sequence_open,
     make_type_to_opener,
     typed_collection_open,
@@ -875,9 +876,11 @@ class Kotlin(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=(
-                    f"linkedMapOf<{default_dict_key_type}"
-                    f", {default_dict_value_type}>("
+                ordered_map_open=fixed_dict_open(
+                    open_str=(
+                        f"linkedMapOf<{default_dict_key_type}"
+                        f", {default_dict_value_type}>("
+                    )
                 ),
                 close=")",
                 preamble_lines=(),

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -436,7 +436,7 @@ class Lua(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -485,7 +485,7 @@ class Matlab(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="struct(",
+                ordered_map_open=fixed_dict_open(open_str="struct("),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
+    fixed_dict_open,
     make_element_to_type,
     make_type_to_opener,
 )
@@ -439,7 +440,7 @@ class Mojo(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[",
+                ordered_map_open=fixed_dict_open(open_str="["),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -527,7 +527,7 @@ class Nim(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=("import json",),
             )

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -443,7 +443,7 @@ class Nix(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -369,7 +369,7 @@ class Norg(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -427,7 +427,7 @@ class ObjectiveC(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="@{",
+                ordered_map_open=fixed_dict_open(open_str="@{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -549,7 +549,9 @@ class OCaml(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"{constructor_prefix}Map [",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"{constructor_prefix}Map [",
+                ),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -389,7 +389,9 @@ class Occam(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
+                ordered_map_open=fixed_dict_open(
+                    open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
+                ),
                 close="])",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -446,7 +446,7 @@ class Odin(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="map[string]any{",
+                ordered_map_open=fixed_dict_open(open_str="map[string]any{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -463,7 +463,7 @@ class Perl(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -441,7 +441,7 @@ class Php(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[",
+                ordered_map_open=fixed_dict_open(open_str="["),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -386,7 +386,7 @@ class PowerShell(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[ordered]@{",
+                ordered_map_open=fixed_dict_open(open_str="[ordered]@{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -729,7 +729,9 @@ class PureScript(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"{constructor_prefix}Dict [",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"{constructor_prefix}Dict [",
+                ),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -955,7 +955,7 @@ class Python(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="OrderedDict([",
+                ordered_map_open=fixed_dict_open(open_str="OrderedDict(["),
                 close="])",
                 preamble_lines=("from collections import OrderedDict",),
             )

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -462,7 +462,7 @@ class R(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="list(",
+                ordered_map_open=fixed_dict_open(open_str="list("),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -361,7 +361,7 @@ class Racket(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="(hash ",
+                ordered_map_open=fixed_dict_open(open_str="(hash "),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -460,7 +460,7 @@ class Raku(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -506,7 +506,7 @@ class Ruby(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from beartype import beartype
 
+from literalizer._formatters.collection_openers import fixed_dict_open
 from literalizer._formatters.format_dates import (
     format_date_iso,
     format_datetime_iso,
@@ -637,7 +638,7 @@ class Rust(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="HashMap::from([",
+                ordered_map_open=fixed_dict_open(open_str="HashMap::from(["),
                 close="])",
                 preamble_lines=("use std::collections::HashMap;",),
             )

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -11,6 +11,7 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
     TypeOpeners,
+    fixed_dict_open,
     fixed_sequence_open,
     fixed_set_open,
     make_type_to_opener,
@@ -624,7 +625,9 @@ class Scala(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="scala.collection.immutable.ListMap(",
+                ordered_map_open=fixed_dict_open(
+                    open_str="scala.collection.immutable.ListMap("
+                ),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -361,7 +361,7 @@ class Scheme(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="(list ",
+                ordered_map_open=fixed_dict_open(open_str="(list "),
                 close=")",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -578,7 +578,9 @@ class Sml(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=f"{constructor_prefix}Map [",
+                ordered_map_open=fixed_dict_open(
+                    open_str=f"{constructor_prefix}Map [",
+                ),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -9,6 +9,7 @@ from typing import assert_never
 
 from beartype import beartype
 
+from literalizer._formatters.collection_openers import fixed_dict_open
 from literalizer._formatters.format_dates import (
     format_date_iso,
     format_datetime_iso,
@@ -680,7 +681,7 @@ class Swift(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[",
+                ordered_map_open=fixed_dict_open(open_str="["),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -417,7 +417,7 @@ class SystemVerilog(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="'{",
+                ordered_map_open=fixed_dict_open(open_str="'{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -406,7 +406,7 @@ class Tcl(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="[dict create ",
+                ordered_map_open=fixed_dict_open(open_str="[dict create "),
                 close="]",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -399,7 +399,7 @@ class Toml(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -639,7 +639,7 @@ class TypeScript(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -424,7 +424,7 @@ class V(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -383,7 +383,7 @@ class Wren(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -379,7 +379,7 @@ class Yaml(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str="{",
+                ordered_map_open=fixed_dict_open(open_str="{"),
                 close="}",
                 preamble_lines=(),
             )

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -477,7 +477,7 @@ class Zig(metaclass=LanguageCls):
         self.comment_config: CommentConfig = comment_format.value
         self.ordered_map_format_config: OrderedMapFormatConfig = (
             OrderedMapFormatConfig(
-                open_str=".{ .map = &.{",
+                ordered_map_open=fixed_dict_open(open_str=".{ .map = &.{"),
                 close="}}",
                 preamble_lines=(),
             )


### PR DESCRIPTION
## Summary
- Replace `OrderedMapFormatConfig.open_str: str` with `ordered_map_open: Callable[[dict[str, Value]], str]` so it matches the `sequence_open` / `dict_open` / `set_open` pattern used by the other collection configs.
- Static openers across 60 language files now wrap their string via `fixed_dict_open(open_str="...")`; `ordered_map_format_factory` does the wrapping for template-based builders.
- Call sites in `_core.py` now invoke the callable (with a cast from the underlying `ordereddict` data).

Closes #1273.

## Test plan
- [x] `uv run pytest tests/` (12527 passed, 2 skipped)
- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it touches core literal formatting and updates ordered-map configuration across many language specs; regressions would show up as incorrect delimiters/types in ordered-map output.
> 
> **Overview**
> **Ordered-map formatting is refactored to use a dynamic opener callable.** `OrderedMapFormatConfig.open_str` is replaced with `ordered_map_open(items)`, and `_core.py` now calls this opener when formatting/wrapping ordered maps.
> 
> Language specs and `ordered_map_format_factory` are updated to wrap fixed opener strings via `fixed_dict_open(...)`, standardizing ordered-map openers with the existing `sequence_open`/`dict_open`/`set_open` pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cccadbf613e81b9723efc43a8badd15b49282e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->