### PR TITLE
ObjectiveC: k-prefix dotted-call const globals for clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks: >
   -cppcoreguidelines-narrowing-conversions,
   -fuchsia-default-arguments-calls,
   -google-objc-function-naming,
-  -google-objc-global-variable-declaration,
   -google-runtime-int,
   -hicpp-named-parameter,
   -llvm-include-order,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Changelog
 Next
 ----
 
+- ``ObjectiveC`` call stubs now emit ``k``-prefixed, title-cased root
+  names for the ``static const struct`` globals that back dotted call
+  targets, so a user-written ``throttler.check(...)`` literalizes to
+  ``kThrottler.check(...)`` (and ``app.client.fetch`` to
+  ``kApp.client.fetch``).  clang-tidy's
+  ``google-objc-global-variable-declaration`` check, previously
+  suppressed in ``.clang-tidy`` because the bare root names did not
+  conform, is now enforced.
+
 2026.04.24
 ----------
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -133,8 +133,8 @@ def _format_objc_bytes_base64(value: bytes) -> str:
 
 @beartype
 def _objc_global_root(root: str, /) -> str:
-    """Return a ``k``-prefixed, title-cased root for an ObjC const
-    global, so the emitted name satisfies clang-tidy's
+    """Return a ``k``-prefixed, title-cased root for an Objective-C
+    const global, so the emitted name satisfies clang-tidy's
     ``google-objc-global-variable-declaration`` check.
     """
     return f"k{root.title()}"

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -49,7 +49,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -132,6 +131,28 @@ def _format_objc_bytes_base64(value: bytes) -> str:
     return f'@"{encoded.decode(encoding="ascii")}"'
 
 
+@beartype
+def _objc_global_root(root: str, /) -> str:
+    """Return a ``k``-prefixed, title-cased root for an ObjC const
+    global, so the emitted name satisfies clang-tidy's
+    ``google-objc-global-variable-declaration`` check.
+    """
+    return f"k{root.title()}"
+
+
+@beartype
+def _objc_format_call_target(name: str, /) -> str:
+    """Rewrite the root of a dotted call target to its k-prefixed form
+    so the call site matches the renamed const global emitted by
+    :func:`_objc_call_stub`.  Single-name calls resolve to a ``static``
+    function (not a const global) and are returned unchanged.
+    """
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return name
+    return ".".join((_objc_global_root(parts[0]), *parts[1:]))
+
+
 def _objc_call_stub(
     name: str,
     params: Sequence[str],
@@ -148,6 +169,10 @@ def _objc_call_stub(
     Objective-C object.  This avoids K&R unspecified-parameter syntax
     and the ``-Wstrict-prototypes`` / ``-Wdeprecated-non-prototype``
     warnings that clang would otherwise emit.
+
+    The root of a dotted target is rewritten to ``k{Title}`` form (e.g.
+    ``throttler`` → ``kThrottler``) so the const global satisfies
+    clang-tidy's ``google-objc-global-variable-declaration`` check.
 
     Single-name calls emit a ``static`` definition so the fixture links
     under the lint workflow's run step — a bare prototype without a body
@@ -168,10 +193,10 @@ def _objc_call_stub(
             f"static {return_keyword} {parts[0]}({stub_signature}) "
             f"{stub_body}",
         )
-    root = parts[0]
+    root = _objc_global_root(parts[0])
     method = parts[-1]
     fields = parts[1:-1]
-    stub_fn = "_".join((*parts, "stub_"))
+    stub_fn = "_".join((root, *parts[1:], "stub_"))
     if not fields:
         type_name = f"{root}Type_"
         return (
@@ -561,10 +586,10 @@ class ObjectiveC(metaclass=LanguageCls):
 
     @cached_property
     def format_call_target(self) -> Callable[[str], str]:
-        """Rewrite a dotted call target into the language's call
-        syntax.
+        """Rewrite a dotted call target so the root matches the
+        ``k``-prefixed const global emitted by :func:`_objc_call_stub`.
         """
-        return identity_call_target
+        return _objc_format_call_target
 
     @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:

--- a/tests/integration/cases/call_deep_dotted_method/ObjectiveC_call.m
+++ b/tests/integration/cases/call_deep_dotted_method/ObjectiveC_call.m
@@ -1,11 +1,11 @@
 #import <Foundation/Foundation.h>
-static void obj_api_client_post_stub_(id _a0) { (void)_a0; }
+static void kObj_api_client_post_stub_(id _a0) { (void)_a0; }
 struct clientType_ { void (*post)(id); };
 struct apiType_ { struct clientType_ client; };
-struct objType_ { struct apiType_ api; };
-static const struct objType_ obj = { .api = { .client = { .post = obj_api_client_post_stub_ } } };
+struct kObjType_ { struct apiType_ api; };
+static const struct kObjType_ kObj = { .api = { .client = { .post = kObj_api_client_post_stub_ } } };
 void check_(void) {
-obj.api.client.post(@"hello");
-obj.api.client.post(@(42));
-obj.api.client.post(@YES);
+kObj.api.client.post(@"hello");
+kObj.api.client.post(@(42));
+kObj.api.client.post(@YES);
 }

--- a/tests/integration/cases/call_deep_dotted_transformed/ObjectiveC_call.m
+++ b/tests/integration/cases/call_deep_dotted_transformed/ObjectiveC_call.m
@@ -1,11 +1,11 @@
 #import <Foundation/Foundation.h>
-static id app_client_fetch_stub_(id _a0) { (void)_a0; return nil; }
+static id kApp_client_fetch_stub_(id _a0) { (void)_a0; return nil; }
 struct clientType_ { id (*fetch)(id); };
-struct appType_ { struct clientType_ client; };
-static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
+struct kAppType_ { struct clientType_ client; };
+static const struct kAppType_ kApp = { .client = { .fetch = kApp_client_fetch_stub_ } };
 static void emit(id _a0) { (void)_a0; }
 void check_(void) {
-emit(app.client.fetch(@"hello"));
-emit(app.client.fetch(@(42)));
-emit(app.client.fetch(@YES));
+emit(kApp.client.fetch(@"hello"));
+emit(kApp.client.fetch(@(42)));
+emit(kApp.client.fetch(@YES));
 }

--- a/tests/integration/cases/call_dotted_method/ObjectiveC_call.m
+++ b/tests/integration/cases/call_dotted_method/ObjectiveC_call.m
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
-static void app_client_fetch_stub_(id _a0) { (void)_a0; }
+static void kApp_client_fetch_stub_(id _a0) { (void)_a0; }
 struct clientType_ { void (*fetch)(id); };
-struct appType_ { struct clientType_ client; };
-static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
+struct kAppType_ { struct clientType_ client; };
+static const struct kAppType_ kApp = { .client = { .fetch = kApp_client_fetch_stub_ } };
 void check_(void) {
-app.client.fetch(@"hello");
-app.client.fetch(@(42));
-app.client.fetch(@YES);
+kApp.client.fetch(@"hello");
+kApp.client.fetch(@(42));
+kApp.client.fetch(@YES);
 }

--- a/tests/integration/cases/call_keyword_args/ObjectiveC_call.m
+++ b/tests/integration/cases/call_keyword_args/ObjectiveC_call.m
@@ -1,9 +1,9 @@
 #import <Foundation/Foundation.h>
-static id throttler_check_stub_(id _a0, id _a1) { (void)_a0; (void)_a1; return nil; }
-struct throttlerType_ { id (*check)(id, id); };
-static const struct throttlerType_ throttler = { .check = throttler_check_stub_ };
+static id kThrottler_check_stub_(id _a0, id _a1) { (void)_a0; (void)_a1; return nil; }
+struct kThrottlerType_ { id (*check)(id, id); };
+static const struct kThrottlerType_ kThrottler = { .check = kThrottler_check_stub_ };
 static void emit(id _a0) { (void)_a0; }
 void check_(void) {
-emit(throttler.check(@"user_1", @(1000.0)));
-emit(throttler.check(@"user_2", @(2000.5)));
+emit(kThrottler.check(@"user_1", @(1000.0)));
+emit(kThrottler.check(@"user_2", @(2000.5)));
 }

--- a/tests/integration/cases/call_mixed_type_dicts/ObjectiveC_call.m
+++ b/tests/integration/cases/call_mixed_type_dicts/ObjectiveC_call.m
@@ -1,9 +1,9 @@
 #import <Foundation/Foundation.h>
-static void app_mgr_op_stub_(id _a0) { (void)_a0; }
+static void kApp_mgr_op_stub_(id _a0) { (void)_a0; }
 struct mgrType_ { void (*op)(id); };
-struct appType_ { struct mgrType_ mgr; };
-static const struct appType_ app = { .mgr = { .op = app_mgr_op_stub_ } };
+struct kAppType_ { struct mgrType_ mgr; };
+static const struct kAppType_ kApp = { .mgr = { .op = kApp_mgr_op_stub_ } };
 void check_(void) {
-app.mgr.op(@{@"type": @"create", @"pr_id": @"pr_1", @"draft": @YES});
-app.mgr.op(@{@"type": @"create", @"pr_id": @"pr_2"});
+kApp.mgr.op(@{@"type": @"create", @"pr_id": @"pr_1", @"draft": @YES});
+kApp.mgr.op(@{@"type": @"create", @"pr_id": @"pr_2"});
 }


### PR DESCRIPTION
## Summary

- Rewrite `_objc_call_stub` so the `static const struct` global backing a dotted call target uses a `k{Title}` root (`throttler` -> `kThrottler`, `app.client.fetch` -> `kApp.client.fetch`), via a new `_objc_global_root` helper threaded through `stub_fn` and the root type name.
- Override `format_call_target` for ObjectiveC with `_objc_format_call_target` so call sites match the renamed global (single-name calls, which resolve to static functions rather than const globals, are returned unchanged).
- Drop `-google-objc-global-variable-declaration` from `.clang-tidy`; regenerate the 5 affected `ObjectiveC_call.m` fixtures; add a CHANGELOG entry.

Closes #1462

## Test plan

- [x] `uv run --extra dev pytest -q -n auto` (1029 passed, 371 skipped)
- [x] Homebrew `clang-tidy` on the regenerated fixtures reports zero warnings for `google-objc-global-variable-declaration`; sanity-checked that the pre-change `throttler` form still triggers the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Objective-C call code generation by renaming dotted-target backing globals and rewriting call targets, which may impact existing golden fixtures and downstream comparisons. No security-sensitive logic is involved, but it affects generated source output and lint enforcement.
> 
> **Overview**
> **Objective-C dotted call stubs are renamed to satisfy clang-tidy.** Dotted call targets now emit `k`-prefixed, title-cased roots (e.g., `throttler` → `kThrottler`) for the `static const struct` globals, and call sites are rewritten to reference the new names via a dedicated `format_call_target` implementation.
> 
> **Lint + fixtures updated accordingly.** The `google-objc-global-variable-declaration` suppression is removed from `.clang-tidy`, the affected Objective-C integration fixtures are regenerated with the new names, and the change is documented in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f6646a3df8e2e5db2ecc1c2031bcf8167ccb45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->