### PR TITLE
Switch lint-scala to scala-cli with a warm Bloop compile server

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -678,30 +678,23 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.scala
-      - name: Install Scala
+      - name: Install scala-cli
         if: steps.find-files.outputs.found == 'true'
-        uses: coursier/setup-action@v3
-        with:
-          apps: scala scalac
-      - name: Check Scala syntax
-        if: steps.find-files.outputs.found == 'true'
-        run: |-
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            scalac -d "$tmpdir" "$f" || exit 1
-          done < /tmp/files-to-lint
+        uses: VirtusLab/scala-cli-setup@v1
       # Fixtures define `object Check { ... }` with no main method, so
       # compile alongside a small @main wrapper that forces the object
-      # (and therefore its val initializers) to load.
+      # (and therefore its val initializers) to load. scala-cli runs
+      # against a persistent Bloop compile server, so the compiler JVM
+      # stays warm across fixtures instead of cold-starting per file.
       - name: Run Scala files
         if: steps.find-files.outputs.found == 'true'
         run: |-
           while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
+            workspace=$(mktemp -d)
+            cp "$f" "$workspace/Fixture.scala"
             printf '@main def __run(): Unit = { val _ = Check }\n' \
-              > "$tmpdir/__Main.scala"
-            scalac -d "$tmpdir" "$f" "$tmpdir/__Main.scala" || exit 1
-            scala --main-class __run --classpath "$tmpdir" || exit 1
+              > "$workspace/Main.scala"
+            scala-cli run "$workspace" --main-class __run || exit 1
           done < /tmp/files-to-lint
 
   lint-dart:


### PR DESCRIPTION
## Summary
The `lint-scala` job ran `scalac` and `scala` in a serial bash loop, cold-starting two JVMs per fixture; with 271 fixtures it had to be cancelled after 22 minutes on #1458. This PR replaces that loop with `scala-cli run`, which keeps a persistent Bloop compile server across iterations, and drops the now-redundant separate syntax-check step since `scala-cli run` compiles as part of running. Local smoke test covered ~33 fixtures in ~16s (~0.48s/file), so the full job should finish in a few minutes rather than 25+.

## Test plan
- [ ] CI `lint-scala` runs `scala-cli run` against all 271 Scala fixtures and finishes well under the previous 22-minute mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change but it replaces the Scala lint execution path and toolchain, which could cause `lint-scala` to behave differently or fail if `scala-cli`/Bloop setup differs from `scalac`/`scala`.
> 
> **Overview**
> Updates the `lint-scala` GitHub Actions job to install and run fixtures with `scala-cli` (backed by a persistent Bloop server) instead of invoking `scalac`/`scala` per file.
> 
> Removes the separate Scala syntax-check step and adjusts the run loop to copy each fixture into a temporary workspace and execute via `scala-cli run` with a generated `@main` wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122f48b50e10b9147f0543651e2804287c6cbc3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->