### PR TITLE
Move `*` marker to start so all params are keyword-only

### DIFF
--- a/src/literalizer/_formatters/format_entries.py
+++ b/src/literalizer/_formatters/format_entries.py
@@ -270,8 +270,8 @@ def _format_dict_entry_with_separator(
 
 @beartype
 def dict_entry_with_separator(
-    separator: str,
     *,
+    separator: str,
     format_value: Callable[[Value, str], str],
 ) -> Callable[[str, Value, str], str]:
     """Return a ``format_dict_entry`` callable that joins key and value

--- a/src/literalizer/_formatters/format_integers.py
+++ b/src/literalizer/_formatters/format_integers.py
@@ -93,7 +93,7 @@ def format_integer_binary_erlang(value: int) -> str:
 
 
 @beartype
-def _format_integer_grouped(value: int, *, separator: str) -> str:
+def _format_integer_grouped(*, value: int, separator: str) -> str:
     """Format an integer with digit-group separators every 3 digits.
 
     Example: ``_format_integer_grouped(1000000, separator="_")``
@@ -171,8 +171,8 @@ def _format_overflow_suffix(
 
 @beartype
 def make_overflow_suffix_formatter(
-    base: Callable[[int], str],
     *,
+    base: Callable[[int], str],
     min_value: int,
     max_value: int,
     suffix: str,

--- a/src/literalizer/_formatters/format_strings.py
+++ b/src/literalizer/_formatters/format_strings.py
@@ -17,7 +17,7 @@ class _StringFormatter(Protocol):
 
 
 @beartype
-def _backslash_escape(value: str, *, quote_char: str) -> str:
+def _backslash_escape(*, value: str, quote_char: str) -> str:
     r"""Apply base backslash escapes to *value*.
 
     Escapes backslashes, *quote_char*, ``\r``, ``\n``, and ``\t``.
@@ -277,7 +277,7 @@ def _apply_concat_control(
 
 
 @beartype
-def escape_control_chars(value: str, *, fmt: str) -> str:
+def escape_control_chars(*, value: str, fmt: str) -> str:
     r"""Replace C0 control characters (U+0000-U+001F) with escape sequences.
 
     Call **after** replacing named escapes (``\t``, ``\n``, ``\r``) so that
@@ -295,8 +295,8 @@ def escape_control_chars(value: str, *, fmt: str) -> str:
 
 @beartype
 def format_string_backslash_control(
-    value: str,
     *,
+    value: str,
     control_char_fmt: str,
 ) -> str:
     r"""Format a string using backslash escaping plus control-char escaping.
@@ -305,10 +305,8 @@ def format_string_backslash_control(
     :func:`escape_control_chars` in one step.  The *control_char_fmt*
     is passed directly to :func:`escape_control_chars`.
 
-    Example with ``control_char_fmt="\\x{:02x}"``::
-
-        format_string_backslash_control("\x01hi", control_char_fmt="\\x{:02x}")
-        # => '"\\x01hi"'
+    Example with ``control_char_fmt="\\x{:02x}"`` and ``value="\x01hi"``
+    returns ``'"\\x01hi"'``.
     """
     escaped = _backslash_escape(value=value, quote_char='"')
     escaped = escape_control_chars(value=escaped, fmt=control_char_fmt)

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -64,9 +64,9 @@ from literalizer._types import Value
 
 @beartype
 def _apply_format_c_entry(
+    *,
     original: Value,
     formatted: str,
-    *,
     int_field: str,
     float_field: str,
     string_field: str,

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from types import MappingProxyType
@@ -141,8 +140,8 @@ _CSHARP_SCALAR_TYPES: dict[type, str] = {
 
 @beartype
 def _csharp_scalar_type(
-    value: Value,
     *,
+    value: Value,
     date_hint: str,
     datetime_hint: str,
 ) -> str:
@@ -156,8 +155,8 @@ def _csharp_scalar_type(
 
 @beartype
 def _csharp_common_element_type(
-    items: list[Value],
     *,
+    items: list[Value],
     date_hint: str,
     datetime_hint: str,
     dict_value_type: str,
@@ -183,8 +182,8 @@ def _csharp_common_element_type(
 
 @beartype
 def _csharp_type_hint(
-    data: Value,
     *,
+    data: Value,
     date_hint: str,
     datetime_hint: str,
     dict_value_type: str,
@@ -225,11 +224,11 @@ def _csharp_type_hint(
 
 @beartype
 def _format_csharp_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     modifiers: frozenset[enum.Enum],
-    *,
     date_hint: str,
     datetime_hint: str,
     dict_value_type: str,
@@ -957,12 +956,28 @@ class CSharp(metaclass=LanguageCls):
             if self.datetime_format.value.type_produced is str
             else "DateTime"
         )
-        return functools.partial(
-            _format_csharp_declaration,
-            date_hint=date_hint,
-            datetime_hint=datetime_hint,
-            dict_value_type=self.default_dict_value_type,
-        )
+        dict_value_type = self.default_dict_value_type
+
+        def _formatter(
+            name: str,
+            value: str,
+            data: Value,
+            modifiers: frozenset[enum.Enum],
+        ) -> str:
+            """Adapt :func:`_format_csharp_declaration` to the positional
+            formatter interface.
+            """
+            return _format_csharp_declaration(
+                name=name,
+                value=value,
+                data=data,
+                modifiers=modifiers,
+                date_hint=date_hint,
+                datetime_hint=datetime_hint,
+                dict_value_type=dict_value_type,
+            )
+
+        return _formatter
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -88,8 +88,8 @@ def _format_dart_bigint_literal(value: int) -> str:
 
 @beartype
 def _dart_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
-    data: Value,
     *,
+    data: Value,
     date_hint: str,
     datetime_hint: str,
     default_set_element_type: str,
@@ -157,11 +157,11 @@ def _dart_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C
 
 @beartype
 def _format_dart_typed_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     keyword: str,
     date_hint: str,
     datetime_hint: str,
@@ -457,16 +457,31 @@ class Dart(metaclass=LanguageCls):
             """Return the variable declaration formatter."""
             if self is type(self).AUTO:
                 return auto_formatter
-            return functools.partial(
-                _format_dart_typed_declaration,
-                keyword=keyword,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                default_set_element_type=default_set_element_type,
-                default_dict_key_type=default_dict_key_type,
-                default_dict_value_type=default_dict_value_type,
-                sequence_is_tuple=sequence_is_tuple,
-            )
+
+            def _typed_formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_dart_typed_declaration` to the
+                positional formatter interface.
+                """
+                return _format_dart_typed_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    _modifiers=modifiers,
+                    keyword=keyword,
+                    date_hint=date_hint,
+                    datetime_hint=datetime_hint,
+                    default_set_element_type=default_set_element_type,
+                    default_dict_key_type=default_dict_key_type,
+                    default_dict_value_type=default_dict_value_type,
+                    sequence_is_tuple=sequence_is_tuple,
+                )
+
+            return _typed_formatter
 
     variable_type_hints_formats = VariableTypeHints
     declaration_styles = DeclarationStyles

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -62,9 +62,9 @@ from literalizer._types import Value
 
 @beartype
 def _apply_fortran_entry(
+    *,
     original: Value,
     formatted: str,
-    *,
     int_name: str,
     real_name: str,
     str_name: str,

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -127,10 +127,10 @@ _format_fsharp_entry = _build_fsharp_entry_formatter(prefix="F")
 
 @beartype
 def _apply_fsharp_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
-    *,
     template: str,
     sequence_declared_type: str,
     scalar_declared_type: str,

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property
@@ -337,10 +336,13 @@ def _build_string_formatters(
     For ``DOUBLE`` format, values pass through unmodified, and dict
     entries use tuple formatting.
     """
-    base_format_string: Callable[[str], str] = functools.partial(
-        format_string_backslash_control,
-        control_char_fmt="\\x{:02x}",
-    )
+
+    def base_format_string(value: str) -> str:
+        r"""Format a Haskell string with ``\x..`` control-char escapes."""
+        return format_string_backslash_control(
+            value=value,
+            control_char_fmt="\\x{:02x}",
+        )
 
     if string_format_name != "EXPLICIT":
         return _StringFormatters(
@@ -634,11 +636,11 @@ class _DeclarationFormatters:
 
 @beartype
 def _format_haskell_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     modifiers: frozenset[enum.Enum],
-    *,
     base_declaration: Callable[[str, str, Value, frozenset[enum.Enum]], str],
     sequence_declared_type: str | None,
     type_name: str,

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -220,8 +220,8 @@ def _java_box(type_name: str) -> str:
 
 @beartype
 def _java_common_element_type(
-    elements: list[Value],
     *,
+    elements: list[Value],
     boxed: bool,
     int_type: str,
     date_hint: str,
@@ -259,8 +259,8 @@ def _java_common_element_type(
 
 @beartype
 def _java_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
-    data: Value,
     *,
+    data: Value,
     int_type: str,
     date_hint: str,
     datetime_hint: str,
@@ -362,11 +362,11 @@ def _java_modifier_prefix(modifiers: frozenset[enum.Enum]) -> str:
 
 @beartype
 def _format_java_typed_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     modifiers: frozenset[enum.Enum],
-    *,
     int_type: str,
     date_hint: str,
     datetime_hint: str,
@@ -390,11 +390,11 @@ def _format_java_typed_declaration(
 
 @beartype
 def _apply_java_object_nil_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     modifiers: frozenset[enum.Enum],
-    *,
     base_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
     typed_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
 ) -> str:
@@ -410,8 +410,8 @@ def _apply_java_object_nil_declaration(
 
 @beartype
 def _object_nil_declaration(
-    base_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
     *,
+    base_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
     typed_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
 ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
     """Wrap *base_formatter* so top-level ``null`` gets a typed form.
@@ -816,15 +816,29 @@ class Java(metaclass=LanguageCls):
             set_outer: str,
         ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
             """Return the variable declaration formatter."""
-            typed = functools.partial(
-                _format_java_typed_declaration,
-                int_type=int_type,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                seq_is_array=seq_is_array,
-                dict_outer=dict_outer,
-                set_outer=set_outer,
-            )
+
+            def typed(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_java_typed_declaration` to the
+                positional formatter interface.
+                """
+                return _format_java_typed_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    modifiers=modifiers,
+                    int_type=int_type,
+                    date_hint=date_hint,
+                    datetime_hint=datetime_hint,
+                    seq_is_array=seq_is_array,
+                    dict_outer=dict_outer,
+                    set_outer=set_outer,
+                )
+
             if self is type(self).AUTO:
                 return _object_nil_declaration(
                     base_formatter=auto_formatter,

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 import re
 from collections.abc import Callable, Sequence
 from functools import cached_property
@@ -463,10 +462,15 @@ class Json5(metaclass=LanguageCls):
     @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Callable that formats a string value as a quoted literal."""
-        return functools.partial(
-            format_string_backslash_control,
-            control_char_fmt="\\u{:04x}",
-        )
+
+        def _format(value: str) -> str:
+            """Format a string as a JSON5 quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\u{:04x}",
+            )
+
+        return _format
 
     @cached_property
     def format_float(self) -> Callable[[float], str]:

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 import re
 from collections.abc import Callable, Sequence
 from functools import cached_property
@@ -494,10 +493,15 @@ class Jsonnet(metaclass=LanguageCls):
     @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Callable that formats a string value as a quoted literal."""
-        return functools.partial(
-            format_string_backslash_control,
-            control_char_fmt="\\u{:04x}",
-        )
+
+        def _format(value: str) -> str:
+            """Format a string as a Jsonnet quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\u{:04x}",
+            )
+
+        return _format
 
     @cached_property
     def format_float(self) -> Callable[[float], str]:

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -194,8 +194,8 @@ def _kotlin_type_to_opener(
 
 @beartype
 def _kotlin_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
-    data: Value,
     *,
+    data: Value,
     date_hint: str,
     datetime_hint: str,
     default_set_element_type: str,
@@ -298,11 +298,11 @@ def _kotlin_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
 
 @beartype
 def _format_kotlin_typed_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     keyword: str,
     date_hint: str,
     datetime_hint: str,
@@ -703,18 +703,33 @@ class Kotlin(metaclass=LanguageCls):
             """Return the variable declaration formatter."""
             if self is type(self).AUTO:
                 return auto_formatter
-            return functools.partial(
-                _format_kotlin_typed_declaration,
-                keyword=keyword,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                default_set_element_type=default_set_element_type,
-                default_dict_key_type=default_dict_key_type,
-                default_dict_value_type=default_dict_value_type,
-                dict_outer=dict_outer,
-                set_outer=set_outer,
-                sequence_format_name=sequence_format_name,
-            )
+
+            def _typed_formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_kotlin_typed_declaration` to the
+                positional formatter interface.
+                """
+                return _format_kotlin_typed_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    _modifiers=modifiers,
+                    keyword=keyword,
+                    date_hint=date_hint,
+                    datetime_hint=datetime_hint,
+                    default_set_element_type=default_set_element_type,
+                    default_dict_key_type=default_dict_key_type,
+                    default_dict_value_type=default_dict_value_type,
+                    dict_outer=dict_outer,
+                    set_outer=set_outer,
+                    sequence_format_name=sequence_format_name,
+                )
+
+            return _typed_formatter
 
     variable_type_hints_formats = VariableTypeHints
     declaration_styles = DeclarationStyles

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -71,10 +71,10 @@ from literalizer._types import Value
 
 @beartype
 def _apply_nim_variable_declaration(
+    *,
     name: str,
     value: str,
     _data: Value,
-    *,
     uses_typed_literal_for_scalars: bool,
     keyword: str,
     force_sequence: bool,
@@ -133,10 +133,10 @@ def _make_variable_declaration(
 
 @beartype
 def _apply_nim_variable_assignment(
+    *,
     name: str,
     value: str,
     _data: Value,
-    *,
     uses_typed_literal_for_scalars: bool,
 ) -> str:
     """Format an assignment, using ``@`` for flat sequences of

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -136,10 +136,10 @@ _format_ocaml_entry = _build_ocaml_entry_formatter(prefix="O")
 
 @beartype
 def _apply_ocaml_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
-    *,
     sequence_declared_type: str,
     scalar_declared_type: str,
     entry_formatter: Callable[[Value, str], str],

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -130,11 +130,11 @@ def _needs_type_annotation(data: Value) -> bool:
 
 @beartype
 def _format_variable_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     bytes_hint: str,
     date_hint: str,
     datetime_hint: str,
@@ -171,11 +171,11 @@ def _format_variable_declaration(
 
 @beartype
 def _format_inline_type_hint_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     bytes_hint: str,
     date_hint: str,
     datetime_hint: str,
@@ -274,8 +274,8 @@ def _merge_dict_elements(*, elements: list[Value]) -> list[Value]:
 
 @beartype
 def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
-    data: Value,
     *,
+    data: Value,
     bytes_hint: str,
     date_hint: str,
     datetime_hint: str,
@@ -663,30 +663,64 @@ class Python(metaclass=LanguageCls):
             style.
             """
             if self is type(self).ALWAYS:
-                return functools.partial(
-                    _format_inline_type_hint_declaration,
+
+                def _always_formatter(
+                    name: str,
+                    value: str,
+                    data: Value,
+                    modifiers: frozenset[enum.Enum],
+                ) -> str:
+                    """Adapt the inline-hint declaration to the positional
+                    formatter interface.
+                    """
+                    return _format_inline_type_hint_declaration(
+                        name=name,
+                        value=value,
+                        data=data,
+                        _modifiers=modifiers,
+                        bytes_hint=bytes_hint,
+                        date_hint=date_hint,
+                        datetime_hint=datetime_hint,
+                        sequence_hint=sequence_hint,
+                        set_hint=set_hint,
+                        default_set_element_type=default_set_element_type,
+                        default_sequence_element_type=(
+                            default_sequence_element_type
+                        ),
+                        default_dict_value_type=default_dict_value_type,
+                        default_dict_key_type=default_dict_key_type,
+                    )
+
+                return _always_formatter
+
+            def _auto_formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt the variable declaration to the positional
+                formatter interface.
+                """
+                return _format_variable_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    _modifiers=modifiers,
                     bytes_hint=bytes_hint,
                     date_hint=date_hint,
                     datetime_hint=datetime_hint,
                     sequence_hint=sequence_hint,
                     set_hint=set_hint,
                     default_set_element_type=default_set_element_type,
-                    default_sequence_element_type=default_sequence_element_type,
+                    default_sequence_element_type=(
+                        default_sequence_element_type
+                    ),
                     default_dict_value_type=default_dict_value_type,
                     default_dict_key_type=default_dict_key_type,
                 )
-            return functools.partial(
-                _format_variable_declaration,
-                bytes_hint=bytes_hint,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                sequence_hint=sequence_hint,
-                set_hint=set_hint,
-                default_set_element_type=default_set_element_type,
-                default_sequence_element_type=default_sequence_element_type,
-                default_dict_value_type=default_dict_value_type,
-                default_dict_key_type=default_dict_key_type,
-            )
+
+            return _auto_formatter
 
     class CommentFormats(enum.Enum):
         """Comment style options."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property
@@ -141,8 +140,8 @@ def _unify_rust_types(types: Sequence[str]) -> str:
 
 @beartype
 def _rust_scalar_type(  # noqa: PLR0911
-    data: Scalar,
     *,
+    data: Scalar,
     date_type: str,
     datetime_type: str,
 ) -> str:
@@ -170,8 +169,8 @@ def _rust_scalar_type(  # noqa: PLR0911
 
 @beartype
 def _rust_homogeneous_element_type(
-    elements: Sequence[Value],
     *,
+    elements: Sequence[Value],
     infer: Callable[[Value], str],
     default_type: str,
 ) -> str:
@@ -184,8 +183,8 @@ def _rust_homogeneous_element_type(
 
 @beartype
 def _rust_type_annotation(
-    data: Value,
     *,
+    data: Value,
     date_type: str,
     datetime_type: str,
     sequence_format_type_annotation: Callable[[str, int], str],
@@ -208,19 +207,25 @@ def _rust_type_annotation(
     dict data is supported and the arm emits ``HashMap<K, V>`` or
     ``BTreeMap<K, V>``.
     """
-    recurse = functools.partial(
-        _rust_type_annotation,
-        date_type=date_type,
-        datetime_type=datetime_type,
-        sequence_format_type_annotation=sequence_format_type_annotation,
-        sequence_supports_heterogeneity=sequence_supports_heterogeneity,
-        set_format_type_annotation=set_format_type_annotation,
-        dict_format_type_annotation=dict_format_type_annotation,
-        default_sequence_element_type=default_sequence_element_type,
-        default_set_element_type=default_set_element_type,
-        default_dict_key_type=default_dict_key_type,
-        default_dict_value_type=default_dict_value_type,
-    )
+
+    def recurse(element: Value) -> str:
+        """Recurse into nested ``Value`` data, preserving
+        configuration.
+        """
+        return _rust_type_annotation(
+            data=element,
+            date_type=date_type,
+            datetime_type=datetime_type,
+            sequence_format_type_annotation=sequence_format_type_annotation,
+            sequence_supports_heterogeneity=sequence_supports_heterogeneity,
+            set_format_type_annotation=set_format_type_annotation,
+            dict_format_type_annotation=dict_format_type_annotation,
+            default_sequence_element_type=default_sequence_element_type,
+            default_set_element_type=default_set_element_type,
+            default_dict_key_type=default_dict_key_type,
+            default_dict_value_type=default_dict_value_type,
+        )
+
     match data:
         case set():
             element_type = _rust_homogeneous_element_type(
@@ -274,11 +279,11 @@ def _rust_type_annotation(
 
 @beartype
 def _format_typed_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     keyword: str,
     date_type: str,
     datetime_type: str,
@@ -309,11 +314,11 @@ def _format_typed_declaration(
 
 @beartype
 def _format_lazy_static_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     date_type: str,
     datetime_type: str,
     sequence_format_type_annotation: Callable[[str, int], str],
@@ -411,8 +416,8 @@ class _VariantSignature:
 
 @beartype
 def _heterogeneous_variant_for_scalar(  # noqa: PLR0911
-    value: Scalar,
     *,
+    value: Scalar,
     date_type: str,
     datetime_type: str,
 ) -> _VariantSignature:
@@ -523,8 +528,8 @@ def _flag_if_siblings_mixed(
 
 @beartype
 def _collect_from_dict(
-    data: dict[str, Value],
     *,
+    data: dict[str, Value],
     ids: set[int],
 ) -> None:
     """Collect ids for a dict and its children."""
@@ -537,8 +542,8 @@ def _collect_from_dict(
 
 @beartype
 def _collect_from_list(
-    data: list[Value],
     *,
+    data: list[Value],
     ids: set[int],
 ) -> None:
     """Collect ids for a list, its sibling children, and descendants."""
@@ -564,8 +569,8 @@ def _collect_from_list(
 
 @beartype
 def _collect_heterogeneous_container_ids(
-    data: Value,
     *,
+    data: Value,
     ids: set[int],
 ) -> None:
     """Populate *ids* with container ids whose scalar children need
@@ -592,8 +597,8 @@ def _collect_heterogeneous_container_ids(
 
 @beartype
 def _iter_wrapped_scalars(
-    data: Value,
     *,
+    data: Value,
     wrap_ids: frozenset[int],
 ) -> list[Scalar]:
     """Return scalars that will be wrapped when rendering *data*.
@@ -1084,8 +1089,62 @@ class Rust(metaclass=LanguageCls):
             """
             cls = type(self)
             if self is cls.LAZY_STATIC:
-                return functools.partial(
-                    _format_lazy_static_declaration,
+
+                def _lazy_formatter(
+                    name: str,
+                    value: str,
+                    data: Value,
+                    modifiers: frozenset[enum.Enum],
+                ) -> str:
+                    """Adapt :func:`_format_lazy_static_declaration` to the
+                    positional formatter interface.
+                    """
+                    return _format_lazy_static_declaration(
+                        name=name,
+                        value=value,
+                        data=data,
+                        _modifiers=modifiers,
+                        date_type=date_type,
+                        datetime_type=datetime_type,
+                        sequence_format_type_annotation=(
+                            sequence_format_type_annotation
+                        ),
+                        sequence_supports_heterogeneity=(
+                            sequence_supports_heterogeneity
+                        ),
+                        set_format_type_annotation=set_format_type_annotation,
+                        dict_format_type_annotation=(
+                            dict_format_type_annotation
+                        ),
+                        default_sequence_element_type=(
+                            default_sequence_element_type
+                        ),
+                        default_set_element_type=default_set_element_type,
+                        default_dict_key_type=default_dict_key_type,
+                        default_dict_value_type=default_dict_value_type,
+                    )
+
+                return _lazy_formatter
+            if self not in {cls.CONST, cls.STATIC}:
+                config: DeclarationStyleConfig = self.value
+                return config.formatter
+            keyword = self.name.lower()
+
+            def _formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_typed_declaration` to the
+                positional formatter interface.
+                """
+                return _format_typed_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    _modifiers=modifiers,
+                    keyword=keyword,
                     date_type=date_type,
                     datetime_type=datetime_type,
                     sequence_format_type_annotation=(
@@ -1095,32 +1154,13 @@ class Rust(metaclass=LanguageCls):
                         sequence_supports_heterogeneity
                     ),
                     set_format_type_annotation=set_format_type_annotation,
-                    dict_format_type_annotation=dict_format_type_annotation,
                     default_sequence_element_type=(
                         default_sequence_element_type
                     ),
                     default_set_element_type=default_set_element_type,
-                    default_dict_key_type=default_dict_key_type,
-                    default_dict_value_type=default_dict_value_type,
                 )
-            if self not in {cls.CONST, cls.STATIC}:
-                config: DeclarationStyleConfig = self.value
-                return config.formatter
-            return functools.partial(
-                _format_typed_declaration,
-                keyword=self.name.lower(),
-                date_type=date_type,
-                datetime_type=datetime_type,
-                sequence_format_type_annotation=(
-                    sequence_format_type_annotation
-                ),
-                sequence_supports_heterogeneity=(
-                    sequence_supports_heterogeneity
-                ),
-                set_format_type_annotation=set_format_type_annotation,
-                default_sequence_element_type=(default_sequence_element_type),
-                default_set_element_type=default_set_element_type,
-            )
+
+            return _formatter
 
     class DictEntryStyles(enum.Enum):
         """Dict entry style options."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -209,9 +209,7 @@ def _rust_type_annotation(
     """
 
     def recurse(element: Value) -> str:
-        """Recurse into nested ``Value`` data, preserving
-        configuration.
-        """
+        """Delegate to module-level implementation."""
         return _rust_type_annotation(
             data=element,
             date_type=date_type,

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -236,7 +236,7 @@ def _rust_type_annotation(
             return set_format_type_annotation(element_type)
         case list():
             if sequence_supports_heterogeneity:
-                element_types = [recurse(e) for e in data]
+                element_types = [recurse(element=e) for e in data]
                 inner = ", ".join(element_types)
                 if len(element_types) == 1:
                     inner += ","

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from types import MappingProxyType
@@ -176,10 +175,10 @@ def _build_sml_entry_formatter(
 
 @beartype
 def _apply_sml_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
-    *,
     sequence_declared_type: str,
     scalar_declared_type: str,
     entry_formatter: Callable[[Value, str], str],
@@ -564,9 +563,15 @@ class Sml(metaclass=LanguageCls):
     @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Format a string value as a quoted literal."""
-        return functools.partial(
-            format_string_backslash_control, control_char_fmt="\\{:03d}"
-        )
+
+        def _format(value: str) -> str:
+            """Format a string as an SML quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\{:03d}",
+            )
+
+        return _format
 
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -152,8 +152,8 @@ def _swift_call_stub(
 
 @beartype
 def _swift_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
-    data: Value,
     *,
+    data: Value,
     date_hint: str,
     datetime_hint: str,
     default_set_element_type: str,
@@ -225,11 +225,11 @@ def _swift_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: 
 
 @beartype
 def _format_swift_typed_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     keyword: str,
     date_hint: str,
     datetime_hint: str,
@@ -253,11 +253,11 @@ def _format_swift_typed_declaration(
 
 @beartype
 def _apply_swift_optional_nil_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     base_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
     keyword: str,
 ) -> str:
@@ -269,8 +269,8 @@ def _apply_swift_optional_nil_declaration(
 
 @beartype
 def _optional_nil_declaration(
-    base_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
     *,
+    base_formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
     keyword: str,
 ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
     """Wrap *base_formatter* so top-level ``nil`` gets an optional type.
@@ -584,16 +584,33 @@ class Swift(metaclass=LanguageCls):
                     base_formatter=auto_formatter,
                     keyword=keyword,
                 )
-            return functools.partial(
-                _format_swift_typed_declaration,
-                keyword=keyword,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                default_set_element_type=default_set_element_type,
-                default_sequence_element_type=(default_sequence_element_type),
-                default_dict_value_type=default_dict_value_type,
-                sequence_is_tuple=sequence_is_tuple,
-            )
+
+            def _typed_formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_swift_typed_declaration` to the
+                positional formatter interface.
+                """
+                return _format_swift_typed_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    _modifiers=modifiers,
+                    keyword=keyword,
+                    date_hint=date_hint,
+                    datetime_hint=datetime_hint,
+                    default_set_element_type=default_set_element_type,
+                    default_sequence_element_type=(
+                        default_sequence_element_type
+                    ),
+                    default_dict_value_type=default_dict_value_type,
+                    sequence_is_tuple=sequence_is_tuple,
+                )
+
+            return _typed_formatter
 
     variable_type_hints_formats = VariableTypeHints
     declaration_styles = DeclarationStyles
@@ -713,9 +730,15 @@ class Swift(metaclass=LanguageCls):
     @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Format a string value as a quoted literal."""
-        return functools.partial(
-            format_string_backslash_control, control_char_fmt="\\u{{{:x}}}"
-        )
+
+        def _format(value: str) -> str:
+            """Format a string as a Swift quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\u{{{:x}}}",
+            )
+
+        return _format
 
     @cached_property
     def format_set_entry(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 import re
 from collections.abc import Callable, Sequence
 from functools import cached_property
@@ -481,10 +480,15 @@ class Toml(metaclass=LanguageCls):
     @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Callable that formats a string value as a quoted literal."""
-        return functools.partial(
-            format_string_backslash_control,
-            control_char_fmt="\\u{:04x}",
-        )
+
+        def _format(value: str) -> str:
+            """Format a string as a TOML quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\u{:04x}",
+            )
+
+        return _format
 
     @cached_property
     def format_float(self) -> Callable[[float], str]:

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -99,8 +99,8 @@ def _ts_element_union(*, types: list[str]) -> str:
 
 @beartype
 def _ts_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
-    data: Value,
     *,
+    data: Value,
     date_hint: str,
     datetime_hint: str,
     dict_hint_template: str,
@@ -167,11 +167,11 @@ def _ts_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C90
 
 @beartype
 def _format_ts_typed_declaration(
+    *,
     name: str,
     value: str,
     data: Value,
     _modifiers: frozenset[enum.Enum],
-    *,
     keyword: str,
     date_hint: str,
     datetime_hint: str,
@@ -520,14 +520,29 @@ class TypeScript(metaclass=LanguageCls):
             """Return the variable declaration formatter."""
             if self is type(self).AUTO:
                 return auto_formatter
-            return functools.partial(
-                _format_ts_typed_declaration,
-                keyword=keyword,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                dict_hint_template=dict_hint_template,
-                sequence_is_tuple=sequence_is_tuple,
-            )
+
+            def _typed_formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_ts_typed_declaration` to the
+                positional formatter interface.
+                """
+                return _format_ts_typed_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    _modifiers=modifiers,
+                    keyword=keyword,
+                    date_hint=date_hint,
+                    datetime_hint=datetime_hint,
+                    dict_hint_template=dict_hint_template,
+                    sequence_is_tuple=sequence_is_tuple,
+                )
+
+            return _typed_formatter
 
     variable_type_hints_formats = VariableTypeHints
     declaration_styles = DeclarationStyles

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import ClassVar
@@ -455,10 +454,15 @@ class Yaml(metaclass=LanguageCls):
     @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Callable that formats a string value as a quoted literal."""
-        return functools.partial(
-            format_string_backslash_control,
-            control_char_fmt="\\x{:02x}",
-        )
+
+        def _format(value: str) -> str:
+            """Format a string as a YAML quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\x{:02x}",
+            )
+
+        return _format
 
     @cached_property
     def format_float(self) -> Callable[[float], str]:

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import functools
 import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property
@@ -583,10 +582,15 @@ class Zig(metaclass=LanguageCls):
     @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Callable that formats a string value as a quoted literal."""
-        return functools.partial(
-            format_string_backslash_control,
-            control_char_fmt="\\x{:02x}",
-        )
+
+        def _format(value: str) -> str:
+            """Format a string as a Zig quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\x{:02x}",
+            )
+
+        return _format
 
     @cached_property
     def format_float(self) -> Callable[[float], str]:


### PR DESCRIPTION
## Summary
- Move the `*` marker to the start of the argument list for every function that had it mid-list, so all non-`self` parameters are keyword-only.
- Rewrite `functools.partial` wrappers that relied on positional invocation downstream as nested `def` functions, and drop the newly-unused `functools` imports.

## Test plan
- [x] `uv run --python 3.13 python -m pytest` — 936 passed, 300 skipped
- [x] pre-commit (mypy, ruff, pyright, ty, pyrefly) green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an API-level signature change (many functions now require keyword arguments), which can break downstream callers even though internal call sites are updated. Logic is largely unchanged, but the broad surface-area refactor across multiple language specs increases the chance of missed call sites.
> 
> **Overview**
> Makes numerous formatter/helpers across `src/literalizer/_formatters` and per-language specs **fully keyword-only** by moving the `*` to the start of parameter lists.
> 
> Replaces several `functools.partial`-based adapters with small nested wrapper functions (and drops now-unused `functools` imports), keeping the same formatter behavior while matching the project’s positional-formatter interfaces. Also includes a small docstring tweak in `format_string_backslash_control`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c9772b61be9f1b7ab66ee85a62bca6c8bb532c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->