### PR TITLE
Cache default lang_cls() instances during integration test collection

### DIFF
--- a/src/literalizer/_coercions.py
+++ b/src/literalizer/_coercions.py
@@ -686,7 +686,7 @@ def apply_coercions(
     """Apply heterogeneous-type coercions controlled by the sequence
     format.
     """
-    if not spec.sequence_format.supports_heterogeneity:
+    if not spec.sequence_format_config.supports_heterogeneity:
         steps = _build_coercion_steps(spec=spec)
         if error_on_coercion:
             for step in steps:

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -196,15 +196,6 @@ class CallStyleConfig:
     keyword_separator: str | None = None
 
 
-class SequenceFormat(Protocol):
-    """Protocol for sequence format Enum members."""
-
-    @property
-    def supports_heterogeneity(self) -> bool:
-        """Whether this sequence format supports mixed-type elements."""
-        ...  # pylint: disable=unnecessary-ellipsis
-
-
 class FloatSpecialsMixin:
     """Mixin for ``FloatFormats`` enums that provides ``__call__``.
 
@@ -309,6 +300,11 @@ class LanguageCls(type):
     ) -> str:
         """Wrap a declaration and assignment in a complete, valid file."""
         raise NotImplementedError  # pragma: no cover
+
+    def __call__(cls, *args: object, **kwargs: object) -> "Language":
+        """Construct a language instance, typed as :class:`Language`."""
+        instance: Language = super().__call__(*args, **kwargs)
+        return instance
 
 
 @runtime_checkable
@@ -650,8 +646,12 @@ class Language(Protocol):  # pylint: disable=too-many-public-methods
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def sequence_format(self) -> SequenceFormat:
-        """The sequence format chosen for this language instance."""
+    def sequence_format(self) -> enum.Enum:
+        """The sequence format chosen for this language instance.
+
+        ``sequence_format_config`` exposes the format-specific
+        configuration (e.g. ``supports_heterogeneity``).
+        """
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -157,13 +157,6 @@ class Ada(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Ada."""
 

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -177,13 +177,6 @@ class Bash(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Bash."""
 

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -155,13 +155,6 @@ class C(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for C."""
 

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -122,13 +122,6 @@ class Clojure(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Clojure."""
 

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -302,13 +302,6 @@ class Cobol(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for COBOL."""
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -130,13 +130,6 @@ class CommonLisp(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Common Lisp."""
 

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -781,17 +781,6 @@ class Cpp(metaclass=LanguageCls):
                 datetime_type=datetime_type,
             )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.get_config(
-                int_type="int",
-                date_type=None,
-                datetime_type=None,
-            ).supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for C++."""
 

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -185,13 +185,6 @@ class Crystal(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Crystal."""
 

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -224,13 +224,6 @@ class CSharp(metaclass=LanguageCls):
             """Create a sequence format config for the given type."""
             return self.value(default_type)
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self(default_type="object").supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for C#."""
 

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -182,13 +182,6 @@ class D(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for D."""
 

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -282,13 +282,6 @@ class Dart(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Dart."""
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -237,13 +237,6 @@ class Dhall(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Dhall."""
 

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -193,13 +193,6 @@ class Elixir(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Elixir."""
 

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -399,13 +399,6 @@ class Elm(metaclass=LanguageCls):
             declared_type="Val",
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Elm."""
 

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -194,13 +194,6 @@ class Erlang(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Erlang."""
 

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -215,13 +215,6 @@ class Forth(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options."""
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -238,13 +238,6 @@ class Fortran(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Fortran."""
 

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -278,13 +278,6 @@ class FSharp(metaclass=LanguageCls):
             declared_type="Val array",
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for F#."""
 

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -383,13 +383,6 @@ class Gleam(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Gleam."""
 

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -244,13 +244,6 @@ class Go(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Go."""
 

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -164,13 +164,6 @@ class Groovy(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Groovy."""
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -835,13 +835,6 @@ class Haskell(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Haskell."""
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -124,13 +124,6 @@ class Hcl(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for HCL."""
 

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -475,13 +475,6 @@ class Java(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Java."""
 

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -173,13 +173,6 @@ class JavaScript(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for JavaScript."""
 

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -158,13 +158,6 @@ class Json5(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for JSON5."""
 

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -178,13 +178,6 @@ class Jsonnet(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Jsonnet."""
 

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -222,13 +222,6 @@ class Julia(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Julia."""
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -484,13 +484,6 @@ class Kotlin(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Kotlin."""
 

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -181,13 +181,6 @@ class Lua(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Lua."""
 

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -233,13 +233,6 @@ class Matlab(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for MATLAB."""
 

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -150,13 +150,6 @@ class Mojo(metaclass=LanguageCls):
             """Create a sequence format config for the given type."""
             return self.value(default_type)
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self(default_type="String").supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Mojo."""
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -241,13 +241,6 @@ class Nim(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Nim."""
 

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -209,13 +209,6 @@ class Nix(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Nix."""
 

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -132,13 +132,6 @@ class Norg(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Norg."""
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -181,13 +181,6 @@ class ObjectiveC(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Objective-C."""
 

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -244,13 +244,6 @@ class OCaml(metaclass=LanguageCls):
             declared_type="val_t array",
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for OCaml."""
 

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -140,13 +140,6 @@ class Occam(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Occam."""
 

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -138,13 +138,6 @@ class Odin(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Odin."""
 

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -181,13 +181,6 @@ class Perl(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Perl."""
 

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -145,13 +145,6 @@ class Php(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for PHP."""
 

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -147,13 +147,6 @@ class PowerShell(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for PowerShell."""
 

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -434,13 +434,6 @@ class PureScript(metaclass=LanguageCls):
             declared_type="Val",
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for PureScript."""
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -605,13 +605,6 @@ class Python(metaclass=LanguageCls):
             """Python type hint name for this sequence format."""
             return "tuple" if self is type(self).TUPLE else "list"
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Python."""
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -220,13 +220,6 @@ class R(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for R."""
 

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -122,13 +122,6 @@ class Racket(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Racket."""
 

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -181,13 +181,6 @@ class Raku(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Raku."""
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -207,13 +207,6 @@ class Ruby(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Ruby."""
 

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -295,13 +295,6 @@ class Rust(metaclass=LanguageCls):
             """Create a sequence format config for the given type."""
             return self.value(default_type)
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self(default_type="String").supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Rust."""
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -294,13 +294,6 @@ class Scala(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Scala."""
 

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -122,13 +122,6 @@ class Scheme(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Scheme."""
 

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -285,13 +285,6 @@ class Sml(metaclass=LanguageCls):
             declared_type="val_t",
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Standard ML."""
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -333,13 +333,6 @@ class Swift(metaclass=LanguageCls):
             """Create a sequence format config for the given type."""
             return self.value(default_type)
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self(default_type="Any").supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Swift."""
 

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -172,13 +172,6 @@ class SystemVerilog(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for SystemVerilog."""
 

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -170,13 +170,6 @@ class Tcl(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options."""
 

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -164,13 +164,6 @@ class Toml(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for TOML."""
 

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -292,13 +292,6 @@ class TypeScript(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for TypeScript."""
 

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -140,13 +140,6 @@ class V(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for V."""
 

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -187,13 +187,6 @@ class VisualBasic(metaclass=LanguageCls):
 
         ARRAY = "array"
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return True
-
     class SetFormats(enum.Enum):
         """Set type options for Visual Basic."""
 

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -132,13 +132,6 @@ class Wren(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Wren."""
 

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -141,13 +141,6 @@ class Yaml(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for YAML."""
 

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -194,13 +194,6 @@ class Zig(metaclass=LanguageCls):
             declared_type=None,
         )
 
-        @property
-        def supports_heterogeneity(self) -> bool:
-            """Whether this sequence format supports mixed-type
-            elements.
-            """
-            return self.value.supports_heterogeneity
-
     class SetFormats(enum.Enum):
         """Set type options for Zig."""
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,6 +17,7 @@ import enum
 import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import cast
 
 import pytest
 from beartype import beartype
@@ -109,7 +110,10 @@ _SORTED_LANGUAGES: list[literalizer.LanguageCls] = sorted(
 
 
 @functools.cache
-def _default_spec(lang_cls: literalizer.LanguageCls) -> literalizer.Language:
+def _default_spec(
+    *,
+    lang_cls: literalizer.LanguageCls,
+) -> literalizer.Language:
     """Return a memoized default-constructed instance of *lang_cls*.
 
     Each ``lang_cls()`` call rebuilds ``@beartype``-wrapped closures
@@ -117,8 +121,7 @@ def _default_spec(lang_cls: literalizer.LanguageCls) -> literalizer.Language:
     instance per class cuts thousands of redundant builds during test
     collection.
     """
-    instance: literalizer.Language = lang_cls()
-    return instance
+    return cast("literalizer.Language", lang_cls())
 
 
 @dataclasses.dataclass
@@ -152,7 +155,7 @@ def _build_non_default_variants(
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls)
+        spec = _default_spec(lang_cls=lang_cls)
         default_format = get_default(spec)
         for fmt in get_formats(spec):
             if fmt is default_format:
@@ -357,7 +360,7 @@ def _build_line_ending_decl_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls)
+        spec = _default_spec(lang_cls=lang_cls)
         default_line_ending = spec.line_ending
         default_declaration_style = spec.declaration_style
         non_default_line_endings = [
@@ -399,16 +402,17 @@ def _build_sequence_decl_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls)
-        default_sequence_format = spec.sequence_format
+        spec = _default_spec(lang_cls=lang_cls)
+        # spec.sequence_format is typed as the SequenceFormat protocol,
+        # but at runtime it is the Enum member that lives in
+        # spec.sequence_formats; cast so the identity check below
+        # type-checks.
+        default_sequence_format = cast("enum.Enum", spec.sequence_format)
         default_declaration_style = spec.declaration_style
         non_default_sequence_formats = [
             sequence_format
             for sequence_format in spec.sequence_formats
-            # default is typed as the SequenceFormat protocol; iterating
-            # sequence_formats yields plain Enum, so type checkers miss
-            # the overlap.
-            if sequence_format is not default_sequence_format  # type: ignore[comparison-overlap]  # pyright: ignore[reportUnnecessaryComparison]
+            if sequence_format is not default_sequence_format
         ]
         non_default_declaration_styles = [
             declaration_style
@@ -677,7 +681,7 @@ def _discover_combined_cases() -> list[_CombinedCase]:
                 and not lang_cls.supports_non_printable_ascii_dict_keys
             ):
                 continue
-            spec = _default_spec(lang_cls)
+            spec = _default_spec(lang_cls=lang_cls)
             redef_styles = _find_redefinition_styles(spec=spec)
             for style in redef_styles:
                 if style is redef_styles[0]:
@@ -963,7 +967,7 @@ def _build_type_hints_cross_variants() -> list[_Variant]:
     ]
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
-        spec = _default_spec(lang_cls)
+        spec = _default_spec(lang_cls=lang_cls)
         default_th = spec.variable_type_hints
         lang_name = lang_cls.__name__
         for th_fmt in spec.variable_type_hints_formats:
@@ -1306,7 +1310,7 @@ def _build_line_ending_combined_cases() -> list[_LineEndingCombinedCase]:
     cases: list[_LineEndingCombinedCase] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls)
+        spec = _default_spec(lang_cls=lang_cls)
         if not _find_redefinition_styles(spec=spec):
             continue
         default_line_ending = spec.line_ending

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,7 +17,6 @@ import enum
 import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import cast
 
 import pytest
 from beartype import beartype
@@ -121,7 +120,7 @@ def _default_spec(
     instance per class cuts thousands of redundant builds during test
     collection.
     """
-    return cast("literalizer.Language", lang_cls())
+    return lang_cls()
 
 
 @dataclasses.dataclass
@@ -403,11 +402,7 @@ def _build_sequence_decl_variants() -> Iterable[_Variant]:
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
         spec = _default_spec(lang_cls=lang_cls)
-        # spec.sequence_format is typed as the SequenceFormat protocol,
-        # but at runtime it is the Enum member that lives in
-        # spec.sequence_formats; cast so the identity check below
-        # type-checks.
-        default_sequence_format = cast("enum.Enum", spec.sequence_format)
+        default_sequence_format = spec.sequence_format
         default_declaration_style = spec.declaration_style
         non_default_sequence_formats = [
             sequence_format

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -113,7 +113,7 @@ def _default_spec(
     *,
     lang_cls: literalizer.LanguageCls,
 ) -> literalizer.Language:
-    """Return a memoized default-constructed instance of *lang_cls*.
+    """Return a cached default-constructed instance of *lang_cls*.
 
     Each ``lang_cls()`` call rebuilds ``@beartype``-wrapped closures
     inside the formatter factories; sharing one default-constructed

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -117,7 +117,8 @@ def _default_spec(lang_cls: literalizer.LanguageCls) -> literalizer.Language:
     instance per class cuts thousands of redundant builds during test
     collection.
     """
-    return lang_cls()
+    instance: literalizer.Language = lang_cls()
+    return instance
 
 
 @dataclasses.dataclass
@@ -405,9 +406,9 @@ def _build_sequence_decl_variants() -> Iterable[_Variant]:
             sequence_format
             for sequence_format in spec.sequence_formats
             # default is typed as the SequenceFormat protocol; iterating
-            # sequence_formats yields plain Enum, so pyright misses the
-            # overlap.
-            if sequence_format is not default_sequence_format  # pyright: ignore[reportUnnecessaryComparison]
+            # sequence_formats yields plain Enum, so type checkers miss
+            # the overlap.
+            if sequence_format is not default_sequence_format  # type: ignore[comparison-overlap]  # pyright: ignore[reportUnnecessaryComparison]
         ]
         non_default_declaration_styles = [
             declaration_style

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -14,6 +14,7 @@ To regenerate all golden files after changing output::
 
 import dataclasses
 import enum
+import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
 
@@ -107,6 +108,18 @@ _SORTED_LANGUAGES: list[literalizer.LanguageCls] = sorted(
 )
 
 
+@functools.cache
+def _default_spec(lang_cls: literalizer.LanguageCls) -> literalizer.Language:
+    """Return a memoized default-constructed instance of *lang_cls*.
+
+    Each ``lang_cls()`` call rebuilds ``@beartype``-wrapped closures
+    inside the formatter factories; sharing one default-constructed
+    instance per class cuts thousands of redundant builds during test
+    collection.
+    """
+    return lang_cls()
+
+
 @dataclasses.dataclass
 class _VariantCase:
     """A format-variant golden-file test case."""
@@ -138,7 +151,7 @@ def _build_non_default_variants(
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = lang_cls()
+        spec = _default_spec(lang_cls)
         default_format = get_default(spec)
         for fmt in get_formats(spec):
             if fmt is default_format:
@@ -343,7 +356,7 @@ def _build_line_ending_decl_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = lang_cls()
+        spec = _default_spec(lang_cls)
         default_line_ending = spec.line_ending
         default_declaration_style = spec.declaration_style
         non_default_line_endings = [
@@ -385,13 +398,16 @@ def _build_sequence_decl_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = lang_cls()
+        spec = _default_spec(lang_cls)
         default_sequence_format = spec.sequence_format
         default_declaration_style = spec.declaration_style
         non_default_sequence_formats = [
             sequence_format
             for sequence_format in spec.sequence_formats
-            if sequence_format is not default_sequence_format
+            # default is typed as the SequenceFormat protocol; iterating
+            # sequence_formats yields plain Enum, so pyright misses the
+            # overlap.
+            if sequence_format is not default_sequence_format  # pyright: ignore[reportUnnecessaryComparison]
         ]
         non_default_declaration_styles = [
             declaration_style
@@ -660,7 +676,7 @@ def _discover_combined_cases() -> list[_CombinedCase]:
                 and not lang_cls.supports_non_printable_ascii_dict_keys
             ):
                 continue
-            spec = lang_cls()
+            spec = _default_spec(lang_cls)
             redef_styles = _find_redefinition_styles(spec=spec)
             for style in redef_styles:
                 if style is redef_styles[0]:
@@ -946,7 +962,7 @@ def _build_type_hints_cross_variants() -> list[_Variant]:
     ]
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
-        spec = lang_cls()
+        spec = _default_spec(lang_cls)
         default_th = spec.variable_type_hints
         lang_name = lang_cls.__name__
         for th_fmt in spec.variable_type_hints_formats:
@@ -1289,7 +1305,7 @@ def _build_line_ending_combined_cases() -> list[_LineEndingCombinedCase]:
     cases: list[_LineEndingCombinedCase] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = lang_cls()
+        spec = _default_spec(lang_cls)
         if not _find_redefinition_styles(spec=spec):
             continue
         default_line_ending = spec.line_ending


### PR DESCRIPTION
## Summary

- Adds a `functools.cache`-d `_default_spec(lang_cls)` helper and uses it in the six discovery functions inside `tests/integration/test_integration.py` that only need a default-constructed language spec.
- Each `lang_cls()` call rebuilds many `@beartype`-wrapped formatter closures, so caching one instance per class drops `test_integration.py` import time from ~14s to ~2s (~7× speedup), with biggest impact in `_discover_combined_cases` which iterated cases × languages.
- Adds one `# type: ignore` / `# pyright: ignore` for an Enum-vs-Protocol comparison that was previously masked because `lang_cls()` was inferred as `Any`.

Closes #1281

## Test plan

- [x] `uv run --extra=dev pytest tests/integration/test_integration.py -n auto` (12,059 pass, 2 skipped)
- [x] `uv run --extra=dev pyright tests/integration/test_integration.py`
- [x] `uv run --extra=dev mypy tests/integration/test_integration.py`
- [x] `uv run --extra=dev ruff check tests/integration/test_integration.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are mostly type/Protocol cleanup and integration test performance optimizations, with a small behavioral touchpoint in coercion gating now reading `sequence_format_config` directly.
> 
> **Overview**
> Speeds up integration test collection by caching a single default-constructed `lang_cls()` instance per language and reusing it across variant/case discovery in `tests/integration/test_integration.py`.
> 
> Simplifies sequence-format typing by removing the `SequenceFormat` Protocol and the per-language `supports_heterogeneity` enum property wrappers, and updates coercion gating to consult `spec.sequence_format_config.supports_heterogeneity` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0942ce62728bcd807639a609ca3a34a57f385c9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->