### PR TITLE
Switch Mojo lint to project-local pixi env per Modular docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1101,7 +1101,7 @@ jobs:
           while IFS= read -r -d '' f; do
             ok=0
             for attempt in 1 2 3; do
-              if pixi run --manifest-path "$MOJO_PIXI_MANIFEST" mojo run --Werror "$f"; then
+              if pixi run --manifest-path "$MOJO_PIXI_MANIFEST" mojo run --Werror "$GITHUB_WORKSPACE/$f"; then
                 ok=1
                 break
               fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1069,7 +1069,11 @@ jobs:
       - name: Install Mojo
         if: steps.find-files.outputs.found == 'true'
         run: |-
-          pixi global install --channel conda-forge --channel https://conda.modular.com/max mojo
+          pixi init "$RUNNER_TEMP/mojo-env" \
+            -c https://conda.modular.com/max \
+            -c conda-forge
+          pixi add --manifest-path "$RUNNER_TEMP/mojo-env/pixi.toml" mojo
+          echo "MOJO_PIXI_MANIFEST=$RUNNER_TEMP/mojo-env/pixi.toml" >> "$GITHUB_ENV"
       # Mojo reserves ~3.6 GB of virtual address space per invocation
       # (upstream: modular/modular#6433). On the 7 GB GitHub runner the
       # kernel's default overcommit heuristic refuses the allocation and
@@ -1097,7 +1101,7 @@ jobs:
           while IFS= read -r -d '' f; do
             ok=0
             for attempt in 1 2 3; do
-              if mojo run --Werror "$f"; then
+              if pixi run --manifest-path "$MOJO_PIXI_MANIFEST" mojo run --Werror "$f"; then
                 ok=1
                 break
               fi


### PR DESCRIPTION
## Summary
- Replace `pixi global install mojo` with Modular's documented project-local flow (`pixi init` + `pixi add mojo`), and invoke via `pixi run --manifest-path`.
- Channels and the stable `max` index are preserved; the swap/overcommit workaround for the libKGEN virtual-address crash (modular/modular#6433) is untouched, since install method does not affect that reservation.

## Test plan
- [ ] `lint-mojo` job passes on this PR against the existing `tests/integration/cases/**/*.mojo` fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how Mojo is installed and invoked in CI, which could break the `lint-mojo` job if pixi environment setup or paths behave differently on runners.
> 
> **Overview**
> Updates the `lint-mojo` GitHub Actions job to stop using a global `pixi` install of Mojo and instead create a temporary project-local pixi environment (`pixi init` + `pixi add mojo`), exporting the manifest path via `MOJO_PIXI_MANIFEST`.
> 
> Mojo checks are now executed with `pixi run --manifest-path ...` (using workspace-qualified file paths) while keeping the existing swap/overcommit workaround and retry loop unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90eb1d6ccd48a35fec05436ad6cc206c29ed1355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->