### PR TITLE
Move Rust heterogeneous_value_enum_name to golden-file coverage

### DIFF
--- a/tests/integration/cases/dict_mixed_scalars/Rust_heterogeneous_value_enum_name_JsonValue.rs
+++ b/tests/integration/cases/dict_mixed_scalars/Rust_heterogeneous_value_enum_name_JsonValue.rs
@@ -1,0 +1,12 @@
+use std::collections::HashMap;
+enum JsonValue {
+    I32(i32),
+    Str(&'static str),
+}
+fn main() {
+    let my_data = HashMap::from([
+        ("a", JsonValue::I32(1)),
+        ("b", JsonValue::Str("x")),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -139,6 +139,12 @@ _CONSTRUCTOR_PREFIX_OVERRIDES: dict[literalizer.LanguageCls, str] = {
     PureScript: "J",
 }
 
+# Languages whose heterogeneous-value enum name is configurable (Rust's
+# ``TAGGED_ENUM`` strategy); the value is the test override to apply.
+_HETEROGENEOUS_VALUE_ENUM_NAME_OVERRIDES: dict[
+    literalizer.LanguageCls, str
+] = {Rust: "JsonValue"}
+
 # Languages that accept constructor-name kwargs (Fortran) or field-name
 # kwargs (C); the inner dict is the kwargs to pass to the constructor.
 _CONSTRUCTOR_NAME_OVERRIDES: dict[literalizer.LanguageCls, dict[str, str]] = {
@@ -1019,6 +1025,41 @@ def _build_constructor_prefix_variants() -> Iterable[_Variant]:
 
 
 @beartype
+def _build_heterogeneous_value_name_variants() -> Iterable[_Variant]:
+    """Build heterogeneous-value-enum-name variants for languages that
+    generate a named type for their heterogeneous strategy (e.g. Rust's
+    ``TAGGED_ENUM``).  The ``heterogeneous_value_enum_name`` constructor
+    parameter lets users customize that name.
+    """
+    variants: list[_Variant] = []
+    for lang_cls in _sorted_languages():
+        custom_name = _HETEROGENEOUS_VALUE_ENUM_NAME_OVERRIDES.get(lang_cls)
+        if custom_name is None:
+            continue
+        default_spec = _spec(lang_cls=lang_cls)
+        tagged_enum = next(
+            strategy
+            for strategy in default_spec.heterogeneous_strategies
+            if strategy.name == "TAGGED_ENUM"
+        )
+        spec = lang_cls(
+            heterogeneous_strategy=tagged_enum,
+            heterogeneous_value_enum_name=custom_name,
+        )
+        variants.append(
+            _Variant(
+                name=(
+                    f"{lang_cls.__name__}"
+                    f"_heterogeneous_value_enum_name_{custom_name}"
+                ),
+                spec=spec,
+                lang_cls=lang_cls,
+            )
+        )
+    return variants
+
+
+@beartype
 def _build_c_field_name_variants() -> Iterable[_Variant]:
     """Build field-name variants for languages listed in
     :data:`_FIELD_NAME_OVERRIDES` (e.g. C).
@@ -1553,6 +1594,11 @@ def _build_variant_cases() -> list[_VariantCase]:
         (type_hints_cross, "float_list", ""),
         (heterogeneous_strategy, "mixed_type_dicts_in_sequence", ""),
         (heterogeneous_strategy, "dict_mixed_scalars", ""),
+        (
+            _build_heterogeneous_value_name_variants(),
+            "dict_mixed_scalars",
+            "",
+        ),
         (heterogeneous_strategy, "nested_mixed_types", "_sibling"),
         (heterogeneous_strategy, "nested_mixed_inner", "_inner"),
         (heterogeneous_strategy, "nested_mixed_dict", ""),

--- a/tests/test_rust_tagged_enum.py
+++ b/tests/test_rust_tagged_enum.py
@@ -96,35 +96,6 @@ def test_integer_variants_use_narrowest_width() -> None:
     assert result.code == expected
 
 
-def test_configurable_enum_name() -> None:
-    """The emitted enum name comes from the
-    ``heterogeneous_value_enum_name`` constructor argument.
-    """
-    result = literalize(
-        source='{"a": 1, "b": "x"}',
-        input_format=InputFormat.JSON,
-        language=Rust(
-            heterogeneous_strategy=Rust.heterogeneous_strategies.TAGGED_ENUM,
-            heterogeneous_value_enum_name="JsonValue",
-        ),
-        wrap_in_file=True,
-    )
-    expected = (
-        "use std::collections::HashMap;\n"
-        "enum JsonValue {\n"
-        "    I32(i32),\n"
-        "    Str(&'static str),\n"
-        "}\n"
-        "fn main() {\n"
-        "    HashMap::from([\n"
-        '        ("a", JsonValue::I32(1)),\n'
-        '        ("b", JsonValue::Str("x")),\n'
-        "    ])\n"
-        "}"
-    )
-    assert result.code == expected
-
-
 def test_null_variant_has_no_payload() -> None:
     """The ``Null`` variant is emitted as a unit variant without
     parentheses; callers use it as ``Value::Null``.


### PR DESCRIPTION
## Summary

Closes #1393. Adds `_build_heterogeneous_value_name_variants` (mirroring `_build_type_name_variants` / `_build_constructor_prefix_variants`), pairing `HeterogeneousStrategies.TAGGED_ENUM` with a `JsonValue` override and wiring it against `dict_mixed_scalars`. Drops the now-redundant `test_configurable_enum_name` unit test in favor of the new `Rust_heterogeneous_value_enum_name_JsonValue.rs` golden.

## Test plan

- [x] `uv run pytest tests/` (935 passed, 13195 subtests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only reshuffles test coverage, moving one Rust behavior check from a unit test to the golden-file integration suite without changing production code paths.
> 
> **Overview**
> Moves coverage of Rust’s configurable tagged-enum name (`heterogeneous_value_enum_name`) from `tests/test_rust_tagged_enum.py` into the golden-file integration suite.
> 
> Adds a new integration variant builder (`_build_heterogeneous_value_name_variants`) and wires it to run `dict_mixed_scalars` with a Rust override (`JsonValue`), along with a new golden output file `Rust_heterogeneous_value_enum_name_JsonValue.rs`, and deletes the now-redundant unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558bd77f2450ff9cd96d0e7989614bc65af62b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->