### PR TITLE
Use match statements for remaining isinstance chains

### DIFF
--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -59,19 +59,16 @@ def infer_element_type(
     element_types: set[type | ListType] = set()
     all_dict_values: list[Value] = []
     for item in items:
-        match item:
-            case list():
-                inner = infer_element_type(items=item)
-                if inner is None:
-                    return None
-                element_types.add(ListType(inner=inner))
-            case _ordereddict():
-                element_types.add(type(item))
-            case dict():
-                all_dict_values.extend(item.values())
-                element_types.add(dict)
-            case _:
-                element_types.add(type(item))
+        if isinstance(item, list):
+            inner = infer_element_type(items=item)
+            if inner is None:
+                return None
+            element_types.add(ListType(inner=inner))
+        elif isinstance(item, dict) and not isinstance(item, _ordereddict):
+            all_dict_values.extend(item.values())
+            element_types.add(dict)
+        else:
+            element_types.add(type(item))
     if len(element_types) == 1:
         the_type = next(iter(element_types))
         if the_type is dict:

--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -59,16 +59,19 @@ def infer_element_type(
     element_types: set[type | ListType] = set()
     all_dict_values: list[Value] = []
     for item in items:
-        if isinstance(item, list):
-            inner = infer_element_type(items=item)
-            if inner is None:
-                return None
-            element_types.add(ListType(inner=inner))
-        elif isinstance(item, dict) and not isinstance(item, _ordereddict):
-            all_dict_values.extend(item.values())
-            element_types.add(dict)
-        else:
-            element_types.add(type(item))
+        match item:
+            case list():
+                inner = infer_element_type(items=item)
+                if inner is None:
+                    return None
+                element_types.add(ListType(inner=inner))
+            case _ordereddict():
+                element_types.add(type(item))
+            case dict():
+                all_dict_values.extend(item.values())
+                element_types.add(dict)
+            case _:
+                element_types.add(type(item))
     if len(element_types) == 1:
         the_type = next(iter(element_types))
         if the_type is dict:

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -417,26 +417,27 @@ def _wrap_body(
     """Wrap ``body`` in the language's open/close delimiters."""
     ci = spec.indent if spec.indent_closing_delimiter else ""
     close_prefix = f"{line_prefix}{ci}"
-    if is_ordered_map and isinstance(data, dict):
-        ordered_map_cfg = spec.ordered_map_format_config
-        open_str = ordered_map_cfg.ordered_map_open(data)
-        opening = f"{line_prefix}{open_str}"
-        closing = f"{close_prefix}{ordered_map_cfg.close}"
-    elif isinstance(data, dict):
-        dict_cfg = spec.dict_format_config
-
-        opening = f"{line_prefix}{dict_cfg.dict_open(data)}"
-        closing = f"{close_prefix}{dict_cfg.close}"
-    elif isinstance(data, set):
-        sorted_set: list[Value] = sorted(
-            data,
-            key=lambda v: (type(v).__name__, repr(v)),
-        )
-        opening = f"{line_prefix}{spec.set_format_config.set_open(sorted_set)}"
-        closing = f"{close_prefix}{spec.set_format_config.close}"
-    else:
-        opening = f"{line_prefix}{spec.sequence_open(data)}"
-        closing = f"{close_prefix}{spec.sequence_format_config.close}"
+    match data:
+        case dict() if is_ordered_map:
+            ordered_map_cfg = spec.ordered_map_format_config
+            open_str = ordered_map_cfg.ordered_map_open(data)
+            opening = f"{line_prefix}{open_str}"
+            closing = f"{close_prefix}{ordered_map_cfg.close}"
+        case dict():
+            dict_cfg = spec.dict_format_config
+            opening = f"{line_prefix}{dict_cfg.dict_open(data)}"
+            closing = f"{close_prefix}{dict_cfg.close}"
+        case set():
+            sorted_set: list[Value] = sorted(
+                data,
+                key=lambda v: (type(v).__name__, repr(v)),
+            )
+            set_cfg = spec.set_format_config
+            opening = f"{line_prefix}{set_cfg.set_open(sorted_set)}"
+            closing = f"{close_prefix}{set_cfg.close}"
+        case _:
+            opening = f"{line_prefix}{spec.sequence_open(data)}"
+            closing = f"{close_prefix}{spec.sequence_format_config.close}"
     return f"{opening.rstrip()}\n{body}\n{closing}"
 
 
@@ -679,20 +680,22 @@ def _apply_variable_wrapper(
     """Optionally wrap *result* in a variable declaration or
     assignment.
     """
-    if variable_form is None:
-        return result
-    if isinstance(variable_form, NewVariable):
-        return language.format_variable_declaration(
-            variable_form.name,
-            result,
-            data,
-            variable_form.modifiers,
-        )
-    return language.format_variable_assignment(
-        variable_form.name,
-        result,
-        data,
-    )
+    match variable_form:
+        case None:
+            return result
+        case NewVariable(name=name, modifiers=modifiers):
+            return language.format_variable_declaration(
+                name,
+                result,
+                data,
+                modifiers,
+            )
+        case ExistingVariable(name=name):
+            return language.format_variable_assignment(
+                name,
+                result,
+                data,
+            )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -690,9 +690,9 @@ def _apply_variable_wrapper(
                 data,
                 modifiers,
             )
-        case ExistingVariable(name=name):
+        case _:
             return language.format_variable_assignment(
-                name,
+                variable_form.name,
                 result,
                 data,
             )


### PR DESCRIPTION
## Summary
- Replace the isinstance chain in `_apply_variable_wrapper` with a `match` that destructures `NewVariable` / `ExistingVariable` dataclass fields.
- Replace the `is_ordered_map and isinstance(data, dict)` chain in `_wrap_body` with a `match` on `data`, using a guard for the ordered-map case so type narrowing flows through.
- Replace the isinstance chain with negative guard in `infer_element_type` with a `match` that checks `_ordereddict()` before `dict()` to preserve the exclusion semantics.

## Test plan
- [x] `uv run pytest tests --ignore=tests/integration` (461 passed)
- [x] `uv run ty check src/literalizer/_literalize.py`
- [x] Pre-push hooks (mypy, pyright, ty, pyrefly, ruff) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to control-flow rewrites in formatting helpers; behavior should be unchanged but could affect edge-case type dispatch (ordered maps/sets/variable forms) if pattern matching semantics differ.
> 
> **Overview**
> Refactors `src/literalizer/_literalize.py` to replace remaining `isinstance`/`if` chains with `match` statements.
> 
> `_wrap_body` now pattern-matches on `data` (with a guard for the ordered-map case) and `_apply_variable_wrapper` now matches and destructures `NewVariable` vs assignment forms, with no intended output/behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1ef36568bb1267447696f24bff687749d0d9c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->