### PR TITLE
Use pytest-beartype-tests plugin for test type checking

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,13 +3,6 @@
 from pathlib import Path
 
 import pytest
-from beartype import beartype
-
-
-def pytest_collection_modifyitems(items: list[pytest.Function]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        item.obj = beartype(obj=item.obj)
 
 
 @pytest.fixture(scope="session", name="lazy_datadir")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "pytest-xdist==3.8.0",
@@ -365,7 +366,6 @@ linewrap-full-docstring = true
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",


### PR DESCRIPTION
## Summary

Replace the hand-rolled `pytest_collection_modifyitems` hook in `conftest.py` with the `pytest-beartype-tests` plugin, which provides the same behaviour (applying `@beartype` to every collected test function) via the `pytest11` entry point. The corresponding `pytest_collection_modifyitems` entry is removed from `tool.vulture.ignore_names` since it's no longer defined in-repo.

## Test plan

- [x] `uv run pytest` — 13527 passed, 14 skipped
- [x] Confirmed plugin is active: a deliberate signature/fixture type mismatch raises `BeartypeCallHintParamViolation`
- [x] `uv run vulture .`, `uv run deptry .`, `uv run mypy conftest.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps a local `pytest_collection_modifyitems` hook for an external pytest plugin and adjusts static-analysis config, affecting only test-time behavior and dev dependencies.
> 
> **Overview**
> Moves test type-checking from a custom `conftest.py` `pytest_collection_modifyitems` hook (that wrapped all tests in `@beartype`) to the `pytest-beartype-tests` plugin.
> 
> Adds `pytest-beartype-tests` to dev dependencies and removes the now-unused `pytest_collection_modifyitems` entry from `tool.vulture.ignore_names`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897a211bf97c5272d5a9e141dc9414b97da747a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->