### PR TITLE
Drop redundant nim check step from lint-nim

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1090,16 +1090,6 @@ jobs:
         run: find tests/integration/cases -name '*.nim' -print0 > /tmp/files-to-lint
       - name: Install Nim
         uses: jiro4989/setup-nim-action@v2
-      - name: Check Nim syntax
-        run: |-
-          cat > /tmp/check-nim.sh <<'SCRIPT'
-          read -r -a warning_flags <<< "$NIM_WARNING_FLAGS"
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          nim check --hints:off "${warning_flags[@]}" \
-            --nimcache:"$tmpdir" "$1"
-          SCRIPT
-          xargs -0 -P "$(nproc)" -n1 bash /tmp/check-nim.sh < /tmp/files-to-lint
       - name: Run Nim files
         run: |-
           cat > /tmp/run-nim.sh <<'SCRIPT'


### PR DESCRIPTION
## Summary
The following `nim c -r` step compiles and runs each fixture with the same `$NIM_WARNING_FLAGS` and `--hints:off` flags, which performs the semantic check as part of compilation — so the separate `nim check` pass was redundant work.

## Test plan
- [ ] CI `lint-nim` job still fails on fixtures that violate any of the listed `--warningAsError` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just removes a redundant lint step; main risk is missing any checks that `nim check` caught but `nim c -r` doesn’t in edge cases.
> 
> **Overview**
> Removes the standalone `nim check` syntax/semantic validation step from the `lint-nim` job in `.github/workflows/lint.yml`.
> 
> The workflow now only runs `nim c -r` for each Nim fixture with the shared `NIM_WARNING_FLAGS`, reducing duplicate work while still failing CI on promoted warnings during compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b057bf6eed81ef5f648064d7f7e7fd69d76700f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->