### PR TITLE
Parallelize hcl2json in lint-hcl

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -670,10 +670,9 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Check HCL syntax
         if: steps.find-files.outputs.found == 'true'
-        run: |-
-          while IFS= read -r -d '' f; do
-            hcl2json "$f" > /dev/null || exit 1
-          done < /tmp/files-to-lint
+        run: >-
+          xargs -0 -P "$(nproc)" -n1 hcl2json
+          < /tmp/files-to-lint > /dev/null
 
   lint-clojure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace the serial `while` loop in `lint-hcl` with `xargs -0 -P "$(nproc)" -n1 hcl2json`, mirroring the pattern used for `lint-swift` in #1480.

Closes #1492.

## Test plan
- [ ] CI `lint-hcl` job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that switches `lint-hcl` from a serial loop to parallel `xargs` execution; main risk is altered failure/log ordering or runner-specific `xargs`/`nproc` behavior.
> 
> **Overview**
> Updates the `lint-hcl` GitHub Actions job to **run `hcl2json` over HCL fixtures in parallel** using `xargs -0 -P "$(nproc)" -n1`, replacing the previous per-file `while` loop.
> 
> This keeps the same input source (`/tmp/files-to-lint`) and still discards output, but should reduce lint runtime by leveraging available CPU cores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ecb7227c9366a86c2cdac78c6cb794f7d64bd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->