### PR TITLE
Re-enable cppcoreguidelines-missing-std-forward

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@ Checks: >
   -clang-analyzer-deadcode.DeadStores,
   -clang-diagnostic-implicitly-unsigned-literal,
   -cppcoreguidelines-avoid-magic-numbers,
-  -cppcoreguidelines-missing-std-forward,
   -cppcoreguidelines-narrowing-conversions,
   -fuchsia-default-arguments-calls,
   -google-explicit-constructor,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- ``.clang-tidy`` re-enables
+  ``cppcoreguidelines-missing-std-forward``; the check guards
+  against forwarding references that are not ``std::forward``-ed,
+  and the current C++ generator output has no such patterns, so no
+  fixture changes were needed.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs its
   ``swiftc -typecheck`` step in parallel via ``xargs -P``, replacing
   the previous serial ``while`` loop so the job no longer cold-starts

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,6 @@ Changelog
 Next
 ----
 
-- ``.clang-tidy`` re-enables
-  ``cppcoreguidelines-missing-std-forward``; the check guards
-  against forwarding references that are not ``std::forward``-ed,
-  and the current C++ generator output has no such patterns, so no
-  fixture changes were needed.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs its
   ``swiftc -typecheck`` step in parallel via ``xargs -P``, replacing
   the previous serial ``while`` loop so the job no longer cold-starts


### PR DESCRIPTION
## Summary
- Remove `-cppcoreguidelines-missing-std-forward` from `.clang-tidy` so the check runs again.
- No fixture changes needed: the current C++ generator output contains no forwarding references, so nothing is flagged.

Closes #1467.

## Test plan
- [x] `clang-tidy --extra-arg=-std=c++20` across all `tests/integration/cases/**/*.cpp` fixtures with the new config produces no warnings.
- [ ] CI `lint-cpp` job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only configuration change with no runtime impact; risk is limited to potential new CI warnings if code relies on the previously-disabled check.
> 
> **Overview**
> Re-enables the `cppcoreguidelines-missing-std-forward` clang-tidy check by removing it from the `.clang-tidy` ignore list, so forwarding-reference code must use `std::forward`.
> 
> No other code or fixtures are changed; this PR only tightens C++ linting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb3db4008da22888a838c552e3663a2cbce61d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->