### PR TITLE
Run Elm files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -433,7 +433,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.elm
-          extra_config_patterns: check_elm_syntax.py
+          extra_config_patterns: |
+            check_elm_syntax.py
+            run_elm.py
       - name: Install elm-format and elm
         if: steps.find-files.outputs.found == 'true'
         run: npm install -g elm-format elm
@@ -452,6 +454,9 @@ jobs:
       - name: Check Elm compiles
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 uv run --no-project python check_elm_syntax.py < /tmp/files-to-lint
+      - name: Run Elm files
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 uv run --no-project python run_elm.py < /tmp/files-to-lint
 
   lint-erlang:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Next
 ----
 
+- ``lint-elm`` in ``.github/workflows/lint.yml`` now runs each Elm
+  fixture end-to-end.  A new ``Run Elm files`` step compiles each
+  fixture alongside a small ``Main.elm`` wrapper whose
+  ``Platform.worker`` init forces ``Check.my_data``, emits
+  JavaScript via ``elm make``, and executes it with Node so
+  runtime crashes such as ``Debug.todo`` surface in CI.  The
+  ``scalar_int_very_negative_large`` fixture is skipped because
+  the Elm 0.19.1 code generator emits ``--<digits>`` (two unary
+  minuses) for integers at the int64 boundary, which JavaScript
+  rejects as a prefix-decrement syntax error.
 - ``lint-sml`` in ``.github/workflows/lint.yml`` now runs each
   Standard ML fixture end-to-end.  Because ``MLton`` never evaluates
   a ``structure``'s body unless a top-level expression forces it,

--- a/run_elm.py
+++ b/run_elm.py
@@ -1,0 +1,146 @@
+"""Run Elm golden files end-to-end via ``elm make`` + Node to catch
+runtime errors that survive the compile-only check.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_ELM_JSON = json.dumps(
+    obj={
+        "type": "application",
+        "source-directories": ["src"],
+        "elm-version": "0.19.1",
+        "dependencies": {
+            "direct": {"elm/core": "1.0.5"},
+            "indirect": {"elm/json": "1.1.3"},
+        },
+        "test-dependencies": {"direct": {}, "indirect": {}},
+    },
+)
+
+# Wrap ``Check.my_data`` in a ``Platform.worker`` so loading the compiled
+# JavaScript evaluates the fixture's top-level value, surfacing runtime
+# crashes such as ``Debug.todo`` or references that pass type-checking
+# but fail at evaluation.
+_MAIN_ELM = """\
+module Main exposing (main)
+
+import Check
+import Platform
+
+
+main : Program () () Never
+main =
+    Platform.worker
+        { init = \\_ -> forceData Check.my_data
+        , update = \\_ m -> ( m, Cmd.none )
+        , subscriptions = \\_ -> Sub.none
+        }
+
+
+forceData : a -> ( (), Cmd Never )
+forceData _ =
+    ( (), Cmd.none )
+"""
+
+# The Elm 0.19.1 code generator emits ``--<digits>`` (two unary minuses
+# glued together) when it negates an integer literal whose magnitude
+# reaches the int64 boundary.  JavaScript parses ``--<digits>`` as a
+# prefix-decrement of a numeric literal and rejects the file with a
+# ``SyntaxError``.  ``check_elm_syntax.py`` still validates the Elm
+# source for these fixtures; only the compile-and-execute step is
+# skipped.
+_SKIP_SUFFIXES = (
+    "tests/integration/cases/scalar_int_very_negative_large/Elm.elm",
+)
+
+
+def _run_fixture(
+    *,
+    filename: str,
+    tmpdir: Path,
+    check_path: Path,
+    output_js: Path,
+    elm_path: str,
+    node_path: str,
+    env: dict[str, str],
+) -> bool:
+    """Compile and run one fixture.  Return True on failure."""
+    src = Path(filename)
+    check_path.write_text(
+        data=src.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    compile_result = subprocess.run(
+        args=[
+            elm_path,
+            "make",
+            "src/Main.elm",
+            f"--output={output_js}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=tmpdir,
+        env=env,
+    )
+    if compile_result.returncode != 0:
+        msg = f"{filename}: elm make failed\n"
+        msg += compile_result.stderr + compile_result.stdout
+        sys.stderr.write(msg)
+        return True
+    run_result = subprocess.run(
+        args=[node_path, str(object=output_js)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if run_result.returncode != 0:
+        msg = f"{filename}: node run failed\n"
+        msg += run_result.stderr + run_result.stdout
+        sys.stderr.write(msg)
+        return True
+    return False
+
+
+def main() -> None:
+    """Run each Elm golden file end-to-end."""
+    filenames = sys.argv[1:]
+    elm_path = shutil.which(cmd="elm") or "elm"
+    node_path = shutil.which(cmd="node") or "node"
+    failed = False
+    with tempfile.TemporaryDirectory() as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+        src_dir = tmpdir / "src"
+        src_dir.mkdir()
+        (tmpdir / "elm.json").write_text(data=_ELM_JSON, encoding="utf-8")
+        (src_dir / "Main.elm").write_text(data=_MAIN_ELM, encoding="utf-8")
+        elm_home = tmpdir / ".elm"
+        elm_home.mkdir()
+        env = {**os.environ, "ELM_HOME": str(object=elm_home)}
+        check_path = src_dir / "Check.elm"
+        output_js = tmpdir / "main.js"
+        for filename in filenames:
+            if any(filename.endswith(suffix) for suffix in _SKIP_SUFFIXES):
+                continue
+            if _run_fixture(
+                filename=filename,
+                tmpdir=tmpdir,
+                check_path=check_path,
+                output_js=output_js,
+                elm_path=elm_path,
+                node_path=node_path,
+                env=env,
+            ):
+                failed = True
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a `Run Elm files` step to `lint-elm` that compiles each Elm fixture alongside a `Platform.worker` wrapper forcing `Check.my_data`, emits JavaScript via `elm make`, and executes it with Node — catching runtime crashes (e.g. `Debug.todo`) that the existing compile-only step never surfaces.
- Skip `scalar_int_very_negative_large/Elm.elm`: Elm 0.19.1 emits `--<digits>` (two unary minuses) for integers at the int64 boundary, which JavaScript rejects as a prefix-decrement syntax error. The existing `Check Elm compiles` step still validates this fixture's source.

Closes #1413

## Test plan
- [x] `uv run --no-project python run_elm.py` passes for every `tests/integration/cases/**/*.elm` fixture locally.
- [x] `uv run --no-project python check_elm_syntax.py` still passes (unchanged script, unchanged step).
- [x] `prek run --all-files actionlint` passes.
- [x] Manually verified the wrapper catches runtime failures by replacing `my_data` with `Debug.todo "..."` — `node main.js` exits non-zero with the expected `TODO in module Check` stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new CI execution step (Elm compile + Node run) that can increase runtime and introduce environment-dependent failures, plus fixture-specific skipping logic.
> 
> **Overview**
> `lint-elm` in `.github/workflows/lint.yml` now goes beyond formatting/compilation and **runs each Elm fixture end-to-end** by compiling it with a generated `Main.elm` wrapper and executing the resulting JS with Node.
> 
> This PR adds `run_elm.py` to drive the compile-and-run loop (skipping `scalar_int_very_negative_large` due to an Elm→JS `--<digits>` emission that Node treats as a syntax error) and updates `find-lint-files` inputs so changes to `run_elm.py` retrigger the Elm lint job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a13d849ac5cbb1eb2647361ab1f9901efe18cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->