### PR TITLE
Split UnsupportedCallStyleError into language- vs tool-specific variants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Next
 ----
 
 
+- ``literalize_call`` now distinguishes two reasons a language has no
+  call support.  The single ``UnsupportedCallStyleError`` has been
+  replaced by ``CallsNotSupportedByLanguageError`` (raised for
+  data/markup formats like YAML, TOML, JSON5, Norg that have no
+  function call syntax) and ``CallsNotSupportedByToolError`` (raised
+  for programming languages whose call rendering literalizer has not
+  yet implemented).  The new ``CallSupport`` enum on a language's
+  ``call_style_config`` attribute captures which case applies.
 - Lint workflow now runs pre-commit hooks against the full supported
   Python matrix (3.12, 3.13, 3.14) instead of 3.13 only, to catch
   version-specific lint issues.

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -197,6 +197,22 @@ CallStyle = PositionalCallStyle | KeywordCallStyle | ObjectCallStyle
 """Tagged union describing how a language passes call arguments."""
 
 
+class CallSupport(enum.Enum):
+    """Sentinel describing why a language does not have a
+    :class:`CallStyle` configured.
+    """
+
+    NOT_IN_LANGUAGE = "not_in_language"
+    """The target language has no function call syntax (e.g. pure
+    data/markup formats like YAML, TOML, JSON5, Norg).
+    """
+
+    NOT_IMPLEMENTED_BY_TOOL = "not_implemented_by_tool"
+    """The target language has function call syntax but literalizer
+    has not yet implemented call rendering for it.
+    """
+
+
 class FloatSpecialsMixin:
     """Mixin for ``FloatFormats`` enums that provides ``__call__``.
 
@@ -896,12 +912,15 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle | CallSupport:
         """Describes how this language passes arguments in function
         calls.
 
-        ``None`` for languages with an empty :attr:`CallStyles` enum.
-        See :data:`CallStyle` for the variant types.
+        Returns a :class:`CallStyle` variant for supported languages,
+        or a :class:`CallSupport` sentinel for languages with an empty
+        :attr:`CallStyles` enum (distinguishing whether the language
+        has no call syntax at all, or literalizer has not yet
+        implemented call rendering for it).
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -21,6 +21,7 @@ from literalizer._formatters.type_inference import (
     infer_element_type,
 )
 from literalizer._language import (
+    CallSupport,
     KeywordCallStyle,
     Language,
     ObjectCallStyle,
@@ -30,8 +31,9 @@ from literalizer._parsing import InputFormat, parse_input
 from literalizer._preamble import compute_preamble
 from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
+    CallsNotSupportedByLanguageError,
+    CallsNotSupportedByToolError,
     PerElementNotListError,
-    UnsupportedCallStyleError,
 )
 
 
@@ -1022,10 +1024,6 @@ def _format_call_args(
     literals which may use ``"; "`` (F#) or other separators.
     """
     style = language.call_style_config
-    if style is None:
-        raise UnsupportedCallStyleError(
-            language_name=type(language).__name__,
-        )
     formatted = [
         _format_value(value=v, spec=language, dict_open_override=None)
         for v in values
@@ -1033,6 +1031,14 @@ def _format_call_args(
     sep = ", "
 
     match style:
+        case CallSupport.NOT_IN_LANGUAGE:
+            raise CallsNotSupportedByLanguageError(
+                language_name=type(language).__name__,
+            )
+        case CallSupport.NOT_IMPLEMENTED_BY_TOOL:
+            raise CallsNotSupportedByToolError(
+                language_name=type(language).__name__,
+            )
         case PositionalCallStyle():
             inner = sep.join(formatted)
         case KeywordCallStyle(separator=kw_sep):
@@ -1144,10 +1150,17 @@ def literalize_call(
         result = "\n".join(lines)
     else:
         check_data(data=data, spec=language)
-        if language.call_style_config is None:
-            raise UnsupportedCallStyleError(
-                language_name=type(language).__name__,
-            )
+        match language.call_style_config:
+            case CallSupport.NOT_IN_LANGUAGE:
+                raise CallsNotSupportedByLanguageError(
+                    language_name=type(language).__name__,
+                )
+            case CallSupport.NOT_IMPLEMENTED_BY_TOOL:
+                raise CallsNotSupportedByToolError(
+                    language_name=type(language).__name__,
+                )
+            case _:
+                pass
         lit = _literalize(
             data=data,
             language=language,

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -85,13 +85,28 @@ class PerElementNotListError(Exception):
     """
 
 
-class UnsupportedCallStyleError(Exception):
-    """Raised when a language does not support function call rendering."""
+class CallsNotSupportedByLanguageError(Exception):
+    """Raised when the target language itself has no function call
+    syntax (e.g. pure data/markup formats like YAML, TOML, JSON5, Norg).
+    """
 
     def __init__(self, *, language_name: str) -> None:
-        """Create an ``UnsupportedCallStyleError``."""
+        """Create a ``CallsNotSupportedByLanguageError``."""
+        super().__init__(f"{language_name} has no function call syntax")
+        self.language_name = language_name
+
+
+class CallsNotSupportedByToolError(Exception):
+    """Raised when literalizer has not yet implemented function call
+    rendering for the target language, even though the language itself
+    has function call syntax.
+    """
+
+    def __init__(self, *, language_name: str) -> None:
+        """Create a ``CallsNotSupportedByToolError``."""
         super().__init__(
-            f"{language_name} does not support function call rendering"
+            f"literalizer does not support function call rendering "
+            f"for {language_name}"
         )
         self.language_name = language_name
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_concat_control
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -378,7 +379,9 @@ class Ada(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -380,7 +381,9 @@ class Bash(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -40,6 +40,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -386,7 +387,9 @@ class C(metaclass=LanguageCls):
     statement_terminator: ClassVar[str] = ";"
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ("#include <math.h>",)
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -317,7 +318,9 @@ class Clojure(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_integers import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -519,7 +520,9 @@ class Cobol(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -34,6 +34,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_double_minimal
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -334,7 +335,9 @@ class CommonLisp(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1385,6 +1385,6 @@ class Cpp(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -605,6 +605,6 @@ class Crystal(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -968,6 +968,6 @@ class CSharp(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -578,6 +578,6 @@ class D(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -49,6 +49,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -560,7 +561,9 @@ class Dart(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid code for *data*.

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -435,7 +436,9 @@ class Dhall(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash_hash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -424,7 +425,9 @@ class Elixir(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -39,6 +39,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -656,7 +657,9 @@ class Elm(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -39,6 +39,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -406,7 +407,9 @@ class Erlang(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -22,6 +22,7 @@ from literalizer._formatters.format_entries import (
 from literalizer._formatters.format_floats import format_float_scientific
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -420,7 +421,9 @@ class Forth(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_concat_control
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -520,7 +521,9 @@ class Fortran(metaclass=LanguageCls):
     special_float_preamble: ClassVar[tuple[str, ...]] = (
         "  use, intrinsic :: ieee_arithmetic",
     )
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -831,6 +831,6 @@ class FSharp(metaclass=LanguageCls):
         return _compute
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -43,6 +43,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -712,7 +713,9 @@ class Gleam(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -792,6 +792,6 @@ class Go(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -534,6 +534,6 @@ class Groovy(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1392,7 +1392,7 @@ class Haskell(metaclass=LanguageCls):
         return self._preamble.compute_body_preamble
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -497,6 +497,6 @@ class Hcl(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1178,6 +1178,6 @@ class Java(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -628,6 +628,6 @@ class JavaScript(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -39,6 +39,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -349,7 +350,9 @@ class Json5(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IN_LANGUAGE
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -540,6 +540,6 @@ class Jsonnet(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -637,6 +637,6 @@ class Julia(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -1060,6 +1060,6 @@ class Kotlin(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -560,6 +560,6 @@ class Lua(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_concat_control
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -448,7 +449,9 @@ class Matlab(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -41,6 +41,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -382,7 +383,9 @@ class Mojo(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ("import std.math",)
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -532,7 +533,9 @@ class Nim(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -39,6 +39,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -417,7 +418,9 @@ class Nix(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -324,7 +325,9 @@ class Norg(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IN_LANGUAGE
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_integers import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -392,7 +393,9 @@ class ObjectiveC(metaclass=LanguageCls):
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -515,7 +516,9 @@ class OCaml(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -358,7 +359,9 @@ class Occam(metaclass=LanguageCls):
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -43,6 +43,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -423,7 +424,9 @@ class Odin(metaclass=LanguageCls):
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ('import "core:math"',)
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -582,6 +582,6 @@ class Perl(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -555,6 +555,6 @@ class Php(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -34,6 +34,7 @@ from literalizer._formatters.format_floats import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -347,7 +348,9 @@ class PowerShell(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -43,6 +43,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -748,7 +749,9 @@ class PureScript(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1086,6 +1086,6 @@ class Python(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -578,6 +578,6 @@ class R(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -321,7 +322,9 @@ class Racket(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ("#lang racket",)
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -46,6 +46,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -415,7 +416,9 @@ class Raku(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -624,6 +624,6 @@ class Ruby(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1096,6 +1096,6 @@ class Rust(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -778,6 +778,6 @@ class Scala(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -321,7 +322,9 @@ class Scheme(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -46,6 +46,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -543,7 +544,9 @@ class Sml(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -867,6 +867,6 @@ class Swift(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return self.call_style.value

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -420,7 +421,9 @@ class SystemVerilog(metaclass=LanguageCls):
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -34,6 +34,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -373,7 +374,9 @@ class Tcl(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -41,6 +41,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -357,7 +358,9 @@ class Toml(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IN_LANGUAGE
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -798,6 +798,6 @@ class TypeScript(metaclass=LanguageCls):
         )
 
     @cached_property
-    def call_style_config(self) -> CallStyle | None:
+    def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         return cast("CallStyle", self.call_style.value)

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -46,6 +46,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -389,7 +390,9 @@ class V(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ("import math",)
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -44,6 +44,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -450,7 +451,9 @@ class VisualBasic(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -343,7 +344,9 @@ class Wren(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -40,6 +40,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -333,7 +334,9 @@ class Yaml(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IN_LANGUAGE
+    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     CallStyle,
+    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -466,7 +467,9 @@ class Zig(metaclass=LanguageCls):
     special_float_preamble: ClassVar[tuple[str, ...]] = (
         'const std = @import("std");',
     )
-    call_style_config: ClassVar[CallStyle | None] = None
+    call_style_config: ClassVar[CallStyle | CallSupport] = (
+        CallSupport.NOT_IMPLEMENTED_BY_TOOL
+    )
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -17,9 +17,10 @@ from literalizer import (
 )
 from literalizer._language import LanguageCls
 from literalizer.exceptions import (
+    CallsNotSupportedByLanguageError,
+    CallsNotSupportedByToolError,
     NullInCollectionError,
     PerElementNotListError,
-    UnsupportedCallStyleError,
 )
 from literalizer.languages import (
     Cobol,
@@ -499,13 +500,13 @@ def test_literalize_call_per_element_non_list_raises() -> None:
         )
 
 
-def test_literalize_call_unsupported_language_raises() -> None:
-    """Literalize_call raises UnsupportedCallStyleError for a language
-    without call support.
+def test_literalize_call_language_without_calls_raises() -> None:
+    """Literalize_call raises CallsNotSupportedByLanguageError for a
+    data-format language (Yaml) that has no call syntax.
     """
     with pytest.raises(
-        expected_exception=UnsupportedCallStyleError,
-        match=r"^Yaml does not support function call rendering$",
+        expected_exception=CallsNotSupportedByLanguageError,
+        match=r"^Yaml has no function call syntax$",
     ):
         literalize_call(
             source="[[1, 2]]",
@@ -516,18 +517,60 @@ def test_literalize_call_unsupported_language_raises() -> None:
         )
 
 
-def test_literalize_call_unsupported_language_per_element_false() -> None:
-    """Literalize_call raises UnsupportedCallStyleError for a non-call
-    language with per_element=False.
+def test_literalize_call_language_without_calls_per_element_false() -> None:
+    """Literalize_call raises CallsNotSupportedByLanguageError for a
+    data-format language with per_element=False.
     """
     with pytest.raises(
-        expected_exception=UnsupportedCallStyleError,
-        match=r"^Yaml does not support function call rendering$",
+        expected_exception=CallsNotSupportedByLanguageError,
+        match=r"^Yaml has no function call syntax$",
     ):
         literalize_call(
             source="[1, 2]",
             input_format=InputFormat.JSON,
             language=Yaml(),
+            target_function="f",
+            parameter_names=["data"],
+            per_element=False,
+        )
+
+
+def test_literalize_call_tool_unsupported_language_raises() -> None:
+    """Literalize_call raises CallsNotSupportedByToolError for a
+    programming language whose calls literalizer has not yet
+    implemented (Cobol).
+    """
+    with pytest.raises(
+        expected_exception=CallsNotSupportedByToolError,
+        match=(
+            r"^literalizer does not support function call rendering "
+            r"for Cobol$"
+        ),
+    ):
+        literalize_call(
+            source="[[1, 2]]",
+            input_format=InputFormat.JSON,
+            language=COBOL,
+            target_function="f",
+            parameter_names=["a", "b"],
+        )
+
+
+def test_literalize_call_tool_unsupported_language_per_element_false() -> None:
+    """Literalize_call raises CallsNotSupportedByToolError for a
+    programming language with per_element=False.
+    """
+    with pytest.raises(
+        expected_exception=CallsNotSupportedByToolError,
+        match=(
+            r"^literalizer does not support function call rendering "
+            r"for Cobol$"
+        ),
+    ):
+        literalize_call(
+            source="[1, 2]",
+            input_format=InputFormat.JSON,
+            language=COBOL,
             target_function="f",
             parameter_names=["data"],
             per_element=False,


### PR DESCRIPTION
## Summary
- Languages without function call support now explicitly declare whether the language has no call syntax at all (YAML, TOML, JSON5, Norg) or whether literalizer has not yet implemented call rendering for it (34 programming languages), via a new `CallSupport` enum exposed through `call_style_config`.
- `literalize_call` raises the matching exception: `CallsNotSupportedByLanguageError` or `CallsNotSupportedByToolError`, replacing the single `UnsupportedCallStyleError`.
- Golden files for noop languages continue to not be generated (the integration test already skipped them).

## Test plan
- [x] `uv run --extra dev pytest tests/` (829 passed)
- [x] `uv run --extra dev mypy src/ tests/`
- [x] `uv run --extra dev pyright src/ tests/`
- [x] `uv run --extra dev ruff check src/ tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public `Language.call_style_config` contract and exception types thrown by `literalize_call`, so downstream callers/tests may break even though behavior is mostly additive/refinement.
> 
> **Overview**
> **`literalize_call` now differentiates why calls aren’t supported** by introducing a `CallSupport` enum (`NOT_IN_LANGUAGE` vs `NOT_IMPLEMENTED_BY_TOOL`) and threading it through `Language.call_style_config`.
> 
> The single `UnsupportedCallStyleError` is replaced with two explicit exceptions—`CallsNotSupportedByLanguageError` for data/markup formats (e.g. YAML/TOML/JSON5/Norg) and `CallsNotSupportedByToolError` for programming languages where call rendering isn’t implemented yet—plus broad per-language updates to declare the appropriate sentinel and updated tests/Changelog to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9502f31fa07c59c8d1b0364ef9d470100083590a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->