### PR TITLE
Run SML files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1176,6 +1176,24 @@ jobs:
       - name: Check SML syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(nproc)" -n1 mlton -stop tc < /tmp/files-to-lint
+      # Fixtures only declare `structure Check` with a `my_data` val;
+      # MLton never evaluates the body unless a top-level expression
+      # references it, so compile alongside a small force file that
+      # forces `Check.my_data` to be constructed.
+      - name: Run SML files
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          # shellcheck disable=SC2016  # $0/$tmpdir/SML_LIB expand in the inner shell
+          xargs -0 -P "$(nproc)" -n1 bash -c '
+            tmpdir=$(mktemp -d)
+            trap "rm -rf $tmpdir" EXIT
+            cp "$0" "$tmpdir/check.sml"
+            printf "val _ = Check.my_data\n" > "$tmpdir/force.sml"
+            printf "\$(SML_LIB)/basis/basis.mlb\ncheck.sml\nforce.sml\n" \
+              > "$tmpdir/main.mlb"
+            mlton -output "$tmpdir/out" "$tmpdir/main.mlb" || exit 1
+            "$tmpdir/out" || exit 1
+          ' < /tmp/files-to-lint
 
   lint-scheme:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- ``lint-sml`` in ``.github/workflows/lint.yml`` now runs each
+  Standard ML fixture end-to-end.  Because ``MLton`` never evaluates
+  a ``structure``'s body unless a top-level expression forces it,
+  the new step compiles each fixture via an ML Basis file that
+  concatenates the fixture with a small ``val _ = Check.my_data``
+  snippet and runs the resulting binary, catching runtime errors
+  such as references to undefined names, missing module imports,
+  or failed assertions.
 - Removed the K&R-style empty-prototype suppression directives from
   C and Objective-C call stubs.
   ``C.format_call_preamble_stub`` and


### PR DESCRIPTION
## Summary

- ``lint-sml`` in ``.github/workflows/lint.yml`` previously only type-checked each fixture with ``mlton -stop tc``, so references to undefined names and failed assertions slipped past CI.
- Added a second ``Run SML files`` step that compiles each fixture via an inline ML Basis file (fixture + a ``val _ = Check.my_data`` force snippet, since MLton never evaluates a ``structure``'s body unless a top-level expression forces it) and runs the resulting binary.
- Added a CHANGELOG entry under ``Next``.

Closes #1433

## Test plan

- [ ] CI: ``lint-sml`` job passes, now including the new ``Run SML files`` step.
- [x] Local: all 127 SML fixtures run cleanly on MLton 20241230 in ~40 s across 10 cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now compiles and executes every `.sml` fixture, which can increase runtime and introduce new failure modes tied to MLton execution/environment variables rather than just typechecking.
> 
> **Overview**
> `lint-sml` in `.github/workflows/lint.yml` now goes beyond `mlton -stop tc` by compiling each Standard ML fixture together with a generated `force.sml` (referencing `Check.my_data`) via a temporary `.mlb`, then running the produced binary to catch runtime issues.
> 
> Adds a corresponding `CHANGELOG.rst` entry describing the new end-to-end SML linting behavior and the kinds of runtime errors it will now fail on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90fad92de7df667887f8ac7865e2712c3b022c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->