### PR TITLE
Reduce module-level globals by localizing single-use constants

### DIFF
--- a/check_csharp_syntax.py
+++ b/check_csharp_syntax.py
@@ -7,10 +7,21 @@ import sys
 import tempfile
 from pathlib import Path
 
-_DOTNET_ENV = {
-    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
-    "DOTNET_NOLOGO": "1",
-}
+
+def _dotnet_env(tmp_home: Path) -> dict[str, str]:
+    """Return an environment for invoking ``dotnet`` rooted at
+    ``tmp_home``.
+    """
+    env = os.environ.copy()
+    env.update(
+        {
+            "TMPDIR": tmp_home.as_posix(),
+            "HOME": tmp_home.as_posix(),
+            "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
+            "DOTNET_NOLOGO": "1",
+        }
+    )
+    return env
 
 
 def _target_framework(dotnet_path: str) -> str:
@@ -20,20 +31,12 @@ def _target_framework(dotnet_path: str) -> str:
     with tempfile.TemporaryDirectory() as tmpdir:
         dotnet_tmp = Path(tmpdir) / "tmp"
         dotnet_tmp.mkdir()
-        env = os.environ.copy()
-        env.update(
-            {
-                "TMPDIR": dotnet_tmp.as_posix(),
-                "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
-            }
-        )
         result = subprocess.run(
             args=[dotnet_path, "--version"],
             capture_output=True,
             text=True,
             check=False,
-            env=env,
+            env=_dotnet_env(tmp_home=dotnet_tmp),
         )
     version = result.stdout.strip()
     major_minor = ".".join(version.split(sep=".")[:2])
@@ -72,20 +75,12 @@ def main() -> None:
         csproj_path.write_text(data=csproj, encoding="utf-8")
         dotnet_tmp = Path(tmpdir) / "tmp"
         dotnet_tmp.mkdir()
-        env = os.environ.copy()
-        env.update(
-            {
-                "TMPDIR": dotnet_tmp.as_posix(),
-                "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
-            }
-        )
         result = subprocess.run(
             args=[dotnet_path, "build", csproj_path.as_posix()],
             capture_output=True,
             text=True,
             check=False,
-            env=env,
+            env=_dotnet_env(tmp_home=dotnet_tmp),
         )
     if result.returncode != 0:
         msg = (

--- a/check_gleam_syntax.py
+++ b/check_gleam_syntax.py
@@ -6,7 +6,10 @@ import sys
 import tempfile
 from pathlib import Path
 
-_GLEAM_TOML = """\
+
+def main() -> None:
+    """Check syntax of the given Gleam golden file."""
+    gleam_toml = """\
 name = "check"
 version = "1.0.0"
 target = "erlang"
@@ -14,17 +17,13 @@ target = "erlang"
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 """
-
-
-def main() -> None:
-    """Check syntax of the given Gleam golden file."""
     filename = sys.argv[1]
     gleam_path = shutil.which(cmd="gleam") or "gleam"
     with tempfile.TemporaryDirectory() as tmpdir:
         src_dir = Path(tmpdir) / "src"
         src_dir.mkdir()
         gleam_toml_path = Path(tmpdir) / "gleam.toml"
-        gleam_toml_path.write_text(data=_GLEAM_TOML, encoding="utf-8")
+        gleam_toml_path.write_text(data=gleam_toml, encoding="utf-8")
         deps_result = subprocess.run(
             args=[gleam_path, "deps", "download"],
             capture_output=True,

--- a/check_purescript_syntax.py
+++ b/check_purescript_syntax.py
@@ -6,28 +6,26 @@ import sys
 import tempfile
 from pathlib import Path
 
-_PRELUDE_PURS = """\
+
+def main() -> None:
+    """Check syntax of a single PureScript file."""
+    prelude_purs_content = """\
 module Prelude where
 foreign import negate :: forall a. a -> a
 foreign import div :: forall a. a -> a -> a
 infixl 7 div as /
 """
-
-_PRELUDE_JS = """\
+    prelude_js_content = """\
 export const negate = x => -x;
 export const div = x => y => x / y;
 """
-
-
-def main() -> None:
-    """Check syntax of a single PureScript file."""
     filename = sys.argv[1]
     purs_path: str = shutil.which(cmd="purs") or "purs"
     with tempfile.TemporaryDirectory() as tmpdir:
         prelude_purs = Path(tmpdir) / "Prelude.purs"
         prelude_js = Path(tmpdir) / "Prelude.js"
-        prelude_purs.write_text(data=_PRELUDE_PURS, encoding="utf-8")
-        prelude_js.write_text(data=_PRELUDE_JS, encoding="utf-8")
+        prelude_purs.write_text(data=prelude_purs_content, encoding="utf-8")
+        prelude_js.write_text(data=prelude_js_content, encoding="utf-8")
         output_dir = Path(tmpdir) / "output"
 
         result = subprocess.run(

--- a/check_vb_syntax.py
+++ b/check_vb_syntax.py
@@ -7,10 +7,21 @@ import sys
 import tempfile
 from pathlib import Path
 
-_DOTNET_ENV = {
-    "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
-    "DOTNET_NOLOGO": "1",
-}
+
+def _dotnet_env(tmp_home: Path) -> dict[str, str]:
+    """Return an environment for invoking ``dotnet`` rooted at
+    ``tmp_home``.
+    """
+    env = os.environ.copy()
+    env.update(
+        {
+            "TMPDIR": tmp_home.as_posix(),
+            "HOME": tmp_home.as_posix(),
+            "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
+            "DOTNET_NOLOGO": "1",
+        }
+    )
+    return env
 
 
 def _target_framework(dotnet_path: str) -> str:
@@ -20,20 +31,12 @@ def _target_framework(dotnet_path: str) -> str:
     with tempfile.TemporaryDirectory() as tmpdir:
         dotnet_tmp = Path(tmpdir) / "tmp"
         dotnet_tmp.mkdir()
-        env = os.environ.copy()
-        env.update(
-            {
-                "TMPDIR": dotnet_tmp.as_posix(),
-                "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
-            }
-        )
         result = subprocess.run(
             args=[dotnet_path, "--version"],
             capture_output=True,
             text=True,
             check=False,
-            env=env,
+            env=_dotnet_env(tmp_home=dotnet_tmp),
         )
     version = result.stdout.strip()
     major_minor = ".".join(version.split(sep=".")[:2])
@@ -71,20 +74,12 @@ def main() -> None:
         vbproj_path.write_text(data=vbproj, encoding="utf-8")
         dotnet_tmp = Path(tmpdir) / "tmp"
         dotnet_tmp.mkdir()
-        env = os.environ.copy()
-        env.update(
-            {
-                "TMPDIR": dotnet_tmp.as_posix(),
-                "HOME": dotnet_tmp.as_posix(),
-                **_DOTNET_ENV,
-            }
-        )
         result = subprocess.run(
             args=[dotnet_path, "build", vbproj_path.as_posix()],
             capture_output=True,
             text=True,
             check=False,
-            env=env,
+            env=_dotnet_env(tmp_home=dotnet_tmp),
         )
     if result.returncode != 0:
         msg = (

--- a/src/literalizer/_heterogeneous.py
+++ b/src/literalizer/_heterogeneous.py
@@ -16,16 +16,6 @@ from ruamel.yaml.compat import ordereddict
 
 from literalizer._types import Scalar, Value
 
-_SCALAR_BUCKETS: tuple[type, ...] = (
-    bool,
-    int,
-    float,
-    str,
-    bytes,
-    datetime.datetime,
-    datetime.date,
-)
-
 
 @beartype
 def _scalar_bucket(value: Value) -> type | None:
@@ -38,7 +28,16 @@ def _scalar_bucket(value: Value) -> type | None:
     """
     if value is None:
         return type(None)
-    for bucket in _SCALAR_BUCKETS:
+    buckets: tuple[type, ...] = (
+        bool,
+        int,
+        float,
+        str,
+        bytes,
+        datetime.datetime,
+        datetime.date,
+    )
+    for bucket in buckets:
         if isinstance(value, bucket):
             return bucket
     return None

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -130,15 +130,6 @@ def _csharp_modifier_prefix(modifiers: frozenset[enum.Enum]) -> str:
     return " ".join(keywords) + " "
 
 
-_CSHARP_SCALAR_TYPES: dict[type, str] = {
-    bool: "bool",
-    int: "int",
-    float: "double",
-    str: "string",
-    bytes: "string",
-}
-
-
 @beartype
 def _csharp_scalar_type(
     *,
@@ -151,7 +142,14 @@ def _csharp_scalar_type(
         return datetime_hint
     if isinstance(value, datetime.date):
         return date_hint
-    return _CSHARP_SCALAR_TYPES.get(type(value), "object")
+    scalar_types: dict[type, str] = {
+        bool: "bool",
+        int: "int",
+        float: "double",
+        str: "string",
+        bytes: "string",
+    }
+    return scalar_types.get(type(value), "object")
 
 
 @beartype

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -296,16 +296,6 @@ def _build_union_type_preamble(
     return _preamble
 
 
-_ERROR_STRATEGY = _HeterogeneousStrategyConfig(
-    build_behavior=_build_error_behavior,
-    build_preamble=_build_error_preamble,
-)
-_UNION_TYPE_STRATEGY = _HeterogeneousStrategyConfig(
-    build_behavior=_build_union_type_behavior,
-    build_preamble=_build_union_type_preamble,
-)
-
-
 @beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Dhall(metaclass=LanguageCls):
@@ -532,7 +522,10 @@ class Dhall(metaclass=LanguageCls):
         span more than one Dhall type.
         """
 
-        ERROR = _ERROR_STRATEGY
+        ERROR = _HeterogeneousStrategyConfig(
+            build_behavior=_build_error_behavior,
+            build_preamble=_build_error_preamble,
+        )
         """Raise
         :exc:`~literalizer.exceptions.HeterogeneousScalarCollectionError`
         (or
@@ -542,7 +535,10 @@ class Dhall(metaclass=LanguageCls):
         strict-typing convention.
         """
 
-        UNION_TYPE = _UNION_TYPE_STRATEGY
+        UNION_TYPE = _HeterogeneousStrategyConfig(
+            build_behavior=_build_union_type_behavior,
+            build_preamble=_build_union_type_preamble,
+        )
         """Auto-generate a Dhall union type in the preamble containing
         only the variants actually present in the data, and wrap each
         heterogeneous scalar value as ``{UnionName}.{Variant} payload``.

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -397,16 +397,6 @@ def _build_object_variant_preamble(
     return _preamble
 
 
-_ERROR_STRATEGY = _HeterogeneousStrategyConfig(
-    build_behavior=_build_error_behavior,
-    build_preamble=_build_error_preamble,
-)
-_OBJECT_VARIANT_STRATEGY = _HeterogeneousStrategyConfig(
-    build_behavior=_build_object_variant_behavior,
-    build_preamble=_build_object_variant_preamble,
-)
-
-
 @beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Nim(metaclass=LanguageCls):
@@ -708,7 +698,10 @@ class Nim(metaclass=LanguageCls):
         span more than one Nim type.
         """
 
-        ERROR = _ERROR_STRATEGY
+        ERROR = _HeterogeneousStrategyConfig(
+            build_behavior=_build_error_behavior,
+            build_preamble=_build_error_preamble,
+        )
         """Raise
         :exc:`~literalizer.exceptions.HeterogeneousScalarCollectionError`
         (or
@@ -719,7 +712,10 @@ class Nim(metaclass=LanguageCls):
         used without JSON wrapping.
         """
 
-        OBJECT_VARIANT = _OBJECT_VARIANT_STRATEGY
+        OBJECT_VARIANT = _HeterogeneousStrategyConfig(
+            build_behavior=_build_object_variant_behavior,
+            build_preamble=_build_object_variant_preamble,
+        )
         """Auto-generate a Nim object variant in the preamble containing
         only the branches actually present in the data, and wrap each
         heterogeneous scalar value as

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -577,16 +577,6 @@ def _build_tagged_enum_preamble(
     return _preamble
 
 
-_ERROR_STRATEGY = _HeterogeneousStrategyConfig(
-    build_behavior=_build_error_behavior,
-    build_preamble=_build_error_preamble,
-)
-_TAGGED_ENUM_STRATEGY = _HeterogeneousStrategyConfig(
-    build_behavior=_build_tagged_enum_behavior,
-    build_preamble=_build_tagged_enum_preamble,
-)
-
-
 def _rust_call_stub(
     name: str,
     params: Sequence[str],
@@ -1177,7 +1167,10 @@ class Rust(metaclass=LanguageCls):
         span more than one Rust type.
         """
 
-        ERROR = _ERROR_STRATEGY
+        ERROR = _HeterogeneousStrategyConfig(
+            build_behavior=_build_error_behavior,
+            build_preamble=_build_error_preamble,
+        )
         """Raise
         :exc:`~literalizer.exceptions.HeterogeneousScalarCollectionError`
         (or :exc:`~literalizer.exceptions.HeterogeneousSiblingListsError`)
@@ -1186,7 +1179,10 @@ class Rust(metaclass=LanguageCls):
         strict-typing convention.
         """
 
-        TAGGED_ENUM = _TAGGED_ENUM_STRATEGY
+        TAGGED_ENUM = _HeterogeneousStrategyConfig(
+            build_behavior=_build_tagged_enum_behavior,
+            build_preamble=_build_tagged_enum_preamble,
+        )
         """Auto-generate a tagged ``enum`` in the preamble containing
         only the variants actually present in the data, and wrap each
         heterogeneous scalar value with ``{EnumName}::{Variant}(value)``.


### PR DESCRIPTION
## Summary
- Move private module-level constants (``_SCALAR_BUCKETS``, ``_CSHARP_SCALAR_TYPES``, ``_GLEAM_TOML``, ``_PRELUDE_PURS``/``_PRELUDE_JS``) into the one function that reads them.
- Inline ``_ERROR_STRATEGY``/``_TAGGED_ENUM_STRATEGY``/``_UNION_TYPE_STRATEGY``/``_OBJECT_VARIANT_STRATEGY`` as enum member values in rust/dhall/nim.
- Replace the duplicated ``_DOTNET_ENV`` module-level dict in ``check_csharp_syntax.py`` and ``check_vb_syntax.py`` with a small ``_dotnet_env`` helper used at both call sites.

## Test plan
- [x] ``uv run pytest tests/ -x -q --ignore=tests/integration`` (487 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily refactoring that moves single-use constants/config objects into local scopes and factors a small `dotnet` env helper; behavior should be unchanged aside from minor risk of subtle env/config differences at call sites.
> 
> **Overview**
> Reduces module-level globals by moving single-use constants into the functions that consume them (e.g., scalar bucket/type maps and temporary project file contents in the syntax-check scripts).
> 
> Refactors the C#/VB syntax checkers to share a `_dotnet_env()` helper that sets `TMPDIR`/`HOME` and `DOTNET_*` flags, and inlines previously module-level heterogeneous-strategy config instances directly into the `Dhall`, `Nim`, and `Rust` `HeterogeneousStrategies` enum members.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17246e824d74693d3f2bbd48a97421619a371691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->