### PR TITLE
Batch dart analyze across all fixtures in lint-dart

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -716,15 +716,25 @@ jobs:
       - name: Install Dart
         if: steps.find-files.outputs.found == 'true'
         uses: dart-lang/setup-dart@v1
+      # Each fixture is its own implicit Dart library (no `library`
+      # or `part` directives), so copying them all into one package
+      # and analyzing in a single `dart analyze` invocation pays the
+      # Dart VM startup cost once instead of per fixture. Fixtures are
+      # renamed to `fixture_N.dart` because several fixtures share a
+      # basename (e.g. `Dart.dart`); the mapping is printed so failures
+      # still point back to the original path.
       - name: Check Dart syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-
+          tmpdir=$(mktemp -d)
+          printf 'name: check\nenvironment:\n  sdk: ^3.0.0\n' > "$tmpdir/pubspec.yaml"
+          i=0
           while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            printf 'name: check\nenvironment:\n  sdk: ^3.0.0\n' > "$tmpdir/pubspec.yaml"
-            cp "$f" "$tmpdir/check.dart"
-            dart analyze --fatal-infos "$tmpdir/check.dart" || exit 1
+            cp "$f" "$tmpdir/fixture_$i.dart"
+            printf 'fixture_%s.dart <- %s\n' "$i" "$f"
+            i=$((i+1))
           done < /tmp/files-to-lint
+          dart analyze --fatal-infos "$tmpdir"
 
   lint-dhall:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- ``lint-dart`` in ``.github/workflows/lint.yml`` now copies every
+  fixture into one package and runs a single ``dart analyze``
+  invocation, instead of cold-starting the Dart VM per fixture
+  inside a serial ``while`` loop.  Mirrors the Bloop-backed warm-up
+  added to ``lint-scala`` in the prior change.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs each
   Swift fixture end-to-end via ``swift`` in script mode, catching
   runtime errors that ``swiftc -typecheck`` alone could miss

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,6 @@ Changelog
 Next
 ----
 
-- ``lint-dart`` in ``.github/workflows/lint.yml`` now copies every
-  fixture into one package and runs a single ``dart analyze``
-  invocation, instead of cold-starting the Dart VM per fixture
-  inside a serial ``while`` loop.  Mirrors the Bloop-backed warm-up
-  added to ``lint-scala`` in the prior change.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs each
   Swift fixture end-to-end via ``swift`` in script mode, catching
   runtime errors that ``swiftc -typecheck`` alone could miss


### PR DESCRIPTION
## Summary
- Closes #1477
- `lint-dart` previously iterated fixtures in a serial `while` loop and cold-started the Dart VM per file
- Now copies every fixture into one package (renamed `fixture_N.dart` to avoid basename collisions like `Dart.dart`) and runs a single `dart analyze --fatal-infos` invocation
- Prints the `fixture_N -> original path` mapping so failures still point at the real source file

## Test plan
- [ ] `lint-dart` CI job runs green
- [ ] Wall-clock duration of `lint-dart` drops noticeably versus `main`
- [ ] Intentionally broken fixture surfaces both the `fixture_N.dart` error and the printed mapping back to the original path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI linting behavior for Dart fixtures; while mostly a performance optimization, batching analysis and renaming files could change diagnostics/output paths or surface different analyzer interactions across fixtures.
> 
> **Overview**
> The `lint-dart` workflow step now copies all Dart integration fixtures into a single temporary Dart package (renaming them to `fixture_N.dart` to avoid basename collisions) and runs one `dart analyze --fatal-infos` over the directory, printing a mapping back to the original fixture paths.
> 
> This replaces the previous loop that created a temp package and cold-started the Dart VM for each fixture, reducing CI time at the cost of slightly different analysis context and error file names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0f63aa874300defeb6c4495cd50d27f4730b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->