### PR TITLE
Parallelize lint-dhall checks with xargs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -775,9 +775,10 @@ jobs:
       - name: Check Dhall syntax
         if: steps.find-files.outputs.found == 'true'
         run: |-
-          while IFS= read -r -d '' f; do
-            dhall < "$f" > /dev/null || exit 1
-          done < /tmp/files-to-lint
+          cat > /tmp/check-dhall.sh <<'SCRIPT'
+          dhall < "$1" > /dev/null
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/check-dhall.sh < /tmp/files-to-lint
 
   lint-julia:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Closes #1493
- Replaces the serial `while` loop in the `lint-dhall` job with a `xargs -0 -P "$(nproc)" -n1` invocation, matching the parallelization pattern used elsewhere in `lint.yml` (Swift/SML/Crystal).
- Uses a small helper script at `/tmp/check-dhall.sh` so `dhall` can read each fixture from stdin without needing a shellcheck directive for `$0` inside single-quoted `bash -c`.

## Test plan
- [ ] CI `lint-dhall` job passes and runs noticeably faster than before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: switches Dhall linting from a serial loop to parallel `xargs`, which could alter failure ordering/output but not runtime behavior of the codebase.
> 
> **Overview**
> Speeds up the `lint-dhall` GitHub Actions job by replacing the serial per-file `dhall` syntax check loop with a parallel `xargs -P "$(nproc)"` execution via a small `/tmp/check-dhall.sh` helper script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523b6e75420e08536673b7a350fb4d984471053b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->