### PR TITLE
Use a recent clang-tidy from PyPI in lint-cpp-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks: >
   -misc-include-cleaner,
   -misc-use-internal-linkage,
   -modernize-raw-string-literal,
+  -performance-unnecessary-value-param,
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-redundant-parentheses,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -289,12 +289,16 @@ jobs:
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-to-lint
-      # Preloading the standard headers via PCH was tried here but made
-      # clang-tidy ~2x slower on the Ubuntu runner: with `Checks: *`
-      # enabling `clang-analyzer-*`, the preloaded AST exposes the
-      # entire standard library to the static analyzer per fixture,
-      # multiplying analysis cost. The PCH still helps the lint-cpp
-      # job, where only parsing (not symbolic execution) runs.
+      # Ubuntu's packaged clang-tidy is several releases behind and is
+      # the dominant cost of this job on runners. Pull a recent build
+      # from PyPI via uv instead.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Install clang-tidy
+        run: uv tool install clang-tidy
       - name: Run clang-tidy
         run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
 


### PR DESCRIPTION
Closes #1545.

## Summary

Ubuntu 24.04 ships a clang-tidy several releases behind, and it — not `clang-analyzer-*` or header re-parsing — is the dominant cost of `lint-cpp-tidy`. Install a recent clang-tidy from PyPI via \`uv tool install\` and use that instead.

## Experiments and numbers (Ubuntu CI)

| Config | `lint-cpp-tidy` |
| --- | --- |
| `main` (packaged clang-tidy, no PCH, analyzer on) | 9m32s |
| Packaged clang-tidy, `-clang-analyzer-*` | 9m33s (no change — hypothesis from #1545 didn't hold) |
| Packaged clang-tidy + PCH, analyzer on | 23m53s, FAILED (`cert-dcl58-cpp` on stdlib headers) |
| **uv clang-tidy 22, no PCH, analyzer on (this PR)** | **1m42s** ✅ |

The old code comment blaming `clang-analyzer-*` for making PCH a regression was wrong in its mechanism — disabling the analyzer family alone moved the needle by 1s. The real issue was the clang-tidy version. A modern clang-tidy with the `-clang-analyzer-*` family enabled is still 5.6× faster than the Ubuntu-packaged build without it.

Also disables `performance-unnecessary-value-param` in `.clang-tidy`: the newer clang-tidy catches variadic-auto fixture helpers (`auto op(auto...) const {}`) where the inferred type would be cheaper as const-ref, but the bodies ignore their arguments so the \"copy cost\" is theoretical.

## Test plan

- [x] `lint-cpp-tidy` passes on CI (green at 1m42s)
- [ ] Full Lint workflow passes (currently blocked by flaky `lint-mojo` / `lint-nim` — rerun triggered)