### PR TITLE
Silence pre-commit warning about top-level .uv_version key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
 ---
 fail_fast: true
 
-.uv_version: &uv_version uv==0.11.7
-
 ci:
   skip:
     - actionlint
@@ -118,7 +116,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies: [&uv_version uv==0.11.7]
         priority: 500
         stages: [pre-commit]
 


### PR DESCRIPTION
## Summary
- Pre-commit 4.5 warns on unknown top-level keys, flagging the `.uv_version` anchor holder.
- Defined the anchor inline on the first `additional_dependencies` entry so all `[*uv_version]` references keep resolving to `uv==0.11.7` without a top-level key.

## Test plan
- [x] `pre-commit run --all-files check-yaml` no longer emits the `Ignored unexpected keys ... .uv_version` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that keeps the `uv==0.11.7` pin but moves the YAML anchor definition to avoid pre-commit’s unknown top-level key warning.
> 
> **Overview**
> Silences pre-commit 4.5 warnings by removing the top-level `.uv_version` key from `.pre-commit-config.yaml`.
> 
> The `uv==0.11.7` pin is now defined inline as a YAML anchor on the first `additional_dependencies` entry, with all other hooks continuing to reference it via `[*uv_version]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843ac5f8edd30559f6c0e63e5211d0d0f68f44a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->