### PR TITLE
Parallelize lint-nim check and run steps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1073,20 +1073,24 @@ jobs:
         uses: jiro4989/setup-nim-action@v2
       - name: Check Nim syntax
         run: |-
+          cat > /tmp/check-nim.sh <<'SCRIPT'
           read -r -a warning_flags <<< "$NIM_WARNING_FLAGS"
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            nim check --hints:off "${warning_flags[@]}" \
-              --nimcache:"$tmpdir" "$f" || exit 1
-          done < /tmp/files-to-lint
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          nim check --hints:off "${warning_flags[@]}" \
+            --nimcache:"$tmpdir" "$1"
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/check-nim.sh < /tmp/files-to-lint
       - name: Run Nim files
         run: |-
+          cat > /tmp/run-nim.sh <<'SCRIPT'
           read -r -a warning_flags <<< "$NIM_WARNING_FLAGS"
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            nim c -r --hints:off "${warning_flags[@]}" \
-              --nimcache:"$tmpdir" "$f" || exit 1
-          done < /tmp/files-to-lint
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          nim c -r --hints:off "${warning_flags[@]}" \
+            --nimcache:"$tmpdir" "$1"
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-nim.sh < /tmp/files-to-lint
 
   lint-nix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace the serial `while read` loops in `lint-nim` (both `nim check` and `nim c -r`) with `xargs -0 -P "$(nproc)" -n1` driving a small `/tmp/check-nim.sh` / `/tmp/run-nim.sh` helper, matching the pattern used elsewhere in the file (e.g. `lint-cpp`, `lint-crystal`).
- Each helper inherits `NIM_WARNING_FLAGS` from the job-level env, uses a per-file `nimcache` tmpdir with a cleanup trap, and relies on xargs to propagate child failures. Expected ~4× speedup on the ~211 Nim fixtures on a 4-core runner.

## Test plan
- [ ] CI `lint-nim` job passes and runs noticeably faster than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `lint-nim` CI execution model to run fixtures concurrently, which could introduce new flakiness (resource contention, ordering, or `xargs` error propagation differences) despite keeping per-file `nimcache` isolation.
> 
> **Overview**
> **Parallelizes the Nim lint job in CI.** The `lint-nim` workflow replaces serial `while read` loops with `xargs -0 -P "$(nproc)" -n1` to run `nim check` and `nim c -r` across fixtures concurrently.
> 
> Each invocation now runs via a small `/tmp/check-nim.sh` / `/tmp/run-nim.sh` wrapper that parses `NIM_WARNING_FLAGS`, creates a per-file temp `--nimcache` directory, and cleans it up via `trap`, aiming to speed up CI while preserving per-file isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04cebe58f0fb01748e5016542be5bd956537375f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->