### PR TITLE
Deduplicate fixed_{set,sequence,dict}_open into fixed_open

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- **Breaking:** Replaced the three public collection-opener helpers
+  ``fixed_set_open``, ``fixed_sequence_open``, and ``fixed_dict_open``
+  with a single ``fixed_open``.  They had identical implementations
+  and differed only in the type hint of the unused parameter.  Replace
+  each call with ``fixed_open(open_str=...)``.
 - The ``lint-julia`` CI job now executes Julia golden files instead
   of only parsing them, catching ``UndefVarError`` and other runtime
   errors.

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -100,7 +100,7 @@ and attributes:
 
    import enum
 
-   from literalizer._formatters.collection_openers import fixed_sequence_open
+   from literalizer._formatters.collection_openers import fixed_open
    from literalizer._formatters.format_entries import passthrough_sequence_entry
    from literalizer._language import LanguageCls, SequenceFormatConfig
 
@@ -112,7 +112,7 @@ and attributes:
 
        class SequenceFormats(enum.Enum):
            LIST = SequenceFormatConfig(
-               sequence_open=fixed_sequence_open(open_str="["),
+               sequence_open=fixed_open(open_str="["),
                close="]",
                supports_heterogeneity=True,
                single_element_trailing_comma=False,

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -1,9 +1,7 @@
 """Convert data structures to native language literal syntax."""
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._language import (
     CallStyle,
@@ -57,9 +55,7 @@ __all__ = [
     "SetFormatConfig",
     "TrailingCommaConfig",
     "VariableForm",
-    "fixed_dict_open",
-    "fixed_sequence_open",
-    "fixed_set_open",
+    "fixed_open",
     "literalize",
     "literalize_call",
 ]

--- a/src/literalizer/_formatters/collection_openers.py
+++ b/src/literalizer/_formatters/collection_openers.py
@@ -16,64 +16,21 @@ from literalizer._types import Value
 
 
 @beartype
-def _fixed_list_open_impl(_items: list[Value], open_str: str) -> str:
-    """Return the fixed opening delimiter for sequence/set items."""
-    return open_str
+def fixed_open(
+    *, open_str: str
+) -> Callable[[list[Value] | dict[str, Value]], str]:
+    """Return an opener callable that always returns *open_str*.
 
+    Use this as ``sequence_open``, ``set_open``, ``dict_open``, or
+    ``ordered_map_open`` when the opening delimiter is a fixed string
+    that does not depend on the collection contents.
 
-@beartype
-def _fixed_dict_open_impl(_items: dict[str, Value], open_str: str) -> str:
-    """Return the fixed opening delimiter for dict items."""
-    return open_str
-
-
-@beartype
-def fixed_set_open(*, open_str: str) -> Callable[[list[Value]], str]:
-    """Return a ``set_open`` callable that always returns *open_str*.
-
-    Use this as ``set_open`` when the opening delimiter for sets
-    is a fixed string that does not depend on the set contents.
-
-    Example: ``fixed_set_open(open_str="{")([1, 2, 3])`` -> ``"{"``.
+    Example: ``fixed_open(open_str="[")([1, 2, 3])`` -> ``"["``.
     """
 
-    def _open(_items: list[Value]) -> str:
-        """Delegate to module-level implementation."""
-        return _fixed_list_open_impl(_items=_items, open_str=open_str)
-
-    return _open
-
-
-@beartype
-def fixed_sequence_open(*, open_str: str) -> Callable[[list[Value]], str]:
-    """Return a ``sequence_open`` callable that always returns *open_str*.
-
-    Use this as ``sequence_open`` when the opening delimiter for sequences
-    is a fixed string that does not depend on the sequence contents.
-
-    Example: ``fixed_sequence_open(open_str="[")([1, 2, 3])`` -> ``"["``.
-    """
-
-    def _open(_items: list[Value]) -> str:
-        """Delegate to module-level implementation."""
-        return _fixed_list_open_impl(_items=_items, open_str=open_str)
-
-    return _open
-
-
-@beartype
-def fixed_dict_open(*, open_str: str) -> Callable[[dict[str, Value]], str]:
-    """Return a ``dict_open`` callable that always returns *open_str*.
-
-    Use this as ``dict_open`` when the opening delimiter for dicts
-    is a fixed string that does not depend on the dict contents.
-
-    Example: ``fixed_dict_open(open_str="{")({"a": 1})`` -> ``"{"``.
-    """
-
-    def _open(_items: dict[str, Value]) -> str:
-        """Delegate to module-level implementation."""
-        return _fixed_dict_open_impl(_items=_items, open_str=open_str)
+    def _open(_items: list[Value] | dict[str, Value], /) -> str:
+        """Return the fixed opening delimiter, ignoring *_items*."""
+        return open_str
 
     return _open
 

--- a/src/literalizer/_formatters/format_factories.py
+++ b/src/literalizer/_formatters/format_factories.py
@@ -6,9 +6,7 @@ from typing import Protocol, runtime_checkable
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._language import (
     DictFormatConfig,
@@ -65,7 +63,7 @@ def _build_sequence_format_config(
 ) -> SequenceFormatConfig:
     """Build a ``SequenceFormatConfig`` with the given default type."""
     return SequenceFormatConfig(
-        sequence_open=fixed_sequence_open(
+        sequence_open=fixed_open(
             open_str=open_template.format(type=default_type),
         ),
         close=close,
@@ -109,7 +107,7 @@ def sequence_format_factory(
     given type.
 
     Templates use ``{type}`` as the placeholder for the default type
-    name.  The ``open_template`` is wrapped in ``fixed_sequence_open``.
+    name.  The ``open_template`` is wrapped in ``fixed_open``.
     """
 
     def _build(default_type: str) -> SequenceFormatConfig:
@@ -144,7 +142,7 @@ def _build_set_format_config(
     """Build a ``SetFormatConfig`` with the given default type."""
     open_str = open_template.format(type=default_type)
     return SetFormatConfig(
-        set_open=fixed_set_open(open_str=open_str),
+        set_open=fixed_open(open_str=open_str),
         close=close.format(type=default_type),
         empty_set=(
             empty_template.format(type=default_type)
@@ -214,7 +212,7 @@ def _build_dict_format_config(
     """Build a ``DictFormatConfig`` with the given default type."""
     fmt_kwargs = {"type": default_type, "key_type": default_key_type}
     return DictFormatConfig(
-        dict_open=fixed_dict_open(
+        dict_open=fixed_open(
             open_str=open_template.format(**fmt_kwargs),
         ),
         close=close,
@@ -244,7 +242,7 @@ def dict_format_factory(
 
     Templates use ``{type}`` and optionally ``{key_type}`` as
     placeholders for the default value type and key type names.
-    The ``open_template`` is wrapped in ``fixed_dict_open``.
+    The ``open_template`` is wrapped in ``fixed_open``.
     """
 
     def _build(
@@ -279,7 +277,7 @@ def _build_ordered_map_format_config(
     """Build an ``OrderedMapFormatConfig`` with the given default type."""
     fmt_kwargs = {"type": default_type, "key_type": default_key_type}
     return OrderedMapFormatConfig(
-        ordered_map_open=fixed_dict_open(
+        ordered_map_open=fixed_open(
             open_str=open_template.format(**fmt_kwargs),
         ),
         close=close,

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -554,7 +554,7 @@ class Language(Protocol):
 
         Receives the list of items about to be formatted, so the delimiter
         can depend on the element types when needed.  For a fixed delimiter
-        use :func:`~literalizer.fixed_sequence_open`.
+        use :func:`~literalizer.fixed_open`.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -154,7 +152,7 @@ class Ada(metaclass=LanguageCls):
         """Sequence type options for Ada."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="AList'("),
+            sequence_open=fixed_open(open_str="AList'("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -172,7 +170,7 @@ class Ada(metaclass=LanguageCls):
         """Set type options for Ada."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="ASet'("),
+            set_open=fixed_open(open_str="ASet'("),
             close=")",
             empty_set="ASet'(1 .. 0 => ANull)",
             preamble_lines=(),
@@ -451,7 +449,7 @@ class Ada(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="AMap'("),
+            dict_open=fixed_open(open_str="AMap'("),
             close=")",
             format_entry=dict_entry_with_template(
                 template="AEntry ({key}, {value})",
@@ -507,7 +505,7 @@ class Ada(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="AMap'("),
+            ordered_map_open=fixed_open(open_str="AMap'("),
             close=")",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -170,7 +168,7 @@ class Bash(metaclass=LanguageCls):
         """Sequence type options for Bash."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="("),
+            sequence_open=fixed_open(open_str="("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -188,7 +186,7 @@ class Bash(metaclass=LanguageCls):
         """Set type options for Bash."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="("),
+            set_open=fixed_open(open_str="("),
             close=")",
             empty_set=None,
             preamble_lines=(),
@@ -445,7 +443,7 @@ class Bash(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="("),
+            dict_open=fixed_open(open_str="("),
             close=")",
             format_entry=_format_bash_dict_entry,
             empty_dict=None,
@@ -492,7 +490,7 @@ class Bash(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="("),
+            ordered_map_open=fixed_open(open_str="("),
             close=")",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -161,7 +159,7 @@ class C(metaclass=LanguageCls):
         """Sequence type options for C."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(
+            sequence_open=fixed_open(
                 open_str="((CVal){.a = (CVal[]){",
             ),
             close="}})",
@@ -181,7 +179,7 @@ class C(metaclass=LanguageCls):
         """Set type options for C."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="((CVal){.a = (CVal[]){"),
+            set_open=fixed_open(open_str="((CVal){.a = (CVal[]){"),
             close="}})",
             empty_set=None,
             preamble_lines=(),
@@ -463,7 +461,7 @@ class C(metaclass=LanguageCls):
         """Configuration for the chosen sequence format."""
         fmt = self.sequence_format.value
         return SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str=self._seq_open_str),
+            sequence_open=fixed_open(open_str=self._seq_open_str),
             close="}})",
             supports_heterogeneity=fmt.supports_heterogeneity,
             single_element_trailing_comma=(fmt.single_element_trailing_comma),
@@ -485,7 +483,7 @@ class C(metaclass=LanguageCls):
     def set_format_config(self) -> SetFormatConfig:
         """Configuration for the chosen set format."""
         return SetFormatConfig(
-            set_open=fixed_set_open(open_str=self._seq_open_str),
+            set_open=fixed_open(open_str=self._seq_open_str),
             close="}})",
             empty_set=self.set_format.value.empty_set,
             preamble_lines=self.set_format.value.preamble_lines,
@@ -502,7 +500,7 @@ class C(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str=self._map_open_str),
+            dict_open=fixed_open(open_str=self._map_open_str),
             close="}})",
             format_entry=braced_dict_entry(
                 format_value=self._format_entry,
@@ -570,7 +568,7 @@ class C(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str=self._map_open_str),
+            ordered_map_open=fixed_open(open_str=self._map_open_str),
             close="}})",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -110,7 +108,7 @@ class Clojure(metaclass=LanguageCls):
         """Sequence type options for Clojure."""
 
         VECTOR = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -128,7 +126,7 @@ class Clojure(metaclass=LanguageCls):
         """Set type options for Clojure."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="#{"),
+            set_open=fixed_open(open_str="#{"),
             close="}",
             empty_set=None,
             preamble_lines=(),
@@ -387,7 +385,7 @@ class Clojure(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" ",
@@ -432,7 +430,7 @@ class Clojure(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -299,7 +297,7 @@ class Cobol(metaclass=LanguageCls):
         """Sequence type options for COBOL."""
 
         SEQUENCE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str=""),
+            sequence_open=fixed_open(open_str=""),
             close="",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -317,7 +315,7 @@ class Cobol(metaclass=LanguageCls):
         """Set type options for COBOL."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str=""),
+            set_open=fixed_open(open_str=""),
             close="",
             empty_set="05 FILLER PIC X(1) VALUE SPACES.",
             preamble_lines=(),
@@ -602,7 +600,7 @@ class Cobol(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str=""),
+            dict_open=fixed_open(open_str=""),
             close="",
             format_entry=_format_cobol_dict_entry,
             empty_dict="05 FILLER PIC X(1) VALUE SPACES.",
@@ -644,7 +642,7 @@ class Cobol(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str=""),
+            ordered_map_open=fixed_open(open_str=""),
             close="",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -119,7 +117,7 @@ class CommonLisp(metaclass=LanguageCls):
         """Sequence type options for Common Lisp."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="(list "),
+            sequence_open=fixed_open(open_str="(list "),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -137,7 +135,7 @@ class CommonLisp(metaclass=LanguageCls):
         """Set type options for Common Lisp."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="(list "),
+            set_open=fixed_open(open_str="(list "),
             close=")",
             empty_set="nil",
             preamble_lines=(),
@@ -409,7 +407,7 @@ class CommonLisp(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="(list "),
+            dict_open=fixed_open(open_str="(list "),
             close=")",
             format_entry=_format_cons_entry,
             empty_dict="nil",
@@ -451,7 +449,7 @@ class CommonLisp(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="(list "),
+            ordered_map_open=fixed_open(open_str="(list "),
             close=")",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -11,8 +11,7 @@ from typing import ClassVar, cast
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -174,7 +173,7 @@ class Crystal(metaclass=LanguageCls):
         """Sequence type options for Crystal."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             empty_sequence="[] of Nil",
             supports_heterogeneity=True,
@@ -188,7 +187,7 @@ class Crystal(metaclass=LanguageCls):
             declared_type=None,
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="{"),
+            sequence_open=fixed_open(open_str="{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -564,7 +563,7 @@ class Crystal(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -177,7 +175,7 @@ class D(metaclass=LanguageCls):
         """Sequence type options for D."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="JSONValue(["),
+            sequence_open=fixed_open(open_str="JSONValue(["),
             close="])",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -195,7 +193,7 @@ class D(metaclass=LanguageCls):
         """Set type options for D."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="JSONValue(["),
+            set_open=fixed_open(open_str="JSONValue(["),
             close="])",
             empty_set='parseJSON("[]")',
             preamble_lines=(),
@@ -493,7 +491,7 @@ class D(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="JSONValue(["),
+            dict_open=fixed_open(open_str="JSONValue(["),
             close="])",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -545,7 +543,7 @@ class D(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="JSONValue(["),
+            ordered_map_open=fixed_open(open_str="JSONValue(["),
             close="])",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -13,8 +13,7 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
     TypeOpeners,
-    fixed_dict_open,
-    fixed_sequence_open,
+    fixed_open,
     typed_collection_open,
     typed_dict_open,
 )
@@ -276,7 +275,7 @@ class Dart(metaclass=LanguageCls):
         """Sequence type options for Dart."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -290,7 +289,7 @@ class Dart(metaclass=LanguageCls):
             declared_type=None,
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="("),
+            sequence_open=fixed_open(open_str="("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=True,
@@ -774,7 +773,7 @@ class Dart(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -225,7 +223,7 @@ class Dhall(metaclass=LanguageCls):
         """Sequence type options for Dhall."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
@@ -243,7 +241,7 @@ class Dhall(metaclass=LanguageCls):
         """Set type options for Dhall."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set="[] : List {}",
             preamble_lines=(),
@@ -515,7 +513,7 @@ class Dhall(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=_format_dhall_dict_entry,
             empty_dict="{=}",
@@ -557,7 +555,7 @@ class Dhall(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -12,9 +12,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -166,7 +164,7 @@ class Elixir(metaclass=LanguageCls):
         """Sequence type options for Elixir."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -180,7 +178,7 @@ class Elixir(metaclass=LanguageCls):
             declared_type=None,
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="{"),
+            sequence_open=fixed_open(open_str="{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -198,7 +196,7 @@ class Elixir(metaclass=LanguageCls):
         """Set type options for Elixir."""
 
         MAP_SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="MapSet.new(["),
+            set_open=fixed_open(open_str="MapSet.new(["),
             close="])",
             empty_set="MapSet.new()",
             preamble_lines=(),
@@ -489,7 +487,7 @@ class Elixir(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="%{"),
+            dict_open=fixed_open(open_str="%{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",
@@ -541,7 +539,7 @@ class Elixir(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="["),
+            ordered_map_open=fixed_open(open_str="["),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -12,9 +12,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -444,7 +442,7 @@ class Elm(metaclass=LanguageCls):
         """Sequence type options for Elm."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="EList ["),
+            sequence_open=fixed_open(open_str="EList ["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -462,7 +460,7 @@ class Elm(metaclass=LanguageCls):
         """Set type options for Elm."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="ESet ["),
+            set_open=fixed_open(open_str="ESet ["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -715,7 +713,7 @@ class Elm(metaclass=LanguageCls):
     @cached_property
     def _seq_open(self) -> Callable[[list[Value]], str]:
         """Shared sequence opener with configured constructor prefix."""
-        return fixed_sequence_open(
+        return fixed_open(
             open_str=f"{self.constructor_prefix}List [",
         )
 
@@ -737,7 +735,7 @@ class Elm(metaclass=LanguageCls):
         """Configuration for the chosen set format."""
         return dataclasses.replace(
             self.set_format.value,
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Set [",
             ),
         )
@@ -751,7 +749,7 @@ class Elm(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Dict [",
             ),
             close="]",
@@ -839,7 +837,7 @@ class Elm(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Dict [",
             ),
             close="]",

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -174,7 +172,7 @@ class Erlang(metaclass=LanguageCls):
         """Sequence type options for Erlang."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -188,7 +186,7 @@ class Erlang(metaclass=LanguageCls):
             declared_type=None,
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="{"),
+            sequence_open=fixed_open(open_str="{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -206,7 +204,7 @@ class Erlang(metaclass=LanguageCls):
         """Set type options for Erlang."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="sets:from_list(["),
+            set_open=fixed_open(open_str="sets:from_list(["),
             close="])",
             empty_set="sets:from_list([])",
             preamble_lines=(),
@@ -478,7 +476,7 @@ class Erlang(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="#{"),
+            dict_open=fixed_open(open_str="#{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",
@@ -528,7 +526,7 @@ class Erlang(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="["),
+            ordered_map_open=fixed_open(open_str="["),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_entries import (
     assignment_formatter_from_declaration,
@@ -229,7 +227,7 @@ class Forth(metaclass=LanguageCls):
         """Sequence type options."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str=""),
+            sequence_open=fixed_open(open_str=""),
             close="",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -247,7 +245,7 @@ class Forth(metaclass=LanguageCls):
         """Set type options."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str=""),
+            set_open=fixed_open(open_str=""),
             close="",
             empty_set=None,
             preamble_lines=(),
@@ -512,7 +510,7 @@ class Forth(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str=""),
+            dict_open=fixed_open(open_str=""),
             close="",
             format_entry=_format_forth_dict_entry,
             empty_dict=None,
@@ -559,7 +557,7 @@ class Forth(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str=""),
+            ordered_map_open=fixed_open(open_str=""),
             close="",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -274,7 +272,7 @@ class Fortran(metaclass=LanguageCls):
         """Sequence type options for Fortran."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="flist([fval_t :: "),
+            sequence_open=fixed_open(open_str="flist([fval_t :: "),
             close="])",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -292,7 +290,7 @@ class Fortran(metaclass=LanguageCls):
         """Set type options for Fortran."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="fset([fval_t :: "),
+            set_open=fixed_open(open_str="fset([fval_t :: "),
             close="])",
             empty_set=None,
             preamble_lines=(),
@@ -588,7 +586,7 @@ class Fortran(metaclass=LanguageCls):
         """Configuration for the chosen sequence format."""
         fmt = self.sequence_format.value
         return SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(
+            sequence_open=fixed_open(
                 open_str=f"{self.list_name}([fval_t :: ",
             ),
             close="])",
@@ -612,7 +610,7 @@ class Fortran(metaclass=LanguageCls):
     def set_format_config(self) -> SetFormatConfig:
         """Configuration for the chosen set format."""
         return SetFormatConfig(
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.set_name}([fval_t :: ",
             ),
             close="])",
@@ -631,7 +629,7 @@ class Fortran(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str=f"{self.map_name}([fval_t :: ",
             ),
             close="])",
@@ -699,7 +697,7 @@ class Fortran(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"{self.map_name}([fval_t :: ",
             ),
             close="])",

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -12,9 +12,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -295,7 +293,7 @@ class FSharp(metaclass=LanguageCls):
         """Sequence type options for F#."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="FList ["),
+            sequence_open=fixed_open(open_str="FList ["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -309,7 +307,7 @@ class FSharp(metaclass=LanguageCls):
             declared_type="Val",
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="[|"),
+            sequence_open=fixed_open(open_str="[|"),
             close="|]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -327,7 +325,7 @@ class FSharp(metaclass=LanguageCls):
         """Set type options for F#."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="FSet ["),
+            set_open=fixed_open(open_str="FSet ["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -610,7 +608,7 @@ class FSharp(metaclass=LanguageCls):
             return fmt
         return dataclasses.replace(
             fmt,
-            sequence_open=fixed_sequence_open(
+            sequence_open=fixed_open(
                 open_str=f"{self.constructor_prefix}List [",
             ),
         )
@@ -625,7 +623,7 @@ class FSharp(metaclass=LanguageCls):
         """Configuration for the chosen set format."""
         return dataclasses.replace(
             self.set_format.value,
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Set [",
             ),
         )
@@ -634,7 +632,7 @@ class FSharp(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Map [",
             ),
             close="]",
@@ -700,7 +698,7 @@ class FSharp(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Map [",
             ),
             close="]",

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -13,9 +13,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -421,7 +419,7 @@ class Gleam(metaclass=LanguageCls):
         """Sequence type options for Gleam."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="GList(["),
+            sequence_open=fixed_open(open_str="GList(["),
             close="])",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -435,7 +433,7 @@ class Gleam(metaclass=LanguageCls):
             declared_type=None,
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="#("),
+            sequence_open=fixed_open(open_str="#("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -453,7 +451,7 @@ class Gleam(metaclass=LanguageCls):
         """Set type options for Gleam."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="GSet(["),
+            set_open=fixed_open(open_str="GSet(["),
             close="])",
             empty_set=None,
             preamble_lines=(),
@@ -780,7 +778,7 @@ class Gleam(metaclass=LanguageCls):
         if self.sequence_format.name == "LIST":
             return dataclasses.replace(
                 fmt,
-                sequence_open=fixed_sequence_open(
+                sequence_open=fixed_open(
                     open_str=f"{self.constructor_prefix}List([",
                 ),
             )
@@ -796,7 +794,7 @@ class Gleam(metaclass=LanguageCls):
         """Configuration for the chosen set format."""
         return dataclasses.replace(
             self.set_format.value,
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Set([",
             ),
         )
@@ -805,7 +803,7 @@ class Gleam(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Dict([",
             ),
             close="])",
@@ -898,7 +896,7 @@ class Gleam(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Dict([",
             ),
             close="])",

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -11,8 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
+    fixed_open,
     make_element_to_type,
     make_type_to_opener,
     typed_collection_open,
@@ -296,7 +295,7 @@ class Go(metaclass=LanguageCls):
         """Sequence type options for Go."""
 
         SLICE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="[]any{"),
+            sequence_open=fixed_open(open_str="[]any{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -740,7 +739,7 @@ class Go(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"[][2]{self.default_ordered_map_value_type}{{"
             ),
             close="}",

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -10,8 +10,7 @@ from typing import ClassVar, cast
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -151,7 +150,7 @@ class Groovy(metaclass=LanguageCls):
         """Sequence type options for Groovy."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -441,7 +440,7 @@ class Groovy(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="["),
+            dict_open=fixed_open(open_str="["),
             close="]",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -486,7 +485,7 @@ class Groovy(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="["),
+            ordered_map_open=fixed_open(open_str="["),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -13,9 +13,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -609,7 +607,7 @@ def _build_sequence_setup(
     """Build sequence format config, customizing the opener for LIST."""
     fmt: SequenceFormatConfig = sequence_format.value
     if sequence_format.name == "LIST":
-        seq_open = fixed_sequence_open(
+        seq_open = fixed_open(
             open_str=f"{constructor_prefix}List [",
         )
         return _SequenceSetup(
@@ -903,7 +901,7 @@ class Haskell(metaclass=LanguageCls):
         """Sequence type options for Haskell."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="HList ["),
+            sequence_open=fixed_open(open_str="HList ["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -917,7 +915,7 @@ class Haskell(metaclass=LanguageCls):
             declared_type="Val",
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="("),
+            sequence_open=fixed_open(open_str="("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -935,7 +933,7 @@ class Haskell(metaclass=LanguageCls):
         """Set type options for Haskell."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="HSet ["),
+            set_open=fixed_open(open_str="HSet ["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -1219,7 +1217,7 @@ class Haskell(metaclass=LanguageCls):
         """Configuration for the chosen set format."""
         return dataclasses.replace(
             self.set_format.value,
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Set [",
             ),
         )
@@ -1248,7 +1246,7 @@ class Haskell(metaclass=LanguageCls):
         """Configuration for dict formatting."""
         map_open = f"{self.constructor_prefix}Map ["
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str=map_open),
+            dict_open=fixed_open(open_str=map_open),
             close="]",
             format_entry=self._string_fmts.format_dict_entry,
             empty_dict=None,
@@ -1261,7 +1259,7 @@ class Haskell(metaclass=LanguageCls):
         """Configuration for ordered-map formatting."""
         map_open = f"{self.constructor_prefix}Map ["
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str=map_open),
+            ordered_map_open=fixed_open(open_str=map_open),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -110,7 +108,7 @@ class Hcl(metaclass=LanguageCls):
         """Sequence type options for HCL."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -128,7 +126,7 @@ class Hcl(metaclass=LanguageCls):
         """Set type options for HCL."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -404,7 +402,7 @@ class Hcl(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" = ",
@@ -449,7 +447,7 @@ class Hcl(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -15,9 +15,7 @@ from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
     typed_collection_open,
 )
 from literalizer._formatters.format_dates import (
@@ -572,7 +570,7 @@ class Java(metaclass=LanguageCls):
         """Sequence type options for Java."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="new Object[]{"),
+            sequence_open=fixed_open(open_str="new Object[]{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -604,7 +602,7 @@ class Java(metaclass=LanguageCls):
         """Set type options for Java."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="Set.of("),
+            set_open=fixed_open(open_str="Set.of("),
             close=")",
             empty_set=None,
             preamble_lines=("import java.util.Set;",),
@@ -612,7 +610,7 @@ class Java(metaclass=LanguageCls):
             supports_heterogeneity=True,
         )
         TREE_SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="new TreeSet<>(Set.of("),
+            set_open=fixed_open(open_str="new TreeSet<>(Set.of("),
             close="))",
             empty_set="new TreeSet<>()",
             preamble_lines=(
@@ -654,7 +652,7 @@ class Java(metaclass=LanguageCls):
         """Dict/map format options."""
 
         MAP_OF_ENTRIES = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="Map.ofEntries("),
+            dict_open=fixed_open(open_str="Map.ofEntries("),
             close=")",
             format_entry=dict_entry_with_template(
                 template="Map.entry({key}, {value})",
@@ -665,7 +663,7 @@ class Java(metaclass=LanguageCls):
             narrowed_open=None,
         )
         HASH_MAP = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="new HashMap<>(Map.ofEntries("),
+            dict_open=fixed_open(open_str="new HashMap<>(Map.ofEntries("),
             close="))",
             format_entry=dict_entry_with_template(
                 template="Map.entry({key}, {value})",
@@ -1111,7 +1109,7 @@ class Java(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=(
                     "new java.util.ArrayList<>(java.util.Arrays.asList("
                 ),

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -11,9 +11,7 @@ from typing import ClassVar, cast
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -165,7 +163,7 @@ class JavaScript(metaclass=LanguageCls):
         """Sequence type options for JavaScript."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -183,7 +181,7 @@ class JavaScript(metaclass=LanguageCls):
         """Set type options for JavaScript."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="new Set(["),
+            set_open=fixed_open(open_str="new Set(["),
             close="])",
             empty_set="new Set()",
             preamble_lines=(),
@@ -255,7 +253,7 @@ class JavaScript(metaclass=LanguageCls):
         """Dict/map format options."""
 
         OBJECT = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -266,7 +264,7 @@ class JavaScript(metaclass=LanguageCls):
             narrowed_open=None,
         )
         MAP = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="new Map(["),
+            dict_open=fixed_open(open_str="new Map(["),
             close="])",
             format_entry=dict_entry_with_template(
                 template="[{key}, {value}]",
@@ -572,7 +570,7 @@ class JavaScript(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -12,9 +12,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -146,7 +144,7 @@ class Json5(metaclass=LanguageCls):
         """Sequence type options for JSON5."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -164,7 +162,7 @@ class Json5(metaclass=LanguageCls):
         """Set type options for JSON5."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -414,7 +412,7 @@ class Json5(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=_format_json5_dict_entry,
             empty_dict=None,
@@ -464,7 +462,7 @@ class Json5(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -12,9 +12,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -164,7 +162,7 @@ class Jsonnet(metaclass=LanguageCls):
         """Sequence type options for Jsonnet."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -182,7 +180,7 @@ class Jsonnet(metaclass=LanguageCls):
         """Set type options for Jsonnet."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -445,7 +443,7 @@ class Jsonnet(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=_format_jsonnet_dict_entry,
             empty_dict=None,
@@ -495,7 +493,7 @@ class Jsonnet(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -11,9 +11,7 @@ from typing import ClassVar, cast
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -197,7 +195,7 @@ class Julia(metaclass=LanguageCls):
         """Sequence type options for Julia."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -211,7 +209,7 @@ class Julia(metaclass=LanguageCls):
             declared_type=None,
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="("),
+            sequence_open=fixed_open(open_str="("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=True,
@@ -229,7 +227,7 @@ class Julia(metaclass=LanguageCls):
         """Set type options for Julia."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="Set(["),
+            set_open=fixed_open(open_str="Set(["),
             close="])",
             empty_set="Set()",
             preamble_lines=(),
@@ -268,7 +266,7 @@ class Julia(metaclass=LanguageCls):
         """Dict/map format options."""
 
         DICT = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="Dict("),
+            dict_open=fixed_open(open_str="Dict("),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" => ",
@@ -279,7 +277,7 @@ class Julia(metaclass=LanguageCls):
             narrowed_open=None,
         )
         ORDERED = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="OrderedDict("),
+            dict_open=fixed_open(open_str="OrderedDict("),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" => ",
@@ -586,7 +584,7 @@ class Julia(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="["),
+            ordered_map_open=fixed_open(open_str="["),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -15,8 +15,7 @@ from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
-    fixed_dict_open,
-    fixed_sequence_open,
+    fixed_open,
     make_type_to_opener,
     typed_collection_open,
     typed_dict_open,
@@ -494,7 +493,7 @@ class Kotlin(metaclass=LanguageCls):
             declared_type=None,
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="arrayOf<Any?>("),
+            sequence_open=fixed_open(open_str="arrayOf<Any?>("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -988,7 +987,7 @@ class Kotlin(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=(
                     f"linkedMapOf<{self.default_dict_key_type}"
                     f", {self.default_dict_value_type}>("

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -172,7 +170,7 @@ class Lua(metaclass=LanguageCls):
         """Sequence type options for Lua."""
 
         TABLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="{"),
+            sequence_open=fixed_open(open_str="{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -190,7 +188,7 @@ class Lua(metaclass=LanguageCls):
         """Set type options for Lua."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="{"),
+            set_open=fixed_open(open_str="{"),
             close="}",
             empty_set=None,
             preamble_lines=(),
@@ -463,7 +461,7 @@ class Lua(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=self._dict_entry,
             empty_dict=None,
@@ -515,7 +513,7 @@ class Lua(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -222,7 +220,7 @@ class Matlab(metaclass=LanguageCls):
         """Sequence type options for MATLAB."""
 
         CELL_ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="{"),
+            sequence_open=fixed_open(open_str="{"),
             close="}",
             empty_sequence="{}",
             supports_heterogeneity=True,
@@ -240,7 +238,7 @@ class Matlab(metaclass=LanguageCls):
         """Set type options for MATLAB."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="{"),
+            set_open=fixed_open(open_str="{"),
             close="}",
             empty_set="{}",
             preamble_lines=(),
@@ -279,7 +277,7 @@ class Matlab(metaclass=LanguageCls):
         """Dict/map format options."""
 
         STRUCT = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="struct("),
+            dict_open=fixed_open(open_str="struct("),
             close=")",
             format_entry=_format_matlab_dict_entry,
             empty_dict="struct()",
@@ -559,7 +557,7 @@ class Matlab(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="struct("),
+            ordered_map_open=fixed_open(open_str="struct("),
             close=")",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -11,7 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
+    fixed_open,
     make_element_to_type,
     make_type_to_opener,
 )
@@ -511,7 +511,7 @@ class Mojo(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="["),
+            ordered_map_open=fixed_open(open_str="["),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -260,7 +258,7 @@ class Nim(metaclass=LanguageCls):
         """Sequence type options for Nim."""
 
         SEQ = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=False,
             single_element_trailing_comma=False,
@@ -274,7 +272,7 @@ class Nim(metaclass=LanguageCls):
             declared_type=None,
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -292,7 +290,7 @@ class Nim(metaclass=LanguageCls):
         """Set type options for Nim."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=("import json",),
@@ -597,7 +595,7 @@ class Nim(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -652,7 +650,7 @@ class Nim(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=("import json",),
         )

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -213,7 +211,7 @@ class Nix(metaclass=LanguageCls):
         """Sequence type options for Nix."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -231,7 +229,7 @@ class Nix(metaclass=LanguageCls):
         """Set type options for Nix."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -495,7 +493,7 @@ class Nix(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=_format_nix_dict_entry,
             empty_dict="{ }",
@@ -537,7 +535,7 @@ class Nix(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -119,7 +117,7 @@ class Norg(metaclass=LanguageCls):
         """Sequence type options for Norg."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -137,7 +135,7 @@ class Norg(metaclass=LanguageCls):
         """Set type options for Norg."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -409,7 +407,7 @@ class Norg(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=self._dict_entry,
             empty_dict=None,
@@ -451,7 +449,7 @@ class Norg(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -170,7 +168,7 @@ class ObjectiveC(metaclass=LanguageCls):
         """Sequence type options for Objective-C."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="@["),
+            sequence_open=fixed_open(open_str="@["),
             close="]",
             empty_sequence="@[]",
             supports_heterogeneity=True,
@@ -188,7 +186,7 @@ class ObjectiveC(metaclass=LanguageCls):
         """Set type options for Objective-C."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="[NSSet setWithArray:@["),
+            set_open=fixed_open(open_str="[NSSet setWithArray:@["),
             close="]]",
             empty_set="[NSSet set]",
             preamble_lines=(),
@@ -470,7 +468,7 @@ class ObjectiveC(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="@{"),
+            dict_open=fixed_open(open_str="@{"),
             close="}",
             format_entry=self._dict_entry,
             empty_dict="@{}",
@@ -517,7 +515,7 @@ class ObjectiveC(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="@{"),
+            ordered_map_open=fixed_open(open_str="@{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -12,9 +12,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -262,7 +260,7 @@ class OCaml(metaclass=LanguageCls):
         """Sequence type options for OCaml."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="OList ["),
+            sequence_open=fixed_open(open_str="OList ["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -276,7 +274,7 @@ class OCaml(metaclass=LanguageCls):
             declared_type="val_t",
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="[|"),
+            sequence_open=fixed_open(open_str="[|"),
             close="|]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -294,7 +292,7 @@ class OCaml(metaclass=LanguageCls):
         """Set type options for OCaml."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="OSet ["),
+            set_open=fixed_open(open_str="OSet ["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -576,7 +574,7 @@ class OCaml(metaclass=LanguageCls):
         """Configuration for the chosen sequence format."""
         fmt = self.sequence_format.value
         if self.sequence_format.name == "LIST":
-            _seq_open = fixed_sequence_open(
+            _seq_open = fixed_open(
                 open_str=f"{self.constructor_prefix}List [",
             )
             return dataclasses.replace(fmt, sequence_open=_seq_open)
@@ -587,7 +585,7 @@ class OCaml(metaclass=LanguageCls):
         """Callable that returns the opening delimiter for a sequence."""
         fmt = self.sequence_format.value
         if self.sequence_format.name == "LIST":
-            return fixed_sequence_open(
+            return fixed_open(
                 open_str=f"{self.constructor_prefix}List [",
             )
         return fmt.sequence_open
@@ -597,7 +595,7 @@ class OCaml(metaclass=LanguageCls):
         """Configuration for the chosen set format."""
         return dataclasses.replace(
             self.set_format.value,
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Set [",
             ),
         )
@@ -606,7 +604,7 @@ class OCaml(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Map [",
             ),
             close="]",
@@ -687,7 +685,7 @@ class OCaml(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Map [",
             ),
             close="]",

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -127,7 +125,7 @@ class Occam(metaclass=LanguageCls):
         """Sequence type options for Occam."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(
+            sequence_open=fixed_open(
                 open_str="MOBILE LIT(lit.list; MOBILE []MOBILE LIT [",
             ),
             close="])",
@@ -147,7 +145,7 @@ class Occam(metaclass=LanguageCls):
         """Set type options for Occam."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str="MOBILE LIT(lit.set; MOBILE []MOBILE LIT [",
             ),
             close="])",
@@ -441,7 +439,7 @@ class Occam(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
             ),
             close="])",
@@ -485,7 +483,7 @@ class Occam(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str="MOBILE LIT(lit.map; MOBILE []MOBILE LIT [",
             ),
             close="])",

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -11,8 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
+    fixed_open,
     make_element_to_type,
     make_type_to_opener,
 )
@@ -169,7 +168,7 @@ class Odin(metaclass=LanguageCls):
         """Sequence type options for Odin."""
 
         DYNAMIC_ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="[dynamic]any{"),
+            sequence_open=fixed_open(open_str="[dynamic]any{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -515,7 +514,7 @@ class Odin(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str="map[string]any{",
             ),
             close="}",
@@ -569,7 +568,7 @@ class Odin(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="map[string]any{"),
+            ordered_map_open=fixed_open(open_str="map[string]any{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -167,7 +165,7 @@ class Perl(metaclass=LanguageCls):
         """Sequence type options for Perl."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -185,7 +183,7 @@ class Perl(metaclass=LanguageCls):
         """Set type options for Perl."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -474,7 +472,7 @@ class Perl(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",
@@ -531,7 +529,7 @@ class Perl(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -11,9 +11,7 @@ from typing import ClassVar, cast
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -177,7 +175,7 @@ class Php(metaclass=LanguageCls):
         """Sequence type options for PHP."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -195,7 +193,7 @@ class Php(metaclass=LanguageCls):
         """Set type options for PHP."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -508,7 +506,7 @@ class Php(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="["),
+            dict_open=fixed_open(open_str="["),
             close="]",
             format_entry=self._dict_entry,
             empty_dict=None,
@@ -562,7 +560,7 @@ class Php(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="["),
+            ordered_map_open=fixed_open(open_str="["),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -136,7 +134,7 @@ class PowerShell(metaclass=LanguageCls):
         """Sequence type options for PowerShell."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="@("),
+            sequence_open=fixed_open(open_str="@("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -154,7 +152,7 @@ class PowerShell(metaclass=LanguageCls):
         """Set type options for PowerShell."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="@("),
+            set_open=fixed_open(open_str="@("),
             close=")",
             empty_set=None,
             preamble_lines=(),
@@ -430,7 +428,7 @@ class PowerShell(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="@{"),
+            dict_open=fixed_open(open_str="@{"),
             close="}",
             format_entry=self._dict_entry,
             empty_dict=None,
@@ -472,7 +470,7 @@ class PowerShell(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="[ordered]@{"),
+            ordered_map_open=fixed_open(open_str="[ordered]@{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -12,9 +12,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -536,7 +534,7 @@ class PureScript(metaclass=LanguageCls):
         """Sequence type options for PureScript."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="PList ["),
+            sequence_open=fixed_open(open_str="PList ["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -554,7 +552,7 @@ class PureScript(metaclass=LanguageCls):
         """Set type options for PureScript."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="PSet ["),
+            set_open=fixed_open(open_str="PSet ["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -817,7 +815,7 @@ class PureScript(metaclass=LanguageCls):
         """Sequence opener built from the configured constructor
         prefix.
         """
-        return fixed_sequence_open(
+        return fixed_open(
             open_str=f"{self.constructor_prefix}List [",
         )
 
@@ -839,7 +837,7 @@ class PureScript(metaclass=LanguageCls):
         """Configuration for the chosen set format."""
         return dataclasses.replace(
             self.set_format.value,
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Set [",
             ),
         )
@@ -853,7 +851,7 @@ class PureScript(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Dict [",
             ),
             close="]",
@@ -944,7 +942,7 @@ class PureScript(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Dict [",
             ),
             close="]",

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -14,9 +14,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -582,7 +580,7 @@ class Python(metaclass=LanguageCls):
         """Sequence type options for Python."""
 
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="("),
+            sequence_open=fixed_open(open_str="("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=True,
@@ -596,7 +594,7 @@ class Python(metaclass=LanguageCls):
             declared_type=None,
         )
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -619,7 +617,7 @@ class Python(metaclass=LanguageCls):
         """Set type options for Python."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="{"),
+            set_open=fixed_open(open_str="{"),
             close="}",
             empty_set="set()",
             preamble_lines=(),
@@ -627,7 +625,7 @@ class Python(metaclass=LanguageCls):
             supports_heterogeneity=True,
         )
         FROZENSET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="frozenset({"),
+            set_open=fixed_open(open_str="frozenset({"),
             close="})",
             empty_set="frozenset()",
             preamble_lines=(),
@@ -969,7 +967,7 @@ class Python(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -1026,7 +1024,7 @@ class Python(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="OrderedDict(["),
+            ordered_map_open=fixed_open(open_str="OrderedDict(["),
             close="])",
             preamble_lines=("from collections import OrderedDict",),
         )

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -10,9 +10,7 @@ from typing import ClassVar, cast
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -209,7 +207,7 @@ class R(metaclass=LanguageCls):
         """Sequence type options for R."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="list("),
+            sequence_open=fixed_open(open_str="list("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -227,7 +225,7 @@ class R(metaclass=LanguageCls):
         """Set type options for R."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="list("),
+            set_open=fixed_open(open_str="list("),
             close=")",
             empty_set=None,
             preamble_lines=(),
@@ -490,7 +488,7 @@ class R(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="list("),
+            dict_open=fixed_open(open_str="list("),
             close=")",
             format_entry=self.empty_dict_key,
             empty_dict=None,
@@ -537,7 +535,7 @@ class R(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="list("),
+            ordered_map_open=fixed_open(open_str="list("),
             close=")",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -110,7 +108,7 @@ class Racket(metaclass=LanguageCls):
         """Sequence type options for Racket."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="(list "),
+            sequence_open=fixed_open(open_str="(list "),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -128,7 +126,7 @@ class Racket(metaclass=LanguageCls):
         """Set type options for Racket."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="(set "),
+            set_open=fixed_open(open_str="(set "),
             close=")",
             empty_set="(set)",
             preamble_lines=(),
@@ -396,7 +394,7 @@ class Racket(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="(hash "),
+            dict_open=fixed_open(open_str="(hash "),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" ",
@@ -441,7 +439,7 @@ class Racket(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="(hash "),
+            ordered_map_open=fixed_open(open_str="(hash "),
             close=")",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -168,7 +166,7 @@ class Raku(metaclass=LanguageCls):
         """Sequence type options for Raku."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -186,7 +184,7 @@ class Raku(metaclass=LanguageCls):
         """Set type options for Raku."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -482,7 +480,7 @@ class Raku(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=" => ",
@@ -539,7 +537,7 @@ class Raku(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -11,9 +11,7 @@ from typing import ClassVar, cast
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -196,7 +194,7 @@ class Ruby(metaclass=LanguageCls):
         """Sequence type options for Ruby."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -214,7 +212,7 @@ class Ruby(metaclass=LanguageCls):
         """Set type options for Ruby."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="Set.new(["),
+            set_open=fixed_open(open_str="Set.new(["),
             close="])",
             empty_set="Set.new",
             preamble_lines=("require 'set'",),
@@ -519,7 +517,7 @@ class Ruby(metaclass=LanguageCls):
         """Configuration for dict formatting."""
         (format_entry,) = self.dict_entry_style.value
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=format_entry,
             empty_dict=None,
@@ -573,7 +571,7 @@ class Ruby(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -12,7 +12,7 @@ from typing import ClassVar, assert_never
 
 from beartype import beartype
 
-from literalizer._formatters.collection_openers import fixed_dict_open
+from literalizer._formatters.collection_openers import fixed_open
 from literalizer._formatters.format_dates import (
     format_date_iso,
     format_datetime_iso,
@@ -1038,7 +1038,7 @@ class Rust(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="HashMap::from(["),
+            ordered_map_open=fixed_open(open_str="HashMap::from(["),
             close="])",
             preamble_lines=("use std::collections::HashMap;",),
         )

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -13,9 +13,7 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
     TypeOpeners,
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
     make_type_to_opener,
     typed_collection_open,
     typed_dict_open,
@@ -270,7 +268,7 @@ class Scala(metaclass=LanguageCls):
         """Sequence type options for Scala."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="List("),
+            sequence_open=fixed_open(open_str="List("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -284,7 +282,7 @@ class Scala(metaclass=LanguageCls):
             declared_type=None,
         )
         SEQ = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="Seq("),
+            sequence_open=fixed_open(open_str="Seq("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -298,7 +296,7 @@ class Scala(metaclass=LanguageCls):
             declared_type=None,
         )
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="Array("),
+            sequence_open=fixed_open(open_str="Array("),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -316,7 +314,7 @@ class Scala(metaclass=LanguageCls):
         """Set type options for Scala."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="Set("),
+            set_open=fixed_open(open_str="Set("),
             close=")",
             empty_set=None,
             preamble_lines=(),
@@ -324,7 +322,7 @@ class Scala(metaclass=LanguageCls):
             supports_heterogeneity=True,
         )
         TREE_SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="TreeSet("),
+            set_open=fixed_open(open_str="TreeSet("),
             close=")",
             empty_set=None,
             preamble_lines=("import scala.collection.immutable.TreeSet",),
@@ -737,7 +735,7 @@ class Scala(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str="scala.collection.immutable.ListMap("
             ),
             close=")",

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -110,7 +108,7 @@ class Scheme(metaclass=LanguageCls):
         """Sequence type options for Scheme."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="(list "),
+            sequence_open=fixed_open(open_str="(list "),
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -128,7 +126,7 @@ class Scheme(metaclass=LanguageCls):
         """Set type options for Scheme."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="(list "),
+            set_open=fixed_open(open_str="(list "),
             close=")",
             empty_set="(list)",
             preamble_lines=(),
@@ -396,7 +394,7 @@ class Scheme(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="(list "),
+            dict_open=fixed_open(open_str="(list "),
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" ",
@@ -441,7 +439,7 @@ class Scheme(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="(list "),
+            ordered_map_open=fixed_open(open_str="(list "),
             close=")",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -13,9 +13,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
@@ -315,7 +313,7 @@ class Sml(metaclass=LanguageCls):
         """Sequence type options for Standard ML."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="SList ["),
+            sequence_open=fixed_open(open_str="SList ["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -333,7 +331,7 @@ class Sml(metaclass=LanguageCls):
         """Set type options for Standard ML."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="SSet ["),
+            set_open=fixed_open(open_str="SSet ["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -608,7 +606,7 @@ class Sml(metaclass=LanguageCls):
         """Configuration for the chosen sequence format."""
         return dataclasses.replace(
             self.sequence_format.value,
-            sequence_open=fixed_sequence_open(
+            sequence_open=fixed_open(
                 open_str=f"{self.constructor_prefix}List [",
             ),
         )
@@ -616,7 +614,7 @@ class Sml(metaclass=LanguageCls):
     @cached_property
     def sequence_open(self) -> Callable[[list[Value]], str]:
         """Callable that returns the opening delimiter for a sequence."""
-        return fixed_sequence_open(
+        return fixed_open(
             open_str=f"{self.constructor_prefix}List [",
         )
 
@@ -625,7 +623,7 @@ class Sml(metaclass=LanguageCls):
         """Configuration for the chosen set format."""
         return dataclasses.replace(
             self.set_format.value,
-            set_open=fixed_set_open(
+            set_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Set [",
             ),
         )
@@ -634,7 +632,7 @@ class Sml(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(
+            dict_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Map [",
             ),
             close="]",
@@ -715,7 +713,7 @@ class Sml(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(
+            ordered_map_open=fixed_open(
                 open_str=f"{self.constructor_prefix}Map [",
             ),
             close="]",

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -11,7 +11,7 @@ from typing import ClassVar, assert_never
 
 from beartype import beartype
 
-from literalizer._formatters.collection_openers import fixed_dict_open
+from literalizer._formatters.collection_openers import fixed_open
 from literalizer._formatters.format_dates import (
     format_date_iso,
     format_datetime_iso,
@@ -811,7 +811,7 @@ class Swift(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="["),
+            ordered_map_open=fixed_open(open_str="["),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -187,7 +185,7 @@ class SystemVerilog(metaclass=LanguageCls):
         """Sequence type options for SystemVerilog."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="'{"),
+            sequence_open=fixed_open(open_str="'{"),
             close="}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -205,7 +203,7 @@ class SystemVerilog(metaclass=LanguageCls):
         """Set type options for SystemVerilog."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="'{"),
+            set_open=fixed_open(open_str="'{"),
             close="}",
             empty_set="'{}",
             preamble_lines=(),
@@ -503,7 +501,7 @@ class SystemVerilog(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="'{"),
+            dict_open=fixed_open(open_str="'{"),
             close="}",
             format_entry=self._vkv_entry,
             empty_dict="'{}",
@@ -555,7 +553,7 @@ class SystemVerilog(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="'{"),
+            ordered_map_open=fixed_open(open_str="'{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -164,7 +162,7 @@ class Tcl(metaclass=LanguageCls):
         """Sequence type options."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="[list "),
+            sequence_open=fixed_open(open_str="[list "),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -182,7 +180,7 @@ class Tcl(metaclass=LanguageCls):
         """Set type options."""
 
         DICT = SetFormatConfig(
-            set_open=fixed_set_open(open_str="[dict create "),
+            set_open=fixed_open(open_str="[dict create "),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -443,7 +441,7 @@ class Tcl(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="[dict create "),
+            dict_open=fixed_open(open_str="[dict create "),
             close="]",
             format_entry=_format_tcl_dict_entry,
             empty_dict=None,
@@ -490,7 +488,7 @@ class Tcl(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="[dict create "),
+            ordered_map_open=fixed_open(open_str="[dict create "),
             close="]",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -12,9 +12,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -152,7 +150,7 @@ class Toml(metaclass=LanguageCls):
         """Sequence type options for TOML."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -170,7 +168,7 @@ class Toml(metaclass=LanguageCls):
         """Set type options for TOML."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -432,7 +430,7 @@ class Toml(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=_format_toml_dict_entry,
             empty_dict=None,
@@ -482,7 +480,7 @@ class Toml(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -14,9 +14,7 @@ from beartype import beartype
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -272,7 +270,7 @@ class TypeScript(metaclass=LanguageCls):
         """Sequence type options for TypeScript."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -286,7 +284,7 @@ class TypeScript(metaclass=LanguageCls):
             declared_type=None,
         )
         TUPLE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="] as const",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -304,7 +302,7 @@ class TypeScript(metaclass=LanguageCls):
         """Set type options for TypeScript."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="new Set(["),
+            set_open=fixed_open(open_str="new Set(["),
             close="])",
             empty_set="new Set()",
             preamble_lines=(),
@@ -382,7 +380,7 @@ class TypeScript(metaclass=LanguageCls):
         """Dict/map format options."""
 
         OBJECT = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -393,7 +391,7 @@ class TypeScript(metaclass=LanguageCls):
             narrowed_open=None,
         )
         MAP = DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="new Map<string, unknown>(["),
+            dict_open=fixed_open(open_str="new Map<string, unknown>(["),
             close="])",
             format_entry=dict_entry_with_template(
                 template="[{key}, {value}]",
@@ -724,7 +722,7 @@ class TypeScript(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -12,9 +12,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -137,7 +135,7 @@ class V(metaclass=LanguageCls):
         """Sequence type options for V."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -155,7 +153,7 @@ class V(metaclass=LanguageCls):
         """Set type options for V."""
 
         ARRAY = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -459,7 +457,7 @@ class V(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -517,7 +515,7 @@ class V(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -10,9 +10,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -121,7 +119,7 @@ class Wren(metaclass=LanguageCls):
         """Sequence type options for Wren."""
 
         LIST = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -139,7 +137,7 @@ class Wren(metaclass=LanguageCls):
         """Set type options for Wren."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="{"),
+            set_open=fixed_open(open_str="{"),
             close="}",
             empty_set=None,
             preamble_lines=(),
@@ -416,7 +414,7 @@ class Wren(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=self._dict_entry,
             empty_dict=None,
@@ -468,7 +466,7 @@ class Wren(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -11,9 +11,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     date_iso_formatter,
@@ -128,7 +126,7 @@ class Yaml(metaclass=LanguageCls):
         """Sequence type options for YAML."""
 
         SEQUENCE = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str="["),
+            sequence_open=fixed_open(open_str="["),
             close="]",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -146,7 +144,7 @@ class Yaml(metaclass=LanguageCls):
         """Set type options for YAML."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str="["),
+            set_open=fixed_open(open_str="["),
             close="]",
             empty_set=None,
             preamble_lines=(),
@@ -403,7 +401,7 @@ class Yaml(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str="{"),
+            dict_open=fixed_open(open_str="{"),
             close="}",
             format_entry=dict_entry_with_separator(
                 separator=": ",
@@ -456,7 +454,7 @@ class Yaml(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str="{"),
+            ordered_map_open=fixed_open(open_str="{"),
             close="}",
             preamble_lines=(),
         )

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -13,9 +13,7 @@ from typing import ClassVar
 from beartype import beartype
 
 from literalizer._formatters.collection_openers import (
-    fixed_dict_open,
-    fixed_sequence_open,
-    fixed_set_open,
+    fixed_open,
 )
 from literalizer._formatters.format_dates import (
     format_date_iso,
@@ -203,7 +201,7 @@ class Zig(metaclass=LanguageCls):
         """Sequence type options for Zig."""
 
         ARRAY = SequenceFormatConfig(
-            sequence_open=fixed_sequence_open(open_str=".{ .arr = &.{"),
+            sequence_open=fixed_open(open_str=".{ .arr = &.{"),
             close="}}",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
@@ -221,7 +219,7 @@ class Zig(metaclass=LanguageCls):
         """Set type options for Zig."""
 
         SET = SetFormatConfig(
-            set_open=fixed_set_open(open_str=".{ .set = &.{"),
+            set_open=fixed_open(open_str=".{ .set = &.{"),
             close="}}",
             empty_set=None,
             preamble_lines=(),
@@ -531,7 +529,7 @@ class Zig(metaclass=LanguageCls):
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
         return DictFormatConfig(
-            dict_open=fixed_dict_open(open_str=".{ .map = &.{"),
+            dict_open=fixed_open(open_str=".{ .map = &.{"),
             close="}}",
             format_entry=dict_entry_with_template(
                 template=".{{ .key = {key}, .val = {value} }}",
@@ -591,7 +589,7 @@ class Zig(metaclass=LanguageCls):
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
         return OrderedMapFormatConfig(
-            ordered_map_open=fixed_dict_open(open_str=".{ .map = &.{"),
+            ordered_map_open=fixed_open(open_str=".{ .map = &.{"),
             close="}}",
             preamble_lines=(),
         )


### PR DESCRIPTION
## Summary

Three public helpers in `collection_openers.py` (`fixed_set_open`, `fixed_sequence_open`, `fixed_dict_open`) had identical closures and differed only in the type hint of an unused parameter. Consolidated them into a single `fixed_open` returning `Callable[[list[Value] | dict[str, Value]], str]`, which is assignable to every sequence/set/dict/ordered-map opener field by parameter contravariance. Updated ~60 language modules, docs, and CHANGELOG; all 465 non-integration tests pass.

Closes #1189

## Test plan

- [ ] CI passes (mypy, pyright, ruff, pytest)
- [ ] Verify CHANGELOG entry renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior should be unchanged but this is a public, breaking API rename that will require downstream call-site updates and could surface typing incompatibilities in user code.
> 
> **Overview**
> **Breaking API change:** removes `fixed_set_open`, `fixed_sequence_open`, and `fixed_dict_open` and replaces them with a single `fixed_open(open_str=...)` helper for fixed collection delimiters.
> 
> Updates public exports, docs, and format factories, and migrates all language definitions to use `fixed_open` for sequence/set/dict/ordered-map openers; implementation is simplified to one closure that ignores items and returns `open_str`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53b44befa0668fa3f1148ef58855d6ee9955ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->