### PR TITLE
Split lint-c into syntax and clang-tidy jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Check Java syntax
         run: xargs -0 java CheckJavaSyntax.java < /tmp/files-to-lint
 
-  lint-c:
+  lint-c-syntax:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -227,6 +227,16 @@ jobs:
         run: find tests/integration/cases -name '*.c' -print0 > /tmp/files-to-lint
       - name: Check C syntax
         run: xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-to-lint
+
+  lint-c-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Find files to lint
+        shell: bash
+        run: find tests/integration/cases -name '*.c' -print0 > /tmp/files-to-lint
       # Ubuntu's packaged clang-tidy is several releases behind and is
       # the dominant cost of this job on runners. Pull a recent build
       # from PyPI via uv instead.
@@ -1507,7 +1517,8 @@ jobs:
       - lint-jsonnet
       - lint-typescript
       - lint-java
-      - lint-c
+      - lint-c-syntax
+      - lint-c-tidy
       - lint-cobol
       - lint-cpp
       - lint-cpp-tidy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Check Java syntax
         run: xargs -0 java CheckJavaSyntax.java < /tmp/files-to-lint
 
-  lint-c-syntax:
+  lint-c:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -1517,7 +1517,7 @@ jobs:
       - lint-jsonnet
       - lint-typescript
       - lint-java
-      - lint-c-syntax
+      - lint-c
       - lint-c-tidy
       - lint-cobol
       - lint-cpp


### PR DESCRIPTION
## Summary
- Split `lint-c` into `lint-c-syntax` (clang `-fsyntax-only`) and `lint-c-tidy` (uv-installed clang-tidy), mirroring the existing `lint-cpp` / `lint-cpp-tidy` split.
- The syntax pass over 29 C fixtures finishes in seconds; clang-tidy dominates the job tail, so parallelizing shortens the critical path.
- Updated `completion-lint` to depend on both new jobs.

## Test plan
- [ ] CI lint workflow runs both `lint-c-syntax` and `lint-c-tidy` to green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just restructures the lint workflow; main risk is increased CI flakiness/time due to separate `clang-tidy` install/execution.
> 
> **Overview**
> Splits the C linting in `.github/workflows/lint.yml` so basic C compilation/syntax checking runs as its own fast `lint-c` job, while `clang-tidy` analysis runs in a new parallel `lint-c-tidy` job installed via `uv`.
> 
> Updates `completion-lint` to require both `lint-c` and `lint-c-tidy`, ensuring the overall workflow still gates on both checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ead7e6bf446870d4f14ae2c0a6145d3498767a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->