### PR TITLE
Use match to destructure single-element unique type lists

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -206,9 +206,11 @@ def _format_inline_type_hint_declaration(
 def _element_union(*, types: list[str]) -> str:
     """Remove duplicate *types* and join them into a union."""
     unique: list[str] = list(dict.fromkeys(types))
-    if len(unique) == 1:
-        return unique[0]
-    return " | ".join(unique)
+    match unique:
+        case [only]:
+            return only
+        case _:
+            return " | ".join(unique)
 
 
 @beartype

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -132,9 +132,11 @@ def _unify_rust_types(types: Sequence[str]) -> str:
     Callers must pass a non-empty sequence.
     """
     unique = list(dict.fromkeys(types))
-    if len(unique) == 1:
-        return unique[0]
-    return max(unique, key=_INTEGER_TYPES.index)
+    match unique:
+        case [only]:
+            return only
+        case _:
+            return max(unique, key=_INTEGER_TYPES.index)
 
 
 @beartype

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -90,9 +90,11 @@ def _ts_call_stub(
 def _ts_element_union(*, types: list[str]) -> str:
     """Remove duplicate types and join into a TypeScript union."""
     unique: list[str] = list(dict.fromkeys(types))
-    if len(unique) == 1:
-        return unique[0]
-    return " | ".join(unique)
+    match unique:
+        case [only]:
+            return only
+        case _:
+            return " | ".join(unique)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace `if len(unique) == 1: return unique[0]` with `match unique: case [only]: return only` in the Python, Rust, and TypeScript language backends' union-building helpers
- `match` destructures the single-element branch in one step, avoiding a redundant index after the length check
- Set-based equivalents in `java.py` and `csharp.py` were intentionally left alone since `match` does not destructure sets cleanly

## Test plan
- [x] `uv run python -m pytest tests/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes control flow in union/type unification helpers; output should be identical but touches code paths used when generating type hints across multiple language backends.
> 
> **Overview**
> Refactors the Python, Rust, and TypeScript backends’ union/type-unification helpers to use `match` destructuring for the single-unique-type case (e.g., `case [only]: return only`) instead of `if len(unique) == 1`.
> 
> Behavior is intended to be unchanged: multi-type cases still join unions (`" | "`) in Python/TypeScript and still widen integers in Rust.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56e5e7138b25dd424d91f78d105c113be977226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->