### PR TITLE
Run Julia golden files in lint-julia CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -694,10 +694,16 @@ jobs:
       - name: Install Julia
         if: steps.find-files.outputs.found == 'true'
         uses: julia-actions/setup-julia@v3
-      - name: Check Julia syntax
+      - name: Set up Julia project
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 julia --startup-file=no -e 'Meta.parseall(read(ARGS[1],
-          String))' -- < /tmp/files-to-lint
+        run: |
+          mkdir -p /tmp/julia-lint
+          julia --startup-file=no --project=/tmp/julia-lint -e \
+            'using Pkg; Pkg.add("DataStructures"); Pkg.precompile()'
+      - name: Run Julia golden files
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 julia --startup-file=no --project=/tmp/julia-lint
+          < /tmp/files-to-lint
 
   lint-perl:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- The ``lint-julia`` CI job now executes Julia golden files instead
+  of only parsing them, catching ``UndefVarError`` and other runtime
+  errors.
+
 2026.04.21.1
 ------------
 


### PR DESCRIPTION
## Summary
- Replace the ``Meta.parseall`` syntax-only check in the ``lint-julia`` CI job with actual execution via ``julia --project``, so ``UndefVarError`` and similar runtime errors in golden files are caught.
- Set up a scratch Julia project with ``DataStructures`` (needed by ``Julia_dict_format_ordered`` variants) and precompile once before running files in parallel.
- Closes #1238.

## Test plan
- [ ] CI ``lint-julia`` job passes on all existing Julia golden files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no production code impact; main risk is increased CI time or new failures due to runtime execution/environment dependencies.
> 
> **Overview**
> The `lint-julia` workflow step now **runs** each Julia golden file instead of doing a syntax-only `Meta.parseall` check, so CI can catch runtime failures like `UndefVarError`.
> 
> To support execution, the job creates a temporary Julia project in `/tmp/julia-lint`, installs `DataStructures`, and precompiles once before running files in parallel under `--project=/tmp/julia-lint`. The changelog is updated to document the new CI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a7d5c3265ab7f05ee14a906d8b3adad3922f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->