### PR TITLE
Run Nim files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1007,6 +1007,13 @@ jobs:
             tmpdir=$(mktemp -d)
             nim check --hints:off --nimcache:"$tmpdir" "$f" || exit 1
           done < /tmp/files-to-lint
+      - name: Run Nim files
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          while IFS= read -r -d '' f; do
+            tmpdir=$(mktemp -d)
+            nim c -r --hints:off --nimcache:"$tmpdir" "$f" || exit 1
+          done < /tmp/files-to-lint
 
   lint-nix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `Run Nim files` step to the `lint-nim` job that invokes `nim c -r` per fixture, mirroring the pattern used by `lint-bash`, `lint-ruby`, `lint-javascript`, `lint-go`, `lint-julia`, and `lint-perl`. `nim check` alone only performs semantic checks, so runtime errors (undefined calls, missing imports, failed assertions) previously slipped past CI.
- All 198 existing `tests/integration/cases/**/*.nim` fixtures run end-to-end with this step; no stubs required.

Closes #1428.

## Test plan
- [ ] CI `lint-nim` job passes on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds runtime execution of Nim fixtures; main impact is potentially longer lint times and new failures surfaced in existing test cases.
> 
> **Overview**
> The `lint-nim` GitHub Actions job now **runs** each `tests/integration/cases/**/*.nim` fixture via `nim c -r` after `nim check`, so CI catches runtime failures (e.g., missing imports/undefined calls/assertions) in addition to syntax/semantic issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89605c16e0bc2a47c3836c9ef4ace3e6f8fa740a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->