### PR TITLE
Batch lint-fsharp fixtures in a single FSI session

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -491,14 +491,20 @@ jobs:
         run: |
           mkdir -p /tmp/.dotnet/shm
           dotnet --info
+      # Generate an FSX driver that `#load`s every fixture, then
+      # evaluate it in a single `dotnet fsi --exec` invocation so
+      # the .NET runtime and FSI compiler start up once instead of
+      # per fixture. Each fixture re-declares `module Check`; FSI
+      # shadows the previous definition, which is fine because the
+      # top-level bindings still execute at load time.
       - name: Check F# syntax
         run: |-
+          driver=$(mktemp -d)/driver.fsx
           while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 \
-              TMPDIR="$tmpdir" HOME="$tmpdir" \
-              dotnet fsi --nologo --exec "$f" || exit 1
-          done < /tmp/files-to-lint
+            printf '#load "%s"\n' "$(realpath "$f")"
+          done < /tmp/files-to-lint > "$driver"
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 \
+            dotnet fsi --nologo --exec "$driver"
 
   lint-ocaml:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `lint-fsharp` ran `dotnet fsi --exec` in a serial `while` loop, cold-starting the .NET runtime and FSI compiler per fixture.
- Generate an FSX driver that `#load`s every fixture and evaluate it in a single `dotnet fsi --exec` invocation so the runtime starts up once. Each fixture re-declares `module Check`; FSI shadows the previous definition, and top-level bindings still execute at load time.
- Locally this takes ~5s for all 272 fixtures, versus ~30s for 20 serial invocations (~400s extrapolated).

Closes #1486.

## Test plan
- [ ] `lint-fsharp` CI job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `lint-fsharp` GitHub Actions step to run fixtures via a generated driver script; main risk is altered execution ordering/side effects between fixtures within one FSI process.
> 
> **Overview**
> Speeds up the `lint-fsharp` CI job by replacing the per-fixture `dotnet fsi --exec` loop with a single FSI invocation over a generated `driver.fsx` that `#load`s all F# fixtures.
> 
> Adds inline workflow documentation explaining why reusing one FSI session is safe despite repeated `module Check` declarations, and relies on absolute paths (`realpath`) when building the driver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f417f6baa37f11ac2854382d98fd576e56fd628e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->