### PR TITLE
Batch lint-powershell pwsh invocations into one process

### DIFF
--- a/.github/scripts/lint-powershell.ps1
+++ b/.github/scripts/lint-powershell.ps1
@@ -1,0 +1,15 @@
+$stream = [Console]::OpenStandardInput()
+$buffer = New-Object System.IO.MemoryStream
+$stream.CopyTo($buffer)
+$paths = [System.Text.Encoding]::UTF8.GetString($buffer.ToArray()) -split "`0" |
+    Where-Object { $_ }
+$failed = $false
+foreach ($p in $paths) {
+    try {
+        $null = [scriptblock]::Create((Get-Content -Raw -LiteralPath $p))
+    } catch {
+        [Console]::Error.WriteLine("FAIL ${p}: $($_.Exception.Message)")
+        $failed = $true
+    }
+}
+if ($failed) { exit 1 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -928,13 +928,27 @@ jobs:
         id: find-files
         with:
           lang_patterns: tests/integration/cases/**/*.ps1
+      # Parse every fixture inside a single pwsh invocation so the .NET
+      # and PowerShell startup cost is paid once instead of per fixture.
       - name: Check PowerShell syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-
-          while IFS= read -r -d '' f; do
-            pwsh -NoProfile -NonInteractive -Command \
-              "\$null = [scriptblock]::Create((Get-Content -Raw '$f'))" || exit 1
-          done < /tmp/files-to-lint
+          cat > /tmp/lint.ps1 <<'SCRIPT'
+          $bytes = [System.IO.File]::ReadAllBytes('/tmp/files-to-lint')
+          $paths = [System.Text.Encoding]::UTF8.GetString($bytes) -split "`0" |
+              Where-Object { $_ }
+          $failed = $false
+          foreach ($p in $paths) {
+              try {
+                  $null = [scriptblock]::Create((Get-Content -Raw -LiteralPath $p))
+              } catch {
+                  [Console]::Error.WriteLine("FAIL ${p}: $($_.Exception.Message)")
+                  $failed = $true
+              }
+          }
+          if ($failed) { exit 1 }
+          SCRIPT
+          pwsh -NoProfile -NonInteractive -File /tmp/lint.ps1
 
   lint-ada:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -932,23 +932,8 @@ jobs:
       # and PowerShell startup cost is paid once instead of per fixture.
       - name: Check PowerShell syntax
         if: steps.find-files.outputs.found == 'true'
-        run: |-
-          cat > /tmp/lint.ps1 <<'SCRIPT'
-          $bytes = [System.IO.File]::ReadAllBytes('/tmp/files-to-lint')
-          $paths = [System.Text.Encoding]::UTF8.GetString($bytes) -split "`0" |
-              Where-Object { $_ }
-          $failed = $false
-          foreach ($p in $paths) {
-              try {
-                  $null = [scriptblock]::Create((Get-Content -Raw -LiteralPath $p))
-              } catch {
-                  [Console]::Error.WriteLine("FAIL ${p}: $($_.Exception.Message)")
-                  $failed = $true
-              }
-          }
-          if ($failed) { exit 1 }
-          SCRIPT
-          pwsh -NoProfile -NonInteractive -File /tmp/lint.ps1
+        run: pwsh -NoProfile -NonInteractive -File .github/scripts/lint-powershell.ps1
+          < /tmp/files-to-lint
 
   lint-ada:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- ``lint-powershell`` in ``.github/workflows/lint.yml`` now parses every
+  fixture inside a single ``pwsh`` invocation instead of cold-starting
+  ``pwsh`` once per file, paying the .NET and PowerShell startup cost
+  once for the whole job.
 - The ``heterogeneous_strategy`` variant case list now includes the
   ``ordered_map`` fixture, covering Rust ``TAGGED_ENUM`` and Dhall
   ``UNION_TYPE`` rendering on ``!!omap`` inputs.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,6 @@ Changelog
 Next
 ----
 
-- ``lint-powershell`` in ``.github/workflows/lint.yml`` now parses every
-  fixture inside a single ``pwsh`` invocation instead of cold-starting
-  ``pwsh`` once per file, paying the .NET and PowerShell startup cost
-  once for the whole job.
 - The ``heterogeneous_strategy`` variant case list now includes the
   ``ordered_map`` fixture, covering Rust ``TAGGED_ENUM`` and Dhall
   ``UNION_TYPE`` rendering on ``!!omap`` inputs.


### PR DESCRIPTION
## Summary
- Replace the serial `while` loop that cold-started `pwsh` per fixture with a small driver script run inside a single warm `pwsh`, paying the .NET and PowerShell startup cost once for the whole job.
- The driver iterates the null-delimited `/tmp/files-to-lint` list and calls `[scriptblock]::Create` per file (matching the previous syntax check), collecting failures across all fixtures instead of aborting on the first.

Closes #1489

## Test plan
- [ ] `lint-powershell` job passes on CI.
- [ ] Deliberately break a `.ps1` fixture to confirm failures surface with the original path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters how PowerShell fixtures are syntax-checked; main risk is missed/changed failure behavior if the new driver script handles paths or errors differently.
> 
> **Overview**
> Speeds up the `lint-powershell` GitHub Actions job by replacing per-file `pwsh` startups with a single invocation that parses all `.ps1` fixtures.
> 
> Adds `.github/scripts/lint-powershell.ps1`, which reads the null-delimited file list from stdin, runs `[scriptblock]::Create` on each file, and reports all failures before exiting non-zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ca7020cca206f9ad484810e757a5c539e0bd39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->