### PR TITLE
Run C++ files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -298,6 +298,20 @@ jobs:
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
+      # Fixtures define `void check_()` with no main, so compile alongside
+      # a tiny wrapper that invokes it and link into a runnable binary.
+      - name: Run C++ files
+        if: steps.find-files.outputs.found == 'true'
+        run: |-
+          # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
+          xargs -0 -P "$(nproc)" -n1 bash -c '
+            tmpdir=$(mktemp -d)
+            trap "rm -rf $tmpdir" EXIT
+            printf "void check_();\nint main(){ check_(); return 0; }\n" \
+              > "$tmpdir/__main.cpp"
+            clang++ -std=c++20 "$0" "$tmpdir/__main.cpp" -o "$tmpdir/run" || exit 1
+            "$tmpdir/run" || exit 1
+          ' < /tmp/files-to-lint
 
   lint-kotlin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `lint-cpp` only ran `clang++ -fsyntax-only` and `clang-tidy`, so runtime errors (calls to undefined names, failed assertions, etc.) slipped past CI.
- Adds a `Run C++ files` step that, for each fixture, compiles it together with a tiny `int main(){ check_(); }` wrapper in a private tmpdir and runs the resulting binary — mirroring the pattern already used by `lint-scala`, `lint-sml`, and friends.
- Verified locally against all 269 `tests/integration/cases/**/*.cpp` fixtures: every file compiles and runs cleanly, so no stubs are needed.

Closes #1409

## Test plan

- [ ] Wait for `lint-cpp` to pass on this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI behavior by executing newly built binaries in parallel, which can increase runtime and introduce environment-dependent failures if any fixtures have hidden runtime assumptions.
> 
> **Overview**
> The `lint-cpp` job now **runs** each `tests/integration/cases/**/*.cpp` fixture after `clang++ -fsyntax-only` and `clang-tidy` by compiling it with a temporary wrapper `main` that calls `check_()` and executing the resulting binary.
> 
> This adds per-file tempdir isolation and parallel execution to surface runtime errors (e.g., failed assertions or missing symbols) during CI linting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a46c2a272373abaa4a19e82f2baf412b124b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->