### PR TITLE
Run lint workflow on full Python matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
   pre-commit:
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
         hook-stage: [pre-commit, pre-push, manual]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+
+- Lint workflow now runs pre-commit hooks against the full supported
+  Python matrix (3.12, 3.13, 3.14) instead of 3.13 only, to catch
+  version-specific lint issues.
+
 2026.04.21.1
 ------------
 


### PR DESCRIPTION
## Summary
- Expand the `pre-commit` job matrix in `.github/workflows/lint.yml` from `['3.13']` to `['3.12', '3.13', '3.14']`, matching the CI test matrix so version-specific lint/type-check results are caught on all supported versions.
- Add a CHANGELOG entry under `Next`.

Closes #1201.

## Test plan
- [ ] Observe the Lint workflow running pre-commit jobs on 3.12, 3.13, and 3.14 for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes CI lint coverage by expanding the `pre-commit` workflow matrix, with no production/runtime code impact (but may increase CI time and surface new version-specific failures).
> 
> **Overview**
> Updates the GitHub Actions `Lint` workflow to run the `pre-commit` job across the full supported Python versions (**3.12, 3.13, 3.14**) instead of only 3.13, helping catch version-specific linting issues earlier.
> 
> Adds a `CHANGELOG.rst` entry under `Next` documenting the expanded lint matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a653a51d64b0d7adcd943c3ada02230923b4f85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->