### PR TITLE
Speed up lint-objectivec with PCH and parallel run step

### DIFF
--- a/.github/scripts/lint-objc-pch.h
+++ b/.github/scripts/lint-objc-pch.h
@@ -1,0 +1,1 @@
+#import <Foundation/Foundation.h>

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1383,19 +1383,17 @@ jobs:
       # preload it in the syntax-check and build-and-run steps so the
       # parsed AST is reused instead of re-parsed per fixture. clang-tidy
       # deliberately skips the PCH — see the note on `lint-cpp-tidy`.
+      #
+      # PCH is compiler-version specific, so all clang invocations that
+      # read it must use Apple's clang. The `Install clang-tidy` step
+      # below prepends Homebrew's llvm to `PATH`, which would shadow
+      # `clang` with an incompatible build, so every Objective-C compile
+      # step runs before that install.
       - name: Build precompiled header
         run: clang -x objective-c-header .github/scripts/lint-objc-pch.h -o /tmp/pch.h.pch
       - name: Check Objective-C syntax
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only -Werror -include-pch
           /tmp/pch.h.pch < /tmp/files-to-lint
-      # macos-15-arm64 ships Apple's clang but no clang-tidy, so pull it
-      # from Homebrew's llvm formula.
-      - name: Install clang-tidy
-        run: |-
-          brew install --quiet llvm
-          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
-      - name: Run clang-tidy
-        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy < /tmp/files-to-lint
       # Fixtures define `check_(void)` with no main entry point, so
       # compile each alongside a tiny wrapper that calls it. Link
       # against Foundation and execute to surface runtime errors. Each
@@ -1411,6 +1409,14 @@ jobs:
           "$tmpdir/out" || exit 1
           SCRIPT
           xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 bash /tmp/run-objc.sh < /tmp/files-to-lint
+      # macos-15-arm64 ships Apple's clang but no clang-tidy, so pull it
+      # from Homebrew's llvm formula.
+      - name: Install clang-tidy
+        run: |-
+          brew install --quiet llvm
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+      - name: Run clang-tidy
+        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy < /tmp/files-to-lint
 
   lint-wren:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1378,9 +1378,16 @@ jobs:
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name 'ObjectiveC*.m' -print0 > /tmp/files-to-lint
+      # Every fixture `#import`s `<Foundation/Foundation.h>`, whose parse
+      # cost dominates each tiny TU. Precompile Foundation once and
+      # preload it in the syntax-check and build-and-run steps so the
+      # parsed AST is reused instead of re-parsed per fixture. clang-tidy
+      # deliberately skips the PCH — see the note on `lint-cpp-tidy`.
+      - name: Build precompiled header
+        run: clang -x objective-c-header .github/scripts/lint-objc-pch.h -o /tmp/pch.h.pch
       - name: Check Objective-C syntax
-        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only -Werror <
-          /tmp/files-to-lint
+        run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only -Werror -include-pch
+          /tmp/pch.h.pch < /tmp/files-to-lint
       # macos-15-arm64 ships Apple's clang but no clang-tidy, so pull it
       # from Homebrew's llvm formula.
       - name: Install clang-tidy
@@ -1391,16 +1398,19 @@ jobs:
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy < /tmp/files-to-lint
       # Fixtures define `check_(void)` with no main entry point, so
       # compile each alongside a tiny wrapper that calls it. Link
-      # against Foundation and execute to surface runtime errors.
+      # against Foundation and execute to surface runtime errors. Each
+      # invocation gets a private tmpdir so parallel builds don't clobber
+      # each other's output binary.
       - name: Run Objective-C files
         run: |-
+          cat > /tmp/run-objc.sh <<'SCRIPT'
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
-          while IFS= read -r -d '' f; do
-            out="$tmpdir/out"
-            clang -framework Foundation -Werror "$f" .github/scripts/objc_main.m -o "$out" || exit 1
-            "$out" || exit 1
-          done < /tmp/files-to-lint
+          clang -framework Foundation -Werror -include-pch /tmp/pch.h.pch "$1" \
+            .github/scripts/objc_main.m -o "$tmpdir/out" || exit 1
+          "$tmpdir/out" || exit 1
+          SCRIPT
+          xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 bash /tmp/run-objc.sh < /tmp/files-to-lint
 
   lint-wren:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Precompile `<Foundation/Foundation.h>` once and preload it via `-include-pch` in the syntax-check and build-and-run steps, so Foundation is parsed once instead of per fixture (~10× faster locally on the syntax check).
- Parallelise the `Run Objective-C files` step with `xargs -P` and a per-invocation tmpdir, replacing the serial `while` loop (~5× faster locally; 140s → 27s on 240 fixtures).
- Leaves clang-tidy unchanged — the repo's `.clang-tidy` uses `Checks: *`, which the existing `lint-cpp-tidy` note documents as being slowed down by PCH preloading.

## Test plan
- [ ] `lint-objectivec` job passes on CI with the new PCH + parallel run step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow changes that adjust how Objective-C fixtures are compiled/run; main risk is macOS toolchain/PCH compatibility causing false failures or missed issues.
> 
> **Overview**
> Speeds up the `lint-objectivec` GitHub Actions job by **precompiling `Foundation` into a PCH** (`.github/scripts/lint-objc-pch.h`) and reusing it via `-include-pch` for both the syntax check and compile/run steps.
> 
> Updates the run step to execute fixtures **in parallel** using an `xargs -P`-driven wrapper script with a per-invocation temp directory to avoid output clobbering, and reorders steps so Objective-C compilation happens before Homebrew’s `llvm` install to keep PCH/clang versions consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67e82b68f0a26d9c1f6d2f734eb1925947aeb9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->