### PR TITLE
Drop redundant crystal build pass from lint-crystal (#1547)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -875,8 +875,6 @@ jobs:
         run: find tests/integration/cases -name '*.cr' -print0 > /tmp/files-to-lint
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
-      - name: Check Crystal syntax
-        run: xargs -0 -P "$(nproc)" -n1 crystal build --no-codegen < /tmp/files-to-lint
       # Crystal derives the compiled binary name from the source file's
       # basename (e.g. Crystal.cr -> ~/.cache/crystal/crystal-run-Crystal.tmp).
       # Many fixtures share basenames, so parallel `crystal run` invocations


### PR DESCRIPTION
## Summary
- `lint-crystal` in `.github/workflows/lint.yml` previously ran `crystal build --no-codegen` over every fixture before `crystal run`. Since `crystal run` already parses and typechecks, the first pass was pure duplication.
- Removing it should roughly halve the job's wall time; any syntax or type error the first pass would have caught still fails the `crystal run` step.

Closes #1547

## Test plan
- [ ] CI `lint-crystal` still passes and runs noticeably faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes a duplicate `crystal build --no-codegen` step in CI; failures should still be caught by the remaining `crystal run` execution, with the main impact being faster job runtime.
> 
> **Overview**
> Simplifies the `lint-crystal` GitHub Actions job by **dropping the separate `crystal build --no-codegen` syntax/typecheck pass** and relying solely on the existing parallel `crystal run` step (with per-invocation cache isolation). This reduces duplicated work and should speed up the Crystal lint job without changing the set of files executed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29240a382fe53e97985709657a798e26ad2e6fe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->