### PR TITLE
Preload C++ standard headers via PCH in lint-cpp

### DIFF
--- a/.github/scripts/lint-cpp-pch.hpp
+++ b/.github/scripts/lint-cpp-pch.hpp
@@ -1,0 +1,11 @@
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <initializer_list>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -333,22 +333,16 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cpp
-          extra_config_patterns: |
-            .clang-tidy
-            .github/scripts/lint-cpp-pch.hpp
-      # Preload the standard headers once via a precompiled header so
-      # clang-tidy does not re-parse them for each of the 269 fixtures.
-      - name: Build precompiled header
-        if: steps.find-files.outputs.found == 'true'
-        run: clang++ -std=c++20 -x c++-header .github/scripts/lint-cpp-pch.hpp -o
-          /tmp/pch.hpp.pch
-      # Pass -include-pch as two separate args; clang's driver treats it
-      # as a Separate option, so the joined `-include-pch=PATH` form is
-      # parsed as `-include -pch=PATH` and fails to find the file.
+          extra_config_patterns: .clang-tidy
+      # Preloading the standard headers via PCH was tried here but made
+      # clang-tidy ~2x slower on the Ubuntu runner: with `Checks: *`
+      # enabling `clang-analyzer-*`, the preloaded AST exposes the
+      # entire standard library to the static analyzer per fixture,
+      # multiplying analysis cost. The PCH still helps the lint-cpp
+      # job, where only parsing (not symbolic execution) runs.
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 --extra-arg=-include-pch
-          --extra-arg=/tmp/pch.hpp.pch < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
 
   lint-kotlin:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -340,10 +340,13 @@ jobs:
         if: steps.find-files.outputs.found == 'true'
         run: clang++ -std=c++20 -x c++-header .github/scripts/lint-cpp-pch.hpp -o
           /tmp/pch.hpp.pch
+      # Pass -include-pch as two separate args; clang's driver treats it
+      # as a Separate option, so the joined `-include-pch=PATH` form is
+      # parsed as `-include -pch=PATH` and fails to find the file.
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 --extra-arg=-include-pch=/tmp/pch.hpp.pch
-          < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 --extra-arg=-include-pch
+          --extra-arg=/tmp/pch.hpp.pch < /tmp/files-to-lint
 
   lint-kotlin:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -292,13 +292,26 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.cpp
-          extra_config_patterns: .clang-tidy
+          extra_config_patterns: |
+            .clang-tidy
+            .github/scripts/lint-cpp-pch.hpp
+      # Fixtures are tiny TUs whose cost is dominated by re-parsing the
+      # same standard headers 269 times. Build a precompiled header once
+      # covering every header any fixture includes, then preload it in
+      # each compile and clang-tidy invocation so the parsed AST is
+      # reused instead of re-parsed per file.
+      - name: Build precompiled header
+        if: steps.find-files.outputs.found == 'true'
+        run: clang++ -std=c++20 -x c++-header .github/scripts/lint-cpp-pch.hpp -o
+          /tmp/pch.hpp.pch
       - name: Check C++ syntax
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 clang++ -fsyntax-only -std=c++20 < /tmp/files-to-lint
+        run: xargs -0 clang++ -fsyntax-only -std=c++20 -include-pch /tmp/pch.hpp.pch
+          < /tmp/files-to-lint
       - name: Run clang-tidy
         if: steps.find-files.outputs.found == 'true'
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 --extra-arg=-include-pch=/tmp/pch.hpp.pch
+          < /tmp/files-to-lint
       # Fixtures define `void check_()` with no main, so compile alongside
       # a tiny wrapper that invokes it and link into a runnable binary.
       - name: Run C++ files
@@ -309,7 +322,7 @@ jobs:
           trap 'rm -rf "$tmpdir"' EXIT
           printf 'void check_();\nint main(){ check_(); return 0; }\n' \
             > "$tmpdir/__main.cpp"
-          clang++ -std=c++20 "$1" "$tmpdir/__main.cpp" -o "$tmpdir/run" || exit 1
+          clang++ -std=c++20 -include-pch /tmp/pch.hpp.pch "$1" "$tmpdir/__main.cpp" -o "$tmpdir/run" || exit 1
           "$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-cpp.sh < /tmp/files-to-lint


### PR DESCRIPTION
## Summary
- The 269 C++ fixtures all include the same handful of standard library headers; re-parsing them per file dominates the lint-cpp wall time.
- Build a PCH once from the union of those headers and pass `-include-pch` to `clang++` for the syntax check and the compile+run step.
- Local benchmarks across all fixtures: syntax check 153.7s → 17.1s (~9×), compile+link+run 66.9s → 35.6s (~1.9×). PCH build is ~2-3s upfront.
- PCH was tried in `lint-cpp-tidy` too but made it ~2× slower on the Ubuntu runner — with `Checks: *` enabling `clang-analyzer-*`, the preloaded AST exposes the entire standard library to the static analyzer per fixture, so PCH is intentionally not applied there.

## Test plan
- [ ] CI lint-cpp passes and is faster than the previous run on `main`.
- [ ] CI lint-cpp-tidy is unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that alters how `clang++` is invoked for C++ fixture syntax/run checks; main failure mode is false CI failures if the PCH becomes incompatible with the runner’s clang or fixture includes.
> 
> **Overview**
> Adds a small C++ header set (`.github/scripts/lint-cpp-pch.hpp`) and updates the `lint-cpp` GitHub Actions job to build a precompiled header once and reuse it via `-include-pch` for both the syntax-only pass and the compile+run step.
> 
> Also updates `find-lint-files` inputs to track the new PCH file and documents why PCH is *not* enabled for `lint-cpp-tidy` due to observed performance regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53bd52e07e78c722cb4ed31d5f1e99f84380d667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->