### PR TITLE
Parallelize swiftc -typecheck in lint-swift

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -382,11 +382,13 @@ jobs:
       - name: Check Swift syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-
-          while IFS= read -r -d '' f; do
+          # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
+          xargs -0 -P "$(nproc)" -n1 bash -c '
             tmpdir=$(mktemp -d)
-            cp "$f" "$tmpdir/check.swift"
+            trap "rm -rf $tmpdir" EXIT
+            cp "$0" "$tmpdir/check.swift"
             swiftc -typecheck "$tmpdir/check.swift" || exit 1
-          done < /tmp/files-to-lint
+          ' < /tmp/files-to-lint
       - name: Run Swift files
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 -P "$(nproc)" -n1 swift < /tmp/files-to-lint

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- ``lint-swift`` in ``.github/workflows/lint.yml`` now runs its
+  ``swiftc -typecheck`` step in parallel via ``xargs -P``, replacing
+  the previous serial ``while`` loop so the job no longer cold-starts
+  the compiler one fixture at a time.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs each
   Swift fixture end-to-end via ``swift`` in script mode, catching
   runtime errors that ``swiftc -typecheck`` alone could miss


### PR DESCRIPTION
## Summary
- Replaces the serial `while` loop in `lint-swift`'s syntax-check step with `xargs -0 -P "$(nproc)" -n1 bash -c ...`, matching the pattern already used by `lint-cpp`, `lint-kotlin`, etc.
- Keeps the existing per-file semantics (each fixture copied to `check.swift` in its own tmpdir) since Swift's top-level-code restriction rules out batching fixtures into a single `swiftc` call.

Closes #1478.

## Test plan
- [ ] CI `lint-swift` Check Swift syntax step completes faster than before and still fails when a fixture has a syntax error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main risk is potential quoting/trap issues or increased concurrency load causing intermittent failures on GitHub runners.
> 
> **Overview**
> Speeds up the `lint-swift` CI job by replacing the serial `while` loop used for `swiftc -typecheck` with a parallel `xargs -P "$(nproc)"` invocation, while keeping the per-fixture tempdir copy semantics.
> 
> Updates `CHANGELOG.rst` to document the new parallel Swift syntax-check behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dcfa1c312e1ac6d7f452f5168191e294236a30f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->