### PR TITLE
Lift RLIMIT_AS in lint-mojo to reduce KGEN crashes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -995,6 +995,7 @@ jobs:
       # overcommit + swap step above has given the kernel enough
       # headroom. Recommended by the upstream bug author in
       # HomericIntelligence/ProjectOdyssey#5274.
+      # Local tracking: https://github.com/adamtheturtle/literalizer/issues/1574
       - name: Check Mojo syntax
         run: |-
           ulimit -v unlimited

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -988,8 +988,16 @@ jobs:
           sudo chmod 600 /mnt/extra-swapfile
           sudo mkswap /mnt/extra-swapfile
           sudo swapon /mnt/extra-swapfile
+      # Lift the per-process virtual-address cap so the shell and
+      # each `mojo run` child inherit an unlimited `RLIMIT_AS`. Mojo
+      # reserves ~3.6 GB virtual per invocation; without this, a low
+      # default cap can make the reservation fail even when the
+      # overcommit + swap step above has given the kernel enough
+      # headroom. Recommended by the upstream bug author in
+      # HomericIntelligence/ProjectOdyssey#5274.
       - name: Check Mojo syntax
         run: |-
+          ulimit -v unlimited
           while IFS= read -r -d '' f; do
             mojo run --Werror "$GITHUB_WORKSPACE/$f" || exit 1
           done < /tmp/files-to-lint


### PR DESCRIPTION
## Summary

- Add `ulimit -v unlimited` before the `mojo run` loop in `lint-mojo`, so each invocation inherits an uncapped virtual-address limit.
- Mojo reserves ~3.6 GB virtual per invocation ([modular/modular#6433](https://github.com/modular/modular/issues/6433)); without this, a low default cap can trip the reservation even when the overcommit + swap step has already given the kernel enough headroom.
- Recommended by the upstream bug author in [HomericIntelligence/ProjectOdyssey#5274](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5274).

Related issue: [#1574](https://github.com/adamtheturtle/literalizer/issues/1574) — `lint-mojo fails intermittently with crash in libKGENCompilerRTShared.so`. This PR is the cheap first experiment listed there: if our ~10% `lint-mojo` failure rate drops, the runner baseline was VA-capped despite the overcommit setting; if it stays at ~10%, we're hitting something other than per-process VA limits and should explore the other options tracked in #1574.

## Test plan

- [ ] CI `Lint` workflow passes on this PR.
- [ ] Re-run the `Lint` workflow a few times to sample the post-change failure rate before merge.
- [ ] After merge, watch ~20 runs on `main` and compare `lint-mojo` failure rate to the baseline ~10%. Comment the result on #1574.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just adjusts shell resource limits for the Mojo lint step to reduce flakiness; no production code paths affected.
> 
> **Overview**
> Reduces intermittent `lint-mojo` failures by adding `ulimit -v unlimited` so each `mojo run` inherits an uncapped `RLIMIT_AS` (virtual address space limit) after the existing overcommit+swap setup.
> 
> Also adds inline documentation and links explaining the upstream Mojo virtual-memory reservation behavior and the local tracking issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407d1e75452f8a0ab520c4cee50d0a8aa042ec96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->