### PR TITLE
Anchor pytest.raises match patterns for full string matches

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -454,7 +454,11 @@ def test_literalize_call_per_element_false() -> None:
 
 def test_both_variable_forms_without_wrap_in_file_raises() -> None:
     """BothVariableForms without wrap_in_file=True raises ValueError."""
-    with pytest.raises(expected_exception=ValueError, match="wrap_in_file"):
+    expected_msg = "BothVariableForms requires wrap_in_file=True"
+    with pytest.raises(
+        expected_exception=ValueError,
+        match=f"^{re.escape(pattern=expected_msg)}$",
+    ):
         literalize(
             source="42",
             input_format=InputFormat.JSON,

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -2,6 +2,7 @@
 converter.
 """
 
+import re
 import textwrap
 
 import pytest
@@ -432,8 +433,14 @@ def test_rust_vec_format_type_annotation() -> None:
 
 def test_rust_const_vec_raises() -> None:
     """Rust CONST with vector format raises."""
+    expected_msg = (
+        "Rust CONST requires a constant-expression initializer, "
+        "but the VEC sequence format produces vec![…] which is "
+        "not a constant expression. Use ARRAY or TUPLE instead."
+    )
     with pytest.raises(
-        expected_exception=IncompatibleFormatsError, match="VEC"
+        expected_exception=IncompatibleFormatsError,
+        match=f"^{re.escape(pattern=expected_msg)}$",
     ):
         Rust(
             declaration_style=Rust.declaration_styles.CONST,
@@ -443,8 +450,14 @@ def test_rust_const_vec_raises() -> None:
 
 def test_rust_static_vec_raises() -> None:
     """Rust STATIC with vector format raises."""
+    expected_msg = (
+        "Rust STATIC requires a constant-expression initializer, "
+        "but the VEC sequence format produces vec![…] which is "
+        "not a constant expression. Use ARRAY or TUPLE instead."
+    )
     with pytest.raises(
-        expected_exception=IncompatibleFormatsError, match="VEC"
+        expected_exception=IncompatibleFormatsError,
+        match=f"^{re.escape(pattern=expected_msg)}$",
     ):
         Rust(
             declaration_style=Rust.declaration_styles.STATIC,


### PR DESCRIPTION
## Summary
- Wrap previously substring-only `match=` patterns in three `pytest.raises` calls with `^...$` and `re.escape` so they assert the full error message: the two Rust CONST/STATIC + VEC tests in `tests/test_variables.py` and the `BothVariableForms` test in `tests/test_languages.py`.

## Test plan
- [x] `uv run pytest tests/test_variables.py::test_rust_const_vec_raises tests/test_variables.py::test_rust_static_vec_raises tests/test_languages.py::test_both_variable_forms_without_wrap_in_file_raises`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that make failure assertions stricter and more explicit, without modifying runtime behavior.
> 
> **Overview**
> Updates three `pytest.raises(..., match=...)` assertions to **fully anchor and escape** expected error messages (`^...$` + `re.escape`) so tests validate the complete exception text.
> 
> Adds `re` import and refactors the affected tests to build explicit `expected_msg` strings for `BothVariableForms` and Rust `CONST/STATIC` + `VEC` incompatibility cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69c62b59fe453240187a6ce8923972820f8dbec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->