### PR TITLE
Shard lint-cpp and lint-cpp-tidy across 4 runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -248,13 +248,22 @@ jobs:
 
   lint-cpp:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Find files to lint
         shell: bash
-        run: find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-to-lint
+        run: |
+          find tests/integration/cases -name '*.cpp' -print0 \
+            | sort -z \
+            | gawk -v s=${{ matrix.shard }} -v n=4 \
+                'BEGIN{RS=ORS="\0"} (NR-1) % n == s' \
+            > /tmp/files-to-lint
       # Fixtures are tiny TUs whose cost is dominated by re-parsing the
       # same standard headers 269 times. Build a precompiled header once
       # covering every header any fixture includes, then preload it in
@@ -282,13 +291,22 @@ jobs:
 
   lint-cpp-tidy:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Find files to lint
         shell: bash
-        run: find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-to-lint
+        run: |
+          find tests/integration/cases -name '*.cpp' -print0 \
+            | sort -z \
+            | gawk -v s=${{ matrix.shard }} -v n=4 \
+                'BEGIN{RS=ORS="\0"} (NR-1) % n == s' \
+            > /tmp/files-to-lint
       # Preloading the standard headers via PCH was tried here but made
       # clang-tidy ~2x slower on the Ubuntu runner: with `Checks: *`
       # enabling `clang-analyzer-*`, the preloaded AST exposes the


### PR DESCRIPTION
## Summary
- Add a `shard: [0,1,2,3]` matrix to both `lint-cpp` and `lint-cpp-tidy`, with `fail-fast: false` so all shards report independently.
- Each shard pipes `find -print0 | sort -z | gawk` to deterministically take every 4th file, leaving downstream `xargs -0` consumers (PCH-syntax check, run, clang-tidy) unchanged but processing ~70 files instead of 280.

## Test plan
- [ ] Confirm all four `lint-cpp` shards and all four `lint-cpp-tidy` shards run green on this PR.
- [ ] Verify wall-clock time of the slowest `lint-cpp-tidy` shard is meaningfully lower than the previous single-runner job.
- [ ] If `lint-cpp` / `lint-cpp-tidy` are required status checks in branch protection, update the rules to the new matrix names (e.g. `lint-cpp (0)` … `lint-cpp (3)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it alters job naming and file selection logic, which could affect required status checks and coverage if sharding is misconfigured.
> 
> **Overview**
> Splits the `lint-cpp` and `lint-cpp-tidy` GitHub Actions jobs into a 4-way matrix (`shard: [0..3]`) with `fail-fast: false` so shards run and report independently.
> 
> Each shard now deterministically selects every 4th C++ fixture (`find -print0 | sort -z | gawk`) before running the existing syntax/PCH/run and `clang-tidy` steps, reducing per-runner workload without changing the downstream commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521322053a070458e86d1cf92f01f60c11015504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->