### PR TITLE
Run Scala lint fixtures to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -626,13 +626,26 @@ jobs:
         if: steps.find-files.outputs.found == 'true'
         uses: coursier/setup-action@v3
         with:
-          apps: scalac
+          apps: scala scalac
       - name: Check Scala syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
             tmpdir=$(mktemp -d)
             scalac -d "$tmpdir" "$f" || exit 1
+          done < /tmp/files-to-lint
+      # Fixtures define `object Check { ... }` with no main method, so
+      # compile alongside a small @main wrapper that forces the object
+      # (and therefore its val initializers) to load.
+      - name: Run Scala files
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          while IFS= read -r -d '' f; do
+            tmpdir=$(mktemp -d)
+            printf '@main def __run(): Unit = { val _ = Check }\n' \
+              > "$tmpdir/__Main.scala"
+            scalac -d "$tmpdir" "$f" "$tmpdir/__Main.scala" || exit 1
+            scala --main-class __run --classpath "$tmpdir" || exit 1
           done < /tmp/files-to-lint
 
   lint-dart:


### PR DESCRIPTION
## Summary
- `scalac` only emits class files, so Scala fixtures that would fail at runtime (for example in `val` initializers) passed CI silently.
- Since fixtures wrap their body in `object Check { ... }` with no main method, the new `Run Scala files` step compiles each fixture alongside a tiny `@main` wrapper that references `Check`, forcing its initializers to run.
- Added `scala` to the `coursier/setup-action` apps so the runner is available.

Closes #1418

## Test plan
- [x] Ran the new `scalac` + `scala` loop locally across all 269 `tests/integration/cases/**/*.scala` fixtures — every one compiled and executed successfully, so no fixture stubs were needed.
- [x] Confirmed the step fails loudly on a synthetic fixture that throws from a `val` initializer.
- [x] `pre-commit` (yamlfix, actionlint, zizmor) passes on the modified workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI behavior for `lint-scala` by compiling and executing every Scala fixture, which can increase runtime and introduce new workflow failures if fixtures have runtime-side effects or environment assumptions.
> 
> **Overview**
> Scala linting in `.github/workflows/lint.yml` now **runs** each `tests/integration/cases/**/*.scala` fixture after compiling, via a generated `@main` wrapper that forces `object Check` initializers to execute (catching runtime errors that compilation alone would miss).
> 
> The workflow also installs the `scala` runner (not just `scalac`) so the new execution step can run in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ce4ee51fb4509d240eff0bfd5b8624b07a4d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->