### PR TITLE
Inline _INTEGER_TYPES into sole call site

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -78,9 +78,6 @@ _I64_MIN = -(2**63)
 _I64_MAX = 2**63 - 1
 
 
-_INTEGER_TYPES = ("i32", "i64", "i128")
-
-
 def _rust_integer_type(value: int) -> str:
     """Return the narrowest Rust integer type for *value*."""
     if _I32_MIN <= value <= _I32_MAX:
@@ -136,7 +133,7 @@ def _unify_rust_types(types: Sequence[str]) -> str:
         case [only]:
             return only
         case _:
-            return max(unique, key=_INTEGER_TYPES.index)
+            return max(unique, key=("i32", "i64", "i128").index)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Removed the module-level `_INTEGER_TYPES` tuple in `src/literalizer/languages/rust.py` and inlined the literal `("i32", "i64", "i128")` directly into its only call site in `_unify_rust_types`.

## Test plan
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to removing an unused constant and inlining the same value at its sole call site; behavior should be unchanged.
> 
> **Overview**
> **Refactors Rust type unification** by removing the module-level `_INTEGER_TYPES` constant and inlining the `("i32", "i64", "i128")` ordering directly in `_unify_rust_types` when selecting the widest integer type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c946a45b393c89dc91bbfc62c824c5d3742e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->