### PR TITLE
Use match statement in _csharp_scalar_type

### DIFF
--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -138,18 +138,22 @@ def _csharp_scalar_type(
     datetime_hint: str,
 ) -> str:
     """Return the C# type name for a scalar value."""
-    if isinstance(value, datetime.datetime):
-        return datetime_hint
-    if isinstance(value, datetime.date):
-        return date_hint
-    scalar_types: dict[type, str] = {
-        bool: "bool",
-        int: "int",
-        float: "double",
-        str: "string",
-        bytes: "string",
-    }
-    return scalar_types.get(type(value), "object")
+    match value:
+        case datetime.datetime():
+            return datetime_hint
+        case datetime.date():
+            return date_hint
+        case bool():
+            result = "bool"
+        case int():
+            result = "int"
+        case float():
+            result = "double"
+        case str() | bytes():
+            result = "string"
+        case _:
+            result = "object"
+    return result
 
 
 @beartype


### PR DESCRIPTION
Refactors `_csharp_scalar_type` to use a `match` statement, consistent with the neighboring `_csharp_type_hint` function. Date/datetime cases return early (they use hint parameters); the remaining scalar cases assign to a single `result` variable to stay under the PLR0911 return-count limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to C# scalar type inference; behavior should remain equivalent aside from any subtle pattern-matching edge cases.
> 
> **Overview**
> Refactors C# scalar type selection in `src/literalizer/languages/csharp.py` by rewriting `_csharp_scalar_type` from an `isinstance`/mapping approach to a `match` statement, with early returns for date/datetime hints and a single `result` variable for other scalar types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96cd9e5049d52162c71d08f69872d8a43e086d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->