### PR TITLE
Batch lint-scala fixtures into one scala-cli pass

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -642,20 +642,28 @@ jobs:
         run: find tests/integration/cases -name '*.scala' -print0 > /tmp/files-to-lint
       - name: Install scala-cli
         uses: VirtusLab/scala-cli-setup@v1
-      # Fixtures define `object Check { ... }` with no main method, so
-      # compile alongside a small @main wrapper that forces the object
-      # (and therefore its val initializers) to load. scala-cli runs
-      # against a persistent Bloop compile server, so the compiler JVM
-      # stays warm across fixtures instead of cold-starting per file.
+      # Compile every fixture in a single scala-cli invocation to pay
+      # the Scala compile + Bloop daemon startup cost once instead of
+      # per fixture. Fixtures all declare `object Check { ... }`, so
+      # they are renamed to a unique `object FixtureN` to avoid
+      # collisions; a generated `@main` references each one to force
+      # its val initializers to load. The mapping is printed so
+      # failures still point back to the original path.
       - name: Run Scala files
         run: |-
+          workspace=$(mktemp -d)
+          main="$workspace/Main.scala"
+          printf '@main def __run(): Unit = {\n' > "$main"
+          i=0
           while IFS= read -r -d '' f; do
-            workspace=$(mktemp -d)
-            cp "$f" "$workspace/Fixture.scala"
-            printf '@main def __run(): Unit = { val _ = Check }\n' \
-              > "$workspace/Main.scala"
-            scala-cli run "$workspace" --main-class __run || exit 1
+            sed "s/^object Check {/object Fixture$i {/" "$f" \
+              > "$workspace/Fixture$i.scala"
+            printf 'Fixture%s.scala <- %s\n' "$i" "$f"
+            printf '  val _%s = Fixture%s\n' "$i" "$i" >> "$main"
+            i=$((i+1))
           done < /tmp/files-to-lint
+          printf '}\n' >> "$main"
+          scala-cli run "$workspace" --main-class __run
 
   lint-dart:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,6 @@ Changelog
 Next
 ----
 
-- ``lint-scala`` in ``.github/workflows/lint.yml`` now batches every
-  fixture into a single ``scala-cli`` workspace and runs one
-  compile/run pass instead of invoking ``scala-cli run`` per file.
-  Each fixture's ``object Check`` is renamed to a unique
-  ``object Fixture$i`` and a generated ``@main`` references all of
-  them so initializers still execute.  This pays the Scala compile
-  and Bloop daemon startup cost once across all fixtures.
 - ``lint-haskell`` in ``.github/workflows/lint.yml`` now passes
   ``-Wall -Werror`` to both the syntax check and the end-to-end build,
   so warnings such as ``-Wunused-matches``, ``-Woverlapping-patterns``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- ``lint-scala`` in ``.github/workflows/lint.yml`` now batches every
+  fixture into a single ``scala-cli`` workspace and runs one
+  compile/run pass instead of invoking ``scala-cli run`` per file.
+  Each fixture's ``object Check`` is renamed to a unique
+  ``object Fixture$i`` and a generated ``@main`` references all of
+  them so initializers still execute.  This pays the Scala compile
+  and Bloop daemon startup cost once across all fixtures.
 - ``lint-haskell`` in ``.github/workflows/lint.yml`` now passes
   ``-Wall -Werror`` to both the syntax check and the end-to-end build,
   so warnings such as ``-Wunused-matches``, ``-Woverlapping-patterns``,


### PR DESCRIPTION
## Summary

- Closes #1559
- Rewrites `lint-scala` to copy every fixture into one `scala-cli` workspace and compile/run in a single invocation
- Each fixture's `object Check` is renamed to a unique `object FixtureN` (sed-anchored to `^object Check {`), and a generated `@main` references each one to force its `val` initializers to load

## Test plan

- [x] Locally: 282 fixtures compile + run in a single `scala-cli run` (~3s warm)
- [x] Locally: a deliberately broken fixture causes the run to exit non-zero
- [ ] CI `lint-scala` job completes in well under the previous ~3m45s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CI `lint-scala` execution model (rewriting sources and running all fixtures in one workspace), which could introduce false positives/negatives or new failure modes if fixture patterns differ.
> 
> **Overview**
> Updates the GitHub Actions `lint-scala` job to **run all Scala integration fixtures in one `scala-cli` invocation** instead of spawning a fresh workspace per file, reducing repeated Scala/Bloop startup overhead.
> 
> To avoid `object Check` name collisions, each fixture is copied into a shared temp workspace with `Check` rewritten to a unique `FixtureN`, and a generated `Main.scala` `@main` references each fixture to force initialization; the job prints the fixture-to-source mapping for debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc4687d57cb6f9ef1eba61b25671ce5fb4a54d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->