### PR TITLE
Parse YAML only once per literalize() call

### DIFF
--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -14,7 +14,12 @@ import pyjson5
 import tomlkit
 from beartype import BeartypeConf, beartype
 from ruamel.yaml import YAML
-from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
+from ruamel.yaml.comments import (
+    CommentedMap,
+    CommentedOrderedMap,
+    CommentedSeq,
+    CommentedSet,
+)
 from ruamel.yaml.compat import ordereddict
 from ruamel.yaml.error import YAMLError
 from tomlkit.exceptions import TOMLKitError
@@ -632,7 +637,58 @@ def _wrap_body(
 
 
 @beartype
-def _coerce_yaml_keys(*, data: object) -> Value:
+def _unwrap_yaml_scalar(  # noqa: PLR0911
+    *,
+    value: object,
+) -> object:
+    """Convert a *ruamel.yaml* scalar wrapper to its plain Python type.
+
+    The round-trip loader returns subclasses (``ScalarInt``, ``HexInt``,
+    ``ScalarFloat``, ``LiteralScalarString``, ``TimeStamp``, ...) that
+    preserve source-style metadata.  The literalizer's type-inference
+    paths use ``type(value)`` for exact-type lookups, so these wrappers
+    are demoted to ``int``/``float``/``str``/``datetime`` before they
+    reach those code paths.
+    """
+    # bool is a subclass of int — check first so True/False stays bool.
+    if isinstance(value, bool):
+        return value if type(value) is bool else bool(value)
+    if isinstance(value, int):
+        return value if type(value) is int else int(value)
+    if isinstance(value, float):
+        return value if type(value) is float else float(value)
+    if isinstance(value, str):
+        return value if type(value) is str else str(object=value)
+    # datetime is a subclass of date — check first.
+    if isinstance(value, datetime.datetime):
+        if type(value) is datetime.datetime:
+            return value
+        return datetime.datetime(
+            year=value.year,
+            month=value.month,
+            day=value.day,
+            hour=value.hour,
+            minute=value.minute,
+            second=value.second,
+            microsecond=value.microsecond,
+            tzinfo=value.tzinfo,
+        )
+    if isinstance(value, datetime.date):
+        if type(value) is datetime.date:
+            return value
+        return datetime.date(
+            year=value.year,
+            month=value.month,
+            day=value.day,
+        )
+    return value
+
+
+@beartype
+def _coerce_yaml_keys(  # noqa: PLR0911
+    *,
+    data: object,
+) -> Value:
     """Recursively convert non-string dict keys to their string form.
 
     YAML allows non-string mapping keys (e.g. integers); ``Value``
@@ -641,15 +697,38 @@ def _coerce_yaml_keys(*, data: object) -> Value:
 
     ``ordereddict`` (used for YAML ``!!omap`` nodes) preserves its keys
     (so ordered-map detection in :func:`_literalize` still works) but
-    still walks into its values.
+    still walks into its values.  Round-trip ``CommentedMap`` instances
+    inherit from ``ordereddict`` despite representing plain mappings,
+    so they are matched explicitly and demoted to ``dict``.
+    :class:`CommentedSet` does not subclass :class:`set`, so it is
+    converted as well.  Scalar leaves are unwrapped to plain Python
+    types so type-based dispatch sees ``int`` rather than ``ScalarInt``
+    and friends.
     """
     match data:
-        case ordereddict():
-            omap = cast("dict[object, object]", data)
-            coerced = ordereddict(
-                [(f"{k}", _coerce_yaml_keys(data=v)) for k, v in omap.items()]
+        case CommentedOrderedMap():
+            omap_src = cast("dict[object, object]", data)
+            omap = ordereddict(
+                [
+                    (f"{k}", _coerce_yaml_keys(data=v))
+                    for k, v in omap_src.items()
+                ]
             )
-            return cast("Value", coerced)
+            return cast("Value", omap)
+        case CommentedMap():
+            return {
+                f"{k}": _coerce_yaml_keys(data=v)
+                for k, v in cast("dict[object, object]", data).items()
+            }
+        case ordereddict():
+            ordered_src = cast("dict[object, object]", data)
+            ordered = ordereddict(
+                [
+                    (f"{k}", _coerce_yaml_keys(data=v))
+                    for k, v in ordered_src.items()
+                ]
+            )
+            return cast("Value", ordered)
         case dict():
             return {
                 f"{k}": _coerce_yaml_keys(data=v)
@@ -660,8 +739,14 @@ def _coerce_yaml_keys(*, data: object) -> Value:
                 _coerce_yaml_keys(data=item)
                 for item in cast("list[object]", data)
             ]
+        case CommentedSet():
+            members = cast("set[object]", set(data))
+            return {
+                cast("Scalar", _unwrap_yaml_scalar(value=item))
+                for item in members
+            }
         case _:
-            return cast("Value", data)
+            return cast("Value", _unwrap_yaml_scalar(value=data))
 
 
 def _append_entries(
@@ -944,21 +1029,26 @@ def _parse_json5(*, source: str) -> _ParsedInput:
 
 
 @functools.cache
-def _get_yaml(*, safe: bool) -> YAML:
-    """Return a cached ``YAML`` instance.
+def _get_yaml() -> YAML:
+    """Return the cached round-trip ``YAML`` instance.
 
-    Constructing ``YAML()`` globs the package directory for plug-ins
-    on every call; caching avoids that cost on every parse.
-    ``ruamel`` parsers are not safe for concurrent use within a single
-    instance, so ``literalize`` is not safe to call from multiple
-    threads.
+    The round-trip loader is used everywhere so a single parse covers
+    both data extraction and comment metadata.  Constructing ``YAML()``
+    globs the package directory for plug-ins on every call; caching
+    avoids that cost on every parse.  ``ruamel`` parsers are not safe
+    for concurrent use within a single instance, so ``literalize`` is
+    not safe to call from multiple threads.
     """
-    return YAML(typ="safe") if safe else YAML()
+    return YAML()
 
 
 def _parse_yaml(*, source: str) -> _ParsedInput:
-    """Parse a YAML string into a ``_ParsedInput``."""
-    ruamel_yaml = _get_yaml(safe=True)
+    """Parse a YAML string into a ``_ParsedInput``.
+
+    Uses the comment-preserving (round-trip) loader so the same parse
+    can later feed comment extraction without a second tokenize pass.
+    """
+    ruamel_yaml = _get_yaml()
     try:
         # https://sourceforge.net/p/ruamel-yaml/tickets/564/
         raw_data = ruamel_yaml.load(stream=source)  # pyright: ignore[reportUnknownMemberType]
@@ -1043,7 +1133,7 @@ def _literalize_pre_form(
         )
         resolved = _resolve_yaml_comments(
             yaml_string=source,
-            data=parsed.raw_data,
+            raw_data=parsed.raw_data,
             base=result,
             language=language,
             comment_prefix=cp,
@@ -1602,7 +1692,7 @@ def _resolve_yaml_collection_comments(
 def _resolve_yaml_comments(
     *,
     yaml_string: str,
-    data: object,
+    raw_data: object,
     base: str,
     language: Language,
     comment_prefix: str,
@@ -1611,16 +1701,18 @@ def _resolve_yaml_comments(
     line_prefix: str,
     include_delimiters: bool,
 ) -> _ResolvedComments:
-    """Parse YAML for comment metadata and resolve comments."""
-    if isinstance(data, set):
-        # https://sourceforge.net/p/ruamel-yaml/tickets/328/
-        ruamel_set: CommentedSet = _get_yaml(safe=False).load(  # pyright: ignore[reportUnknownMemberType]
-            stream=StringIO(initial_value=yaml_string),
-        )
+    """Resolve comments using the already-parsed round-trip YAML data.
+
+    *raw_data* is the comment-preserving structure produced by
+    :func:`_parse_yaml` (a :class:`CommentedMap`, :class:`CommentedSeq`,
+    :class:`CommentedSet`, or scalar).  Scalars still need a separate
+    token scan because :meth:`YAML.load` discards comment tokens that
+    are not attached to a collection.
+    """
+    # https://sourceforge.net/p/ruamel-yaml/tickets/328/
+    if isinstance(raw_data, CommentedSet):
         return _resolve_collection_comments(
-            collection_comments=extract_yaml_comments(
-                ruamel_data=ruamel_set,
-            ),
+            collection_comments=extract_yaml_comments(ruamel_data=raw_data),
             base=base,
             language=language,
             comment_prefix=comment_prefix,
@@ -1629,38 +1721,33 @@ def _resolve_yaml_comments(
             include_delimiters=include_delimiters,
         )
 
-    if not isinstance(data, (list, dict)):
-        stream = StringIO(initial_value=yaml_string)
-        # https://sourceforge.net/p/ruamel-yaml/tickets/328/
-        tokens = _get_yaml(safe=False).scan(stream=stream)  # pyright: ignore[reportUnknownMemberType]
-        scalar_result = literalize_yaml_scalar(
-            tokens=tokens,
+    if isinstance(raw_data, (CommentedSeq, CommentedMap)):
+        return _resolve_yaml_collection_comments(
+            ruamel_data=raw_data,
+            data=raw_data,
             base=base,
+            language=language,
             comment_prefix=comment_prefix,
             comment_suffix=comment_suffix,
-            line_prefix=line_prefix,
-            supports_scalar_before_comments=language.supports_scalar_before_comments,
-            supports_scalar_inline_comments=language.supports_scalar_inline_comments,
-        )
-        return _ResolvedComments(
-            result=scalar_result.result,
-            pending=None,
-            pending_scalar_before=scalar_result.pending_before,
+            comment_line_prefix=comment_line_prefix,
+            include_delimiters=include_delimiters,
         )
 
-    # https://sourceforge.net/p/ruamel-yaml/tickets/328/
-    ruamel_data: CommentedSeq | CommentedMap = _get_yaml(safe=False).load(  # pyright: ignore[reportUnknownMemberType]
-        stream=StringIO(initial_value=yaml_string),
-    )
-    return _resolve_yaml_collection_comments(
-        ruamel_data=ruamel_data,
-        data=data,  # pyright: ignore[reportUnknownArgumentType]
+    stream = StringIO(initial_value=yaml_string)
+    tokens = _get_yaml().scan(stream=stream)  # pyright: ignore[reportUnknownMemberType]
+    scalar_result = literalize_yaml_scalar(
+        tokens=tokens,
         base=base,
-        language=language,
         comment_prefix=comment_prefix,
         comment_suffix=comment_suffix,
-        comment_line_prefix=comment_line_prefix,
-        include_delimiters=include_delimiters,
+        line_prefix=line_prefix,
+        supports_scalar_before_comments=language.supports_scalar_before_comments,
+        supports_scalar_inline_comments=language.supports_scalar_inline_comments,
+    )
+    return _ResolvedComments(
+        result=scalar_result.result,
+        pending=None,
+        pending_scalar_before=scalar_result.pending_before,
     )
 
 

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -643,20 +643,23 @@ def _unwrap_yaml_scalar(*, value: object) -> object:
     The round-trip loader returns subclasses (``ScalarInt``, ``HexInt``,
     ``ScalarFloat``, ``LiteralScalarString``, ``TimeStamp``, ...) that
     preserve source-style metadata.  The literalizer's type-inference
-    paths use ``type(value)`` for exact-type lookups, so these wrappers
-    are demoted to ``int``/``float``/``str``/``datetime`` before they
-    reach those code paths.  YAML dates parse as plain :class:`date`
-    already, so they pass through unchanged.
+    paths compare ``type(value)`` against the plain Python classes,
+    so these wrappers are demoted to
+    ``int``/``float``/``str``/``datetime`` before they reach those code
+    paths.  Built-in constructors short-circuit when given an
+    already-plain instance, so this is essentially free for unwrapped
+    values.  YAML dates parse as plain :class:`date` already, so they
+    pass through unchanged.
     """
     # bool is a subclass of int — check first so True/False stays bool.
     if isinstance(value, bool):
-        return value if type(value) is bool else bool(value)
+        return bool(value)
     if isinstance(value, int):
-        return value if type(value) is int else int(value)
+        return int(value)
     if isinstance(value, float):
-        return value if type(value) is float else float(value)
+        return float(value)
     if isinstance(value, str):
-        return value if type(value) is str else str(object=value)
+        return str(object=value)
     # datetime is a subclass of date — check first.  ``ruamel`` always
     # returns its own ``TimeStamp`` subclass for datetimes, so we always
     # reconstruct.
@@ -1018,7 +1021,8 @@ def _parse_yaml(*, source: str) -> _ParsedInput:
     """Parse a YAML string into a ``_ParsedInput``.
 
     Uses the comment-preserving (round-trip) loader so the same parse
-    can later feed comment extraction without a second tokenize pass.
+    can later feed comment extraction without a second pass through
+    the YAML source.
     """
     ruamel_yaml = _get_yaml()
     try:

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -637,10 +637,7 @@ def _wrap_body(
 
 
 @beartype
-def _unwrap_yaml_scalar(  # noqa: PLR0911
-    *,
-    value: object,
-) -> object:
+def _unwrap_yaml_scalar(*, value: object) -> object:
     """Convert a *ruamel.yaml* scalar wrapper to its plain Python type.
 
     The round-trip loader returns subclasses (``ScalarInt``, ``HexInt``,
@@ -648,7 +645,8 @@ def _unwrap_yaml_scalar(  # noqa: PLR0911
     preserve source-style metadata.  The literalizer's type-inference
     paths use ``type(value)`` for exact-type lookups, so these wrappers
     are demoted to ``int``/``float``/``str``/``datetime`` before they
-    reach those code paths.
+    reach those code paths.  YAML dates parse as plain :class:`date`
+    already, so they pass through unchanged.
     """
     # bool is a subclass of int — check first so True/False stays bool.
     if isinstance(value, bool):
@@ -659,10 +657,10 @@ def _unwrap_yaml_scalar(  # noqa: PLR0911
         return value if type(value) is float else float(value)
     if isinstance(value, str):
         return value if type(value) is str else str(object=value)
-    # datetime is a subclass of date — check first.
+    # datetime is a subclass of date — check first.  ``ruamel`` always
+    # returns its own ``TimeStamp`` subclass for datetimes, so we always
+    # reconstruct.
     if isinstance(value, datetime.datetime):
-        if type(value) is datetime.datetime:
-            return value
         return datetime.datetime(
             year=value.year,
             month=value.month,
@@ -673,37 +671,25 @@ def _unwrap_yaml_scalar(  # noqa: PLR0911
             microsecond=value.microsecond,
             tzinfo=value.tzinfo,
         )
-    if isinstance(value, datetime.date):
-        if type(value) is datetime.date:
-            return value
-        return datetime.date(
-            year=value.year,
-            month=value.month,
-            day=value.day,
-        )
     return value
 
 
 @beartype
-def _coerce_yaml_keys(  # noqa: PLR0911
-    *,
-    data: object,
-) -> Value:
+def _coerce_yaml_keys(*, data: object) -> Value:
     """Recursively convert non-string dict keys to their string form.
 
     YAML allows non-string mapping keys (e.g. integers); ``Value``
     requires ``dict[str, Value]``, so we normalise before passing
     loaded YAML data to :func:`_literalize`.
 
-    ``ordereddict`` (used for YAML ``!!omap`` nodes) preserves its keys
-    (so ordered-map detection in :func:`_literalize` still works) but
-    still walks into its values.  Round-trip ``CommentedMap`` instances
-    inherit from ``ordereddict`` despite representing plain mappings,
-    so they are matched explicitly and demoted to ``dict``.
-    :class:`CommentedSet` does not subclass :class:`set`, so it is
-    converted as well.  Scalar leaves are unwrapped to plain Python
-    types so type-based dispatch sees ``int`` rather than ``ScalarInt``
-    and friends.
+    The round-trip loader returns ``CommentedOrderedMap`` for YAML
+    ``!!omap`` nodes; those are demoted to plain ``ordereddict`` so
+    ordered-map detection in :func:`_literalize` still works.  Other
+    mappings come through as ``CommentedMap`` and are demoted to plain
+    ``dict``.  :class:`CommentedSet` does not subclass :class:`set`, so
+    it is converted as well.  Scalar leaves are unwrapped to plain
+    Python types so type-based dispatch sees ``int`` rather than
+    ``ScalarInt`` and friends.
     """
     match data:
         case CommentedOrderedMap():
@@ -720,21 +706,7 @@ def _coerce_yaml_keys(  # noqa: PLR0911
                 f"{k}": _coerce_yaml_keys(data=v)
                 for k, v in cast("dict[object, object]", data).items()
             }
-        case ordereddict():
-            ordered_src = cast("dict[object, object]", data)
-            ordered = ordereddict(
-                [
-                    (f"{k}", _coerce_yaml_keys(data=v))
-                    for k, v in ordered_src.items()
-                ]
-            )
-            return cast("Value", ordered)
-        case dict():
-            return {
-                f"{k}": _coerce_yaml_keys(data=v)
-                for k, v in cast("dict[object, object]", data).items()
-            }
-        case list():
+        case CommentedSeq():
             return [
                 _coerce_yaml_keys(data=item)
                 for item in cast("list[object]", data)

--- a/src/literalizer/_core.py
+++ b/src/literalizer/_core.py
@@ -651,30 +651,32 @@ def _unwrap_yaml_scalar(*, value: object) -> object:
     values.  YAML dates parse as plain :class:`date` already, so they
     pass through unchanged.
     """
-    # bool is a subclass of int — check first so True/False stays bool.
-    if isinstance(value, bool):
-        return bool(value)
-    if isinstance(value, int):
-        return int(value)
-    if isinstance(value, float):
-        return float(value)
-    if isinstance(value, str):
-        return str(object=value)
-    # datetime is a subclass of date — check first.  ``ruamel`` always
-    # returns its own ``TimeStamp`` subclass for datetimes, so we always
-    # reconstruct.
-    if isinstance(value, datetime.datetime):
-        return datetime.datetime(
-            year=value.year,
-            month=value.month,
-            day=value.day,
-            hour=value.hour,
-            minute=value.minute,
-            second=value.second,
-            microsecond=value.microsecond,
-            tzinfo=value.tzinfo,
-        )
-    return value
+    # ``bool`` and ``datetime.datetime`` come before their bases (``int``
+    # and ``date``) because match arms test class membership in order.
+    # ``ruamel`` always returns its own ``TimeStamp`` subclass for
+    # datetimes, so we always reconstruct.
+    match value:
+        case bool():
+            return bool(value)
+        case int():
+            return int(value)
+        case float():
+            return float(value)
+        case str():
+            return str(object=value)
+        case datetime.datetime():
+            return datetime.datetime(
+                year=value.year,
+                month=value.month,
+                day=value.day,
+                hour=value.hour,
+                minute=value.minute,
+                second=value.second,
+                microsecond=value.microsecond,
+                tzinfo=value.tzinfo,
+            )
+        case _:
+            return value
 
 
 @beartype
@@ -1686,45 +1688,51 @@ def _resolve_yaml_comments(
     are not attached to a collection.
     """
     # https://sourceforge.net/p/ruamel-yaml/tickets/328/
-    if isinstance(raw_data, CommentedSet):
-        return _resolve_collection_comments(
-            collection_comments=extract_yaml_comments(ruamel_data=raw_data),
-            base=base,
-            language=language,
-            comment_prefix=comment_prefix,
-            comment_suffix=comment_suffix,
-            comment_line_prefix=comment_line_prefix,
-            include_delimiters=include_delimiters,
-        )
-
-    if isinstance(raw_data, (CommentedSeq, CommentedMap)):
-        return _resolve_yaml_collection_comments(
-            ruamel_data=raw_data,
-            data=raw_data,
-            base=base,
-            language=language,
-            comment_prefix=comment_prefix,
-            comment_suffix=comment_suffix,
-            comment_line_prefix=comment_line_prefix,
-            include_delimiters=include_delimiters,
-        )
-
-    stream = StringIO(initial_value=yaml_string)
-    tokens = _get_yaml().scan(stream=stream)  # pyright: ignore[reportUnknownMemberType]
-    scalar_result = literalize_yaml_scalar(
-        tokens=tokens,
-        base=base,
-        comment_prefix=comment_prefix,
-        comment_suffix=comment_suffix,
-        line_prefix=line_prefix,
-        supports_scalar_before_comments=language.supports_scalar_before_comments,
-        supports_scalar_inline_comments=language.supports_scalar_inline_comments,
-    )
-    return _ResolvedComments(
-        result=scalar_result.result,
-        pending=None,
-        pending_scalar_before=scalar_result.pending_before,
-    )
+    match raw_data:
+        case CommentedSet():
+            return _resolve_collection_comments(
+                collection_comments=extract_yaml_comments(
+                    ruamel_data=raw_data,
+                ),
+                base=base,
+                language=language,
+                comment_prefix=comment_prefix,
+                comment_suffix=comment_suffix,
+                comment_line_prefix=comment_line_prefix,
+                include_delimiters=include_delimiters,
+            )
+        case CommentedSeq() | CommentedMap():
+            return _resolve_yaml_collection_comments(
+                ruamel_data=raw_data,
+                data=raw_data,
+                base=base,
+                language=language,
+                comment_prefix=comment_prefix,
+                comment_suffix=comment_suffix,
+                comment_line_prefix=comment_line_prefix,
+                include_delimiters=include_delimiters,
+            )
+        case _:
+            stream = StringIO(initial_value=yaml_string)
+            tokens = _get_yaml().scan(stream=stream)  # pyright: ignore[reportUnknownMemberType]
+            scalar_result = literalize_yaml_scalar(
+                tokens=tokens,
+                base=base,
+                comment_prefix=comment_prefix,
+                comment_suffix=comment_suffix,
+                line_prefix=line_prefix,
+                supports_scalar_before_comments=(
+                    language.supports_scalar_before_comments
+                ),
+                supports_scalar_inline_comments=(
+                    language.supports_scalar_inline_comments
+                ),
+            )
+            return _ResolvedComments(
+                result=scalar_result.result,
+                pending=None,
+                pending_scalar_before=scalar_result.pending_before,
+            )
 
 
 @beartype


### PR DESCRIPTION
## Summary

Closes #1336. Switches `_parse_yaml` to the comment-preserving (round-trip) loader so the same parse feeds both data extraction and `_resolve_yaml_comments`, eliminating the second `ruamel.yaml` load that ran for every YAML `literalize()` call. `_coerce_yaml_keys` now distinguishes `CommentedMap` from `CommentedOrderedMap` (so `!!omap` is preserved), demotes `CommentedSet` to plain `set`, and unwraps ruamel scalar wrappers (`ScalarInt`, `HexInt`, `ScalarFloat`, `LiteralScalarString`, `TimeStamp`, ...) to their plain Python types so `type(value)`-based dispatch in `infer_element_type` keeps working. Scalars still go through a separate `scan()` because `load()` discards loose comment tokens; `_get_yaml` is simplified now that only the round-trip loader is needed.

Measured ~24% speedup on a representative comment-bearing input (0.775 → 0.592 ms/call).

## Test plan

- [x] `uv run pytest tests/` (13,345 passed)
- [x] `uv run ruff check src/literalizer/_core.py`
- [x] `uv run mypy src/literalizer/_core.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes YAML parsing/coercion and comment-resolution paths, which could alter inferred types (scalars/sets/!!omap) or comment placement for edge-case YAML inputs.
> 
> **Overview**
> **YAML input is now parsed once per `literalize()` call** by switching `_parse_yaml` to the round-trip `ruamel.yaml` loader and reusing the resulting `raw_data` for `_resolve_yaml_comments`, removing the second YAML load previously done for comment extraction.
> 
> To keep existing formatting/type-inference behavior with round-trip node types, `_coerce_yaml_keys` now handles `CommentedMap`/`CommentedOrderedMap`/`CommentedSeq`/`CommentedSet`, converts `!!omap` to `ordereddict`, normalizes `CommentedSet` to a plain `set`, and unwraps ruamel scalar wrapper subclasses to plain Python scalar types before dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71486b66f08cc8c77eecdcf45cbb80f4dc9021b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->