### PR TITLE
Fail lint-erlang on warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -502,7 +502,7 @@ jobs:
             printf '%s.erl <- %s\n' "$name" "$f"
             i=$((i+1))
           done < /tmp/files-to-lint
-          (cd "$tmpdir" && erlc fixture_*.erl)
+          (cd "$tmpdir" && erlc -Werror fixture_*.erl)
 
   lint-fsharp:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Changelog
 Next
 ----
 
+
+- ``lint-erlang`` in ``.github/workflows/lint.yml`` now passes
+  ``-Werror`` to ``erlc``, so warnings such as ``evaluation of operator
+  '-'/1 will fail with a 'badarith' exception`` fail the job instead of
+  being silently logged.  ``Erlang`` generated output for negative
+  infinity is now the quoted atom ``'-inf'`` instead of the bare
+  ``-inf``, which the compiler treated as unary negation of the atom
+  ``inf`` and flagged as a guaranteed runtime ``badarith``.
+
 2026.04.23
 ----------
 

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -250,7 +250,7 @@ class Erlang(metaclass=LanguageCls):
         FloatSpecialsMixin,
         enum.Enum,
         positive_infinity="inf",
-        negative_infinity="-inf",
+        negative_infinity="'-inf'",
         nan="nan",
     ):
         """Float format options."""

--- a/tests/integration/cases/float_special_values/Erlang.erl
+++ b/tests/integration/cases/float_special_values/Erlang.erl
@@ -3,7 +3,7 @@
 x() ->
     My_data = [
         inf,
-        -inf,
+        '-inf',
         nan
     ],
     My_data.

--- a/tests/integration/cases/float_special_values/Erlang_float_format_fixed_v.erl
+++ b/tests/integration/cases/float_special_values/Erlang_float_format_fixed_v.erl
@@ -3,7 +3,7 @@
 x() ->
     My_data = [
         inf,
-        -inf,
+        '-inf',
         nan
     ],
     My_data.

--- a/tests/integration/cases/float_special_values/Erlang_float_format_scientific_v.erl
+++ b/tests/integration/cases/float_special_values/Erlang_float_format_scientific_v.erl
@@ -3,7 +3,7 @@
 x() ->
     My_data = [
         inf,
-        -inf,
+        '-inf',
         nan
     ],
     My_data.


### PR DESCRIPTION
## Summary
- Pass ``-Werror`` to ``erlc`` in the ``lint-erlang`` workflow so compiler warnings (e.g. ``evaluation of operator '-'/1 will fail with a 'badarith' exception``) fail the job instead of being silently logged.
- Emit negative infinity as the quoted atom ``'-inf'`` rather than the bare ``-inf``, which erlc parsed as unary negation of the atom ``inf`` and flagged as a guaranteed runtime ``badarith``.
- Regenerate the three ``float_special_values`` Erlang golden fixtures and add a changelog entry.

## Test plan
- [x] ``erlc -Werror fixture_*.erl`` over every ``tests/integration/cases/**/*.erl`` fixture exits 0 locally
- [x] ``uv run pytest tests/ -k 'erlang or float_special'`` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes by promoting Erlang compiler warnings to failures, which may surface new breakages in existing or future fixtures. The Erlang negative-infinity literal output format changes, which could affect downstream golden expectations.
> 
> **Overview**
> **Erlang linting is now strict**: `lint-erlang` runs `erlc -Werror`, causing any Erlang compiler warnings in fixtures to fail CI instead of being logged.
> 
> **Erlang float special rendering was updated**: negative infinity is emitted as the quoted atom `'-inf'` (instead of `-inf`) to avoid an `erlc` warning/runtime-issue pattern, and the `float_special_values` Erlang golden fixtures were regenerated accordingly. A `CHANGELOG.rst` entry documents both changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d56281b9eef5b911472e3d1a950ba538149278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->