### PR TITLE
Raise ParameterCountMismatchError for literalize_call mismatches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- ``literalize_call`` now raises ``ParameterCountMismatchError`` with
+  a descriptive ``Expected N parameters but got M values`` message
+  when ``parameter_names`` does not match a row's value count,
+  replacing the opaque ``ValueError`` from ``zip(strict=True)``.
 - The ``lint-julia`` CI job now executes Julia golden files instead
   of only parsing them, catching ``UndefVarError`` and other runtime
   errors.

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -35,6 +35,7 @@ from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
+    ParameterCountMismatchError,
     PerElementNotListError,
 )
 
@@ -1033,12 +1034,20 @@ def _format_call_args(
         case PositionalCallStyle():
             return f"({', '.join(formatted)})"
         case KeywordCallStyle(separator=kw_sep):
+            if len(params) != len(formatted):
+                raise ParameterCountMismatchError(
+                    expected=len(params), got=len(formatted)
+                )
             inner = ", ".join(
                 f"{name}{kw_sep}{val}"
                 for name, val in zip(params, formatted, strict=True)
             )
             return f"({inner})"
         case ObjectCallStyle(separator=kw_sep):
+            if len(params) != len(formatted):
+                raise ParameterCountMismatchError(
+                    expected=len(params), got=len(formatted)
+                )
             named = ", ".join(
                 f"{name}{kw_sep}{val}"
                 for name, val in zip(params, formatted, strict=True)

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -85,6 +85,20 @@ class PerElementNotListError(Exception):
     """
 
 
+class ParameterCountMismatchError(Exception):
+    """Raised when the number of ``parameter_names`` does not match the
+    number of argument values in a function-call row.
+    """
+
+    def __init__(self, *, expected: int, got: int) -> None:
+        """Create a ``ParameterCountMismatchError``."""
+        super().__init__(
+            f"Expected {expected} parameters but got {got} values"
+        )
+        self.expected = expected
+        self.got = got
+
+
 class CallsNotSupportedByLanguageError(Exception):
     """Raised when the target language itself has no function call
     syntax (e.g. pure data/markup formats like YAML, TOML, JSON5, Norg).

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -20,6 +20,7 @@ from literalizer.exceptions import (
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
     NullInCollectionError,
+    ParameterCountMismatchError,
     PerElementNotListError,
 )
 from literalizer.languages import (
@@ -28,6 +29,7 @@ from literalizer.languages import (
     FSharp,
     Go,
     Java,
+    JavaScript,
     Matlab,
     Python,
     Yaml,
@@ -497,6 +499,70 @@ def test_literalize_call_per_element_non_list_raises() -> None:
             target_function="process",
             parameter_names=["value"],
             per_element=True,
+        )
+
+
+def test_literalize_call_parameter_count_too_few_raises() -> None:
+    """Literalize_call raises when fewer parameter_names than values."""
+    with pytest.raises(
+        expected_exception=ParameterCountMismatchError,
+        match=r"^Expected 1 parameters but got 2 values$",
+    ):
+        literalize_call(
+            source="[[1, 2]]",
+            input_format=InputFormat.JSON,
+            language=Python(),
+            target_function="process",
+            parameter_names=["a"],
+        )
+
+
+def test_literalize_call_parameter_count_too_many_raises() -> None:
+    """Literalize_call raises when more parameter_names than values."""
+    with pytest.raises(
+        expected_exception=ParameterCountMismatchError,
+        match=r"^Expected 3 parameters but got 2 values$",
+    ):
+        literalize_call(
+            source="[[1, 2]]",
+            input_format=InputFormat.JSON,
+            language=Python(),
+            target_function="process",
+            parameter_names=["a", "b", "c"],
+        )
+
+
+def test_literalize_call_parameter_count_mismatch_object_style() -> None:
+    """Literalize_call raises ParameterCountMismatchError for object
+    call styles (e.g. JavaScript) too.
+    """
+    with pytest.raises(
+        expected_exception=ParameterCountMismatchError,
+        match=r"^Expected 2 parameters but got 1 values$",
+    ):
+        literalize_call(
+            source="[[1]]",
+            input_format=InputFormat.JSON,
+            language=JavaScript(),
+            target_function="process",
+            parameter_names=["a", "b"],
+        )
+
+
+def test_literalize_call_parameter_count_mismatch_later_row() -> None:
+    """Literalize_call raises when a later per_element row has a
+    different value count than parameter_names.
+    """
+    with pytest.raises(
+        expected_exception=ParameterCountMismatchError,
+        match=r"^Expected 2 parameters but got 1 values$",
+    ):
+        literalize_call(
+            source="[[1, 2], [3]]",
+            input_format=InputFormat.JSON,
+            language=Python(),
+            target_function="process",
+            parameter_names=["a", "b"],
         )
 
 


### PR DESCRIPTION
## Summary
- Replace the opaque `ValueError: zip() has arguments with different lengths` from `_format_call_args` with a new `ParameterCountMismatchError` carrying `expected`/`got` and a message like `Expected 2 parameters but got 1 values`.
- Applies to `KeywordCallStyle` and `ObjectCallStyle` branches, covering per-element rows that don't match `parameter_names`.

Closes #1207

## Test plan
- [x] New tests for too-few, too-many, object-style, and later-row mismatches in `tests/test_languages.py`
- [x] Full pytest suite passes (863 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change limited to error handling for `literalize_call`; main impact is a different exception type/message for mismatched parameter counts.
> 
> **Overview**
> `literalize_call` now raises a dedicated `ParameterCountMismatchError` (with `expected`/`got` and a clear "Expected N parameters but got M values" message) when a per-row argument count doesn’t match `parameter_names`, replacing the prior opaque `ValueError` from `zip(strict=True)`.
> 
> The check is enforced for `KeywordCallStyle` and `ObjectCallStyle`, documented in `CHANGELOG.rst`, and covered by new tests for too-few/too-many parameters, object-style calls, and mismatches that occur on later rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10de6596fc56cc0c4796fd723d0813b829d3015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->