### PR TITLE
Split lint-objectivec into parallel syntax/run and clang-tidy jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1388,13 +1388,8 @@ jobs:
       # cost dominates each tiny TU. Precompile Foundation once and
       # preload it in the syntax-check and build-and-run steps so the
       # parsed AST is reused instead of re-parsed per fixture. clang-tidy
-      # deliberately skips the PCH — see the note on `lint-cpp-tidy`.
-      #
-      # PCH is compiler-version specific, so all clang invocations that
-      # read it must use Apple's clang. The `Install clang-tidy` step
-      # below prepends Homebrew's llvm to `PATH`, which would shadow
-      # `clang` with an incompatible build, so every Objective-C compile
-      # step runs before that install.
+      # runs in a separate job (`lint-objectivec-tidy`) and deliberately
+      # skips the PCH — see the note on `lint-cpp-tidy`.
       - name: Build precompiled header
         run: clang -x objective-c-header .github/scripts/lint-objc-pch.h -o /tmp/pch.h.pch
       - name: Check Objective-C syntax
@@ -1415,8 +1410,23 @@ jobs:
           "$tmpdir/out" || exit 1
           SCRIPT
           xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 bash /tmp/run-objc.sh < /tmp/files-to-lint
+
+  lint-objectivec-tidy:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Find files to lint
+        shell: bash
+        run: find tests/integration/cases -name 'ObjectiveC*.m' -print0 > /tmp/files-to-lint
       # macos-15-arm64 ships Apple's clang but no clang-tidy, so pull it
-      # from Homebrew's llvm formula.
+      # from Homebrew's llvm formula. This job is split from the syntax
+      # and build-and-run job (`lint-objectivec`) so the Homebrew install
+      # runs in parallel with the Apple-clang compile steps instead of
+      # serializing after them — Homebrew's llvm would otherwise prepend
+      # itself to `PATH` and shadow the Apple clang that the PCH was
+      # built against.
       - name: Install clang-tidy
         run: |-
           brew install --quiet llvm
@@ -1529,6 +1539,7 @@ jobs:
       - lint-forth
       - lint-fortran
       - lint-objectivec
+      - lint-objectivec-tidy
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Changelog
 Next
 ----
 
+- The ``lint-objectivec`` job in ``.github/workflows/lint.yml`` has
+  been split into two jobs that run in parallel: ``lint-objectivec``
+  keeps the PCH build, ``-fsyntax-only`` check, and build-and-run
+  steps, while the new ``lint-objectivec-tidy`` job runs
+  ``clang-tidy`` on its own after installing Homebrew's ``llvm``.
+  The Homebrew install no longer serializes behind the Apple-clang
+  compile steps, and the PCH/``PATH`` ordering hazard in the old
+  single job is gone now that Homebrew's ``clang`` never shares a
+  runner with the PCH consumers.
 - ``literalize_call`` now accepts ``{"$ref": "name"}`` markers at
   argument positions, emitting ``name`` as a bare identifier instead
   of formatting the value as a literal.  Refs and literals can be

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,6 @@ Changelog
 Next
 ----
 
-- The ``lint-objectivec`` job in ``.github/workflows/lint.yml`` has
-  been split into two jobs that run in parallel: ``lint-objectivec``
-  keeps the PCH build, ``-fsyntax-only`` check, and build-and-run
-  steps, while the new ``lint-objectivec-tidy`` job runs
-  ``clang-tidy`` on its own after installing Homebrew's ``llvm``.
-  The Homebrew install no longer serializes behind the Apple-clang
-  compile steps, and the PCH/``PATH`` ordering hazard in the old
-  single job is gone now that Homebrew's ``clang`` never shares a
-  runner with the PCH consumers.
 - ``literalize_call`` now accepts ``{"$ref": "name"}`` markers at
   argument positions, emitting ``name`` as a bare identifier instead
   of formatting the value as a literal.  Refs and literals can be


### PR DESCRIPTION
Closes #1546.

Splits `lint-objectivec` into two macOS jobs that run in parallel:

- `lint-objectivec` keeps the PCH build, `-fsyntax-only` check, and build-and-run steps using Apple's clang.
- `lint-objectivec-tidy` is new and runs only `brew install llvm` + `clang-tidy`.

The Homebrew install no longer serializes behind the Apple-clang compile steps, and the PCH/`PATH` ordering hazard is gone since Homebrew's clang never shares a runner with the PCH consumers. Comments in `lint.yml` are updated to reflect the split, and `completion-lint` now waits on the new job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that reorganizes GitHub Actions jobs; main risk is workflow misconfiguration causing Objective-C lint to be skipped or fail due to missing dependencies.
> 
> **Overview**
> **Splits Objective-C linting into two macOS jobs** so Apple-clang PCH-based syntax/build/run checks (`lint-objectivec`) can run in parallel with a new Homebrew LLVM/`clang-tidy` job (`lint-objectivec-tidy`).
> 
> Updates workflow comments to document the PCH/`PATH` toolchain constraint and adds `lint-objectivec-tidy` to `completion-lint` dependencies so the overall lint workflow waits for both jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a967b2dfa2ad6de344299ba46dc54251e2a2afff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->