### PR TITLE
Drop flaky setup-fortran action; use preinstalled gfortran

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1362,6 +1362,7 @@ jobs:
 
   lint-fortran:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1370,9 +1371,6 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.f90
-      - name: Install gfortran
-        if: steps.find-files.outputs.found == 'true'
-        uses: fortran-lang/setup-fortran@v1
       - name: Check Fortran syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 gfortran -std=f2008 -ffree-line-length-none -fsyntax-only <


### PR DESCRIPTION
## Summary

- Removes the `fortran-lang/setup-fortran@v1` step from the `lint-fortran` job, since `ubuntu-latest` runners ship with `gfortran` preinstalled. The action recently hung for six hours, wasting a runner slot.
- Adds `timeout-minutes: 15` to the job as defense-in-depth so any future hang fails fast instead of occupying a runner for the full six-hour job limit.

## Test plan

- [ ] CI: `lint-fortran` runs green and completes in well under 15 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: removes a third-party Fortran setup action and relies on runner-provided `gfortran`, plus adds a job timeout to prevent hangs.
> 
> **Overview**
> Updates the `lint-fortran` GitHub Actions job to **stop using** `fortran-lang/setup-fortran@v1` and instead rely on the `gfortran` already available on `ubuntu-latest`.
> 
> Adds `timeout-minutes: 15` to the Fortran lint job so a stuck tool/action fails fast rather than consuming a runner for hours.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323afee4cb6fdbfc6a7d72dbe1f8fa9078ccf2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->