### PR TITLE
Cache Language instances across integration tests

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -151,6 +151,7 @@ jsonnet
 kotlinc
 kroc
 kts
+kwargs
 linter
 literalize
 literalizer

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -108,18 +108,31 @@ _SORTED_LANGUAGES: list[literalizer.LanguageCls] = sorted(
 
 
 @functools.cache
-def _default_spec(
+def _cached_spec(
     *,
     lang_cls: literalizer.LanguageCls,
+    kwargs_items: frozenset[tuple[str, object]],
 ) -> literalizer.Language:
-    """Return a cached default-constructed instance of *lang_cls*.
+    """Return a cached instance of *lang_cls* built from *kwargs_items*.
 
     Each ``lang_cls()`` call rebuilds ``@beartype``-wrapped closures
-    inside the formatter factories; sharing one default-constructed
-    instance per class cuts thousands of redundant builds during test
-    collection.
+    inside the formatter factories; sharing one instance per
+    ``(class, kwargs)`` combination cuts thousands of redundant builds
+    across collection and test execution.
     """
-    return lang_cls()
+    return lang_cls(**dict(kwargs_items))
+
+
+def _spec(
+    *,
+    lang_cls: literalizer.LanguageCls,
+    **kwargs: object,
+) -> literalizer.Language:
+    """Return a cached instance of *lang_cls* for the given kwargs."""
+    return _cached_spec(
+        lang_cls=lang_cls,
+        kwargs_items=frozenset(kwargs.items()),
+    )
 
 
 @dataclasses.dataclass
@@ -153,7 +166,7 @@ def _build_non_default_variants(
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls=lang_cls)
+        spec = _spec(lang_cls=lang_cls)
         default_format = get_default(spec)
         for fmt in get_formats(spec):
             if fmt is default_format:
@@ -358,7 +371,7 @@ def _build_line_ending_decl_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls=lang_cls)
+        spec = _spec(lang_cls=lang_cls)
         default_line_ending = spec.line_ending
         default_declaration_style = spec.declaration_style
         non_default_line_endings = [
@@ -400,7 +413,7 @@ def _build_sequence_decl_variants() -> Iterable[_Variant]:
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls=lang_cls)
+        spec = _spec(lang_cls=lang_cls)
         default_sequence_format = spec.sequence_format
         default_declaration_style = spec.declaration_style
         non_default_sequence_formats = [
@@ -627,7 +640,7 @@ def test_golden_file(
     result = literalizer.literalize(
         source=yaml_string,
         input_format=literalizer.InputFormat.YAML,
-        language=lang_cls(),
+        language=_spec(lang_cls=lang_cls),
         pre_indent_level=0,
         include_delimiters=True,
         variable_form=_wrap_variable_form(lang_cls=lang_cls),
@@ -675,7 +688,7 @@ def _discover_combined_cases() -> list[_CombinedCase]:
                 and not lang_cls.supports_non_printable_ascii_dict_keys
             ):
                 continue
-            spec = _default_spec(lang_cls=lang_cls)
+            spec = _spec(lang_cls=lang_cls)
             redef_styles = _find_redefinition_styles(spec=spec)
             for style in redef_styles:
                 if style is redef_styles[0]:
@@ -716,7 +729,8 @@ def test_golden_file_combined_variable_forms(
     """
     input_path = cases_dir / combined_case.case_name / "input.yaml"
     lang_cls = combined_case.lang_cls
-    spec = lang_cls(
+    spec = _spec(
+        lang_cls=lang_cls,
         declaration_style=combined_case.declaration_style,
     )
     yaml_string = input_path.read_text()
@@ -908,7 +922,7 @@ def _build_type_hints_cross_variants() -> list[_Variant]:
     ]
     variants: list[_Variant] = []
     for lang_cls in _SORTED_LANGUAGES:
-        spec = _default_spec(lang_cls=lang_cls)
+        spec = _spec(lang_cls=lang_cls)
         default_th = spec.variable_type_hints
         lang_name = lang_cls.__name__
         for th_fmt in spec.variable_type_hints_formats:
@@ -1250,7 +1264,7 @@ def _build_line_ending_combined_cases() -> list[_LineEndingCombinedCase]:
     cases: list[_LineEndingCombinedCase] = []
     for lang_cls in _SORTED_LANGUAGES:
         lang_name = lang_cls.__name__
-        spec = _default_spec(lang_cls=lang_cls)
+        spec = _spec(lang_cls=lang_cls)
         if not _find_redefinition_styles(spec=spec):
             continue
         default_line_ending = spec.line_ending
@@ -1291,10 +1305,11 @@ def test_line_ending_combined_variable_forms(
     """
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    base_spec = case.lang_cls()
+    base_spec = _spec(lang_cls=case.lang_cls)
     redef_styles = _find_redefinition_styles(spec=base_spec)
     assert redef_styles
-    spec = case.lang_cls(
+    spec = _spec(
+        lang_cls=case.lang_cls,
         line_ending=case.line_ending,
         declaration_style=redef_styles[0],
     )
@@ -1346,7 +1361,8 @@ def test_no_dead_golden_files(request: pytest.FixtureRequest) -> None:
         )
 
     for line_ending_case in _LINE_ENDING_COMBINED_CASES:
-        line_ending_spec = line_ending_case.lang_cls(
+        line_ending_spec = _spec(
+            lang_cls=line_ending_case.lang_cls,
             line_ending=line_ending_case.line_ending,
         )
         expected.add(
@@ -1481,7 +1497,7 @@ def test_call_golden_file(
             if s.value.kind == config.call_style_kind
         )
         kwargs["call_style"] = style
-    spec = lang_cls(**kwargs)
+    spec = _spec(lang_cls=lang_cls, **kwargs)
     input_path = cases_dir / config.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
     result = literalizer.literalize_call(


### PR DESCRIPTION
## Summary

- Each `lang_cls(...)` call rebuilds `@beartype`-wrapped closures inside the formatter factories (5–16 beartype compiles per instance). Parametrized tests reconstruct the same spec ~200×/language, so most of that work is redundant.
- Generalises the existing `_default_spec` cache to `_spec(lang_cls=..., **kwargs)`, backed by `functools.cache` keyed on `(lang_cls, frozenset(kwargs.items()))`, and routes all per-test and collection-time construction sites through it.
- Measured: ~12% CPU reduction with `-n auto` (162s → 142s) and ~15% serial wall-clock reduction (101s → 86s); all 12,558 tests still pass, mypy and pyright clean.

## Test plan

- [x] `uv run pytest tests/integration/test_integration.py -n auto`
- [x] `uv run pyright tests/integration/test_integration.py`
- [x] `uv run mypy tests/integration/test_integration.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes integration tests to reuse cached `Language` instances across many parametrizations; if any test or `Language` implementation mutates instance state, sharing could create order-dependent failures.
> 
> **Overview**
> Speeds up integration test collection/execution by replacing the default-only `_default_spec` cache with `_spec(lang_cls=..., **kwargs)` backed by `functools.cache` keyed on `(lang_cls, frozenset(kwargs.items()))`.
> 
> Updates integration tests/variant builders to construct languages via `_spec(...)` (including overridden options like `declaration_style`, `line_ending`, and `call_style`) instead of repeatedly calling `lang_cls()`/`lang_cls(**kwargs)`, and adds `kwargs` to the spelling dictionary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dad2b58c085c9ea8793fa0a20e1c9804cfbd617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->