### PR TITLE
Install Mojo via uv instead of pixi in lint-mojo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -955,15 +955,13 @@ jobs:
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name '*.mojo' -print0 > /tmp/files-to-lint
-      - name: Install pixi
-        uses: fabasoad/setup-mojo-action@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
       - name: Install Mojo
-        run: |-
-          pixi init "$RUNNER_TEMP/mojo-env" \
-            -c https://conda.modular.com/max \
-            -c conda-forge
-          pixi add --manifest-path "$RUNNER_TEMP/mojo-env/pixi.toml" mojo
-          echo "MOJO_PIXI_MANIFEST=$RUNNER_TEMP/mojo-env/pixi.toml" >> "$GITHUB_ENV"
+        run: uv tool install mojo-compiler
       # Mojo reserves ~3.6 GB of virtual address space per invocation
       # (upstream: modular/modular#6433). On the 7 GB GitHub runner the
       # kernel's default overcommit heuristic refuses the allocation and
@@ -989,7 +987,7 @@ jobs:
           while IFS= read -r -d '' f; do
             ok=0
             for attempt in 1 2 3; do
-              if pixi run --manifest-path "$MOJO_PIXI_MANIFEST" mojo run --Werror "$GITHUB_WORKSPACE/$f"; then
+              if mojo run --Werror "$GITHUB_WORKSPACE/$f"; then
                 ok=1
                 break
               fi


### PR DESCRIPTION
## Summary
- Replace `fabasoad/setup-mojo-action` + `pixi init`/`pixi add` with `astral-sh/setup-uv` + `uv tool install mojo-compiler`
- Drop the `MOJO_PIXI_MANIFEST` env var and invoke `mojo run --Werror` directly in the retry loop
- Overcommit/swap workaround and 3× retry loop are unchanged (Mojo runtime issues, unrelated to the installer)

## Test plan
- [ ] `lint-mojo` job passes on CI against the fixtures under `tests/integration/cases/*.mojo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates CI workflow tooling for the `lint-mojo` job, but could cause CI failures if `mojo-compiler` install or `mojo` invocation differs from the prior pixi-based setup.
> 
> **Overview**
> Updates the `lint-mojo` CI job to **install Mojo using `uv`** (`astral-sh/setup-uv` + `uv tool install mojo-compiler`) instead of the previous `setup-mojo-action`/`pixi` environment setup.
> 
> Simplifies the syntax-check loop by **running `mojo run --Werror` directly**, removing the pixi manifest indirection; memory overcommit/swap workaround and the 3× retry behavior remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a459d560af615d3143c57f3582a99e6eff07ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->