### PR TITLE
Exclude raise NotImplementedError from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,6 +335,7 @@ run.omit = [
 report.exclude_also = [
     "case _ as unreachable:\n\\s*assert_never\\(",
     "if TYPE_CHECKING:",
+    "raise NotImplementedError",
 ]
 report.show_missing = true
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -291,7 +291,7 @@ class LanguageCls(type):
         body_preamble: tuple[str, ...],
     ) -> str:
         """Wrap a code snippet in a complete, valid file."""
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError
 
     @staticmethod
     def wrap_combined_in_file(
@@ -301,7 +301,7 @@ class LanguageCls(type):
         body_preamble: tuple[str, ...],
     ) -> str:
         """Wrap a declaration and assignment in a complete, valid file."""
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""


### PR DESCRIPTION
Add ``raise NotImplementedError`` to ``report.exclude_also`` and drop the two ``# pragma: no cover`` comments that are now redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts coverage configuration and removes `# pragma: no cover` from intentional `NotImplementedError` stubs, with no runtime behavior change beyond coverage reporting.
> 
> **Overview**
> Updates coverage reporting to exclude lines containing `raise NotImplementedError` via `tool.coverage.report.exclude_also` in `pyproject.toml`.
> 
> Removes the now-redundant `# pragma: no cover` comments from the abstract `LanguageCls.wrap_in_file` and `LanguageCls.wrap_combined_in_file` stub implementations in `src/literalizer/_language.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cdf8b4b6774d8b98844baa22746a632479dc0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->