### PR TITLE
Add function call rendering to Common Lisp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- Added ``literalize_call`` support for Common Lisp:
+  ``CommonLisp.format_call_stub`` emits ``defun`` stubs with
+  ``&rest args`` so generated definitions accept any mix of positional
+  and keyword arguments, and ``CommonLisp.CallStyles.PREFIX_KEYWORD``
+  renders calls as ``(func :name value)``.
 - Added ``literalize_call`` support for Racket:
   ``Racket.format_call_stub`` now generates
   ``make-keyword-procedure`` stub definitions, and a new

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -33,7 +33,6 @@ from literalizer._formatters.format_strings import format_string_double_minimal
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -43,6 +42,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     LanguageCls,
     OrderedMapFormatConfig,
+    PrefixCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -66,6 +66,32 @@ def _format_cons_entry(
 ) -> str:
     """Format a Common Lisp association-list entry as a ``cons`` pair."""
     return f"(cons {key} {formatted_value})"
+
+
+def _common_lisp_call_stub(
+    name: str,
+    _params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Common Lisp stub definitions for a call name.
+
+    For dotted names like ``app.client.fetch``, one ``defun`` is
+    emitted per prefix so that intermediate identifiers are bound.
+    Each stub declares ``&rest args`` and ignores them, so the
+    generated function accepts any combination of positional and
+    keyword arguments — necessary because the same formatter is used
+    both for the call target (invoked with ``:key value`` pairs) and
+    for transform wrapper functions (invoked positionally).  Stub
+    bodies return ``nil`` for void stubs and ``0`` for value stubs.
+    """
+    body = "nil" if stub_return is StubReturn.VOID else "0"
+    parts = name.split(sep=".")
+    return tuple(
+        f"(defun {'.'.join(parts[: i + 1])} "
+        f"(&rest args) (declare (ignore args)) {body})"
+        for i in range(len(parts))
+    )
 
 
 @beartype
@@ -264,6 +290,11 @@ class CommonLisp(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """CommonLisp call style options."""
 
+        PREFIX_KEYWORD = PrefixCallStyle(
+            arg_separator=" ",
+            keyword_prefix=":",
+        )
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -329,6 +360,7 @@ class CommonLisp(metaclass=LanguageCls):
     numeric_style: NumericStyles = NumericStyles.OVERLOADED
     string_format: StringFormats = StringFormats.DOUBLE
     trailing_comma: TrailingCommas = TrailingCommas.NO
+    call_style: CallStyles = CallStyles.PREFIX_KEYWORD
     line_ending: LineEndings = LineEndings.SEMICOLON
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
@@ -348,9 +380,11 @@ class CommonLisp(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for Common Lisp's call style."""
+        return self.call_style.value
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -399,7 +433,7 @@ class CommonLisp(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _common_lisp_call_stub
 
     @cached_property
     def format_call_preamble_stub(

--- a/tests/integration/cases/call_deep_dotted_method/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_deep_dotted_method/CommonLisp_call.lisp
@@ -1,0 +1,7 @@
+(defun obj (&rest args) (declare (ignore args)) nil)
+(defun obj.api (&rest args) (declare (ignore args)) nil)
+(defun obj.api.client (&rest args) (declare (ignore args)) nil)
+(defun obj.api.client.post (&rest args) (declare (ignore args)) nil)
+(obj.api.client.post :data "hello")
+(obj.api.client.post :data 42)
+(obj.api.client.post :data t)

--- a/tests/integration/cases/call_deep_dotted_transformed/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_deep_dotted_transformed/CommonLisp_call.lisp
@@ -1,0 +1,7 @@
+(defun app (&rest args) (declare (ignore args)) 0)
+(defun app.client (&rest args) (declare (ignore args)) 0)
+(defun app.client.fetch (&rest args) (declare (ignore args)) 0)
+(defun emit (&rest args) (declare (ignore args)) nil)
+(emit (app.client.fetch :payload "hello"))
+(emit (app.client.fetch :payload 42))
+(emit (app.client.fetch :payload t))

--- a/tests/integration/cases/call_dotted_method/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_dotted_method/CommonLisp_call.lisp
@@ -1,0 +1,6 @@
+(defun app (&rest args) (declare (ignore args)) nil)
+(defun app.client (&rest args) (declare (ignore args)) nil)
+(defun app.client.fetch (&rest args) (declare (ignore args)) nil)
+(app.client.fetch :payload "hello")
+(app.client.fetch :payload 42)
+(app.client.fetch :payload t)

--- a/tests/integration/cases/call_keyword_args/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_keyword_args/CommonLisp_call.lisp
@@ -1,0 +1,5 @@
+(defun throttler (&rest args) (declare (ignore args)) 0)
+(defun throttler.check (&rest args) (declare (ignore args)) 0)
+(defun emit (&rest args) (declare (ignore args)) nil)
+(emit (throttler.check :user_id "user_1" :ts 1000.0))
+(emit (throttler.check :user_id "user_2" :ts 2000.5))

--- a/tests/integration/cases/call_per_element_false/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_per_element_false/CommonLisp_call.lisp
@@ -1,0 +1,2 @@
+(defun process (&rest args) (declare (ignore args)) nil)
+(process :data 1)

--- a/tests/integration/cases/call_scalar_args/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_scalar_args/CommonLisp_call.lisp
@@ -1,0 +1,4 @@
+(defun process (&rest args) (declare (ignore args)) nil)
+(process :value "hello")
+(process :value 42)
+(process :value t)

--- a/tests/integration/cases/call_transform_no_wrapper/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_transform_no_wrapper/CommonLisp_call.lisp
@@ -1,0 +1,4 @@
+(defun process (&rest args) (declare (ignore args)) 0)
+(process :value "hello")
+(process :value 42)
+(process :value t)


### PR DESCRIPTION
## Summary
- Wire `CommonLisp` through `PrefixCallStyle` with a `PREFIX_KEYWORD` variant (`:` prefix, space separator) so `literalize_call` renders `(func :name value)`.
- Implement `_common_lisp_call_stub` to emit `(defun name (&rest args) (declare (ignore args)) nil|0)`, one per dotted prefix; the `&rest` signature lets one stub accept both keyword-style target calls and positional transform-wrapper calls.
- Add seven golden files (all six base call cases plus `call_per_element_false`), validated by loading each in SBCL.

Closes #1111.

## Test plan
- [x] `pytest tests/` — 931 passed, 12,825 subtests
- [x] Each new `.lisp` golden file loads cleanly with `sbcl --non-interactive --load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Common Lisp call rendering/stub generation and add golden integration outputs without affecting other languages’ call paths.
> 
> **Overview**
> Adds Common Lisp support to `literalize_call` by wiring `CommonLisp` to a new `CallStyles.PREFIX_KEYWORD` (`(func :name value)` formatting) via `PrefixCallStyle`.
> 
> Implements `_common_lisp_call_stub` so generated call stubs emit one `defun` per dotted-name prefix using `&rest args` (ignored) and returning `nil`/`0`, and updates integration golden files to cover scalar/keyword/dotted/transform/per-element call cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5b05bf992a328819c4aad7b3df98f0903e5434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->