### PR TITLE
Cover ordered_map with heterogeneous_strategy variants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Next
 ----
 
+- The ``heterogeneous_strategy`` variant case list now includes the
+  ``ordered_map`` fixture, covering Rust ``TAGGED_ENUM`` and Dhall
+  ``UNION_TYPE`` rendering on ``!!omap`` inputs.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs its
   ``swiftc -typecheck`` step in parallel via ``xargs -P``, replacing
   the previous serial ``while`` loop so the job no longer cold-starts

--- a/tests/integration/cases/ordered_map/Dhall_heterogeneous_strategy_union_type.dhall
+++ b/tests/integration/cases/ordered_map/Dhall_heterogeneous_strategy_union_type.dhall
@@ -1,0 +1,6 @@
+let Value = < Str : Text | Int : Integer | Bool : Bool > in
+let my_data = {
+  name = Value.Str "Alice",
+  age = Value.Int +30,
+  active = Value.Bool True,
+} in my_data

--- a/tests/integration/cases/ordered_map/Rust_heterogeneous_strategy_tagged_enum.rs
+++ b/tests/integration/cases/ordered_map/Rust_heterogeneous_strategy_tagged_enum.rs
@@ -1,0 +1,14 @@
+use std::collections::HashMap;
+enum Value {
+    Str(&'static str),
+    I32(i32),
+    Bool(bool),
+}
+fn main() {
+    let my_data = HashMap::from([
+        ("name", Value::Str("Alice")),
+        ("age", Value::I32(30)),
+        ("active", Value::Bool(true)),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1653,6 +1653,7 @@ def _build_variant_cases() -> list[_VariantCase]:
         (heterogeneous_strategy, "dict_all_scalar_types", ""),
         (heterogeneous_strategy, "nested_sequences", ""),
         (heterogeneous_strategy, "dict_mixed_int_widths", ""),
+        (heterogeneous_strategy, "ordered_map", ""),
     ]
     for variants, case_dir_name, suffix in variant_sources:
         cases.extend(


### PR DESCRIPTION
## Summary
- Add `(heterogeneous_strategy, "ordered_map", "")` to `variant_sources` so the `!!omap` fixture exercises Rust `TAGGED_ENUM` and Dhall `UNION_TYPE` render paths.
- Regenerate the resulting `Rust_heterogeneous_strategy_tagged_enum.rs` and `Dhall_heterogeneous_strategy_union_type.dhall` goldens.

Closes #1523

## Test plan
- [x] `uv run pytest tests/integration/test_integration.py::test_format_variant_golden_file[Rust] tests/integration/test_integration.py::test_format_variant_golden_file[Dhall]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test parametrization and new golden fixtures, with no production formatting logic modified.
> 
> **Overview**
> Adds the `ordered_map` fixture to the `heterogeneous_strategy` variant test matrix so `!!omap` inputs exercise Rust `TAGGED_ENUM` and Dhall `UNION_TYPE` rendering.
> 
> Regenerates/introduces the corresponding golden outputs for Rust and Dhall, and documents the new coverage in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5a0d90ccb628d4f52868a7f09511258248b43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->