### PR TITLE
Run VB.NET files in lint.yml to catch runtime errors

### DIFF
--- a/.github/scripts/lint-vb/Program.cs
+++ b/.github/scripts/lint-vb/Program.cs
@@ -92,9 +92,17 @@ for (var i = 0; i < paths.Count; i++)
     catch (Exception ex)
     {
         allOk = false;
-        var inner = ex is TargetInvocationException tie && tie.InnerException is not null
-            ? tie.InnerException
-            : ex;
+        // `RunClassConstructor` wraps cctor failures in
+        // `TypeInitializationException`, and `MethodInfo.Invoke` wraps
+        // callee failures in `TargetInvocationException`; peel both
+        // layers so the reported error points at the fixture's actual
+        // runtime failure.
+        var inner = ex;
+        while (inner is TargetInvocationException or TypeInitializationException
+            && inner.InnerException is not null)
+        {
+            inner = inner.InnerException;
+        }
         Console.Error.WriteLine($"{path}: VB runtime error: {inner}");
     }
 }

--- a/.github/scripts/lint-vb/Program.cs
+++ b/.github/scripts/lint-vb/Program.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 
@@ -56,6 +58,44 @@ for (var i = 0; i < paths.Count; i++)
         {
             Console.Error.WriteLine($"  {diag}");
         }
+        continue;
+    }
+
+    var assembly = Assembly.Load(ms.ToArray());
+    var checkType = assembly.GetType("Check");
+    if (checkType is null)
+    {
+        allOk = false;
+        Console.Error.WriteLine($"{path}: expected `Module Check` but it was not found");
+        continue;
+    }
+    try
+    {
+        // Module-level `Dim` initializers run in the type's cctor, so
+        // forcing it exercises fixtures that define `my_data` directly
+        // in `Module Check`.
+        RuntimeHelpers.RunClassConstructor(checkType.TypeHandle);
+        // Fixtures that wrap `my_data` inside `Sub _declaration()` and
+        // `Sub _assignment()` only execute those bodies when the subs
+        // are invoked, so call every declared parameterless shared sub.
+        var methods = checkType.GetMethods(
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        foreach (var method in methods)
+        {
+            if (method.GetParameters().Length == 0
+                && method.ReturnType == typeof(void))
+            {
+                method.Invoke(obj: null, parameters: null);
+            }
+        }
+    }
+    catch (Exception ex)
+    {
+        allOk = false;
+        var inner = ex is TargetInvocationException tie && tie.InnerException is not null
+            ? tie.InnerException
+            : ex;
+        Console.Error.WriteLine($"{path}: VB runtime error: {inner}");
     }
 }
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1334,7 +1334,7 @@ jobs:
       - name: Build VB lint host
         run: dotnet publish .github/scripts/lint-vb/lint-vb.csproj -c Release -o /tmp/lint-vb
           --nologo
-      - name: Check VB.NET syntax
+      - name: Check and run VB.NET files
         run: dotnet /tmp/lint-vb/lint-vb.dll < /tmp/files-to-lint
 
   lint-forth:


### PR DESCRIPTION
## Summary
- Extend the Roslyn `lint-vb` host to load each compiled fixture, force `Module Check`'s class constructor so module-level `Dim` initializers run, and invoke every declared parameterless shared `Sub` so fixtures that wrap `my_data` in `_declaration` / `_assignment` bodies execute
- Runtime exceptions unwrap `TargetInvocationException` and fail the job, bringing `lint-visualbasic` in line with the end-to-end pattern used by lint-bash / lint-ruby / lint-javascript / lint-perl etc
- Rename the workflow step from "Check VB.NET syntax" to "Check and run VB.NET files"

Closes #1435

## Test plan
- [ ] `lint-visualbasic` CI job passes on all 231 existing VB fixtures
- [ ] Verified locally that deliberate runtime errors in both fixture shapes (module-level `Dim` and `Sub`-wrapped) surface with a non-zero exit and descriptive message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now loads and executes compiled VB fixtures (cctor + shared subs), which can introduce new lint failures or hangs if fixtures have unexpected runtime behavior despite no production code impact.
> 
> **Overview**
> Upgrades the VB lint host to go beyond Roslyn compilation: it now loads each emitted assembly, requires a `Module Check`, forces its type initializer to run module-level `Dim` initializers, and invokes all declared parameterless `Shared Sub`s to catch runtime failures.
> 
> Updates `lint.yml` to reflect the new behavior by renaming the step to **Check and run VB.NET files**, and reports clearer runtime errors by unwrapping invocation/initialization exception wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c16a3408a7e0964823190fcae53fdddc6fed4e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->