### PR TITLE
Work around modular/modular#6433 in lint-mojo CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -940,10 +940,24 @@ jobs:
         if: steps.find-files.outputs.found == 'true'
         run: |-
           pixi global install --channel conda-forge --channel https://conda.modular.com/max mojo
-      # The Mojo runtime has a known bug where it randomly crashes
-      # with "mojo: error: execution crashed" (see #558).
-      # This is not caused by our code. Retry each file individually
-      # so that a crash on one file does not block the rest.
+      # Mojo reserves ~3.6 GB of virtual address space per invocation
+      # (upstream: modular/modular#6433). On the 7 GB GitHub runner the
+      # kernel's default overcommit heuristic refuses the allocation and
+      # Mojo crashes in libKGENCompilerRTShared.so before producing any
+      # output. Allow overcommit and add a 4 GB swap file so the kernel
+      # has enough headroom to accept the reservation — Mojo only
+      # actually touches ~320 MB of it.
+      - name: Expand memory headroom for Mojo
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          sudo sysctl -w vm.overcommit_memory=1
+          sudo fallocate -l 4G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+      # Even with the headroom above, Mojo occasionally still crashes
+      # non-deterministically (tracked in  # 558). Retry each file a few
+      # times so one crash does not block the rest.
       - name: Check Mojo syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -949,12 +949,14 @@ jobs:
       # actually touches ~320 MB of it.
       - name: Expand memory headroom for Mojo
         if: steps.find-files.outputs.found == 'true'
+        # The GitHub runner already ships a /swapfile mounted as swap, so
+        # add a second file at a fresh path instead of overwriting it.
         run: |-
           sudo sysctl -w vm.overcommit_memory=1
-          sudo fallocate -l 4G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          sudo fallocate -l 4G /mnt/extra-swapfile
+          sudo chmod 600 /mnt/extra-swapfile
+          sudo mkswap /mnt/extra-swapfile
+          sudo swapon /mnt/extra-swapfile
       # Even with the headroom above, Mojo occasionally still crashes
       # non-deterministically (tracked in  # 558). Retry each file a few
       # times so one crash does not block the rest.


### PR DESCRIPTION
## Summary
- Add a step to `lint-mojo` that sets `vm.overcommit_memory=1` and provisions a 4 GB swap file, giving the kernel enough headroom to accept Mojo's ~3.6 GB virtual reservation (upstream: modular/modular#6433).
- Update the workaround comments to explain the root cause and why the retry loop is still needed for residual non-deterministic crashes.

## Test plan
- [ ] Observe `lint-mojo` passing on CI without spurious `libKGENCompilerRTShared.so` crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI runner kernel settings and swap configuration, which could fail or behave differently across GitHub runner images, but is scoped to the `lint-mojo` job.
> 
> **Overview**
> Stabilizes `lint-mojo` in CI by adding a pre-step that enables Linux memory overcommit and provisions an additional 4GB swap file to avoid Mojo crashes caused by large virtual address space reservations (modular/modular#6433).
> 
> Updates the workflow comments to distinguish this memory-headroom workaround from the existing per-file retry loop, which remains to mitigate residual non-deterministic Mojo crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aaffcc6c9aa2056533ee326eb4741e2440892e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->