### PR TITLE
Run Elixir files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -422,6 +422,19 @@ jobs:
             cp "$f" "$tmpdir/check.ex"
             (cd "$tmpdir" && elixirc check.ex) || exit 1
           done < /tmp/files-to-lint
+      # Fixtures only declare `defmodule Check` with a `def x` body, so
+      # `elixir` compiles the module but never invokes it. Append a call
+      # to `Check.x()` so the function body — and any references inside
+      # it — actually executes.
+      - name: Run Elixir files
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          while IFS= read -r -d '' f; do
+            tmpdir=$(mktemp -d)
+            cp "$f" "$tmpdir/check.ex"
+            printf '\nCheck.x()\n' >> "$tmpdir/check.ex"
+            (cd "$tmpdir" && elixir check.ex) || exit 1
+          done < /tmp/files-to-lint
 
   lint-elm:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- ``lint-elixir`` in ``.github/workflows/lint.yml`` now runs each
+  Elixir fixture end-to-end.  ``elixirc`` only compiled the
+  ``defmodule Check`` body, so calls to undefined names or runtime
+  errors inside ``def x`` slipped past CI.  The new ``Run Elixir
+  files`` step copies each fixture, appends ``Check.x()``, and
+  executes it with ``elixir``, catching references that survive
+  compilation but fail at runtime.
 - ``lint-sml`` in ``.github/workflows/lint.yml`` now runs each
   Standard ML fixture end-to-end.  Because ``MLton`` never evaluates
   a ``structure``'s body unless a top-level expression forces it,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,6 @@ Changelog
 Next
 ----
 
-- ``lint-elixir`` in ``.github/workflows/lint.yml`` now runs each
-  Elixir fixture end-to-end.  ``elixirc`` only compiled the
-  ``defmodule Check`` body, so calls to undefined names or runtime
-  errors inside ``def x`` slipped past CI.  The new ``Run Elixir
-  files`` step copies each fixture, appends ``Check.x()``, and
-  executes it with ``elixir``, catching references that survive
-  compilation but fail at runtime.
 - ``lint-sml`` in ``.github/workflows/lint.yml`` now runs each
   Standard ML fixture end-to-end.  Because ``MLton`` never evaluates
   a ``structure``'s body unless a top-level expression forces it,


### PR DESCRIPTION
## Summary
- Add a ``Run Elixir files`` step to ``lint-elixir`` in ``.github/workflows/lint.yml`` that copies each fixture, appends ``Check.x()``, and executes it with ``elixir`` so references and calls inside ``def x`` actually run.
- Previously ``elixirc`` only compiled the module, so undefined names and runtime errors slipped past CI.

Closes #1412

## Test plan
- [x] All existing Elixir fixtures run end-to-end locally with ``elixir`` after the ``Check.x()`` call is appended.
- [ ] CI's new ``Run Elixir files`` step passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it can introduce new lint failures by executing Elixir fixture code (and any side effects) rather than only compiling it.
> 
> **Overview**
> Tightens the Elixir lint job by **running** each `.ex` fixture after a syntax/compile check, so runtime errors and undefined references inside `Check.x/0` are surfaced.
> 
> The new step copies each file to a temp dir, appends `Check.x()` to force execution, and runs it via `elixir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfbe8b153e3792719b6784bfcef13191a986a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->