### PR TITLE
Drop redundant lint-cpp syntax-only step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -273,12 +273,10 @@ jobs:
       - name: Build precompiled header
         run: clang++ -std=c++20 -x c++-header .github/scripts/lint-cpp-pch.hpp -o
           /tmp/pch.hpp.pch
-      - name: Check C++ syntax
-        run: xargs -0 clang++ -fsyntax-only -std=c++20 -include-pch /tmp/pch.hpp.pch
-          < /tmp/files-to-lint
       # Fixtures define `void check_()` with no main, so compile alongside
       # `.github/scripts/cpp_main.cpp` which invokes it and link into a
-      # runnable binary.
+      # runnable binary. The build-and-run step also surfaces any syntax
+      # errors, so a separate `-fsyntax-only` pass would be redundant.
       - name: Run C++ files
         run: |-
           cat > /tmp/run-cpp.sh <<'SCRIPT'


### PR DESCRIPTION
## Summary
- Remove the `Check C++ syntax` step from `lint-cpp`. The following `Run C++ files` step already compiles every fixture with the same `-include-pch /tmp/pch.hpp.pch`, so a separate `-fsyntax-only` pass duplicates work and any syntax error would surface there anyway.
- On the latest successful main run the syntax step took ~2m of the ~4m job — dropping it roughly halves the job's wall time.

## Test plan
- [ ] `lint-cpp` passes on CI with the syntax step removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: removes a duplicate `clang++ -fsyntax-only` step and relies on the existing compile/link/run step to catch syntax errors. Main risk is only reduced granularity in where failures are reported, not behavior changes in production code.
> 
> **Overview**
> Speeds up the `lint-cpp` GitHub Actions job by removing the separate `Check C++ syntax` (`clang++ -fsyntax-only`) step.
> 
> The remaining `Run C++ files` step is now the single compilation gate, with comments updated to clarify that building/linking/running already surfaces syntax errors (while still using the precompiled header).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f1698c2e343abee163c7f581ab6081046fc859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->