### PR TITLE
Add combined-variable-forms golden coverage for heterogeneous strategies

### DIFF
--- a/tests/integration/cases/dict_mixed_scalars/Rust_heterogeneous_strategy_tagged_enum_combined.rs
+++ b/tests/integration/cases/dict_mixed_scalars/Rust_heterogeneous_strategy_tagged_enum_combined.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+enum Value {
+    I32(i32),
+    Str(&'static str),
+}
+fn main() {
+    let mut my_data = HashMap::from([
+        ("a", Value::I32(1)),
+        ("b", Value::Str("x")),
+    ]);
+    my_data = HashMap::from([
+        ("a", Value::I32(1)),
+        ("b", Value::Str("x")),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1831,6 +1831,93 @@ def test_line_ending_combined_variable_forms(
 
 
 @dataclasses.dataclass
+class _HeterogeneousStrategyCombinedCase:
+    """A combined-variable-forms test case with a non-default
+    heterogeneous-scalar strategy.
+    """
+
+    name: str
+    lang_cls: literalizer.LanguageCls
+    heterogeneous_strategy: enum.Enum
+    case_dir_name: str
+
+
+@functools.cache
+@beartype
+def _build_heterogeneous_strategy_combined_cases() -> list[
+    _HeterogeneousStrategyCombinedCase
+]:
+    """Collect combined (declaration + assignment) test cases for
+    non-default heterogeneous-scalar strategies.
+    """
+    cases: list[_HeterogeneousStrategyCombinedCase] = []
+    case_dir_name = "dict_mixed_scalars"
+    for lang_cls in _sorted_languages():
+        lang_name = lang_cls.__name__
+        spec = _spec(lang_cls=lang_cls)
+        if not _find_redefinition_styles(spec=spec):
+            continue
+        default_strategy = spec.heterogeneous_strategy
+        for strategy in spec.heterogeneous_strategies:
+            if strategy is default_strategy:
+                continue
+            name = (
+                f"{lang_name}_heterogeneous_strategy"
+                f"_{strategy.name.lower()}_combined"
+            )
+            cases.append(
+                _HeterogeneousStrategyCombinedCase(
+                    name=name,
+                    lang_cls=lang_cls,
+                    heterogeneous_strategy=strategy,
+                    case_dir_name=case_dir_name,
+                )
+            )
+    return cases
+
+
+@pytest.mark.parametrize(
+    argnames="case",
+    argvalues=_build_heterogeneous_strategy_combined_cases(),
+    ids=[c.name for c in _build_heterogeneous_strategy_combined_cases()],
+)
+def test_heterogeneous_strategy_combined_variable_forms(
+    case: _HeterogeneousStrategyCombinedCase,
+    cases_dir: Path,
+    file_regression: FileRegressionFixture,
+) -> None:
+    """Test that combined (declaration + assignment) output with a
+    non-default heterogeneous-scalar strategy matches the golden file.
+    """
+    input_path = cases_dir / case.case_dir_name / "input.yaml"
+    yaml_string = input_path.read_text()
+    base_spec = _spec(lang_cls=case.lang_cls)
+    redef_styles = _find_redefinition_styles(spec=base_spec)
+    assert redef_styles
+    spec = _spec(
+        lang_cls=case.lang_cls,
+        heterogeneous_strategy=case.heterogeneous_strategy,
+        declaration_style=redef_styles[0],
+    )
+    result = literalizer.literalize(
+        source=yaml_string,
+        input_format=literalizer.InputFormat.YAML,
+        language=spec,
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=literalizer.BothVariableForms(name="my_data"),
+        wrap_in_file=True,
+    )
+    _check_golden(
+        file_regression=file_regression,
+        contents=result.code + "\n",
+        extension=spec.extension,
+        newline=None,
+        golden_path=input_path.parent / (case.name + spec.extension),
+    )
+
+
+@dataclasses.dataclass
 class _PreIndentCase:
     """A ``pre_indent_level`` golden-file test case.
 
@@ -1957,6 +2044,14 @@ def test_no_dead_golden_files(request: pytest.FixtureRequest) -> None:
             cases_dir
             / line_ending_case.case_dir_name
             / (line_ending_case.name + line_ending_spec.extension)
+        )
+
+    for strategy_case in _build_heterogeneous_strategy_combined_cases():
+        ext = strategy_case.lang_cls.extension
+        expected.add(
+            cases_dir
+            / strategy_case.case_dir_name
+            / (strategy_case.name + ext)
         )
 
     for pre_indent_case in _build_pre_indent_cases():


### PR DESCRIPTION
## Summary

- Closes #1519.
- Mirrors `_build_line_ending_combined_cases` / `test_line_ending_combined_variable_forms` with a new `_HeterogeneousStrategyCombinedCase` + `test_heterogeneous_strategy_combined_variable_forms` that drives `BothVariableForms` against `dict_mixed_scalars` for every language with both a redefinition-supporting declaration style and a non-default `heterogeneous_strategy`.
- At present this adds `Rust_heterogeneous_strategy_tagged_enum_combined.rs` under `LET_MUT`, exercising the assignment render path for `TAGGED_ENUM`; `test_no_dead_golden_files` is updated to register the new golden.

## Test plan

- [ ] `uv run pytest tests/integration/test_integration.py` passes locally.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add new golden coverage and parameterized cases without touching production literalization logic. Main risk is increased test matrix/time and potential golden brittleness across languages/strategies.
> 
> **Overview**
> Adds new integration coverage for *combined declaration+assignment output* (`BothVariableForms`) when a language uses a **non-default heterogeneous-scalar strategy**.
> 
> Introduces a new parameterized test that iterates languages supporting redefinition and each non-default `heterogeneous_strategy`, and registers the generated goldens in `test_no_dead_golden_files`. Includes an initial Rust `TAGGED_ENUM` combined golden for the `dict_mixed_scalars` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3829e9c29bea0dc2df7112992b8a47ed216881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->