### PR TITLE
CI: use pytest-xdist --dist=worksteal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run --extra=dev pytest -s -vvv -n auto --cov-fail-under 100 --cov=src/ --cov=tests .
+          uv run --extra=dev pytest -s -vvv -n auto --dist=worksteal --cov-fail-under 100 --cov=src/ --cov=tests .
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- Switch CI pytest invocation to `--dist=worksteal` so idle workers pull from busy workers' queues, reducing straggler wall time on the 12k+ parameterized integration suite.

Closes #1277.

## Test plan
- [ ] CI matrix (Ubuntu + Windows, Python 3.12/3.13/3.14) passes with `--cov-fail-under=100` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tweaks CI test distribution behavior; primary risk is flakiness or timing differences due to changed parallel scheduling.
> 
> **Overview**
> Updates the CI workflow to run `pytest-xdist` with `--dist=worksteal` when executing the test matrix, so idle workers can steal work from busy ones to reduce straggler wall time while keeping coverage enforcement unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7773332fa8cf443d4ef24b51cc4fb8323ea005e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->