### PR TITLE
Clarify why Rust's unreachable dict case arm exists

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -194,9 +194,12 @@ def _rust_type_annotation(
 ) -> str:
     """Derive a Rust type annotation string from a ``Value``.
 
-    Rust ``CONST`` / ``STATIC`` spec+data validation rejects any dict
-    data before this function is called (Rust has no const-expression
-    dict format), so the dict branch is omitted.
+    Only called for ``CONST`` / ``STATIC`` declarations, whose
+    :meth:`Rust.validate_spec_for_data` rejects dict data upstream
+    (Rust has no const-expression dict format).  A ``case dict()``
+    arm is still required so the final ``case _`` narrows to
+    ``Scalar`` for ``_rust_scalar_type``, but it is unreachable at
+    runtime.
     """
     recurse = functools.partial(
         _rust_type_annotation,
@@ -230,6 +233,11 @@ def _rust_type_annotation(
             )
             return sequence_format_type_annotation(element_type, len(data))
         case dict():  # pragma: no cover
+            # Defensive: unreachable at runtime because
+            # validate_spec_for_data rejects dict data for CONST/STATIC
+            # before this function is called.  The arm exists solely
+            # to narrow ``data`` to ``Scalar`` for the ``case _`` below,
+            # which delegates to ``_rust_scalar_type``.
             msg = (
                 "Rust CONST/STATIC reject dict data in validate_spec_for_data"
             )


### PR DESCRIPTION
## Summary
- Updated the docstring and added an inline comment in `_rust_type_annotation` explaining that the `case dict()` arm isn't just defensive — it's required so the final `case _` narrows to `Scalar` for `_rust_scalar_type`. Without it, the type checker rejects the fallthrough.

## Test plan
- [x] `uv run pytest tests/test_variables.py -k rust` (14 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/comment-only change; behavior is unchanged and the `dict` match arm remains unreachable due to upstream validation.
> 
> **Overview**
> Clarifies in `_rust_type_annotation` (`rust.py`) why the `case dict()` match arm exists even though dicts are rejected for `CONST`/`STATIC`: it’s needed for type narrowing so the final `case _` can safely delegate to `_rust_scalar_type`.
> 
> Adds an explicit inline comment on the unreachable `dict` arm and updates the docstring to document the static type-checker requirement; runtime logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b4acbc45d44293fbb2079f7a89cc7de0da4338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->