### PR TITLE
Parallelize lint-json5 with xargs -P

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -183,10 +183,7 @@ jobs:
         run: npm install -g json5
       - name: Check JSON5 syntax
         if: steps.find-files.outputs.found == 'true'
-        run: |-
-          while IFS= read -r -d '' f; do
-            json5 "$f" > /dev/null || exit 1
-          done < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 json5 < /tmp/files-to-lint > /dev/null
 
   lint-jsonnet:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace the serial ``while`` loop in ``lint-json5`` with ``xargs -0 -P "$(nproc)" -n1 json5 < /tmp/files-to-lint > /dev/null``, matching the parallel pattern used by other lint jobs.

Closes #1490.

## Test plan
- [ ] CI ``lint-json5`` job passes and runs faster than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters how JSON5 files are iterated/executed; potential issues are limited to CI behavior (e.g., ordering/log output) and should surface immediately in the workflow run.
> 
> **Overview**
> **Parallelizes JSON5 linting in CI.** The `lint-json5` job in `.github/workflows/lint.yml` replaces a serial `while` loop with `xargs -0 -P "$(nproc)" -n1 json5`, running per-file JSON5 syntax checks concurrently to reduce job runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76af7fcb75820c3e4e1ee2c6cb3756bc2f1fc90f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->