### PR TITLE
Widen Rust TAGGED_ENUM siblings across per-element literalize_call args

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Changelog
 Next
 ----
 
+- ``literalize_call`` with ``per_element=True`` now widens Rust's
+  ``TAGGED_ENUM`` scalar wrapping across sibling calls at matching
+  argument slots.  Previously the wrap analysis ran per call, so a
+  locally-homogeneous sibling dict would emit unwrapped scalars
+  even when another call at the same slot was heterogeneous — a
+  second ``m.process(HashMap::from([("a", "x")]))`` would not match
+  the ``&HashMap<&'static str, Value>`` parameter implied by the
+  first heterogeneous call.  Mirrors the dict-opener widening
+  already applied for typed dict languages on the per-element call
+  path.
+
 2026.04.23
 ----------
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -448,6 +448,28 @@ def _compute_dict_open_override(
 
 
 @beartype
+def _gather_call_slot_values(
+    *,
+    elements: list[Value],
+) -> list[list[Value]]:
+    """Group non-ref argument values by positional slot across calls.
+
+    ``{"$ref": "name"}`` markers are filtered out: the marker isn't
+    rendered as a real value at the call site, so its shape must not
+    influence sibling-aware widening.
+    """
+    slots: list[list[Value]] = []
+    for element in elements:
+        arg_values = element if isinstance(element, list) else [element]
+        for slot_index, arg_value in enumerate(iterable=arg_values):
+            if slot_index >= len(slots):
+                slots.append([])
+            if _extract_call_arg_ref_name(value=arg_value) is None:
+                slots[slot_index].append(arg_value)
+    return slots
+
+
+@beartype
 def _compute_call_slot_overrides(
     *,
     elements: list[Value],
@@ -462,23 +484,38 @@ def _compute_call_slot_overrides(
     no enclosing sequence, so ``narrowed_open`` does not apply here —
     each dict still needs its own full opener, just widened when
     sibling dicts differ in inferred value type.
-
-    ``{"$ref": "name"}`` markers are filtered out of each slot's
-    values: the marker isn't rendered as a dict at the call site, so
-    its shape must not influence widening.
     """
-    slots: list[list[Value]] = []
-    for element in elements:
-        arg_values = element if isinstance(element, list) else [element]
-        for slot_index, arg_value in enumerate(iterable=arg_values):
-            if slot_index >= len(slots):
-                slots.append([])
-            if _extract_call_arg_ref_name(value=arg_value) is None:
-                slots[slot_index].append(arg_value)
+    slots = _gather_call_slot_values(elements=elements)
     return [
         _compute_dict_open_override(items=slot_values, spec=spec)
         for slot_values in slots
     ]
+
+
+@beartype
+def _compute_call_per_element_wrap_ids(
+    *,
+    elements: list[Value],
+    spec: Language,
+) -> frozenset[int]:
+    """Compute wrap_ids spanning sibling per-element calls.
+
+    For each positional argument slot, compute wrap_ids on the slot's
+    values as if they were siblings inside a single list, then union
+    the results.  This mirrors the dict-opener widening done by
+    :func:`_compute_call_slot_overrides` so that render-time wrapping
+    strategies (e.g. Rust's ``TAGGED_ENUM``) stay consistent across
+    sibling calls: a slot whose combined values are heterogeneous
+    triggers wrapping in every sibling at that slot, not just the
+    ones whose own argument is locally mixed.
+    """
+    slots = _gather_call_slot_values(elements=elements)
+    return frozenset[int]().union(
+        *(
+            _compute_wrap_ids(data=slot_values, spec=spec)
+            for slot_values in slots
+        )
+    )
 
 
 @beartype
@@ -1651,11 +1688,16 @@ def _render_call_per_element(
     pointers rather than real data, so they are skipped during
     data-shape validation and wrap-id computation while still
     appearing as identifiers in the rendered call.
-    :func:`_compute_call_slot_overrides` similarly filters them out so
-    the marker's ``{str: str}`` shape does not influence per-slot
-    dict-opener widening.
+    :func:`_compute_call_slot_overrides` and
+    :func:`_compute_call_per_element_wrap_ids` similarly filter them
+    out so the marker's ``{str: str}`` shape does not influence
+    per-slot widening.
     """
     slot_overrides = _compute_call_slot_overrides(
+        elements=data,
+        spec=language,
+    )
+    slot_wrap_ids = _compute_call_per_element_wrap_ids(
         elements=data,
         spec=language,
     )
@@ -1669,9 +1711,8 @@ def _render_call_per_element(
         ]
         for value in non_ref_args:
             check_data(data=value, spec=language)
-        call_wrap_ids = _compute_wrap_ids(
-            data=non_ref_args,
-            spec=language,
+        call_wrap_ids = (
+            _compute_wrap_ids(data=non_ref_args, spec=language) | slot_wrap_ids
         )
         args_str = _format_call_args(
             values=cast("list[Value]", arg_values),

--- a/tests/integration/cases/call_mixed_type_dicts/Rust_heterogeneous_value_enum_name_JsonValue_call.rs
+++ b/tests/integration/cases/call_mixed_type_dicts/Rust_heterogeneous_value_enum_name_JsonValue_call.rs
@@ -1,0 +1,13 @@
+use std::collections::HashMap;
+enum JsonValue {
+    Str(&'static str),
+    Bool(bool),
+}
+fn main() {
+    struct MgrType_;
+    impl MgrType_ { fn op<A>(&self, _operation: A) {} }
+    struct AppType_ { mgr: MgrType_ }
+    let app = AppType_ { mgr: MgrType_ };
+    app.mgr.op(HashMap::from([("type", JsonValue::Str("create")), ("pr_id", JsonValue::Str("pr_1")), ("draft", JsonValue::Bool(true))]));
+    app.mgr.op(HashMap::from([("type", JsonValue::Str("create")), ("pr_id", JsonValue::Str("pr_2"))]));
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2183,6 +2183,15 @@ def test_no_dead_golden_files(request: pytest.FixtureRequest) -> None:
             cases_dir / call_case.config.case_dir_name / (golden_name + ext)
         )
 
+    for call_variant_case in _build_call_variant_cases():
+        variant_spec = call_variant_case.variant.spec
+        golden_name = f"{call_variant_case.variant.name}_call"
+        expected.add(
+            cases_dir
+            / call_variant_case.config.case_dir_name
+            / (golden_name + variant_spec.extension)
+        )
+
     actual = {path for path in cases_dir.rglob(pattern="*") if path.is_file()}
     dead_files = sorted(
         os.path.relpath(path=path, start=cases_dir)
@@ -2316,35 +2325,25 @@ def _discover_call_cases() -> list[_CallCase]:
     return cases
 
 
-@pytest.mark.parametrize(
-    argnames="call_case",
-    argvalues=_discover_call_cases(),
-    ids=[
-        f"{c.config.case_dir_name}/{c.lang_cls.__name__}"
-        for c in _discover_call_cases()
-    ],
-)
-def test_call_golden_file(
-    call_case: _CallCase,
+@beartype
+def _run_call_golden_case(
+    *,
+    config: _CallCaseConfig,
+    spec: literalizer.Language,
+    golden_name: str,
     cases_dir: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
-    """Test that literalize_call output matches expected golden file."""
-    config = call_case.config
-    lang_cls = call_case.lang_cls
-    kwargs: dict[str, object] = {}
-    if config.call_style_type is not None:
-        style = next(
-            s
-            for s in lang_cls.CallStyles
-            if isinstance(s.value, config.call_style_type)
-        )
-        kwargs["call_style"] = style
-    spec = _spec(lang_cls=lang_cls, **kwargs)
+    """Assemble a literalize_call golden-file case against *golden_name*.
+
+    Shared by :func:`test_call_golden_file` (default-spec per language)
+    and :func:`test_call_variant_golden_file` (non-default language
+    variants, e.g. Rust's ``TAGGED_ENUM`` on an input the default
+    ``ERROR`` strategy rejects).
+    """
+    lang_cls = type(spec)
     input_path = cases_dir / config.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    lang_name = lang_cls.__name__
-    golden_name = f"{lang_name}_call"
     golden_path = input_path.parent / (golden_name + lang_cls.extension)
     try:
         # Literalize each ``{"$ref": "name"}`` target into a variable
@@ -2371,7 +2370,7 @@ def test_call_golden_file(
     except HeterogeneousCollectionError:
         golden_path.unlink(missing_ok=True)
         pytest.skip(
-            f"{lang_name} cannot represent this heterogeneous input",
+            f"{lang_cls.__name__} cannot represent this heterogeneous input",
         )
     # Build stub declarations for undefined names.
     body_stubs: list[str] = []
@@ -2438,4 +2437,108 @@ def test_call_golden_file(
         extension=lang_cls.extension,
         newline="",
         golden_path=golden_path,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="call_case",
+    argvalues=_discover_call_cases(),
+    ids=[
+        f"{c.config.case_dir_name}/{c.lang_cls.__name__}"
+        for c in _discover_call_cases()
+    ],
+)
+def test_call_golden_file(
+    call_case: _CallCase,
+    cases_dir: Path,
+    file_regression: FileRegressionFixture,
+) -> None:
+    """Test that literalize_call output matches expected golden file."""
+    config = call_case.config
+    lang_cls = call_case.lang_cls
+    kwargs: dict[str, object] = {}
+    if config.call_style_type is not None:
+        style = next(
+            s
+            for s in lang_cls.CallStyles
+            if isinstance(s.value, config.call_style_type)
+        )
+        kwargs["call_style"] = style
+    spec = _spec(lang_cls=lang_cls, **kwargs)
+    _run_call_golden_case(
+        config=config,
+        spec=spec,
+        golden_name=f"{lang_cls.__name__}_call",
+        cases_dir=cases_dir,
+        file_regression=file_regression,
+    )
+
+
+@dataclasses.dataclass
+class _CallVariantCase:
+    """A ``literalize_call`` golden-file case run with a non-default
+    language spec (e.g. Rust's ``TAGGED_ENUM`` strategy).
+    """
+
+    config: _CallCaseConfig
+    variant: _Variant
+
+
+# Per-case language variants exercised by
+# :func:`test_call_variant_golden_file`.  Each entry names a call-case
+# directory and pairs it with the variant builders that produce a spec
+# capable of representing that case's heterogeneous input — which the
+# default spec rejects, causing :func:`test_call_golden_file` to skip.
+_CALL_VARIANT_SOURCES: list[tuple[str, Callable[[], Iterable[_Variant]]]] = [
+    ("call_mixed_type_dicts", _build_heterogeneous_value_name_variants),
+]
+
+
+@functools.cache
+@beartype
+def _build_call_variant_cases() -> list[_CallVariantCase]:
+    """Return call-test cases for language variants that accept
+    heterogeneous input the default spec rejects.
+    """
+    cases: list[_CallVariantCase] = []
+    for case_dir_name, builder in _CALL_VARIANT_SOURCES:
+        config = next(
+            cfg
+            for cfg in _CALL_CASE_CONFIGS
+            if cfg.case_dir_name == case_dir_name
+        )
+        cases.extend(
+            _CallVariantCase(config=config, variant=variant)
+            for variant in builder()
+        )
+    return cases
+
+
+@pytest.mark.parametrize(
+    argnames="call_variant_case",
+    argvalues=_build_call_variant_cases(),
+    ids=[
+        f"{c.config.case_dir_name}/{c.variant.name}"
+        for c in _build_call_variant_cases()
+    ],
+)
+def test_call_variant_golden_file(
+    call_variant_case: _CallVariantCase,
+    cases_dir: Path,
+    file_regression: FileRegressionFixture,
+) -> None:
+    """Test ``literalize_call`` for a non-default language spec.
+
+    Covers call inputs that the language's default
+    :attr:`Language.heterogeneous_strategy` rejects, which
+    :func:`test_call_golden_file` skips — in particular the
+    sibling-widening behavior of Rust's ``TAGGED_ENUM`` across
+    per-element call arguments.
+    """
+    _run_call_golden_case(
+        config=call_variant_case.config,
+        spec=call_variant_case.variant.spec,
+        golden_name=f"{call_variant_case.variant.name}_call",
+        cases_dir=cases_dir,
+        file_regression=file_regression,
     )


### PR DESCRIPTION
## Summary
- Fixes #1566.  `literalize_call(per_element=True)` now unions each call's wrap-ids with a sibling-aware set gathered per argument slot, so Rust's `TAGGED_ENUM` wraps scalars consistently across sibling calls — matching the dict-opener widening shipped in #1471 so a locally-homogeneous sibling dict no longer breaks a shared `&HashMap<&'static str, Value>` signature.
- Extracts `_gather_call_slot_values` as a shared helper for the new `_compute_call_per_element_wrap_ids` and the existing `_compute_call_slot_overrides`.
- Adds a `test_call_variant_golden_file` harness (`_CallVariantCase` + `_build_call_variant_cases`) that drives call-case inputs through non-default language specs the default spec rejects, plus a Rust TAGGED_ENUM golden for `call_mixed_type_dicts` registered in `test_no_dead_golden_files`.

## Test plan
- [x] `uv run pytest tests/`
- [x] `rustc --edition 2021` compiles and runs the new `Rust_heterogeneous_value_enum_name_JsonValue_call.rs` golden file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `literalize_call(per_element=True)` computes wrap IDs across sibling calls, which can affect generated output and inferred call signatures for Rust heterogeneous strategies. Risk is limited to call rendering/type-wrapping behavior and is covered by new integration golden tests.
> 
> **Overview**
> Fixes `literalize_call(per_element=True)` so scalar wrapping decisions (notably Rust `TAGGED_ENUM`) are **widened across sibling calls per argument slot**, preventing later calls from emitting unwrapped scalars that don’t match the common inferred parameter type.
> 
> Refactors per-element call analysis by extracting `_gather_call_slot_values` and adding `_compute_call_per_element_wrap_ids`, then unions slot-level wrap IDs into each call’s `wrap_ids` during rendering.
> 
> Extends integration coverage with a new Rust `TAGGED_ENUM` call golden for `call_mixed_type_dicts`, plus a `test_call_variant_golden_file` harness to run select call cases against non-default language specs and include them in the “no dead golden files” check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa0d10036aae9a574f2d30b891f08114d62218d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->