### PR TITLE
Parallelize lint-mojo via xargs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -999,9 +999,8 @@ jobs:
       - name: Check Mojo syntax
         run: |-
           ulimit -v unlimited
-          while IFS= read -r -d '' f; do
-            mojo run --Werror "$GITHUB_WORKSPACE/$f" || exit 1
-          done < /tmp/files-to-lint
+          xargs -0 -P "$(nproc)" -I{} mojo run --Werror "$GITHUB_WORKSPACE/{}" \
+            < /tmp/files-to-lint
 
   lint-nim:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace the serial `while` loop in `lint-mojo` with `xargs -0 -P "$(nproc)" -I{}` so fixtures compile in parallel, reusing the existing `ulimit -v unlimited` setup that propagates to child processes.

## Test plan
- [ ] `lint-mojo` job passes on CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI execution behavior and increases concurrency for `mojo run`, which could expose runner resource limits or introduce intermittent failures.
> 
> **Overview**
> **Speeds up CI for Mojo fixtures** by replacing the serial per-file `while` loop in `lint-mojo` with a parallel `xargs -0 -P "$(nproc)"` execution of `mojo run --Werror`.
> 
> The `ulimit -v unlimited` setup is retained so the increased parallelism inherits the same virtual-memory limit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48dc58898bd72a4811234d32cfb10ba401e167b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->