### PR TITLE
Drop Java null/comment unit tests superseded by integration cases

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -58,12 +58,6 @@ FORTRAN = Fortran(
     sequence_format=Fortran.sequence_formats.LIST,
 )
 FSHARP = FSharp()
-JAVA = Java(
-    date_format=Java.date_formats.JAVA,
-    datetime_format=Java.datetime_formats.INSTANT,
-    bytes_format=Java.bytes_formats.HEX,
-    sequence_format=Java.sequence_formats.ARRAY,
-)
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -248,85 +242,6 @@ def test_identity_wrap_scalar_leaves_formatted_output_unchanged() -> None:
         language=_IdentityWrapPython(),
     )
     assert wrapped.code == base.code
-
-
-def test_java_yaml_dict_null_values_with_comments() -> None:
-    """Java YAML dict with null values and comments does not crash."""
-    yaml_string = "# comment\nname: Alice\nscore: null\n"
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=JAVA,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        Map.ofEntries(
-            // comment
-            Map.entry("name", "Alice")
-        )"""
-    )
-    assert result.code == expected
-
-
-def test_java_yaml_dict_null_value_inline_comment_preserved() -> None:
-    """Inline comment on a null-valued dict entry is preserved as a before
-    comment on the next non-null entry when skip_null_dict_values=True.
-    """
-    yaml_string = textwrap.dedent(
-        text="""\
-        host: localhost
-        port: null  # not configured yet
-        debug: true
-        """,
-    )
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=JAVA,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        Map.ofEntries(
-            Map.entry("host", "localhost"),
-            // not configured yet
-            Map.entry("debug", true)
-        )"""
-    )
-    assert result.code == expected
-
-
-def test_java_yaml_null_value_inline_comment_as_trailing() -> None:
-    """Inline comment on a null-valued dict entry at the end becomes a
-    trailing comment when skip_null_dict_values=True.
-    """
-    yaml_string = textwrap.dedent(
-        text="""\
-        host: localhost
-        port: null  # not configured yet
-        """,
-    )
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=JAVA,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        Map.ofEntries(
-            Map.entry("host", "localhost")
-            // not configured yet
-        )"""
-    )
-    assert result.code == expected
 
 
 def test_matlab_dict_key_with_quote() -> None:


### PR DESCRIPTION
## Summary

The three ``test_java_yaml_*`` unit tests added in #1538 used ``variable_form=None`` to work around the trailing-``;`` issue that that PR also fixed. With the fix in place, the existing ``dict_null_leading_comment``, ``dict_null_middle_inline_comment``, and ``dict_null_trailing_inline_comment`` integration cases already cover the same inputs and produce identical Java output via the normal golden-file path.

## Test plan

- [x] ``uv run pytest tests/test_languages.py tests/integration/test_integration.py``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only deletes Java-specific unit tests that are now covered by integration golden-file cases, with no production code changes.
> 
> **Overview**
> Removes three Java YAML unit tests in `tests/test_languages.py` that exercised skipping null-valued map entries while preserving comments, along with the dedicated `JAVA` test fixture configuration.
> 
> Coverage for these scenarios is intended to come from existing integration golden-file cases, avoiding duplicated assertions and prior `variable_form=None` test-only workarounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c299f7d6b694ecdda2c4bbe1301d9424aa20ee31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->