### PR TITLE
Prebuild cpp_main.o once for lint-cpp fixture links

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -278,14 +278,17 @@ jobs:
           < /tmp/files-to-lint
       # Fixtures define `void check_()` with no main, so compile alongside
       # `.github/scripts/cpp_main.cpp` which invokes it and link into a
-      # runnable binary.
+      # runnable binary. Compile `cpp_main.cpp` once up front so each
+      # fixture link reuses the object instead of re-parsing the same TU.
+      - name: Build cpp_main object
+        run: clang++ -std=c++20 -c .github/scripts/cpp_main.cpp -o /tmp/cpp_main.o
       - name: Run C++ files
         run: |-
           cat > /tmp/run-cpp.sh <<'SCRIPT'
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
           clang++ -std=c++20 -include-pch /tmp/pch.hpp.pch "$1" \
-            .github/scripts/cpp_main.cpp -o "$tmpdir/run" || exit 1
+            /tmp/cpp_main.o -o "$tmpdir/run" || exit 1
           "$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-cpp.sh < /tmp/files-to-lint


### PR DESCRIPTION
## Summary
- Compile `.github/scripts/cpp_main.cpp` once to `/tmp/cpp_main.o` in a new lint-cpp step, then link each fixture against the prebuilt object instead of recompiling the same TU alongside every fixture.

## Test plan
- [ ] CI `lint-cpp` job passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only optimization that changes how `lint-cpp` links fixtures but not product/runtime code. Main risk is a CI break if the new object-file link path differs from compiling `cpp_main.cpp` per fixture.
> 
> **Overview**
> Speeds up the `lint-cpp` GitHub Actions job by compiling `.github/scripts/cpp_main.cpp` once to `/tmp/cpp_main.o` and linking each C++ fixture against that object instead of recompiling the same translation unit for every fixture.
> 
> Updates the per-fixture compile command accordingly while keeping the existing precompiled-header setup and the build-and-run validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c69c727d3d8c4762ee12d4acdeeae3c8adf4b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->