### PR TITLE
Align lone `assert_never` site with `exclude_also` pattern

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -213,7 +213,8 @@ def parse_input(*, source: str, input_format: InputFormat) -> _ParsedInput:
             return _parse_yaml(source=source)
         case InputFormat.TOML:
             return _parse_toml(source=source)
-    assert_never(input_format)  # pragma: no cover
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 def _coerce_toml_values(*, data: object) -> Value:


### PR DESCRIPTION
Convert the trailing `assert_never(input_format)  # pragma: no cover` in `parse_input` into a `case _ as unreachable: assert_never(unreachable)` clause, so it is covered by the existing `report.exclude_also` regex in `pyproject.toml` and the `# pragma: no cover` is no longer needed. This was the only `assert_never` site not already using this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small control-flow/style change that only affects the unreachable default branch of `parse_input` and should not change runtime behavior for valid `InputFormat` values.
> 
> **Overview**
> Updates `parse_input`’s match exhaustiveness handling to use the repo-standard `case _ as unreachable: assert_never(unreachable)` pattern, removing the lone `# pragma: no cover` site so coverage exclusion is handled consistently via `pyproject.toml`’s `report.exclude_also` regex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44e8bba8014c7a798381b2638825146b4d2d158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->