### PR TITLE
Carry dict values on DictType to drop unreachable narrowing branch

### DIFF
--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -1,6 +1,6 @@
 """Type inference for homogeneous collections."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from beartype import beartype
 from ruamel.yaml.compat import ordereddict as _ordereddict
@@ -25,9 +25,13 @@ class DictType:
 
     ``value_type`` is the inferred common value type across all dicts
     in a sequence, or ``None`` when values are empty or mixed.
+    ``values`` is the flattened sequence of dict values used to infer
+    ``value_type``; callers can reuse it to derive a language-specific
+    type (e.g. ``std::variant``) without re-walking the source items.
     """
 
     value_type: "type | ListType | DictType | None"
+    values: "tuple[Value, ...]" = field(compare=False)
 
 
 class MixedNumeric:
@@ -69,7 +73,10 @@ def infer_element_type(
         the_type = next(iter(element_types))
         if the_type is dict:
             value_type = infer_element_type(items=all_dict_values)
-            return DictType(value_type=value_type)
+            return DictType(
+                value_type=value_type,
+                values=tuple(all_dict_values),
+            )
         return the_type
     if element_types == {int, float}:
         return MixedNumeric

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -315,15 +315,9 @@ def _compute_element_type_for_items(
     element_type = infer_element_type(items=items)
     if element_type is not None:
         match element_type:
-            case DictType(value_type=None):
-                all_dict_values: list[Value] = [
-                    v
-                    for item in items
-                    if isinstance(item, dict)  # pragma: no branch
-                    for v in item.values()
-                ]
+            case DictType(value_type=None, values=dict_values):
                 value_type = _compute_element_type_for_items(
-                    items=all_dict_values,
+                    items=list(dict_values),
                     element_to_type=element_to_type,
                 )
                 return f"std::map<std::string, {value_type}>"


### PR DESCRIPTION
## Summary

`infer_element_type` already walks dict items to infer their common value type, so expose the flattened values on `DictType` itself. C++'s `_compute_element_type_for_items` now reuses them instead of re-walking `items` with an `isinstance(item, dict)` filter whose false arm was unreachable (previously hidden behind `# pragma: no branch`). `values` uses `field(compare=False)` so unhashable contents don't break `DictType`'s auto-generated `__hash__`.

## Test plan
- [x] Full test suite passes (13410 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small internal refactor of type inference metadata and a corresponding C++ codegen path, with minimal behavior change aside from using cached dict values.
> 
> **Overview**
> `infer_element_type` now returns a richer `DictType` that includes the flattened dict `values` used for inferring `value_type` (marked `compare=False` to avoid hash/compare issues with unhashable contents).
> 
> The C++ type computation (`_compute_element_type_for_items`) reuses `DictType.values` when dict values are mixed/empty (`value_type=None`), removing the previous re-walk/filter over the original `items`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9d9d08ebc7efac9d064e414b14d36687e4733a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->