### PR TITLE
Short-circuit golden-file checks on the pass path

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -95,8 +95,8 @@ def test_check_golden_mismatch_delegates(
 ) -> None:
     """``_check_golden`` delegates to ``file_regression.check`` on miss.
 
-    Production goldens all match in CI, so the fallback branch is
-    otherwise unexercised.
+    Every golden file matches in CI, so nothing else reaches the
+    fallback branch.
     """
     golden = tmp_path / "golden.txt"
     golden.write_text(data="expected\n")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -53,6 +53,43 @@ def fixture_cases_dir(request: pytest.FixtureRequest) -> Path:
 
 
 @beartype
+def _check_golden(
+    *,
+    file_regression: FileRegressionFixture,
+    contents: str,
+    golden_path: Path,
+    extension: str,
+    newline: str | None,
+) -> None:
+    """Compare ``contents`` against ``golden_path`` in memory.
+
+    ``file_regression.check`` writes an ``.obtained`` file, reads both
+    files back from disk, and runs ``difflib`` even on the pass path,
+    which dominates this module's runtime (~13k calls per run).  For
+    the pass path we can compare the already-in-memory ``contents``
+    against the golden file directly; only on miss or regen do we
+    delegate to the fixture for its ``.obtained`` + HTML-diff output.
+    """
+    config = file_regression.request.config
+    regen = file_regression.force_regen or bool(
+        config.getoption(name="regen_all")
+        or config.getoption(name="force_regen"),
+    )
+    if (
+        not regen
+        and golden_path.is_file()
+        and contents.splitlines() == golden_path.read_text().splitlines()
+    ):
+        return
+    file_regression.check(
+        contents=contents,
+        extension=extension,
+        newline=newline,
+        fullpath=golden_path,
+    )
+
+
+@beartype
 def _find_redefinition_styles(
     spec: literalizer.Language,
 ) -> list[enum.Enum]:
@@ -616,11 +653,12 @@ def test_golden_file(
     # newline="" prevents Python text-mode from converting \r\n to \n
     # on Windows, which would corrupt golden files containing literal
     # CR bytes (e.g. CommonLisp string_control_chars).
-    file_regression.check(
+    _check_golden(
+        file_regression=file_regression,
         contents=result.code + "\n",
         extension=lang_cls.extension,
         newline="",
-        fullpath=golden_path,
+        golden_path=golden_path,
     )
 
 
@@ -723,11 +761,12 @@ def test_golden_file_combined_variable_forms(
         pytest.skip(
             f"{lang_cls.__name__} cannot represent this heterogeneous input"
         )
-    file_regression.check(
+    _check_golden(
+        file_regression=file_regression,
         contents=result.code + "\n",
         extension=lang_cls.extension,
         newline="",
-        fullpath=golden_path,
+        golden_path=golden_path,
     )
 
 
@@ -1323,10 +1362,12 @@ def test_format_variant_golden_file(
     except HeterogeneousCollectionError:
         golden_path.unlink(missing_ok=True)
         pytest.skip("Format cannot represent this heterogeneous input")
-    file_regression.check(
+    _check_golden(
+        file_regression=file_regression,
         contents=result.code + "\n",
         extension=variant.spec.extension,
-        fullpath=golden_path,
+        newline=None,
+        golden_path=golden_path,
     )
 
 
@@ -1408,10 +1449,12 @@ def test_line_ending_combined_variable_forms(
         variable_form=literalizer.BothVariableForms(name="my_data"),
         wrap_in_file=True,
     )
-    file_regression.check(
+    _check_golden(
+        file_regression=file_regression,
         contents=result.code + "\n",
         extension=spec.extension,
-        fullpath=input_path.parent / (case.name + spec.extension),
+        newline=None,
+        golden_path=input_path.parent / (case.name + spec.extension),
     )
 
 
@@ -1642,9 +1685,10 @@ def test_call_golden_file(
     wrapped = _prepend_preamble(wrapped=wrapped, preamble=all_preamble)
     lang_name = lang_cls.__name__
     golden_name = f"{lang_name}_call"
-    file_regression.check(
+    _check_golden(
+        file_regression=file_regression,
         contents=wrapped + "\n",
         extension=lang_cls.extension,
         newline="",
-        fullpath=input_path.parent / (golden_name + lang_cls.extension),
+        golden_path=input_path.parent / (golden_name + lang_cls.extension),
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -89,6 +89,30 @@ def _check_golden(
     )
 
 
+def test_check_golden_mismatch_delegates(
+    tmp_path: Path,
+    file_regression: FileRegressionFixture,
+) -> None:
+    """``_check_golden`` delegates to ``file_regression.check`` on miss.
+
+    Production goldens all match in CI, so the fallback branch is
+    otherwise unexercised.
+    """
+    golden = tmp_path / "golden.txt"
+    golden.write_text(data="expected\n")
+    with pytest.raises(
+        expected_exception=AssertionError,
+        match="FILES DIFFER",
+    ):
+        _check_golden(
+            file_regression=file_regression,
+            contents="different\n",
+            golden_path=golden,
+            extension=".txt",
+            newline="",
+        )
+
+
 @beartype
 def _find_redefinition_styles(
     spec: literalizer.Language,


### PR DESCRIPTION
## Summary
- Adds a `_check_golden` helper in `tests/integration/test_integration.py` that compares `contents` against the golden file in memory (via `splitlines()`, matching pytest-regressions' own semantics) and only delegates to `file_regression.check()` on miss, mismatch, or regen.
- Saves ~3s (~13%) of the single-process integration run (22.1s → 19.2s) by eliminating the per-call `.obtained` write + two reads + `difflib` pass that `file_regression.check()` runs even when the test passes.
- Preserves the fixture's `.obtained` file, HTML diff, `--regen-all`, and `--force-regen` behavior on the failure path by falling through to `file_regression.check()`.

Closes #1337

## Test plan
- [x] `uv run pytest tests/integration/ -n auto` — 12843 passed, 258 skipped
- [x] Verified failure path: corrupted a golden file → `.obtained` file, HTML diff, and difflib output still produced
- [x] Verified `--regen-all`: corrupted golden → test passes and golden is rewritten to actual contents
- [x] `uv run ruff check` + `uv run mypy` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Touches only integration test golden-file comparison logic; main risk is subtle mismatch in newline/regen semantics causing false passes or missed diffs, but the failure/regen path still delegates to `file_regression.check`.
> 
> **Overview**
> Speeds up integration golden-file assertions by introducing `_check_golden`, which compares generated output to the existing golden file in-memory and **skips** `pytest-regressions`' disk writes/reads and `difflib` work when the content already matches.
> 
> All golden checks are routed through `_check_golden`, while mismatches or `--regen-all`/`--force-regen` still fall back to `file_regression.check` to preserve `.obtained` files and HTML diff output; a small test is added to ensure delegation on mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6d60ee75b4e9dc92dc14d3228704370e0c4bf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->