### PR TITLE
Drop redundant -stop tc step from lint-sml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1192,8 +1192,6 @@ jobs:
         run: |
           curl -fsSL https://github.com/MLton/mlton/releases/download/on-20241230-release/mlton-20241230-1.amd64-linux.ubuntu-24.04_static.tgz | tar xz -C /tmp
           echo "/tmp/mlton-20241230-1.amd64-linux.ubuntu-24.04_static/bin" >> "$GITHUB_PATH"
-      - name: Check SML syntax
-        run: xargs -0 -P "$(nproc)" -n1 mlton -stop tc < /tmp/files-to-lint
       # Fixtures only declare `structure Check` with a `my_data` val;
       # MLton never evaluates the body unless a top-level expression
       # references it, so compile alongside a small force file that


### PR DESCRIPTION
## Summary
- The `lint-sml` job ran `mlton -stop tc` and then `mlton` (full compile) on the same files, double-paying for parsing and type-checking.
- Drop the `-stop tc` step; the subsequent full-compile step already parses and type-checks. Expected ~40% wall-time cut for the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `lint-sml` GitHub Actions workflow by removing a duplicated `mlton -stop tc` pass; SML fixtures are still fully compiled and executed in the remaining step.
> 
> **Overview**
> Removes the separate `mlton -stop tc` *typecheck-only* pass from the `lint-sml` job, relying solely on the existing compile-and-run step (which already parses and type-checks).
> 
> This reduces duplicated work in CI while keeping the same SML compilation/execution coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a1a557a23ea2cb0471ec37b3431d3399342d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->