### PR TITLE
Add function call rendering to PHP

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- Added ``literalize_call`` support for PHP: ``Php.format_call_stub``
+  now generates function, class, and nested-object stubs for a call
+  expression.
+
 2026.04.21.1
 ------------
 

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -73,6 +73,51 @@ from literalizer._language import (
 from literalizer._types import Value
 
 
+def _php_call_stub(
+    name: str,
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return PHP stub declarations for a call name."""
+    param_list = ", ".join(f"${p}" for p in params)
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"function {parts[0]}({param_list}) {{}}",)
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    if not fields:
+        cls = root.capitalize() + "Type"
+        return (
+            f"class {cls} {{ function {method}({param_list}) {{}} }}",
+            f"${root} = new {cls}();",
+        )
+    lines: list[str] = []
+    inner_cls = fields[-1].capitalize() + "Type"
+    lines.append(
+        f"class {inner_cls} {{ function {method}({param_list}) {{}} }}",
+    )
+    prev_cls = inner_cls
+    for i in range(len(fields) - 2, -1, -1):
+        cls = fields[i].capitalize() + "Type"
+        field = fields[i + 1]
+        lines.append(
+            f"class {cls} {{ public ${field}; "
+            f"function __construct() {{ "
+            f"$this->{field} = new {prev_cls}(); }} }}"
+        )
+        prev_cls = cls
+    root_cls = root.capitalize() + "Type"
+    lines.append(
+        f"class {root_cls} {{ public ${fields[0]}; "
+        f"function __construct() {{ "
+        f"$this->{fields[0]} = new {prev_cls}(); }} }}"
+    )
+    lines.append(f"${root} = new {root_cls}();")
+    return tuple(lines)
+
+
 @beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Php(metaclass=LanguageCls):
@@ -427,7 +472,7 @@ class Php(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _php_call_stub
 
     @cached_property
     def format_call_preamble_stub(

--- a/tests/integration/cases/call_deep_dotted_method/Php_call.php
+++ b/tests/integration/cases/call_deep_dotted_method/Php_call.php
@@ -1,4 +1,8 @@
 <?php
+class ClientType { function post($data) {} }
+class ApiType { public $client; function __construct() { $this->client = new ClientType(); } }
+class ObjType { public $api; function __construct() { $this->api = new ApiType(); } }
+$obj = new ObjType();
 obj.api.client.post(data: "hello");
 obj.api.client.post(data: 42);
 obj.api.client.post(data: true);

--- a/tests/integration/cases/call_deep_dotted_transformed/Php_call.php
+++ b/tests/integration/cases/call_deep_dotted_transformed/Php_call.php
@@ -1,4 +1,8 @@
 <?php
+class ClientType { function fetch($payload) {} }
+class AppType { public $client; function __construct() { $this->client = new ClientType(); } }
+$app = new AppType();
+function emit($_arg) {}
 emit(app.client.fetch(payload: "hello"));
 emit(app.client.fetch(payload: 42));
 emit(app.client.fetch(payload: true));

--- a/tests/integration/cases/call_dotted_method/Php_call.php
+++ b/tests/integration/cases/call_dotted_method/Php_call.php
@@ -1,4 +1,7 @@
 <?php
+class ClientType { function fetch($payload) {} }
+class AppType { public $client; function __construct() { $this->client = new ClientType(); } }
+$app = new AppType();
 app.client.fetch(payload: "hello");
 app.client.fetch(payload: 42);
 app.client.fetch(payload: true);

--- a/tests/integration/cases/call_keyword_args/Php_call.php
+++ b/tests/integration/cases/call_keyword_args/Php_call.php
@@ -1,3 +1,6 @@
 <?php
+class ThrottlerType { function check($user_id, $ts) {} }
+$throttler = new ThrottlerType();
+function emit($_arg) {}
 emit(throttler.check(user_id: "user_1", ts: 1000.0));
 emit(throttler.check(user_id: "user_2", ts: 2000.5));

--- a/tests/integration/cases/call_positional/Php_call.php
+++ b/tests/integration/cases/call_positional/Php_call.php
@@ -1,3 +1,6 @@
 <?php
+class ThrottlerType { function check($user_id, $ts) {} }
+$throttler = new ThrottlerType();
+function emit($_arg) {}
 emit(throttler.check("user_1", 1000.0));
 emit(throttler.check("user_2", 2000.5));

--- a/tests/integration/cases/call_scalar_args/Php_call.php
+++ b/tests/integration/cases/call_scalar_args/Php_call.php
@@ -1,4 +1,5 @@
 <?php
+function process($value) {}
 process(value: "hello");
 process(value: 42);
 process(value: true);


### PR DESCRIPTION
## Summary
- Implements `format_call_stub` for PHP so `literalize_call` emits function, class-method, and nested-object declaration stubs for the call target.
- Regenerates the six `Php_call.php` golden files in `tests/integration/cases/call_*/` to include the new stubs.
- Closes #1137.

## Test plan
- [x] `uv run pytest tests/`
- [x] `uv run ruff check` / `uv run mypy` / `uv run pylint` on the PHP language module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PHP call rendering output and introduces new stub-generation logic for dotted call chains, which could affect downstream consumers expecting previous PHP output formatting.
> 
> **Overview**
> Adds PHP support for `literalize_call` by implementing `Php.format_call_stub` to emit PHP stub declarations for call targets, including plain functions, object method calls, and deeply dotted/nested object chains (with generated classes, fields, constructors, and root variable instantiation).
> 
> Regenerates the PHP integration golden files for call-related cases to include the new stub preamble lines, and documents the change in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2305bef37c383df4042e2acc52623d3b3f9cac20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->