### PR TITLE
Parallelize lint-jsonnet with xargs -P

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -205,10 +205,7 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Check Jsonnet syntax
         if: steps.find-files.outputs.found == 'true'
-        run: |-
-          while IFS= read -r -d '' f; do
-            jsonnet "$f" > /dev/null || exit 1
-          done < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 jsonnet < /tmp/files-to-lint > /dev/null
 
   lint-typescript:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Next
   ``swiftc -typecheck`` step in parallel via ``xargs -P``, replacing
   the previous serial ``while`` loop so the job no longer cold-starts
   the compiler one fixture at a time.
+- ``lint-jsonnet`` in ``.github/workflows/lint.yml`` now runs
+  ``jsonnet`` in parallel via ``xargs -P``, replacing the previous
+  serial ``while`` loop.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs each
   Swift fixture end-to-end via ``swift`` in script mode, catching
   runtime errors that ``swiftc -typecheck`` alone could miss

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,9 +11,6 @@ Next
   ``swiftc -typecheck`` step in parallel via ``xargs -P``, replacing
   the previous serial ``while`` loop so the job no longer cold-starts
   the compiler one fixture at a time.
-- ``lint-jsonnet`` in ``.github/workflows/lint.yml`` now runs
-  ``jsonnet`` in parallel via ``xargs -P``, replacing the previous
-  serial ``while`` loop.
 - ``lint-swift`` in ``.github/workflows/lint.yml`` now runs each
   Swift fixture end-to-end via ``swift`` in script mode, catching
   runtime errors that ``swiftc -typecheck`` alone could miss


### PR DESCRIPTION
## Summary
- Replace the serial `while` loop in `lint-jsonnet` with `xargs -0 -P "$(nproc)" -n1 jsonnet`, mirroring the parallelism used by the other lint jobs (prior art: #1478).

Fixes #1491

## Test plan
- [ ] CI `lint-jsonnet` job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: switches `lint-jsonnet` from a serial loop to parallel `xargs`, which could only affect job ordering and how quickly failures surface.
> 
> **Overview**
> Updates the GitHub Actions `lint-jsonnet` job to run Jsonnet syntax checks in parallel by replacing the per-file `while` loop with `xargs -0 -P "$(nproc)" -n1 jsonnet`, reducing CI runtime while keeping the same validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0ca29adfe4fff658b86a76ea1d7c8fa069bb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->