### PR TITLE
Extract lint-sml fixtures to .github/scripts/sml_force.sml and sml_main.mlb

### DIFF
--- a/.github/scripts/sml_force.sml
+++ b/.github/scripts/sml_force.sml
@@ -1,0 +1,1 @@
+val _ = Check.my_data

--- a/.github/scripts/sml_main.mlb
+++ b/.github/scripts/sml_main.mlb
@@ -1,0 +1,3 @@
+$(SML_LIB)/basis/basis.mlb
+check.sml
+force.sml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1277,9 +1277,8 @@ jobs:
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
           cp "$1" "$tmpdir/check.sml"
-          printf 'val _ = Check.my_data\n' > "$tmpdir/force.sml"
-          printf '$(SML_LIB)/basis/basis.mlb\ncheck.sml\nforce.sml\n' \
-            > "$tmpdir/main.mlb"
+          cp .github/scripts/sml_force.sml "$tmpdir/force.sml"
+          cp .github/scripts/sml_main.mlb "$tmpdir/main.mlb"
           mlton -output "$tmpdir/out" "$tmpdir/main.mlb" || exit 1
           "$tmpdir/out" || exit 1
           SCRIPT


### PR DESCRIPTION
## Summary

- The `Run SML files` step in `.github/workflows/lint.yml` previously `printf`'d a `val _ = Check.my_data` force file and a `main.mlb` template into `$tmpdir` at run time. Commit them as real `.github/scripts/sml_force.sml` and `.github/scripts/sml_main.mlb` source files and copy them in, matching how `lint-kotlin` (#1476 / PR #1483) keeps its driver as a real source file instead of an inline heredoc.
- The heredoc-script + `xargs -0 -P "$(nproc)" -n1 bash /tmp/run-sml.sh` wrapper is preserved so we don't reintroduce the `bash -c '...'` shellcheck SC2016 pattern that PR #1485 just cleaned up.

Closes #1507.

## Test plan

- [x] `actionlint .github/workflows/lint.yml` clean.
- [x] Locally ran the new heredoc script against every fixture under `tests/integration/cases/**/*.sml` (via `xargs -0 -P 4 -n1 bash /tmp/run-sml.sh`) — all pass.
- [ ] CI `lint-sml` job stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors the `lint-sml` GitHub Actions step to copy pre-committed fixtures instead of generating them inline, with no behavior change expected beyond path/file handling.
> 
> **Overview**
> Extracts the SML lint “force” source and `main.mlb` build file from inline `printf` generation in `.github/workflows/lint.yml` into committed files (`.github/scripts/sml_force.sml` and `.github/scripts/sml_main.mlb`).
> 
> Updates the `lint-sml` run script to copy these files into the per-fixture temp directory before compiling/running with MLton.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6acab307f10bc94d989802de8215cc996e316b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->