### PR TITLE
Compose Rust i64/wide-int fallback formatters with base

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -77,24 +77,40 @@ _U64_MAX = 2**64 - 1
 
 
 @beartype
-def _format_rust_i64_literal(value: int) -> str:
-    """Format a value that exceeds ``i32`` but fits ``i64`` as an
-    ``i64``-suffixed Rust literal.
+def _make_rust_i64_formatter(
+    base: Callable[[int], str],
+) -> Callable[[int], str]:
+    """Wrap *base* so its output gets an ``i64`` suffix.
+
+    Used for values that exceed ``i32`` but fit ``i64``.
     """
-    return f"{value}i64"
+
+    @beartype
+    def _format(value: int) -> str:
+        """Format with ``i64`` suffix."""
+        return f"{base(value)}i64"
+
+    return _format
 
 
 @beartype
-def _format_rust_wide_int_literal(value: int) -> str:
-    """Format a value that exceeds i64 range as a Rust typed literal.
+def _make_rust_wide_int_formatter(
+    base: Callable[[int], str],
+) -> Callable[[int], str]:
+    """Wrap *base* so its output gets a ``u64`` or ``i128`` suffix.
 
     Uses ``u64`` for non-negative values that fit in ``u64``; ``i128``
     for everything else (larger positives and negatives below
     ``i64::MIN``).
     """
-    if 0 <= value <= _U64_MAX:
-        return f"{value}u64"
-    return f"{value}i128"
+
+    @beartype
+    def _format(value: int) -> str:
+        """Format with ``u64`` or ``i128`` suffix."""
+        suffix = "u64" if 0 <= value <= _U64_MAX else "i128"
+        return f"{base(value)}{suffix}"
+
+    return _format
 
 
 @beartype
@@ -637,14 +653,16 @@ class Rust(metaclass=LanguageCls):
         )
         _i64_suffixed_int_formatter = make_overflow_fallback_formatter(
             base=_base_int_formatter,
-            fallback=_format_rust_i64_literal,
+            fallback=_make_rust_i64_formatter(base=_base_int_formatter),
             min_value=I32_MIN,
             max_value=I32_MAX,
         )
         self.format_integer: Callable[[int], str] = (
             make_overflow_fallback_formatter(
                 base=_i64_suffixed_int_formatter,
-                fallback=_format_rust_wide_int_literal,
+                fallback=_make_rust_wide_int_formatter(
+                    base=_base_int_formatter,
+                ),
             )
         )
         self.format_sequence_entry: Callable[[Value, str], str] = (


### PR DESCRIPTION
## Summary
- Addresses [bugbot review comment on PR #1295](https://github.com/adamtheturtle/literalizer/pull/1295#discussion_r3105365083)
- The Rust overflow fallbacks used a plain `f\"{value}...\"` template, so hex, binary, octal, and underscore-separator formatting were silently dropped for values outside the i32 range
- Mirror Java/Scala's `make_long_suffix_formatter` pattern: convert the fallbacks to factories that wrap the configured base formatter

## Test plan
- [x] `uv run pytest tests/integration -k Rust` — 259 passed
- [x] Manual sanity check that hex/underscore formatting now reaches i64 and wide-int values (e.g. `0xb2d05e00i64`, `3_000_000_000i64`, `0x8000000000000000u64`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Rust integer literal formatting for values outside the `i32` range, which can affect generated code output for large numbers (hex/binary/octal/underscored). Scope is limited to formatter composition and suffix selection (`i64` vs `u64`/`i128`).
> 
> **Overview**
> Fixes Rust overflow integer literal formatting so values that fall back to `i64`/wide-int forms still preserve the configured base integer style (hex/binary/octal) and numeric separators.
> 
> This replaces the hardcoded fallback literal functions with formatter factories (`_make_rust_i64_formatter`, `_make_rust_wide_int_formatter`) that wrap the base formatter and then append the appropriate Rust type suffix (`i64`, `u64`, or `i128`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6117495891c9c9c90596a8325b27dc633757b181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->