### PR TITLE
Add function call rendering to C

### DIFF
--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -38,8 +38,6 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
-    CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -49,6 +47,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -108,6 +107,69 @@ def _make_format_c_entry(
         )
 
     return _format_c_entry
+
+
+def _c_call_stub(
+    name: str,
+    params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return C stub declarations for a call name.
+
+    C has no member functions and no type-generic function templates,
+    so dotted targets are modeled as a nested chain of ``struct`` types
+    whose leaf field is a function pointer declared with an
+    unspecified (K&R-style) argument list.  Simple targets are emitted
+    as forward declarations with the same unspecified list so the
+    caller may pass any arguments.  A leading pragma suppresses the
+    ``-Wdeprecated-non-prototype`` warning that clang emits for these
+    intentionally type-erased call sites.
+    """
+    del params
+    return_keyword = "int" if stub_return is StubReturn.VALUE else "void"
+    return_body = " return 0; " if stub_return is StubReturn.VALUE else ""
+    pragma = '#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"'
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (pragma, f"{return_keyword} {parts[0]}();")
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    stub_fn = "_".join((*parts, "stub_"))
+    if not fields:
+        type_name = f"{root}Type_"
+        return (
+            pragma,
+            f"static {return_keyword} {stub_fn}() {{{return_body}}}",
+            f"struct {type_name} {{ {return_keyword} (*{method})(); }};",
+            f"static const struct {type_name} {root} = "
+            f"{{ .{method} = {stub_fn} }};",
+        )
+    lines: list[str] = [
+        pragma,
+        f"static {return_keyword} {stub_fn}() {{{return_body}}}",
+    ]
+    inner_type = f"{fields[-1]}Type_"
+    lines.append(
+        f"struct {inner_type} {{ {return_keyword} (*{method})(); }};",
+    )
+    prev_type = inner_type
+    for i in range(len(fields) - 2, -1, -1):
+        curr_type = f"{fields[i]}Type_"
+        lines.append(
+            f"struct {curr_type} {{ struct {prev_type} {fields[i + 1]}; }};",
+        )
+        prev_type = curr_type
+    root_type = f"{root}Type_"
+    lines.append(
+        f"struct {root_type} {{ struct {prev_type} {fields[0]}; }};",
+    )
+    init = f"{{ .{method} = {stub_fn} }}"
+    for field in reversed(fields):
+        init = f"{{ .{field} = {init} }}"
+    lines.append(f"static const struct {root_type} {root} = {init};")
+    return tuple(lines)
 
 
 @beartype
@@ -312,6 +374,8 @@ class C(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """C call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -400,9 +464,12 @@ class C(metaclass=LanguageCls):
     statement_terminator: ClassVar[str] = ";"
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ("#include <math.h>",)
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+    call_style: CallStyles = CallStyles.POSITIONAL
+
+    @cached_property
+    def call_style_config(self) -> PositionalCallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
@@ -433,7 +500,7 @@ class C(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return no_call_stub
+        return _c_call_stub
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/tests/integration/cases/call_deep_dotted_method/C_call.c
+++ b/tests/integration/cases/call_deep_dotted_method/C_call.c
@@ -1,0 +1,26 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static void obj_api_client_post_stub_() {}
+struct clientType_ { void (*post)(); };
+struct apiType_ { struct clientType_ client; };
+struct objType_ { struct apiType_ api; };
+static const struct objType_ obj = { .api = { .client = { .post = obj_api_client_post_stub_ } } };
+void check_(void) {
+obj.api.client.post("hello");
+obj.api.client.post(42);
+obj.api.client.post(((CVal){.b = true}));
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/C_call.c
+++ b/tests/integration/cases/call_deep_dotted_transformed/C_call.c
@@ -1,0 +1,27 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static int app_client_fetch_stub_() { return 0; }
+struct clientType_ { int (*fetch)(); };
+struct appType_ { struct clientType_ client; };
+static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+void emit();
+void check_(void) {
+emit(app.client.fetch("hello"));
+emit(app.client.fetch(42));
+emit(app.client.fetch(((CVal){.b = true})));
+}

--- a/tests/integration/cases/call_dotted_method/C_call.c
+++ b/tests/integration/cases/call_dotted_method/C_call.c
@@ -1,0 +1,25 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static void app_client_fetch_stub_() {}
+struct clientType_ { void (*fetch)(); };
+struct appType_ { struct clientType_ client; };
+static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
+void check_(void) {
+app.client.fetch("hello");
+app.client.fetch(42);
+app.client.fetch(((CVal){.b = true}));
+}

--- a/tests/integration/cases/call_keyword_args/C_call.c
+++ b/tests/integration/cases/call_keyword_args/C_call.c
@@ -1,0 +1,25 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static int throttler_check_stub_() { return 0; }
+struct throttlerType_ { int (*check)(); };
+static const struct throttlerType_ throttler = { .check = throttler_check_stub_ };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+void emit();
+void check_(void) {
+emit(throttler.check("user_1", 1000.0));
+emit(throttler.check("user_2", 2000.5));
+}

--- a/tests/integration/cases/call_scalar_args/C_call.c
+++ b/tests/integration/cases/call_scalar_args/C_call.c
@@ -1,0 +1,22 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+void process();
+void check_(void) {
+process("hello");
+process(42);
+process(((CVal){.b = true}));
+}

--- a/tests/integration/cases/call_transform_no_wrapper/C_call.c
+++ b/tests/integration/cases/call_transform_no_wrapper/C_call.c
@@ -1,0 +1,22 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+int process();
+void check_(void) {
+process("hello");
+process(42);
+process(((CVal){.b = true}));
+}


### PR DESCRIPTION
## Summary
- Adds ``literalize_call`` support to C by populating ``C.CallStyles`` with ``POSITIONAL`` and implementing ``_c_call_stub`` for simple, dotted, and deep-dotted targets.
- Stubs use K&R-style prototypes on function pointers inside a nested chain of ``struct`` types (dotted targets) or forward declarations (simple targets), with a leading pragma silencing clang's ``-Wdeprecated-non-prototype`` at the call sites.
- Adds six C golden files under ``tests/integration/cases/call_*/C_call.c`` covering scalar, keyword-args, dotted, deep-dotted, deep-dotted-transformed, and transform-no-wrapper cases.

Closes #1108.

## Test plan
- [x] Full ``uv run pytest tests/`` suite passes (883 tests, 12825 subtests)
- [x] All six C golden files pass ``clang -fsyntax-only -std=c11 -Wall -Wextra -Werror``
- [x] Existing non-call C goldens still compile under clang
- [x] ``ruff``, ``mypy``, ``pyright``, ``ty``, ``pylint`` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new call-rendering behavior for the C backend, including generated file-scope stubs and pragmas; risk is mainly incorrect stub generation or name collisions causing C output to fail to compile in edge cases.
> 
> **Overview**
> Adds `literalize_call` support for the C backend by introducing a positional call style and generating C-compatible call preamble stubs via `_c_call_stub`.
> 
> The new stub generator emits forward declarations for simple calls and models dotted/deep-dotted targets as nested `struct` chains with function-pointer leaves, including a clang pragma to silence non-prototype warnings. Integration “golden” C outputs are added to cover scalar calls, keyword-like args rendering, dotted/deep-dotted calls, and transformed call cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a1488b3e3c5c873ed6b460ec671cc5c1124db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->