### PR TITLE
Drop Python ALWAYS scalar type-hint tests redundant with goldens

### DIFF
--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -25,35 +25,6 @@ PYTHON_ALWAYS_HINTS = Python(
 )
 
 
-@pytest.mark.parametrize(
-    argnames=("json_input", "expected"),
-    argvalues=[
-        ("42", "my_var: int = 42"),
-        ("3.14", "my_var: float = 3.14"),
-        ("true", "my_var: bool = True"),
-        ("false", "my_var: bool = False"),
-        ("null", "my_var: None = None"),
-        ('"hello"', 'my_var: str = "hello"'),
-    ],
-)
-def test_python_always_type_hints_scalars(
-    *, json_input: str, expected: str
-) -> None:
-    """Python with ALWAYS variable_type_hints adds type annotations
-    for scalar values.
-    """
-    result = literalize(
-        source=json_input,
-        input_format=InputFormat.JSON,
-        language=PYTHON_ALWAYS_HINTS,
-        pre_indent_level=0,
-        include_delimiters=False,
-        variable_form=NewVariable(name="my_var"),
-        error_on_coercion=False,
-    )
-    assert result.code == expected
-
-
 def test_python_always_type_hints_assignment_no_hint() -> None:
     """Python ALWAYS hints do not add type hints for assignments."""
     result = literalize(


### PR DESCRIPTION
## Summary
- Remove the parametrized `test_python_always_type_hints_scalars` from `tests/test_variables.py`. The int/float/bool/null/str → Python-ALWAYS type-hint emission is already covered by the `type_hints/Python_type_hints_always.py` golden (int, bool, null, str as dict values) and `float_list/Python_type_hints_always.py` (float); the bare-scalar path shares the same type-hint rendering logic.

## Test plan
- [x] `uv run pytest tests/test_variables.py` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only removes a parametrized unit test and does not change runtime behavior; the main risk is reduced regression detection if golden coverage is incomplete.
> 
> **Overview**
> Removes the parametrized `test_python_always_type_hints_scalars` from `tests/test_variables.py`, dropping direct assertions that Python `variable_type_hints=ALWAYS` emits annotations for scalar JSON literals.
> 
> All other variable/type-hint tests remain unchanged, relying on existing golden-style coverage for these scalar cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadc12ccf4b65a654e352a34b86ba04abd5078a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->