### PR TITLE
Fix null-filter collapse in _compute_dict_open_override (#1208)

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -311,9 +311,13 @@ def _compute_dict_open_override(
         return None
 
     # Types differ: combine all values to infer the widened type.
+    # Use the unfiltered dicts so that ``None`` values contribute
+    # "unknown type" to the widening — otherwise a dict that filters
+    # to ``{}`` would narrow the widened type to the other dicts'
+    # concrete value type, losing the null slot's uncertainty.
     combined: dict[str, Value] = {}
     idx = 0
-    for d in filtered_dicts:
+    for d in dicts:
         for v in d.values():
             combined[f"_k{idx}"] = v
             idx += 1

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,8 +1,10 @@
 """Language-specific tests for literalizer converter."""
 
+import dataclasses
 import json
 import re
 import textwrap
+from typing import ClassVar
 
 import pytest
 from pygments.lexers import find_lexer_class_by_name
@@ -24,6 +26,7 @@ from literalizer.exceptions import (
 )
 from literalizer.languages import (
     Cobol,
+    Dart,
     Fortran,
     FSharp,
     Go,
@@ -52,6 +55,140 @@ JAVA = Java(
     bytes_format=Java.bytes_formats.HEX,
     sequence_format=Java.sequence_formats.ARRAY,
 )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class _DartSkipNulls(Dart):
+    """Dart subclass that skips null dict values.
+
+    The widening bug in
+    :func:`~literalizer._literalize._compute_dict_open_override` only
+    manifests when a language combines a value-type-sensitive
+    ``dict_open`` (produced by
+    :func:`~literalizer._formatters.collection_openers.typed_dict_open`)
+    with ``skip_null_dict_values=True``.  No production language pairs
+    those two today — the ``typed_dict_open`` languages (Dart, CSharp,
+    Kotlin, Scala, Go) all keep nulls, while the
+    ``skip_null_dict_values=True`` languages (Java, Lua, Toml, Wren)
+    all use ``fixed_dict_open`` whose constant opener never triggers
+    widening.
+
+    That is also why these tests live here rather than in the
+    ``tests/integration/cases/`` golden-file suite, which iterates over
+    :data:`~literalizer.languages.ALL_LANGUAGES` and has no way to
+    inject a test-only language.
+    """
+
+    skip_null_dict_values: ClassVar[bool] = True
+
+
+def test_dart_skip_nulls_widens_across_null_masked_types() -> None:
+    """Widening fires when null-masked dict value types differ.
+
+    With ``skip_null_dict_values=True``, filtering ``None`` out of
+    ``{"a": None, "b": 1}`` and ``{"a": "hello", "b": None}`` leaves
+    dicts whose remaining value types diverge (``int`` vs. ``String``).
+    The override must widen so both dicts share a ``dynamic`` opener.
+    """
+    source = '[{"a": null, "b": 1}, {"a": "hello", "b": null}]'
+    result = literalize(
+        source=source,
+        input_format=InputFormat.JSON,
+        language=_DartSkipNulls(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=None,
+    )
+    expected = textwrap.dedent(
+        text="""\
+        <Map<String, dynamic>>[
+            <String, dynamic>{"b": 1},
+            <String, dynamic>{"a": "hello"},
+        ]""",
+    )
+    assert result.code == expected
+
+
+def test_dart_skip_nulls_widens_when_one_dict_collapses_to_empty() -> None:
+    """Widening fires when one dict collapses to ``{}`` and another is
+    typed.
+
+    ``{"a": None}`` filters to ``{}`` (fallback opener), while
+    ``{"x": 1}`` filters to ``{"x": 1}`` (``<String, int>``).  The
+    override must widen both to the fallback so the sequence is
+    consistent.
+    """
+    source = '[{"a": null}, {"x": 1}]'
+    result = literalize(
+        source=source,
+        input_format=InputFormat.JSON,
+        language=_DartSkipNulls(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=None,
+    )
+    expected = textwrap.dedent(
+        text="""\
+        <Map<String, dynamic>>[
+            <String, dynamic>{},
+            <String, dynamic>{"x": 1},
+        ]""",
+    )
+    assert result.code == expected
+
+
+def test_dart_skip_nulls_no_widening_when_all_dicts_collapse_to_empty() -> (
+    None
+):
+    """No override is needed when every dict collapses to ``{}``.
+
+    Two all-null dicts filter to ``{}`` each.  Both render with the
+    fallback ``<String, dynamic>{`` opener on their own, so widening
+    would be a no-op.
+    """
+    source = '[{"a": null}, {"b": null}]'
+    result = literalize(
+        source=source,
+        input_format=InputFormat.JSON,
+        language=_DartSkipNulls(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=None,
+    )
+    expected = textwrap.dedent(
+        text="""\
+        <Map<String, dynamic>>[
+            <String, dynamic>{},
+            <String, dynamic>{},
+        ]""",
+    )
+    assert result.code == expected
+
+
+def test_dart_skip_nulls_no_widening_when_filtered_dicts_match() -> None:
+    """No override is needed when filtered dicts all share one opener.
+
+    Null masks hide keys ``a`` and ``b`` in each dict, leaving only
+    ``{"n": 1}`` and ``{"n": 2}`` — both ``<String, int>``.  Widening
+    would be redundant; each dict renders with its own inferred opener.
+    """
+    source = '[{"a": null, "n": 1}, {"b": null, "n": 2}]'
+    result = literalize(
+        source=source,
+        input_format=InputFormat.JSON,
+        language=_DartSkipNulls(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=None,
+    )
+    expected = textwrap.dedent(
+        text="""\
+        <Map<String, dynamic>>[
+            <String, int>{"n": 1},
+            <String, int>{"n": 2},
+        ]""",
+    )
+    assert result.code == expected
 
 
 def test_java_yaml_dict_null_values_with_comments() -> None:


### PR DESCRIPTION
## Summary

Fixes #1208.

When a language pairs `skip_null_dict_values=True` with a value-type-sensitive `dict_open`, the widening path filtered nulls out of the combined dict, dropping the "unknown type" contribution of null slots. A sequence like `[{"a": null}, {"x": 1}]` widened to `Map<String, int>` instead of the correct `Map<String, dynamic>`.

The fix sources combined values from the unfiltered dicts. No production language pairs `typed_dict_open` with `skip_null_dict_values=True` today, so the regression tests use a `_DartSkipNulls` fake subclass (and their docstrings explain why they can't live in `tests/integration/cases/`).

## Test plan

- [x] 4 new unit tests in `tests/test_languages.py` — one fails before the fix, all pass after
- [x] Full suite: 863 passed, 12,822 subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core collection type-widening logic that can change emitted literal types for sequences of dicts (especially for languages that skip null dict values), though the change is small and covered by targeted tests.
> 
> **Overview**
> Fixes dict type-widening in `_compute_dict_open_override` when a language skips null dict values: the widening now infers the combined map value type from the *unfiltered* dicts so `None` slots still force an “unknown/dynamic” widening instead of incorrectly narrowing when a dict collapses to `{}`.
> 
> Adds a test-only `_DartSkipNulls` language and four unit tests covering null-masked type divergence, a dict collapsing to empty, and two no-op cases where widening should not occur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e17240e4653245eae805e32ddbca3fe15f6124d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->