### PR TITLE
Override lazy_datadir to skip per-test tmp_path scan

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 """Configuration for pytest."""
 
+from pathlib import Path
+
 import pytest
 from beartype import beartype
 
@@ -8,3 +10,22 @@ def pytest_collection_modifyitems(items: list[pytest.Function]) -> None:
     """Apply the beartype decorator to all collected test functions."""
     for item in items:
         item.obj = beartype(obj=item.obj)
+
+
+@pytest.fixture(scope="session", name="lazy_datadir")
+def fixture_lazy_datadir(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """Override pytest-regressions' ``lazy_datadir`` with a shared path.
+
+    All ``file_regression.check()`` calls in this repo pass ``fullpath=``,
+    so ``lazy_datadir`` is only used to compute the ``.obtained`` file
+    location on failure. Returning a single session-scoped path breaks
+    the per-test ``tmp_path`` dependency, which otherwise dominates
+    runtime via pytest's O(N^2) ``make_numbered_dir``/``find_prefixed``
+    scan.
+    """
+    return tmp_path_factory.mktemp(
+        basename="file_regression_obtained",
+        numbered=False,
+    )

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -185,8 +185,10 @@ pyjson5
 pyrefly
 pyright
 pytest
+pytest's
 rakudo
 regen
+repo
 reportAttributeAccessIssue
 reportMissingTypeStubs
 reportPrivateUsage


### PR DESCRIPTION
## Summary

Profiling showed pytest's `tmp_path` fixture dominated the integration suite (~31% of runtime, ~23s on a 6,136-test subset) because `make_numbered_dir`/`find_prefixed` does an O(N²) scan to allocate per-test numbered directories. Every `file_regression.check()` call here passes `fullpath=`, so `lazy_datadir` is only used to compute the `.obtained` file location on failure — a single session-scoped path suffices and removes the per-test `tmp_path` dependency. Follows the override pattern documented upstream in [pytest-regressions PR #192](https://github.com/ESSS/pytest-regressions/pull/192).

## Test plan

- [x] Full integration suite (13,118 tests) passes in ~52s
- [x] Non-integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-infra change that only affects where `.obtained` files are written on regression failures, but could change failure artifacts/paths if any tests relied on per-test temp dirs.
> 
> **Overview**
> Improves test suite performance by overriding `pytest-regressions`’ `lazy_datadir` fixture with a session-scoped directory created via `tmp_path_factory`, eliminating per-test `tmp_path` directory allocation for `.obtained` outputs.
> 
> Updates the spelling dictionary to include new terms used in the added documentation/comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a125ef3892d83f96064ce63ecc29d5619f2ddee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->