### PR TITLE
Ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ uv.lock
 
 # macOS
 .DS_Store
+
+# Claude Code
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so Claude Code's per-user runtime state (e.g. `scheduled_tasks.lock`) isn't committed.

Closes #1301.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates `.gitignore` only to prevent committing local `.claude/` runtime state, with no impact to application behavior.
> 
> **Overview**
> Adds `.claude/` to `.gitignore` so Claude Code’s per-user runtime/state files are not tracked or accidentally committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa73d269f9a4444a6df81f11cc6ba592d0716b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->