### PR TITLE
Extract inline Groovy lint script from lint.yml

### DIFF
--- a/.github/scripts/lint-groovy.groovy
+++ b/.github/scripts/lint-groovy.groovy
@@ -1,0 +1,11 @@
+def paths = System.in.text.split('\0').findAll { it }
+def failed = false
+paths.each { p ->
+    try {
+        new GroovyShell().parse(new File(p)).run()
+    } catch (Throwable t) {
+        System.err.println("FAIL ${p}:\n${t.message}")
+        failed = true
+    }
+}
+System.exit(failed ? 1 : 0)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -149,22 +149,7 @@ jobs:
       # some fixtures declare top-level classes with shared names.
       - name: Check and run Groovy files
         if: steps.find-files.outputs.found == 'true'
-        run: |-
-          cat > /tmp/lint.groovy <<'SCRIPT'
-          def content = new String(new File('/tmp/files-to-lint').bytes)
-          def paths = content.split('\0').findAll { it }
-          def failed = false
-          paths.each { p ->
-              try {
-                  new GroovyShell().parse(new File(p)).run()
-              } catch (Throwable t) {
-                  System.err.println("FAIL ${p}:\n${t.message}")
-                  failed = true
-              }
-          }
-          System.exit(failed ? 1 : 0)
-          SCRIPT
-          groovy /tmp/lint.groovy
+        run: groovy .github/scripts/lint-groovy.groovy < /tmp/files-to-lint
 
   lint-javascript:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `lint-groovy` in `.github/workflows/lint.yml` embedded a Groovy program in a `cat > /tmp/lint.groovy <<'SCRIPT'` heredoc, leaving the body with no syntax highlighting/linting and heredoc-quoting footguns.
- Commits the body as `.github/scripts/lint-groovy.groovy` (a real Groovy source file) and invokes it as `groovy .github/scripts/lint-groovy.groovy < /tmp/files-to-lint`, mirroring the Kotlin extraction in #1483.

Closes #1502.

## Test plan

- [ ] CI `lint-groovy` job passes.
- [ ] Introduce a deliberately-broken `.groovy` fixture locally and confirm the step exits non-zero with the error surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of CI linting: behavior should remain the same, with minor risk of workflow invocation/input handling differences causing Groovy lint to fail unexpectedly.
> 
> **Overview**
> Moves the Groovy lint runner out of `.github/workflows/lint.yml` into a committed script, `.github/scripts/lint-groovy.groovy`, and updates the `lint-groovy` job to invoke it via stdin (`/tmp/files-to-lint`).
> 
> This preserves the existing per-file `GroovyShell` parse/run and failure reporting, but avoids the inline heredoc script in the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fe625c3798b67837ebf0fbe72323cfdf13cdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->