### PR TITLE
Add function call rendering to Objective-C

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- Added ``literalize_call`` support for Objective-C:
+  ``ObjectiveC.format_call_preamble_stub`` emits C-style forward
+  declarations and nested ``struct`` chains with function-pointer
+  leaves for dotted targets, and ``ObjectiveC.CallStyles.POSITIONAL``
+  renders calls as ``func(arg1, arg2)``.
+
 2026.04.21.5
 ------------
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -121,17 +121,22 @@ def _objc_call_stub(
     dotted targets become a nested chain of ``struct`` types whose leaf
     field is a function pointer with an unspecified (K&R-style)
     argument list, and simple targets are emitted as forward
-    declarations with the same unspecified list.  A leading pragma
-    silences the ``-Wdeprecated-non-prototype`` warning clang emits
-    for these intentionally type-erased call sites.
+    declarations with the same unspecified list.  Two leading
+    ``#pragma clang diagnostic ignored`` directives silence both
+    ``-Wstrict-prototypes`` (Apple Clang) and
+    ``-Wdeprecated-non-prototype`` (upstream Clang 15+) for these
+    intentionally type-erased call sites.
     """
     del params
     return_keyword = "id" if stub_return is StubReturn.VALUE else "void"
     return_body = " return nil; " if stub_return is StubReturn.VALUE else ""
-    pragma = '#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"'
+    pragmas = (
+        '#pragma clang diagnostic ignored "-Wstrict-prototypes"',
+        '#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"',
+    )
     parts = name.split(sep=".")
     if len(parts) == 1:
-        return (pragma, f"{return_keyword} {parts[0]}();")
+        return (*pragmas, f"{return_keyword} {parts[0]}();")
     root = parts[0]
     method = parts[-1]
     fields = parts[1:-1]
@@ -139,14 +144,14 @@ def _objc_call_stub(
     if not fields:
         type_name = f"{root}Type_"
         return (
-            pragma,
+            *pragmas,
             f"static {return_keyword} {stub_fn}() {{{return_body}}}",
             f"struct {type_name} {{ {return_keyword} (*{method})(); }};",
             f"static const struct {type_name} {root} = "
             f"{{ .{method} = {stub_fn} }};",
         )
     lines: list[str] = [
-        pragma,
+        *pragmas,
         f"static {return_keyword} {stub_fn}() {{{return_body}}}",
     ]
     inner_type = f"{fields[-1]}Type_"

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -34,8 +34,6 @@ from literalizer._formatters.format_integers import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
-    CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -45,6 +43,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -108,6 +107,68 @@ def _format_objc_bytes_base64(value: bytes) -> str:
     """
     encoded = base64.b64encode(s=value)
     return f'@"{encoded.decode(encoding="ascii")}"'
+
+
+def _objc_call_stub(
+    name: str,
+    params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Objective-C stub declarations for a call name.
+
+    Objective-C is a superset of C, so call stubs reuse C's structure:
+    dotted targets become a nested chain of ``struct`` types whose leaf
+    field is a function pointer with an unspecified (K&R-style)
+    argument list, and simple targets are emitted as forward
+    declarations with the same unspecified list.  A leading pragma
+    silences the ``-Wdeprecated-non-prototype`` warning clang emits
+    for these intentionally type-erased call sites.
+    """
+    del params
+    return_keyword = "id" if stub_return is StubReturn.VALUE else "void"
+    return_body = " return nil; " if stub_return is StubReturn.VALUE else ""
+    pragma = '#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"'
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (pragma, f"{return_keyword} {parts[0]}();")
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    stub_fn = "_".join((*parts, "stub_"))
+    if not fields:
+        type_name = f"{root}Type_"
+        return (
+            pragma,
+            f"static {return_keyword} {stub_fn}() {{{return_body}}}",
+            f"struct {type_name} {{ {return_keyword} (*{method})(); }};",
+            f"static const struct {type_name} {root} = "
+            f"{{ .{method} = {stub_fn} }};",
+        )
+    lines: list[str] = [
+        pragma,
+        f"static {return_keyword} {stub_fn}() {{{return_body}}}",
+    ]
+    inner_type = f"{fields[-1]}Type_"
+    lines.append(
+        f"struct {inner_type} {{ {return_keyword} (*{method})(); }};",
+    )
+    prev_type = inner_type
+    for i in range(len(fields) - 2, -1, -1):
+        curr_type = f"{fields[i]}Type_"
+        lines.append(
+            f"struct {curr_type} {{ struct {prev_type} {fields[i + 1]}; }};",
+        )
+        prev_type = curr_type
+    root_type = f"{root}Type_"
+    lines.append(
+        f"struct {root_type} {{ struct {prev_type} {fields[0]}; }};",
+    )
+    init = f"{{ .{method} = {stub_fn} }}"
+    for field in reversed(fields):
+        init = f"{{ .{field} = {init} }}"
+    lines.append(f"static const struct {root_type} {root} = {init};")
+    return tuple(lines)
 
 
 @beartype
@@ -319,6 +380,8 @@ class ObjectiveC(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """ObjectiveC call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -348,9 +411,8 @@ class ObjectiveC(metaclass=LanguageCls):
             content=content,
             body_preamble=body_preamble,
         )
-        return (
-            f"void check_(void) {{\n{content}\n    (void){variable_name};\n}}"
-        )
+        use_line = f"\n    (void){variable_name};" if variable_name else ""
+        return f"void check_(void) {{\n{content}{use_line}\n}}"
 
     @staticmethod
     def wrap_combined_in_file(
@@ -406,9 +468,12 @@ class ObjectiveC(metaclass=LanguageCls):
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+    call_style: CallStyles = CallStyles.POSITIONAL
+
+    @cached_property
+    def call_style_config(self) -> PositionalCallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -459,7 +524,7 @@ class ObjectiveC(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return no_call_stub
+        return _objc_call_stub
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/tests/integration/cases/call_deep_dotted_method/ObjectiveC_call.m
+++ b/tests/integration/cases/call_deep_dotted_method/ObjectiveC_call.m
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static void obj_api_client_post_stub_() {}
+struct clientType_ { void (*post)(); };
+struct apiType_ { struct clientType_ client; };
+struct objType_ { struct apiType_ api; };
+static const struct objType_ obj = { .api = { .client = { .post = obj_api_client_post_stub_ } } };
+void check_(void) {
+obj.api.client.post(@"hello");
+obj.api.client.post(42);
+obj.api.client.post(@YES);
+}

--- a/tests/integration/cases/call_deep_dotted_method/ObjectiveC_call.m
+++ b/tests/integration/cases/call_deep_dotted_method/ObjectiveC_call.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 static void obj_api_client_post_stub_() {}
 struct clientType_ { void (*post)(); };

--- a/tests/integration/cases/call_deep_dotted_transformed/ObjectiveC_call.m
+++ b/tests/integration/cases/call_deep_dotted_transformed/ObjectiveC_call.m
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static id app_client_fetch_stub_() { return nil; }
+struct clientType_ { id (*fetch)(); };
+struct appType_ { struct clientType_ client; };
+static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+void emit();
+void check_(void) {
+emit(app.client.fetch(@"hello"));
+emit(app.client.fetch(42));
+emit(app.client.fetch(@YES));
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/ObjectiveC_call.m
+++ b/tests/integration/cases/call_deep_dotted_transformed/ObjectiveC_call.m
@@ -1,9 +1,11 @@
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 static id app_client_fetch_stub_() { return nil; }
 struct clientType_ { id (*fetch)(); };
 struct appType_ { struct clientType_ client; };
 static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 void emit();
 void check_(void) {

--- a/tests/integration/cases/call_dotted_method/ObjectiveC_call.m
+++ b/tests/integration/cases/call_dotted_method/ObjectiveC_call.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 static void app_client_fetch_stub_() {}
 struct clientType_ { void (*fetch)(); };

--- a/tests/integration/cases/call_dotted_method/ObjectiveC_call.m
+++ b/tests/integration/cases/call_dotted_method/ObjectiveC_call.m
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static void app_client_fetch_stub_() {}
+struct clientType_ { void (*fetch)(); };
+struct appType_ { struct clientType_ client; };
+static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
+void check_(void) {
+app.client.fetch(@"hello");
+app.client.fetch(42);
+app.client.fetch(@YES);
+}

--- a/tests/integration/cases/call_keyword_args/ObjectiveC_call.m
+++ b/tests/integration/cases/call_keyword_args/ObjectiveC_call.m
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 static id throttler_check_stub_() { return nil; }
 struct throttlerType_ { id (*check)(); };
 static const struct throttlerType_ throttler = { .check = throttler_check_stub_ };
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 void emit();
 void check_(void) {

--- a/tests/integration/cases/call_keyword_args/ObjectiveC_call.m
+++ b/tests/integration/cases/call_keyword_args/ObjectiveC_call.m
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+static id throttler_check_stub_() { return nil; }
+struct throttlerType_ { id (*check)(); };
+static const struct throttlerType_ throttler = { .check = throttler_check_stub_ };
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+void emit();
+void check_(void) {
+emit(throttler.check(@"user_1", 1000.0));
+emit(throttler.check(@"user_2", 2000.5));
+}

--- a/tests/integration/cases/call_per_element_false/ObjectiveC_call.m
+++ b/tests/integration/cases/call_per_element_false/ObjectiveC_call.m
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+void process();
+void check_(void) {
+process(1);
+}

--- a/tests/integration/cases/call_per_element_false/ObjectiveC_call.m
+++ b/tests/integration/cases/call_per_element_false/ObjectiveC_call.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 void process();
 void check_(void) {

--- a/tests/integration/cases/call_scalar_args/ObjectiveC_call.m
+++ b/tests/integration/cases/call_scalar_args/ObjectiveC_call.m
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+void process();
+void check_(void) {
+process(@"hello");
+process(42);
+process(@YES);
+}

--- a/tests/integration/cases/call_scalar_args/ObjectiveC_call.m
+++ b/tests/integration/cases/call_scalar_args/ObjectiveC_call.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 void process();
 void check_(void) {

--- a/tests/integration/cases/call_transform_no_wrapper/ObjectiveC_call.m
+++ b/tests/integration/cases/call_transform_no_wrapper/ObjectiveC_call.m
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+id process();
+void check_(void) {
+process(@"hello");
+process(42);
+process(@YES);
+}

--- a/tests/integration/cases/call_transform_no_wrapper/ObjectiveC_call.m
+++ b/tests/integration/cases/call_transform_no_wrapper/ObjectiveC_call.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
 id process();
 void check_(void) {


### PR DESCRIPTION
## Summary
- Adds ``literalize_call`` support to Objective-C by populating ``ObjectiveC.CallStyles`` with ``POSITIONAL`` and implementing ``_objc_call_stub`` for simple, dotted, and deep-dotted targets. Call stubs reuse C's approach (K&R forward declarations, nested ``struct`` + function-pointer chains) but return ``id``/``nil`` for value stubs and sit alongside the existing ``#import <Foundation/Foundation.h>`` static preamble.
- Guards ``ObjectiveC.wrap_in_file`` so it no longer emits a stray ``(void);`` when ``variable_name`` is empty (the call-rendering code path).
- Adds 7 golden files under ``tests/integration/cases/call_*/ObjectiveC_call.m`` plus a ``CHANGELOG.rst`` entry.

Closes #1132.

## Test plan
- [x] Full ``uv run pytest tests/`` suite passes (942 tests, 13195 subtests)
- [x] All 7 ObjC golden files pass ``clang -fsyntax-only -fobjc-arc -Wall -Wextra -Werror``
- [x] ``ruff``, ``mypy``, ``pyright``, ``pylint``, ``ty`` all clean on ``objective_c.py``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Objective-C code generation and stub emission paths; incorrect stub shapes or wrapper formatting could break generated code compilation, but changes are localized and covered by new golden tests.
> 
> **Overview**
> Adds `literalize_call` support for Objective-C by introducing a `POSITIONAL` call style and generating file-scope call stubs via `ObjectiveC.format_call_preamble_stub` for simple and dotted targets (including deep dotted chains) using C-style forward declarations / nested `struct` + function-pointer leaves.
> 
> Also fixes `ObjectiveC.wrap_in_file` to avoid emitting a stray `(void);` when no `variable_name` is provided, and adds new Objective-C golden integration fixtures covering scalar calls, transforms, and dotted-call stub generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6acc3e9b38627dafa0de3b755ce129eeedb1b0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->