### PR TITLE
Rename test_rust_tagged_enum to test_heterogeneous_default_errors

### DIFF
--- a/tests/test_heterogeneous_default_errors.py
+++ b/tests/test_heterogeneous_default_errors.py
@@ -1,10 +1,11 @@
-"""Unit tests for Rust's tagged-enum heterogeneous-value strategy.
+"""Cross-language tests for the default heterogeneous-strategy error
+contract.
 
-Golden-file coverage for the rendering paths (dict-mixed, sibling-list,
-sibling-dict heterogeneity, and integer-width variant selection) lives
-in ``tests/integration/cases/*/Rust_heterogeneous_strategy_tagged_enum*.rs``.
-These unit tests cover the error contract, which the integration
-framework silently skips.
+Languages with an opt-in wrapping strategy (e.g. Rust's ``TAGGED_ENUM``)
+must still raise on heterogeneous input under the default ``ERROR``
+strategy.  The integration framework catches
+``HeterogeneousCollectionError`` and silently skips, so the error
+contract has no golden-file surface and needs unit coverage.
 """
 
 import pytest


### PR DESCRIPTION
## Summary

- Renames `tests/test_rust_tagged_enum.py` to `tests/test_heterogeneous_default_errors.py` and regeneralises the docstring to describe the cross-language default-``ERROR``-strategy contract (Rust's ``TAGGED_ENUM`` shown as one example).
- Test bodies are unchanged — still Rust-only — so this is a pure file-level rename that sets up later parametrisation across languages (e.g. Dhall's forthcoming ``UNION_TYPE``) without introducing a near-duplicate file per language.
- Extracted from #1384.

## Test plan

- [x] `pytest tests/test_heterogeneous_default_errors.py` — 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a file-level rename plus docstring rewording; test logic and assertions are unchanged.
> 
> **Overview**
> Renames the existing Rust-focused heterogeneous-input error unit test to `tests/test_heterogeneous_default_errors.py` and updates the module docstring to describe a *cross-language* default-`ERROR` strategy error contract (with Rust `TAGGED_ENUM` as an example).
> 
> No behavioral changes: the two tests and their assertions remain the same (still targeting Rust), and the change primarily sets up future parametrization without duplicating per-language test files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75b96163d2b5a85ab2b321f4e64d463594f091c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->