### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
     "release",
 ]


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

This removes deprecation warnings; the old key may be removed in a future deptry release.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only change that just renames a `deptry` setting to match newer versions; runtime code paths are unaffected.
> 
> **Overview**
> **Deptry config update:** Renames the `deptry` setting in `pyproject.toml` from `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` to align with deptry 0.25+ and avoid deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58dbd2c34b6e575bd7ad84da3f44118c22d1bde0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->