### PR TITLE
Batch lint-groovy compilation in a single GroovyShell JVM

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -142,16 +142,29 @@ jobs:
         uses: wtfjoke/setup-groovy@v3
         with:
           groovy-version: 4.x
-      - name: Check Groovy syntax
+      # Parse and run every fixture inside a single Groovy JVM via
+      # GroovyShell, so the compiler stays warm across iterations
+      # instead of cold-starting groovyc/groovy per file. A fresh
+      # GroovyShell per fixture keeps classloaders isolated, since
+      # some fixtures declare top-level classes with shared names.
+      - name: Check and run Groovy files
         if: steps.find-files.outputs.found == 'true'
         run: |-
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            groovyc -d "$tmpdir" "$(realpath "$f")" || exit 1
-          done < /tmp/files-to-lint
-      - name: Run Groovy files
-        if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 groovy < /tmp/files-to-lint
+          cat > /tmp/lint.groovy <<'SCRIPT'
+          def content = new String(new File('/tmp/files-to-lint').bytes)
+          def paths = content.split('\0').findAll { it }
+          def failed = false
+          paths.each { p ->
+              try {
+                  new GroovyShell().parse(new File(p)).run()
+              } catch (Throwable t) {
+                  System.err.println("FAIL ${p}:\n${t.message}")
+                  failed = true
+              }
+          }
+          System.exit(failed ? 1 : 0)
+          SCRIPT
+          groovy /tmp/lint.groovy
 
   lint-javascript:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `lint-groovy` ran `groovyc` in a serial `while` loop and then re-cold-started `groovy` in a parallel `xargs` step, paying a JVM startup tax per fixture for both compile and run
- Collapsed both steps into a single step that parses and runs every fixture inside one Groovy JVM via `GroovyShell`, so the compiler stays warm across iterations. A fresh `GroovyShell` per fixture keeps classloaders isolated, which matters because a handful of fixtures declare top-level classes (`_ClientType`, etc.) with shared names across files.
- Local smoke test against all 231 fixtures: ~1.5s in a single batched JVM, versus ~8s for just 10 serial `groovyc` invocations (~190s extrapolated). Fixes #1475.

## Test plan
- [ ] CI `lint-groovy` compiles and runs all Groovy fixtures and finishes in seconds rather than minutes.
- [ ] Intentional syntax errors still fail the job (verified locally — exit code 1 with file/line/column reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it alters how Groovy fixtures are executed and could change failure reporting/ordering or expose new cross-file classloading issues.
> 
> **Overview**
> Updates the `lint-groovy` GitHub Actions job to **replace per-file `groovyc` compilation + parallel `groovy` execution** with a single Groovy script that iterates all fixtures and `parse(...).run()`s each one inside one JVM.
> 
> The new step fails the job if any fixture throws, while keeping each fixture in a fresh `GroovyShell` to reduce classloader collisions and significantly cut JVM startup overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df55b18d3815a78f9255a345f2df5aca1a3bfa18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->