### PR TITLE
Drop retry loop from lint-mojo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -978,28 +978,11 @@ jobs:
           sudo chmod 600 /mnt/extra-swapfile
           sudo mkswap /mnt/extra-swapfile
           sudo swapon /mnt/extra-swapfile
-      # Even with the headroom above, Mojo occasionally still crashes
-      # non-deterministically (tracked in  # 558). Retry each file a few
-      # times so one crash does not block the rest.
       - name: Check Mojo syntax
         run: |-
-          failed=0
           while IFS= read -r -d '' f; do
-            ok=0
-            for attempt in 1 2 3; do
-              if mojo run --Werror "$GITHUB_WORKSPACE/$f"; then
-                ok=1
-                break
-              fi
-              echo "::warning::Attempt $attempt failed for $f, retrying..."
-              sleep 2
-            done
-            if [ "$ok" -eq 0 ]; then
-              echo "::error::Failed after 3 attempts: $f"
-              failed=1
-            fi
+            mojo run --Werror "$GITHUB_WORKSPACE/$f" || exit 1
           done < /tmp/files-to-lint
-          exit "$failed"
 
   lint-nim:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Removes the 3-attempt retry loop from `lint-mojo` now that Mojo is installed via uv (not pixi).
- Memory headroom workaround (overcommit + extra swap for upstream `modular/modular#6433`) is left in place; we can revisit it after a few green runs.

## Test plan
- [ ] `lint-mojo` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI-only change, but it may reintroduce lint flakiness if `mojo run` still crashes intermittently and will now fail the job immediately.
> 
> **Overview**
> Removes the 3-attempt retry loop from the `lint-mojo` GitHub Actions job so each `.mojo` file is checked once and the job fails fast on the first `mojo run --Werror` error.
> 
> The swap/overcommit memory headroom workaround for Mojo remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60215e5a46aafc92cb14c1f04d06a40a2dddf4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->