### PR TITLE
Promote Haskell lint warnings to errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -539,7 +539,8 @@ jobs:
       - name: Check Haskell syntax
         run: |-
           tmpdir=$(mktemp -d)
-          xargs -0 -n1 ghc -fno-code -outputdir "$tmpdir" < /tmp/files-to-lint
+          xargs -0 -n1 ghc -fno-code -Wall -Werror -outputdir "$tmpdir" \
+            < /tmp/files-to-lint
       # Most fixtures declare only `module Check` with a `my_data` val; GHC
       # never evaluates its body unless a top-level expression references it,
       # so compile alongside a small Main wrapper that forces `Check.my_data`.
@@ -553,11 +554,11 @@ jobs:
             trap "rm -rf \"$tmpdir\"" EXIT
             cp "$0" "$tmpdir/Check.hs"
             if grep -qE "^main " "$0"; then
-              ghc -main-is Check -outputdir "$tmpdir" \
+              ghc -Wall -Werror -main-is Check -outputdir "$tmpdir" \
                 -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
             else
               cp .github/scripts/haskell_main.hs "$tmpdir/Main.hs"
-              ghc -outputdir "$tmpdir" \
+              ghc -Wall -Werror -outputdir "$tmpdir" \
                 -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
             fi
             "$tmpdir/run" || exit 1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 Next
 ----
 
+- ``lint-haskell`` in ``.github/workflows/lint.yml`` now passes
+  ``-Wall -Werror`` to both the syntax check and the end-to-end build,
+  so warnings such as ``-Wunused-matches``, ``-Woverlapping-patterns``,
+  and ``-Wtype-defaults`` fail the job instead of being silently
+  logged.  ``Haskell`` generated output was updated to compile clean
+  under ``-Wall``: the ``Num`` / ``Fractional`` instances use ``_``
+  for unused parameters, the catch-all ``negate _`` clause is now
+  omitted when ``Val`` has only numeric constructors, tuple-sequence
+  bindings carry a ``(Val, Val, ...)`` annotation, call stubs get
+  explicit type signatures, transform-wrapper stubs use a polymorphic
+  argument type, ``main`` binds each call result with ``_ <-``, and
+  the ``Data.Time`` import set drops ``secondsToDiffTime`` when every
+  datetime has microseconds.
 - ``Java`` declarations and reassignments whose value ends in a ``//``
   line comment now place the terminating ``;`` on the code line rather
   than on the comment line, where ``javac`` previously parsed it as

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1186,7 +1186,7 @@ class Haskell(metaclass=LanguageCls):
             # action returns ``IO ()``.
             indented = "\n".join(
                 f"    _ <- {line}" if line.strip() else line
-                for line in content.split("\n")
+                for line in content.split(sep="\n")
             )
             return (
                 "module Check where\n"

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import ClassVar
@@ -84,15 +83,32 @@ def _haskell_call_preamble_stub(
 def _build_haskell_call_stub_lines(
     name: str,
     params: Sequence[str],
-    _stub_return: StubReturn,
+    stub_return: StubReturn,
     type_name: str,
 ) -> tuple[str, ...]:
     """Return Haskell stub declarations for a call name."""
-    ret = "IO ()"
-    body = "return ()"
+    if stub_return is StubReturn.VALUE:
+        ret = f"IO {type_name}"
+        body = "return undefined"
+    else:
+        ret = "IO ()"
+        body = "return ()"
     parts = name.split(sep=".")
+    # Transform-wrapper stubs are passed a single placeholder param
+    # starting with ``_`` and receive the (already typed) result of
+    # another call. Declare them with a polymorphic argument so GHC
+    # never needs to default the wrapped expression's type.
+    is_wrapper_stub = len(params) == 1 and params[0].startswith("_")
     if len(parts) == 1:
-        return (f"{parts[0]} _ = {body}",)
+        if is_wrapper_stub:
+            sig = f"{parts[0]} :: a -> IO ()"
+        else:
+            if len(params) == 1:
+                arg_type = type_name
+            else:
+                arg_type = "(" + ", ".join(type_name for _ in params) + ")"
+            sig = f"{parts[0]} :: {arg_type} -> {ret}"
+        return (sig, f"{parts[0]} _ = {body}")
     root = parts[0]
     method = parts[-1]
     fields = parts[1:-1]
@@ -105,6 +121,7 @@ def _build_haskell_call_stub_lines(
         cls = root.capitalize() + "Type_"
         return (
             f"data {cls} = {cls} {{ {method} :: {field_type} }}",
+            f"{root} :: {cls}",
             f"{root} = {cls} {{ {method} = \\_ -> {body} }}",
         )
     lines: list[str] = []
@@ -128,6 +145,7 @@ def _build_haskell_call_stub_lines(
         cls = fields[i].capitalize() + "Type_"
         construction = f"{cls} {{ {fields[i + 1]} = {construction} }}"
     construction = f"{root_cls} {{ {fields[0]} = {construction} }}"
+    lines.append(f"{root} :: {root_cls}")
     lines.append(f"{root} = {construction}")
     return tuple(lines)
 
@@ -142,14 +160,14 @@ def _build_haskell_call_stub(
     def _haskell_call_stub(
         name: str,
         params: Sequence[str],
-        _stub_return: StubReturn,
+        stub_return: StubReturn,
         /,
     ) -> tuple[str, ...]:
         """Delegate to module-level implementation."""
         return _build_haskell_call_stub_lines(
             name=name,
             params=params,
-            _stub_return=_stub_return,
+            stub_return=stub_return,
             type_name=type_name,
         )
 
@@ -398,10 +416,17 @@ def _num_instance(
     *,
     has_int: bool,
     has_float: bool,
+    needs_catchall: bool,
     type_name: str,
     constructor_prefix: str,
 ) -> str:
-    """Build the ``Num`` instance with only relevant constructors."""
+    """Build the ``Num`` instance with only relevant constructors.
+
+    *needs_catchall* controls whether a trailing ``negate _`` clause is
+    emitted. When the ``Val`` type has only numeric constructors, the
+    specific ``negate (HInt n)`` / ``negate (HFloat f)`` patterns are
+    exhaustive, and a catch-all would be redundant.
+    """
     if has_int:
         from_integer = f"    fromInteger = {constructor_prefix}Int"
     else:
@@ -419,15 +444,16 @@ def _num_instance(
             f"    negate ({constructor_prefix}Float f) = "
             f"{constructor_prefix}Float (negate f)"
         )
-    negate_parts.append('    negate _ = error "not implemented"')
+    if needs_catchall:
+        negate_parts.append('    negate _ = error "not implemented"')
     return "\n".join(
         [
             f"instance Num {type_name} where",
             from_integer,
-            '    a + b = error "not implemented"',
-            '    a * b = error "not implemented"',
-            '    abs a = error "not implemented"',
-            '    signum a = error "not implemented"',
+            '    _ + _ = error "not implemented"',
+            '    _ * _ = error "not implemented"',
+            '    abs _ = error "not implemented"',
+            '    signum _ = error "not implemented"',
             *negate_parts,
         ]
     )
@@ -449,16 +475,42 @@ def _has_microsecond_datetime(*, data: Value) -> bool:
     return False
 
 
+def _has_nonmicrosecond_datetime(*, data: Value) -> bool:
+    """Return whether *data* contains any datetime without
+    microseconds.
+    """
+    if isinstance(data, datetime.datetime):
+        return not data.microsecond
+    if isinstance(data, datetime.date):
+        return False
+    if isinstance(data, (ordereddict, dict)):
+        return any(
+            _has_nonmicrosecond_datetime(data=v)  # pyright: ignore[reportUnknownArgumentType]
+            for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        )
+    if isinstance(data, (list, set)):
+        return any(_has_nonmicrosecond_datetime(data=v) for v in data)
+    return False
+
+
 def _datetime_import_items(
     *,
     has_from_gregorian: bool,
     has_microsecond: bool,
+    has_nonmicrosecond: bool,
 ) -> list[str]:
-    """Return ``Data.Time`` import names needed for datetime values."""
+    """Return ``Data.Time`` import names needed for datetime values.
+
+    ``secondsToDiffTime`` is imported only when at least one datetime
+    has no microsecond component; otherwise every datetime is rendered
+    via ``picosecondsToDiffTime`` and the seconds helper would be
+    flagged as unused.
+    """
     items = ["UTCTime(..)"]
     if not has_from_gregorian:
         items.append("fromGregorian")
-    items.append("secondsToDiffTime")
+    if has_nonmicrosecond:
+        items.append("secondsToDiffTime")
     if has_microsecond:
         items.append("picosecondsToDiffTime")
     return items
@@ -538,6 +590,9 @@ def _build_scalar_body_preamble(
                 _datetime_import_items(
                     has_from_gregorian="fromGregorian" in import_items,
                     has_microsecond=_has_microsecond_datetime(data=data),
+                    has_nonmicrosecond=_has_nonmicrosecond_datetime(
+                        data=data,
+                    ),
                 ),
             )
 
@@ -572,10 +627,18 @@ def _build_scalar_body_preamble(
         has_float = float in types
         has_int = int in types
         if emit_num and (has_float or has_int):
+            # The numeric catch-all for ``negate`` is redundant when
+            # ``Val`` has only numeric constructors, because the
+            # specific ``HInt`` / ``HFloat`` clauses cover the type.
+            num_constructor_count = (1 if has_int else 0) + (
+                1 if has_float else 0
+            )
+            needs_catchall = len(data_val_parts) > num_constructor_count
             instances.append(
                 _num_instance(
                     has_int=has_int,
                     has_float=has_float,
+                    needs_catchall=needs_catchall,
                     type_name=type_name,
                     constructor_prefix=constructor_prefix,
                 ),
@@ -584,7 +647,7 @@ def _build_scalar_body_preamble(
             instances.append(
                 f"instance Fractional {type_name} where\n"
                 f"    fromRational r = {p}Float (realToFrac r)\n"
-                '    a / b = error "not implemented"'
+                '    _ / _ = error "not implemented"'
             )
 
         lines: list[str] = imports
@@ -650,7 +713,11 @@ def _format_haskell_declaration(
     base = base_declaration(name, value, data, modifiers)
     if isinstance(data, list):
         if sequence_declared_type is None:
-            return base
+            # TUPLE sequence format: pin each slot to ``Val`` so bare
+            # numeric literals in the tuple resolve via ``fromInteger``
+            # instead of triggering ``-Wtype-defaults``.
+            tuple_type = "(" + ", ".join(type_name for _ in data) + ")"
+            return f"{name} :: {tuple_type}\n{base}"
         return f"{name} :: {sequence_declared_type}\n{base}"
     return f"{name} :: {type_name}\n{base}"
 
@@ -1112,8 +1179,15 @@ class Haskell(metaclass=LanguageCls):
         preamble = "\n".join(body_preamble)
         if not variable_name:
             # Call mode: bare expressions are not valid at module
-            # top level in Haskell, so wrap them in ``main``.
-            indented = textwrap.indent(text=content, prefix="    ")
+            # top level in Haskell, so wrap them in ``main``. Each call
+            # statement is bound via ``_ <- `` so that stubs returning
+            # ``IO Val`` (``StubReturn.VALUE``) do not trigger
+            # ``-Wunused-do-bind``. ``_ <-`` is also valid when the
+            # action returns ``IO ()``.
+            indented = "\n".join(
+                f"    _ <- {line}" if line.strip() else line
+                for line in content.split("\n")
+            )
             return (
                 "module Check where\n"
                 + preamble

--- a/tests/integration/cases/call_deep_dotted_method/Haskell_call.hs
+++ b/tests/integration/cases/call_deep_dotted_method/Haskell_call.hs
@@ -3,19 +3,20 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 data ClientType_ = ClientType_ { post :: Val -> IO () }
 data ApiType_ = ApiType_ { client :: ClientType_ }
 data ObjType_ = ObjType_ { api :: ApiType_ }
+obj :: ObjType_
 obj = ObjType_ { api = ApiType_ { client = ClientType_ { post = \_ -> return () } } }
 main :: IO ()
 main = do
-    obj.api.client.post(HStr "hello")
-    obj.api.client.post(42)
-    obj.api.client.post(HBool True)
+    _ <- obj.api.client.post(HStr "hello")
+    _ <- obj.api.client.post(42)
+    _ <- obj.api.client.post(HBool True)
     pure ()

--- a/tests/integration/cases/call_deep_dotted_transformed/Haskell_call.hs
+++ b/tests/integration/cases/call_deep_dotted_transformed/Haskell_call.hs
@@ -3,19 +3,21 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
-data ClientType_ = ClientType_ { fetch :: Val -> IO () }
+data ClientType_ = ClientType_ { fetch :: Val -> IO Val }
 data AppType_ = AppType_ { client :: ClientType_ }
-app = AppType_ { client = ClientType_ { fetch = \_ -> return () } }
+app :: AppType_
+app = AppType_ { client = ClientType_ { fetch = \_ -> return undefined } }
+emit :: a -> IO ()
 emit _ = return ()
 main :: IO ()
 main = do
-    emit(app.client.fetch(HStr "hello"))
-    emit(app.client.fetch(42))
-    emit(app.client.fetch(HBool True))
+    _ <- emit(app.client.fetch(HStr "hello"))
+    _ <- emit(app.client.fetch(42))
+    _ <- emit(app.client.fetch(HBool True))
     pure ()

--- a/tests/integration/cases/call_dotted_method/Haskell_call.hs
+++ b/tests/integration/cases/call_dotted_method/Haskell_call.hs
@@ -3,18 +3,19 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 data ClientType_ = ClientType_ { fetch :: Val -> IO () }
 data AppType_ = AppType_ { client :: ClientType_ }
+app :: AppType_
 app = AppType_ { client = ClientType_ { fetch = \_ -> return () } }
 main :: IO ()
 main = do
-    app.client.fetch(HStr "hello")
-    app.client.fetch(42)
-    app.client.fetch(HBool True)
+    _ <- app.client.fetch(HStr "hello")
+    _ <- app.client.fetch(42)
+    _ <- app.client.fetch(HBool True)
     pure ()

--- a/tests/integration/cases/call_keyword_args/Haskell_call.hs
+++ b/tests/integration/cases/call_keyword_args/Haskell_call.hs
@@ -3,20 +3,22 @@ module Check where
 data Val = HFloat Double | HStr String | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
-data ThrottlerType_ = ThrottlerType_ { check :: (Val, Val) -> IO () }
-throttler = ThrottlerType_ { check = \_ -> return () }
+    _ / _ = error "not implemented"
+data ThrottlerType_ = ThrottlerType_ { check :: (Val, Val) -> IO Val }
+throttler :: ThrottlerType_
+throttler = ThrottlerType_ { check = \_ -> return undefined }
+emit :: a -> IO ()
 emit _ = return ()
 main :: IO ()
 main = do
-    emit(throttler.check(HStr "user_1", 1000.0))
-    emit(throttler.check(HStr "user_2", 2000.5))
+    _ <- emit(throttler.check(HStr "user_1", 1000.0))
+    _ <- emit(throttler.check(HStr "user_2", 2000.5))
     pure ()

--- a/tests/integration/cases/call_mixed_type_dicts/Haskell_call.hs
+++ b/tests/integration/cases/call_mixed_type_dicts/Haskell_call.hs
@@ -3,9 +3,10 @@ module Check where
 data Val = HBool Bool | HStr String | HList [Val] | HMap [(String, Val)]
 data MgrType_ = MgrType_ { op :: Val -> IO () }
 data AppType_ = AppType_ { mgr :: MgrType_ }
+app :: AppType_
 app = AppType_ { mgr = MgrType_ { op = \_ -> return () } }
 main :: IO ()
 main = do
-    app.mgr.op(HMap [("type", HStr "create"), ("pr_id", HStr "pr_1"), ("draft", HBool True)])
-    app.mgr.op(HMap [("type", HStr "create"), ("pr_id", HStr "pr_2")])
+    _ <- app.mgr.op(HMap [("type", HStr "create"), ("pr_id", HStr "pr_1"), ("draft", HBool True)])
+    _ <- app.mgr.op(HMap [("type", HStr "create"), ("pr_id", HStr "pr_2")])
     pure ()

--- a/tests/integration/cases/call_multi_args/Haskell_call.hs
+++ b/tests/integration/cases/call_multi_args/Haskell_call.hs
@@ -2,15 +2,16 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
+process :: (Val, Val) -> IO ()
 process _ = return ()
 main :: IO ()
 main = do
-    process(1, 42)
-    process(2, 100)
+    _ <- process(1, 42)
+    _ <- process(2, 100)
     pure ()

--- a/tests/integration/cases/call_per_element_false/Haskell_call.hs
+++ b/tests/integration/cases/call_per_element_false/Haskell_call.hs
@@ -2,14 +2,14 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
+process :: Val -> IO ()
 process _ = return ()
 main :: IO ()
 main = do
-    process(1)
+    _ <- process(1)
     pure ()

--- a/tests/integration/cases/call_scalar_args/Haskell_call.hs
+++ b/tests/integration/cases/call_scalar_args/Haskell_call.hs
@@ -2,16 +2,17 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
+process :: Val -> IO ()
 process _ = return ()
 main :: IO ()
 main = do
-    process(HStr "hello")
-    process(42)
-    process(HBool True)
+    _ <- process(HStr "hello")
+    _ <- process(42)
+    _ <- process(HBool True)
     pure ()

--- a/tests/integration/cases/call_transform_no_wrapper/Haskell_call.hs
+++ b/tests/integration/cases/call_transform_no_wrapper/Haskell_call.hs
@@ -2,16 +2,17 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
-process _ = return ()
+process :: Val -> IO Val
+process _ = return undefined
 main :: IO ()
 main = do
-    process(HStr "hello")
-    process(42)
-    process(HBool True)
+    _ <- process(HStr "hello")
+    _ <- process(42)
+    _ <- process(HBool True)
     pure ()

--- a/tests/integration/cases/comment_scalar/Haskell.hs
+++ b/tests/integration/cases/comment_scalar/Haskell.hs
@@ -2,12 +2,11 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 -- note
 my_data :: Val
 my_data = 42

--- a/tests/integration/cases/comment_scalar_document_markers/Haskell.hs
+++ b/tests/integration/cases/comment_scalar_document_markers/Haskell.hs
@@ -2,12 +2,11 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 -- note
 my_data :: Val
 my_data = 42

--- a/tests/integration/cases/comment_scalar_inline/Haskell.hs
+++ b/tests/integration/cases/comment_scalar_inline/Haskell.hs
@@ -2,11 +2,10 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 my_data :: Val
 my_data = 42  -- note

--- a/tests/integration/cases/comments/Haskell.hs
+++ b/tests/integration/cases/comments/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/comments/Haskell_comment_block.hs
+++ b/tests/integration/cases/comments/Haskell_comment_block.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/comments_nested_mapping/Haskell.hs
+++ b/tests/integration/cases/comments_nested_mapping/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/comments_vb_before_dim/Haskell.hs
+++ b/tests/integration/cases/comments_vb_before_dim/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/deep_nesting/Haskell.hs
+++ b/tests/integration/cases/deep_nesting/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/dict_all_scalar_types/Haskell.hs
+++ b/tests/integration/cases/dict_all_scalar_types/Haskell.hs
@@ -3,16 +3,16 @@ import Data.Time (Day, fromGregorian, UTCTime(..), secondsToDiffTime)
 data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HMap [(String, Val)] | HDate Day | HDatetime UTCTime
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HMap [
     ("s", HStr "string"),

--- a/tests/integration/cases/dict_mixed_int_widths/Haskell.hs
+++ b/tests/integration/cases/dict_mixed_int_widths/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/dict_mixed_scalars/Haskell.hs
+++ b/tests/integration/cases/dict_mixed_scalars/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/dict_with_list_value/Haskell.hs
+++ b/tests/integration/cases/dict_with_list_value/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/dict_with_nulls/Haskell.hs
+++ b/tests/integration/cases/dict_with_nulls/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HNull | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/float_list/Haskell.hs
+++ b/tests/integration/cases/float_list/Haskell.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     1.1,

--- a/tests/integration/cases/float_list/Haskell_float_format_fixed.hs
+++ b/tests/integration/cases/float_list/Haskell_float_format_fixed.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     1.100000,

--- a/tests/integration/cases/float_list/Haskell_float_format_scientific.hs
+++ b/tests/integration/cases/float_list/Haskell_float_format_scientific.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     1.1,

--- a/tests/integration/cases/float_list/Haskell_prefix_J_float.hs
+++ b/tests/integration/cases/float_list/Haskell_prefix_J_float.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = JFloat Double | JList [Val]
 instance Num Val where
     fromInteger n = JFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (JFloat f) = JFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = JFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = JList [
     1.1,

--- a/tests/integration/cases/float_list/Haskell_sequence_tuple_float.hs
+++ b/tests/integration/cases/float_list/Haskell_sequence_tuple_float.hs
@@ -2,15 +2,16 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
+my_data :: (Val, Val, Val)
 my_data = (
     1.1,
     -2.2,

--- a/tests/integration/cases/float_negative_zero/Haskell.hs
+++ b/tests/integration/cases/float_negative_zero/Haskell.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     -0.0,

--- a/tests/integration/cases/float_scientific_notation/Haskell.hs
+++ b/tests/integration/cases/float_scientific_notation/Haskell.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     0.0,

--- a/tests/integration/cases/float_scientific_notation/Haskell_float_format_fixed_s.hs
+++ b/tests/integration/cases/float_scientific_notation/Haskell_float_format_fixed_s.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     0.000000,

--- a/tests/integration/cases/float_scientific_notation/Haskell_float_format_scientific_s.hs
+++ b/tests/integration/cases/float_scientific_notation/Haskell_float_format_scientific_s.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     0.0,

--- a/tests/integration/cases/float_special_values/Haskell.hs
+++ b/tests/integration/cases/float_special_values/Haskell.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     (1/0),

--- a/tests/integration/cases/float_special_values/Haskell_float_format_fixed_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_float_format_fixed_v.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     (1/0),

--- a/tests/integration/cases/float_special_values/Haskell_float_format_scientific_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_float_format_scientific_v.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     (1/0),

--- a/tests/integration/cases/float_special_values/Haskell_prefix_J_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_prefix_J_v.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = JFloat Double | JList [Val]
 instance Num Val where
     fromInteger n = JFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (JFloat f) = JFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = JFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = JList [
     (1/0),

--- a/tests/integration/cases/int_list/Haskell.hs
+++ b/tests/integration/cases/int_list/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list/Haskell_integer_format_binary.hs
+++ b/tests/integration/cases/int_list/Haskell_integer_format_binary.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list/Haskell_integer_format_hex.hs
+++ b/tests/integration/cases/int_list/Haskell_integer_format_hex.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list/Haskell_integer_format_octal.hs
+++ b/tests/integration/cases/int_list/Haskell_integer_format_octal.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_large/Haskell.hs
+++ b/tests/integration/cases/int_list_large/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_large/Haskell_integer_format_binary_large.hs
+++ b/tests/integration/cases/int_list_large/Haskell_integer_format_binary_large.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_large/Haskell_integer_format_hex_large.hs
+++ b/tests/integration/cases/int_list_large/Haskell_integer_format_hex_large.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_large/Haskell_integer_format_octal_large.hs
+++ b/tests/integration/cases/int_list_large/Haskell_integer_format_octal_large.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_with_zero/Haskell.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_with_zero/Haskell_integer_format_binary_zero.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell_integer_format_binary_zero.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_with_zero/Haskell_integer_format_hex_zero.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell_integer_format_hex_zero.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_list_with_zero/Haskell_integer_format_octal_zero.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell_integer_format_octal_zero.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/int_set/Haskell.hs
+++ b/tests/integration/cases/int_set/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HSet [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/mixed_number_dict/Haskell.hs
+++ b/tests/integration/cases/mixed_number_dict/Haskell.hs
@@ -2,16 +2,16 @@ module Check where
 data Val = HInt Integer | HFloat Double | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HMap [
     ("a", 1),

--- a/tests/integration/cases/mixed_number_list/Haskell.hs
+++ b/tests/integration/cases/mixed_number_list/Haskell.hs
@@ -2,16 +2,16 @@ module Check where
 data Val = HInt Integer | HFloat Double | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     1,

--- a/tests/integration/cases/mixed_set/Haskell.hs
+++ b/tests/integration/cases/mixed_set/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HSet [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_collection_multi_space_string/Haskell.hs
+++ b/tests/integration/cases/nested_collection_multi_space_string/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_deep_mixed/Haskell.hs
+++ b/tests/integration/cases/nested_deep_mixed/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_float_list/Haskell.hs
+++ b/tests/integration/cases/nested_float_list/Haskell.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     HList [1.5, 2.5],

--- a/tests/integration/cases/nested_float_list/Haskell_float_format_fixed_n.hs
+++ b/tests/integration/cases/nested_float_list/Haskell_float_format_fixed_n.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     HList [1.500000, 2.500000],

--- a/tests/integration/cases/nested_float_list/Haskell_float_format_scientific_n.hs
+++ b/tests/integration/cases/nested_float_list/Haskell_float_format_scientific_n.hs
@@ -2,15 +2,15 @@ module Check where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     HList [1.5, 2.5],

--- a/tests/integration/cases/nested_mixed_dict/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_dict/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HNull | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_mixed_inner/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_inner/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_mixed_set/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_set/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)] | HSet [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_mixed_types/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_types/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_sequence/Haskell.hs
+++ b/tests/integration/cases/nested_sequence/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/nested_sequences/Haskell.hs
+++ b/tests/integration/cases/nested_sequences/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/ordered_map/Haskell.hs
+++ b/tests/integration/cases/ordered_map/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/ordered_map_in_sequence/Haskell.hs
+++ b/tests/integration/cases/ordered_map_in_sequence/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/pair_sequence/Haskell.hs
+++ b/tests/integration/cases/pair_sequence/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/pair_sequence/Haskell_sequence_tuple_pair.hs
+++ b/tests/integration/cases/pair_sequence/Haskell_sequence_tuple_pair.hs
@@ -2,12 +2,13 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
+my_data :: (Val, Val)
 my_data = (
     1,
     HStr "hello"

--- a/tests/integration/cases/scalar_datetime_microsecond/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime_microsecond/Haskell.hs
@@ -1,5 +1,5 @@
 module Check where
-import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime, picosecondsToDiffTime)
+import Data.Time (UTCTime(..), fromGregorian, picosecondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val
 my_data = HDatetime (UTCTime (fromGregorian 2024 1 15) (picosecondsToDiffTime 45000123456000000))

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Haskell.hs
@@ -1,5 +1,5 @@
 module Check where
-import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime, picosecondsToDiffTime)
+import Data.Time (UTCTime(..), fromGregorian, picosecondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val
 my_data = HDatetime (UTCTime (fromGregorian 2024 1 15) (picosecondsToDiffTime 45045123456000000))

--- a/tests/integration/cases/scalar_float/Haskell.hs
+++ b/tests/integration/cases/scalar_float/Haskell.hs
@@ -2,14 +2,13 @@ module Check where
 data Val = HFloat Double
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HFloat f) = HFloat (negate f)
-    negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = 3.14

--- a/tests/integration/cases/scalar_int/Haskell.hs
+++ b/tests/integration/cases/scalar_int/Haskell.hs
@@ -2,11 +2,10 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 my_data :: Val
 my_data = 42

--- a/tests/integration/cases/scalar_int_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_large/Haskell.hs
@@ -2,11 +2,10 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 my_data :: Val
 my_data = 2147483648

--- a/tests/integration/cases/scalar_int_negative_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_negative_large/Haskell.hs
@@ -2,11 +2,10 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 my_data :: Val
 my_data = -2147483649

--- a/tests/integration/cases/scalar_int_very_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_very_large/Haskell.hs
@@ -2,11 +2,10 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 my_data :: Val
 my_data = 9223372036854775808

--- a/tests/integration/cases/scalar_int_very_negative_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_very_negative_large/Haskell.hs
@@ -2,11 +2,10 @@ module Check where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
-    negate _ = error "not implemented"
 my_data :: Val
 my_data = -9223372036854775809

--- a/tests/integration/cases/scalars/Haskell.hs
+++ b/tests/integration/cases/scalars/Haskell.hs
@@ -2,16 +2,16 @@ module Check where
 data Val = HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     42,

--- a/tests/integration/cases/sequence_of_dicts/Haskell.hs
+++ b/tests/integration/cases/sequence_of_dicts/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/simple_dict/Haskell.hs
+++ b/tests/integration/cases/simple_dict/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/simple_dict/Haskell_prefix_J.hs
+++ b/tests/integration/cases/simple_dict/Haskell_prefix_J.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = JNull | JBool Bool | JInt Integer | JStr String | JMap [(String, Val)]
 instance Num Val where
     fromInteger = JInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (JInt n) = JInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/simple_dict/Haskell_string_format_double_dict.hs
+++ b/tests/integration/cases/simple_dict/Haskell_string_format_double_dict.hs
@@ -6,10 +6,10 @@ instance IsString Val where
     fromString = HStr
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/simple_dict/Haskell_type_name_JsonVal.hs
+++ b/tests/integration/cases/simple_dict/Haskell_type_name_JsonVal.hs
@@ -2,10 +2,10 @@ module Check where
 data JsonVal = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, JsonVal)]
 instance Num JsonVal where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: JsonVal

--- a/tests/integration/cases/simple_sequence/Haskell.hs
+++ b/tests/integration/cases/simple_sequence/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/simple_sequence/Haskell_sequence_tuple.hs
+++ b/tests/integration/cases/simple_sequence/Haskell_sequence_tuple.hs
@@ -2,12 +2,13 @@ module Check where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
+my_data :: (Val, Val, Val, Val)
 my_data = (
     1,
     HStr "hello",

--- a/tests/integration/cases/simple_sequence/Haskell_sequence_tuple_varname.hs
+++ b/tests/integration/cases/simple_sequence/Haskell_sequence_tuple_varname.hs
@@ -2,12 +2,13 @@ module Check where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
+my_data :: (Val, Val, Val, Val)
 my_data = (
     1,
     HStr "hello",

--- a/tests/integration/cases/triple_sequence/Haskell.hs
+++ b/tests/integration/cases/triple_sequence/Haskell.hs
@@ -2,10 +2,10 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/triple_sequence/Haskell_sequence_tuple_triple.hs
+++ b/tests/integration/cases/triple_sequence/Haskell_sequence_tuple_triple.hs
@@ -2,12 +2,13 @@ module Check where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
+my_data :: (Val, Val, Val)
 my_data = (
     1,
     HStr "hello",

--- a/tests/integration/cases/type_hints/Haskell.hs
+++ b/tests/integration/cases/type_hints/Haskell.hs
@@ -3,10 +3,10 @@ import Data.Time (Day, fromGregorian, UTCTime(..), secondsToDiffTime)
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, Val)] | HDate Day | HDatetime UTCTime
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate _ = error "not implemented"
 my_data :: Val

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Haskell.hs
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Haskell.hs
@@ -2,16 +2,16 @@ module Check where
 data Val = HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt
-    a + b = error "not implemented"
-    a * b = error "not implemented"
-    abs a = error "not implemented"
-    signum a = error "not implemented"
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
     negate (HInt n) = HInt (negate n)
     negate (HFloat f) = HFloat (negate f)
     negate _ = error "not implemented"
 instance Fractional Val where
     fromRational r = HFloat (realToFrac r)
-    a / b = error "not implemented"
+    _ / _ = error "not implemented"
 my_data :: Val
 my_data = HList [
     HMap [("x", 1), ("y", 2.5)],


### PR DESCRIPTION
## Summary

- `lint-haskell` in `.github/workflows/lint.yml` now passes `-Wall -Werror` to both the syntax check and the end-to-end build, so warnings such as `-Wunused-matches`, `-Woverlapping-patterns`, `-Wtype-defaults`, `-Wmissing-signatures`, `-Wunused-imports`, and `-Wunused-do-bind` fail the job instead of being silently logged.
- The Haskell generator (`src/literalizer/languages/haskell.py`) was updated so every one of the 174 golden fixtures compiles clean under `-Wall`. Changes:
  - `Num` / `Fractional` instance bodies use `_` for unused parameters.
  - The `negate _` catch-all is only emitted when `Val` has non-numeric constructors; otherwise the specific `HInt` / `HFloat` clauses are exhaustive.
  - `TUPLE`-format sequences now carry a `(Val, Val, …)` annotation so bare numeric literals inside tuples resolve via `fromInteger` instead of defaulting.
  - Call stubs emit explicit type signatures. Regular stubs pin the argument to `Val` (or a tuple of `Val`), transform-wrapper stubs use a polymorphic `a -> IO ()` so the wrapped expression's type is inferred from the inner call instead of being defaulted.
  - `StubReturn.VALUE` stubs now return `IO Val` with body `return undefined` so callers that consume the result type-check.
  - `main` binds each call result with `_ <-` so `StubReturn.VALUE` stubs don't fire `-Wunused-do-bind`.
  - `Data.Time` import set drops `secondsToDiffTime` when every datetime in the fixture uses microseconds (only `picosecondsToDiffTime` is needed).
- All 174 Haskell golden fixtures were regenerated.

## Test plan

- [x] `uv run --extra=dev pytest tests/` — 1031 passed
- [x] `uv run --extra=dev prek run --all-files` — all hooks pass
- [x] Local `ghc -Wall -Werror` (syntax-only) on all 174 fixtures — clean
- [x] Local build-and-run with `-Wall -Werror` on all 174 fixtures — clean
- [ ] CI `lint-haskell` green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI becomes stricter by failing on Haskell warnings, and the Haskell code generator/stubs were adjusted to satisfy `-Wall -Werror`, which could surface new failures in downstream fixtures/call rendering.
> 
> **Overview**
> `lint-haskell` now compiles and runs fixtures with GHC `-Wall -Werror`, turning previously-ignored warnings into CI failures.
> 
> To keep generated Haskell output warning-free under these flags, the Haskell generator updates call stubs and emitted code: adds explicit type signatures (including polymorphic wrapper stubs), makes `StubReturn.VALUE` stubs return `IO Val`, avoids unused-binder patterns in `Num`/`Fractional` instances, annotates tuple-sequence declarations, binds call results via `_ <-`, and trims `Data.Time` imports when `secondsToDiffTime` would be unused. Golden Haskell fixtures are regenerated accordingly and the changelog documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421944bfca4de3a2f463cce61c0f3b934374d208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->