### PR TITLE
Cache YAML() instances via functools.cache

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime
 import enum
+import functools
 import json
 import math
 from collections.abc import Callable, Sequence
@@ -967,9 +968,21 @@ def _parse_json5(*, source: str) -> _ParsedInput:
     return _ParsedInput(data=data, raw_data=data)
 
 
+@functools.cache
+def _get_yaml(*, safe: bool) -> YAML:
+    """Return a cached ``YAML`` instance.
+
+    Constructing ``YAML()`` globs the package directory for plug-ins
+    (~50 µs); caching avoids that cost on every parse.  ``ruamel``
+    parsers are not safe for concurrent use within a single instance,
+    so ``literalize`` is not safe to call from multiple threads.
+    """
+    return YAML(typ="safe") if safe else YAML()
+
+
 def _parse_yaml(*, source: str) -> _ParsedInput:
     """Parse a YAML string into a ``_ParsedInput``."""
-    ruamel_yaml = YAML(typ="safe")
+    ruamel_yaml = _get_yaml(safe=True)
     try:
         # https://sourceforge.net/p/ruamel-yaml/tickets/564/
         raw_data = ruamel_yaml.load(stream=source)  # pyright: ignore[reportUnknownMemberType]
@@ -1646,7 +1659,7 @@ def _resolve_yaml_comments(
     """Parse YAML for comment metadata and resolve comments."""
     if isinstance(data, set):
         # https://sourceforge.net/p/ruamel-yaml/tickets/328/
-        ruamel_set: CommentedSet = YAML().load(  # pyright: ignore[reportUnknownMemberType]
+        ruamel_set: CommentedSet = _get_yaml(safe=False).load(  # pyright: ignore[reportUnknownMemberType]
             stream=StringIO(initial_value=yaml_string),
         )
         return _resolve_collection_comments(
@@ -1664,7 +1677,7 @@ def _resolve_yaml_comments(
     if not isinstance(data, (list, dict)):
         stream = StringIO(initial_value=yaml_string)
         # https://sourceforge.net/p/ruamel-yaml/tickets/328/
-        tokens = YAML().scan(stream=stream)  # pyright: ignore[reportUnknownMemberType]
+        tokens = _get_yaml(safe=False).scan(stream=stream)  # pyright: ignore[reportUnknownMemberType]
         scalar_result = literalize_yaml_scalar(
             tokens=tokens,
             base=base,
@@ -1681,7 +1694,7 @@ def _resolve_yaml_comments(
         )
 
     # https://sourceforge.net/p/ruamel-yaml/tickets/328/
-    ruamel_data: CommentedSeq | CommentedMap = YAML().load(  # pyright: ignore[reportUnknownMemberType]
+    ruamel_data: CommentedSeq | CommentedMap = _get_yaml(safe=False).load(  # pyright: ignore[reportUnknownMemberType]
         stream=StringIO(initial_value=yaml_string),
     )
     return _resolve_yaml_collection_comments(

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -973,9 +973,10 @@ def _get_yaml(*, safe: bool) -> YAML:
     """Return a cached ``YAML`` instance.
 
     Constructing ``YAML()`` globs the package directory for plug-ins
-    (~50 µs); caching avoids that cost on every parse.  ``ruamel``
-    parsers are not safe for concurrent use within a single instance,
-    so ``literalize`` is not safe to call from multiple threads.
+    on every call; caching avoids that cost on every parse.
+    ``ruamel`` parsers are not safe for concurrent use within a single
+    instance, so ``literalize`` is not safe to call from multiple
+    threads.
     """
     return YAML(typ="safe") if safe else YAML()
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -116,6 +116,27 @@ def test_literalize_yaml_invalid_is_parse_error() -> None:
         )
 
 
+def test_literalize_yaml_after_invalid_uses_cached_instance() -> None:
+    """Cached ``YAML`` instances recover after a parse error.
+
+    Guards against ruamel.yaml ever leaving an instance in a broken
+    state after an exception, which would compound across calls now
+    that we cache instances via ``functools.cache``.
+    """
+    with pytest.raises(expected_exception=YAMLParseError):
+        literalize(
+            source=":\n  :\n    - ][",
+            input_format=InputFormat.YAML,
+            language=PYTHON,
+        )
+    result = literalize(
+        source="foo: bar",
+        input_format=InputFormat.YAML,
+        language=PYTHON,
+    )
+    assert result.declaration_code == '{\n    "foo": "bar",\n}'
+
+
 def test_cpp_array_binary_typed() -> None:
     """C++ ARRAY format infers std::array<std::string, N> for binary
     data.


### PR DESCRIPTION
## Summary

Constructing `YAML()` globs the package directory for plug-ins (~50 µs), and `_core.py` does it on every parse and comment-resolution call. This adds a `@functools.cache`-decorated `_get_yaml(*, safe: bool)` helper and routes all four call sites through it. The cached instance is shared across threads, so the docstring notes that `literalize` is not safe for concurrent use (ruamel parsers aren't either).

Closes #1320

## Test plan

- [x] `pytest -k yaml` (177 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because YAML parsing/comment resolution now reuses cached `ruamel.yaml.YAML` objects, which can introduce state leakage or thread-safety issues if the parser is not fully re-entrant.
> 
> **Overview**
> Reduces YAML overhead by introducing a `@functools.cache`d `_get_yaml(safe=...)` helper and routing YAML parsing plus YAML comment-resolution scan/load paths through these cached `YAML()` instances.
> 
> Adds a regression test ensuring a cached YAML parser still works correctly after a prior parse error, and documents that `literalize` is not thread-safe due to `ruamel` parser instance concurrency limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b687f1179a06c26d7f17f5e4ae2832b52880d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->