### PR TITLE
Fix pre_indent_level interaction with NewVariable wrapping (#1378)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- Fixed ``pre_indent_level`` interaction with ``NewVariable`` and
+  ``ExistingVariable``: a multi-line value no longer inserts the
+  pre-indent between ``=`` and the value (and no longer doubly
+  indents continuation lines).  Every line of the wrapped declaration
+  or assignment is now uniformly offset by ``pre_indent_level``.
 - **Breaking:** Replaced the three public collection-opener helpers
   ``fixed_set_open``, ``fixed_sequence_open``, and ``fixed_dict_open``
   with a single ``fixed_open``.  They had identical implementations

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -784,26 +784,42 @@ def _apply_variable_wrapper(
     language: Language,
     data: Value,
     variable_form: NewVariable | ExistingVariable | None,
+    line_prefix: str,
 ) -> str:
     """Optionally wrap *result* in a variable declaration or
     assignment.
+
+    *result* arrives with *line_prefix* already prepended to every
+    line.  When wrapping in a variable form the leading prefix on the
+    first line is stripped so the value sits flush against the
+    declaration's ``=``, then re-prepended once to the entire wrapped
+    output.  This keeps every line uniformly indented instead of
+    doubly-indenting continuation lines.
     """
+    if variable_form is None:
+        return result
+
+    if line_prefix and result.startswith(line_prefix):
+        value = result[len(line_prefix) :]
+    else:
+        value = result
+
     match variable_form:
-        case None:
-            return result
         case NewVariable(name=name, modifiers=modifiers):
-            return language.format_variable_declaration(
+            wrapped = language.format_variable_declaration(
                 name,
-                result,
+                value,
                 data,
                 modifiers,
             )
         case _:
-            return language.format_variable_assignment(
+            wrapped = language.format_variable_assignment(
                 variable_form.name,
-                result,
+                value,
                 data,
             )
+
+    return line_prefix + wrapped
 
 
 @dataclasses.dataclass(frozen=True)
@@ -912,6 +928,7 @@ def _literalize_apply_form(
         language=language,
         data=pre_form.data,
         variable_form=variable_form,
+        line_prefix=pre_form.line_prefix,
     )
 
     resolved = pre_form.resolved

--- a/tests/integration/cases/simple_dict/CSharp_pre_indent_1_public_static_readonly.cs
+++ b/tests/integration/cases/simple_dict/CSharp_pre_indent_1_public_static_readonly.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+class Check {
+    public static readonly Dictionary<string, object> my_data = new Dictionary<string, object> {
+        ["name"] = "Alice",
+        ["age"] = 30,
+        ["active"] = true,
+        ["score"] = (object?)null
+    };
+    public static void Main() {}
+}

--- a/tests/integration/cases/simple_dict/Cpp_pre_indent_1_static_const.cpp
+++ b/tests/integration/cases/simple_dict/Cpp_pre_indent_1_static_const.cpp
@@ -1,0 +1,13 @@
+#include <initializer_list>
+#include <string>
+#include <cstddef>
+#include <map>
+#include <variant>
+void check_() {
+    static const auto my_data = std::map<std::string, std::variant<std::string, int, bool, std::nullptr_t>>{
+        {"name", "Alice"},
+        {"age", 30},
+        {"active", true},
+        {"score", nullptr},
+    };
+}

--- a/tests/integration/cases/simple_dict/Java_pre_indent_1_public_static_final.java
+++ b/tests/integration/cases/simple_dict/Java_pre_indent_1_public_static_final.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Check {
+    public static final Map<String, Object> my_data = Map.ofEntries(
+        Map.entry("name", "Alice"),
+        Map.entry("age", 30),
+        Map.entry("active", true)
+    );
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1720,6 +1720,94 @@ def test_line_ending_combined_variable_forms(
     )
 
 
+@dataclasses.dataclass
+class _PreIndentCase:
+    """A ``pre_indent_level`` golden-file test case.
+
+    Exercises the interaction between ``pre_indent_level > 0`` and a
+    ``NewVariable`` form with a class-field modifier combination —
+    the scenario that previously placed the indent between ``=`` and a
+    multi-line value and doubly indented continuation lines.
+    """
+
+    name: str
+    lang_cls: literalizer.LanguageCls
+    case_dir_name: str
+    pre_indent_level: int
+    modifiers: frozenset[enum.Enum]
+
+
+@functools.cache
+@beartype
+def _build_pre_indent_cases() -> list[_PreIndentCase]:
+    """Build ``pre_indent_level`` cases keyed off
+    ``modifier_combinations``.
+
+    Languages whose ``wrap_in_file`` recognizes class-field modifiers
+    (``Java``, ``CSharp``, ``Cpp``) place the declaration directly at
+    class scope, so a non-zero ``pre_indent_level`` produces output
+    that is both syntactically valid and visually demonstrates the
+    fix: the declaration line carries the indent, the value sits flush
+    against ``=``, and continuation lines keep their relative offsets.
+    """
+    cases: list[_PreIndentCase] = []
+    case_dir_name = "simple_dict"
+    for lang_cls in _sorted_languages():
+        cases.extend(
+            _PreIndentCase(
+                name=f"{lang_cls.__name__}_pre_indent_1_{combo.name}",
+                lang_cls=lang_cls,
+                case_dir_name=case_dir_name,
+                pre_indent_level=1,
+                modifiers=combo.modifiers,
+            )
+            for combo in lang_cls.modifier_combinations
+        )
+    return cases
+
+
+@pytest.mark.parametrize(
+    argnames="case",
+    argvalues=_build_pre_indent_cases(),
+    ids=[c.name for c in _build_pre_indent_cases()],
+)
+def test_pre_indent_level_with_new_variable_golden_file(
+    case: _PreIndentCase,
+    cases_dir: Path,
+    file_regression: FileRegressionFixture,
+) -> None:
+    """``pre_indent_level > 0`` with ``NewVariable`` produces uniformly
+    indented output.
+
+    Regression test for the bug where the first line of a multi-line
+    value was inserted after ``=`` with the indent baked in, producing
+    extra spaces between ``=`` and the value and shifting continuation
+    lines by an extra indent.
+    """
+    input_path = cases_dir / case.case_dir_name / "input.yaml"
+    yaml_string = input_path.read_text()
+    spec = _spec(lang_cls=case.lang_cls)
+    result = literalizer.literalize(
+        source=yaml_string,
+        input_format=literalizer.InputFormat.YAML,
+        language=spec,
+        pre_indent_level=case.pre_indent_level,
+        include_delimiters=True,
+        variable_form=literalizer.NewVariable(
+            name="my_data",
+            modifiers=case.modifiers,
+        ),
+        wrap_in_file=True,
+    )
+    _check_golden(
+        file_regression=file_regression,
+        contents=result.code + "\n",
+        extension=spec.extension,
+        newline=None,
+        golden_path=input_path.parent / (case.name + spec.extension),
+    )
+
+
 def test_no_dead_golden_files(request: pytest.FixtureRequest) -> None:
     """Every file under ``cases/`` must be referenced by a parameterized
     test.  Orphaned golden files silently rot and waste repository space.
@@ -1759,6 +1847,14 @@ def test_no_dead_golden_files(request: pytest.FixtureRequest) -> None:
             cases_dir
             / line_ending_case.case_dir_name
             / (line_ending_case.name + line_ending_spec.extension)
+        )
+
+    for pre_indent_case in _build_pre_indent_cases():
+        ext = pre_indent_case.lang_cls.extension
+        expected.add(
+            cases_dir
+            / pre_indent_case.case_dir_name
+            / (pre_indent_case.name + ext)
         )
 
     for call_case in _discover_call_cases():


### PR DESCRIPTION
## Summary

- Fixes #1378: ``pre_indent_level > 0`` combined with a ``NewVariable`` (or ``ExistingVariable``) form previously inserted the indent between ``=`` and a multi-line value's first line and doubly indented continuation lines.
- ``_apply_variable_wrapper`` now strips the leading ``line_prefix`` from the formatted value before composing the declaration template, then re-prepends it once to the wrapped output, so every line is uniformly offset.
- Adds a parameterized golden-file integration test (``test_pre_indent_level_with_new_variable_golden_file``) that exercises every language with class-field ``modifier_combinations`` (Java, C#, C++) at ``pre_indent_level=1``, with three new goldens under ``tests/integration/cases/simple_dict/``.

## Test plan

- [x] ``uv run pytest`` (890 passed, 294 skipped, 12825 subtests)
- [x] Verified the bug-report reproduction now produces the expected uniformly-indented output for Java, C#, and C++

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core variable-wrapping formatting for `pre_indent_level`, which can subtly alter generated code across languages when using `NewVariable`/`ExistingVariable` and multiline values.
> 
> **Overview**
> Fixes a formatting bug where `pre_indent_level > 0` combined with `NewVariable`/`ExistingVariable` could insert indentation between `=` and the first line of a multiline value and double-indent continuation lines. `_apply_variable_wrapper` now strips the leading `line_prefix` from the value before rendering the declaration/assignment, then prepends `line_prefix` once to the wrapped result to keep all lines uniformly indented.
> 
> Adds parameterized golden-file integration coverage for this scenario across languages with class-field `modifier_combinations` (with new C#, C++, and Java goldens), and updates the dead-golden-file detector to include these new cases. Updates `CHANGELOG.rst` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1278bdf6ea3529c3b8cd588c27e811e41e2119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->