### PR TITLE
Add missing @beartype decorators in _checks, _literalize, _parsing

### DIFF
--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -106,6 +106,7 @@ def _values_mixed_types(*, values: Sequence[Value]) -> bool:
     return len(families) > 1
 
 
+@beartype
 def _collect_scalar_type_names(*, data: Value) -> set[str]:
     """Collect the names of scalar type buckets found in *data*."""
     names: set[str] = set()
@@ -124,6 +125,7 @@ def _collect_scalar_type_names(*, data: Value) -> set[str]:
     return names
 
 
+@beartype
 def _describe_heterogeneous_types(*, data: Value) -> str:
     """Return a sorted, comma-separated string of scalar type names in
     *data*.
@@ -131,6 +133,7 @@ def _describe_heterogeneous_types(*, data: Value) -> str:
     return ", ".join(sorted(_collect_scalar_type_names(data=data)))
 
 
+@beartype
 def _find_first_mixed_values(
     *,
     data: Value,
@@ -165,6 +168,7 @@ def _find_first_mixed_values(
     return []
 
 
+@beartype
 def _describe_mixed_type_families(
     *,
     data: Value,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -170,6 +170,7 @@ def _format_scalar(*, value: Scalar, spec: Language) -> str:
     return result
 
 
+@beartype
 def _maybe_wrap_child(
     *,
     parent_id: int,
@@ -193,6 +194,7 @@ def _maybe_wrap_child(
     )
 
 
+@beartype
 def _compute_wrap_ids(*, data: Value, spec: Language) -> frozenset[int]:
     """Return container ids whose scalar children should be wrapped.
 
@@ -527,6 +529,7 @@ def _wrap_body(
     return f"{opening.rstrip()}\n{body}\n{closing}"
 
 
+@beartype
 def _append_entries(
     *,
     formatted_entries: Sequence[str],
@@ -543,6 +546,7 @@ def _append_entries(
         lines.append(f"{body_prefix}{entry}{sep}")
 
 
+@beartype
 def _format_collection_lines(
     *,
     data: dict[str, Value] | set[Scalar] | list[Value],

--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -137,6 +137,7 @@ def _coerce_yaml_keys(*, data: object) -> Value:
             return cast("Value", _unwrap_yaml_scalar(value=data))
 
 
+@beartype
 def _parse_json(*, source: str) -> _ParsedInput:
     """Parse a JSON string into a ``_ParsedInput``."""
     try:
@@ -149,6 +150,7 @@ def _parse_json(*, source: str) -> _ParsedInput:
     return _ParsedInput(data=data, raw_data=data)
 
 
+@beartype
 def _parse_json5(*, source: str) -> _ParsedInput:
     """Parse a JSON5 string into a ``_ParsedInput``."""
     try:
@@ -173,6 +175,7 @@ def get_yaml() -> YAML:
     return YAML()
 
 
+@beartype
 def _parse_yaml(*, source: str) -> _ParsedInput:
     """Parse a YAML string into a ``_ParsedInput``.
 
@@ -191,6 +194,7 @@ def _parse_yaml(*, source: str) -> _ParsedInput:
     return _ParsedInput(data=data, raw_data=raw_data)
 
 
+@beartype
 def _parse_toml(*, source: str) -> _ParsedInput:
     """Parse a TOML string into a ``_ParsedInput``."""
     try:
@@ -202,6 +206,7 @@ def _parse_toml(*, source: str) -> _ParsedInput:
     return _ParsedInput(data=toml_data, raw_data=toml_doc)
 
 
+@beartype
 def parse_input(*, source: str, input_format: InputFormat) -> _ParsedInput:
     """Parse and coerce an input string according to its format."""
     match input_format:
@@ -217,6 +222,7 @@ def parse_input(*, source: str, input_format: InputFormat) -> _ParsedInput:
             assert_never(unreachable)
 
 
+@beartype
 def _coerce_toml_values(*, data: object) -> Value:
     """Recursively convert TOML-specific types to ``Value`` types.
 


### PR DESCRIPTION
## Summary
- Adds `@beartype` to 14 operational helpers that were missed in `_checks.py`, `_literalize.py`, and `_parsing.py`, aligning them with surrounding decorated code.
- Skips `_*_call_stub`, `_no_*` default callables, and `_build_*` / `_apply_*` factories per the existing undecorated-by-convention pattern.

## Test plan
- [x] `pytest tests/` — 936 passed
- [x] `mypy src/literalizer` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change that only adds runtime type checking to previously-undeclared helper functions; the main risk is new `beartype` validation errors (or minor overhead) surfacing where these helpers are called with unexpected types.
> 
> **Overview**
> Adds missing `@beartype` decorators across internal helper functions in `_checks.py`, `_literalize.py`, and `_parsing.py` to make runtime type validation consistent with the surrounding code.
> 
> No functional logic is changed beyond enabling `beartype` enforcement on these helpers (e.g., heterogeneous-type description helpers, wrapping/formatting helpers, and JSON/YAML/TOML parsing/coercion helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e112908b76b2f3c915934f71a0a694698903bd96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->