### PR TITLE
Run Haskell files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -546,6 +546,30 @@ jobs:
         run: |-
           tmpdir=$(mktemp -d)
           xargs -0 -n1 ghc -fno-code -outputdir "$tmpdir" < /tmp/files-to-lint
+      # Most fixtures declare only `module Check` with a `my_data` val; GHC
+      # never evaluates its body unless a top-level expression references it,
+      # so compile alongside a small Main wrapper that forces `Check.my_data`.
+      # Fixtures that already define their own `main` compile with
+      # `-main-is Check` instead.
+      - name: Run Haskell files
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
+          xargs -0 -P "$(nproc)" -n1 bash -c '
+            tmpdir=$(mktemp -d)
+            trap "rm -rf $tmpdir" EXIT
+            cp "$0" "$tmpdir/Check.hs"
+            if grep -qE "^main " "$0"; then
+              ghc -main-is Check -outputdir "$tmpdir" \
+                -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
+            else
+              printf "module Main where\nimport Check\nmain :: IO ()\nmain = seq Check.my_data (return ())\n" \
+                > "$tmpdir/Main.hs"
+              ghc -outputdir "$tmpdir" \
+                -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
+            fi
+            "$tmpdir/run" || exit 1
+          ' < /tmp/files-to-lint
 
   lint-commonlisp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `ghc -fno-code` only parses and type-checks, so runtime errors in Haskell fixtures (references to undefined names, missing imports, failed assertions) slipped past CI.
- Adds a `Run Haskell files` step to `lint-haskell` that compiles each fixture as `module Check` alongside a small `Main` wrapper forcing `Check.my_data` — or uses `-main-is Check` for the handful of fixtures that already define their own `main` — and runs the resulting binary.

Closes #1416

## Test plan
- [ ] Lint workflow's `lint-haskell` job passes on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow change, but it increases strictness by compiling and executing Haskell fixtures, which may surface new failures and lengthen lint time.
> 
> **Overview**
> The `lint-haskell` job now goes beyond `ghc -fno-code` by **compiling and running** each Haskell fixture to catch runtime issues that type-checking alone can miss.
> 
> It builds each fixture in an isolated temp dir and either runs it via `-main-is Check` when a `main` is present, or generates a tiny `Main` wrapper that forces evaluation of `Check.my_data` before executing the produced binary (run in parallel via `xargs -P`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd21b7f39ec988cdd58fc1d27c442fc21b85f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->