### PR TITLE
Extract inline Haskell Main wrapper to .github/scripts/haskell_main.hs

### DIFF
--- a/.github/scripts/haskell_main.hs
+++ b/.github/scripts/haskell_main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Check
+
+main :: IO ()
+main = seq Check.my_data (return ())

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -620,7 +620,7 @@ jobs:
           # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
           xargs -0 -P "$(nproc)" -n1 bash -c '
             tmpdir=$(mktemp -d)
-            trap "rm -rf $tmpdir" EXIT
+            trap "rm -rf \"$tmpdir\"" EXIT
             cp "$0" "$tmpdir/Check.hs"
             if grep -qE "^main " "$0"; then
               ghc -main-is Check -outputdir "$tmpdir" \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -617,22 +617,21 @@ jobs:
       - name: Run Haskell files
         if: steps.find-files.outputs.found == 'true'
         run: |-
-          cat > /tmp/run-haskell.sh <<'SCRIPT'
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          cp "$1" "$tmpdir/Check.hs"
-          if grep -qE '^main ' "$1"; then
-            ghc -main-is Check -outputdir "$tmpdir" \
-              -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
-          else
-            printf 'module Main where\nimport Check\nmain :: IO ()\nmain = seq Check.my_data (return ())\n' \
-              > "$tmpdir/Main.hs"
-            ghc -outputdir "$tmpdir" \
-              -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
-          fi
-          "$tmpdir/run" || exit 1
-          SCRIPT
-          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-haskell.sh < /tmp/files-to-lint
+          # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
+          xargs -0 -P "$(nproc)" -n1 bash -c '
+            tmpdir=$(mktemp -d)
+            trap "rm -rf $tmpdir" EXIT
+            cp "$0" "$tmpdir/Check.hs"
+            if grep -qE "^main " "$0"; then
+              ghc -main-is Check -outputdir "$tmpdir" \
+                -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
+            else
+              cp .github/scripts/haskell_main.hs "$tmpdir/Main.hs"
+              ghc -outputdir "$tmpdir" \
+                -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
+            fi
+            "$tmpdir/run" || exit 1
+          ' < /tmp/files-to-lint
 
   lint-commonlisp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ``lint-haskell`` in ``.github/workflows/lint.yml`` used to ``cat > /tmp/run-haskell.sh`` a heredoc which itself ``printf``-ed a small ``Main.hs`` wrapper that forces ``Check.my_data``. The wrapper now lives as a real Haskell source file at ``.github/scripts/haskell_main.hs`` and the step ``cp``-s it into each per-fixture tmpdir. The remaining ``grep -qE '^main '`` branch is handled inline via ``xargs -0 -P \"\$(nproc)\" -n1 bash -c '...'``, so no generated ``/tmp/run-haskell.sh`` is maintained. Mirrors the prior extraction in #1476 / #1483 (Kotlin host as ``.main.kts``).

Closes #1505.

## Test plan
- [ ] CI ``lint-haskell`` job passes.
- [ ] Introduce a deliberately-broken ``.hs`` fixture locally and confirm the step exits non-zero with the ghc error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only refactor: the Haskell lint job’s execution path is equivalent but changes how the wrapper and per-file runner are created, which could affect fixture detection/quoting if wrong.
> 
> **Overview**
> Refactors the `lint-haskell` GitHub Actions step to stop generating a temporary `/tmp/run-haskell.sh` and inline `Main.hs` wrapper.
> 
> Adds a tracked wrapper file (`.github/scripts/haskell_main.hs`) and updates the workflow to copy it into each per-fixture temp dir, running compilation/execution via an inline `bash -c` under `xargs` (still using `-main-is Check` when a fixture defines `main`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f804f336129f5b4ba427dc50ea69e063ba1b9892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->