### PR TITLE
Commit the lint-objectivec main wrapper as a real .m file

### DIFF
--- a/.github/scripts/objc_main.m
+++ b/.github/scripts/objc_main.m
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+extern void check_(void);
+
+int main(void) {
+    @autoreleasepool {
+        check_();
+    }
+    return 0;
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1521,14 +1521,9 @@ jobs:
         run: |-
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
-          cat > "$tmpdir/__main.m" <<'EOF'
-          # import <Foundation/Foundation.h>
-          extern void check_(void);
-          int main(void) { @autoreleasepool { check_(); } return 0; }
-          EOF
           while IFS= read -r -d '' f; do
             out="$tmpdir/out"
-            clang -framework Foundation "$f" "$tmpdir/__main.m" -o "$out" || exit 1
+            clang -framework Foundation "$f" .github/scripts/objc_main.m -o "$out" || exit 1
             "$out" || exit 1
           done < /tmp/files-to-lint
 


### PR DESCRIPTION
## Summary
- Extract the ``__main.m`` wrapper that ``lint-objectivec`` wrote via a heredoc into ``.github/scripts/objc_main.m`` as a real Objective-C source file.
- The workflow step now references the committed file directly, dropping both the heredoc and the ``# import`` workaround (the YAML parser had treated ``#import`` as a comment inline).
- Mirrors the prior-art Kotlin extraction from #1476 / #1483.

Closes #1509.

## Test plan
- [ ] CI ``lint-objectivec`` job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that replaces an inline heredoc wrapper with a committed Objective-C file; failure mode is limited to the `lint-objectivec` job not compiling/running fixtures as expected.
> 
> **Overview**
> The `lint-objectivec` GitHub Actions job now compiles Objective-C fixtures with a **committed** wrapper (`.github/scripts/objc_main.m`) instead of generating `__main.m` via heredoc.
> 
> This removes the inline `#import` YAML parsing workaround and makes the wrapper reusable/stable across runs while keeping the same runtime execution check of `check_()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82db5691c7a3c1d428aebd7b56b0f14132440ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->