### PR TITLE
Split clang-tidy into its own job to parallelize with C++ syntax check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -307,13 +307,9 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cpp
-          extra_config_patterns: .clang-tidy
       - name: Check C++ syntax
         if: steps.find-files.outputs.found == 'true'
         run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint
-      - name: Run clang-tidy
-        if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
       # Fixtures define `void check_()` with no main, so compile alongside
       # a tiny wrapper that invokes it and link into a runnable binary.
       - name: Run C++ files
@@ -328,6 +324,21 @@ jobs:
           "$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-cpp.sh < /tmp/files-to-lint
+
+  lint-cpp-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/find-lint-files
+        id: find-files
+        with:
+          lang_patterns: tests/integration/cases/**/*.cpp
+          extra_config_patterns: .clang-tidy
+      - name: Run clang-tidy
+        if: steps.find-files.outputs.found == 'true'
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
 
   lint-kotlin:
     runs-on: ubuntu-latest
@@ -1596,6 +1607,7 @@ jobs:
       - lint-c
       - lint-cobol
       - lint-cpp
+      - lint-cpp-tidy
       - lint-kotlin
       - lint-rust
       - lint-swift


### PR DESCRIPTION
## Summary
- Extract the `clang-tidy` step from `lint-cpp` into a new `lint-cpp-tidy` job so it runs in parallel with the C++ syntax check and fixture run.
- Add `lint-cpp-tidy` to `completion-lint` needs.

## Test plan
- [ ] CI: both `lint-cpp` and `lint-cpp-tidy` run and pass
- [ ] `completion-lint` waits on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: moves `clang-tidy` into its own job and updates `completion-lint` dependencies, with the main risk being unintended CI behavior changes (e.g., job ordering/coverage) rather than runtime code impact.
> 
> **Overview**
> **CI linting is parallelized for C++ fixtures.** The `clang-tidy` step is removed from `lint-cpp` and reintroduced as a new `lint-cpp-tidy` job that runs the same checks (including `.clang-tidy` discovery) in parallel with the C++ syntax check and fixture execution.
> 
> `completion-lint` is updated to also wait on `lint-cpp-tidy`, ensuring the overall lint gate reflects both C++ compilation/run and `clang-tidy` results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7347676454f6a844a75ab123e98443a2172b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->