### PR TITLE
Preserve each Crystal fixture's own require "set"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -928,9 +928,11 @@ jobs:
       # two reuse the top-level `def emit` / `def process`. `extend
       # self` lets unqualified calls like `emit(...)` inside the module
       # body resolve to the module's own `def emit`. Any
-      # `require "set"` from the original fixture is preserved inside
-      # its module so each fixture keeps its own dependencies; the
-      # driver then `require`s every fixture so each module body
+      # `require "set"` from the original fixture is hoisted to the top
+      # of its per-fixture file (before the module wrapper, since
+      # Crystal rejects `require` inside type declarations) and stripped
+      # from the wrapped body, so each fixture keeps its own dependency.
+      # The driver then `require`s every fixture so each module body
       # executes at program start. The `fixture_N.cr <- original-path`
       # mapping is printed so failures still point back to the source.
       - name: Run Crystal files
@@ -941,9 +943,12 @@ jobs:
           i=0
           while IFS= read -r -d '' f; do
             {
+              if grep -q '^require "set"$' "$f"; then
+                printf 'require "set"\n'
+              fi
               printf 'module Fixture%d\n' "$i"
               printf 'extend self\n'
-              cat "$f"
+              sed '/^require "set"$/d' "$f"
               printf 'end\n'
             } > "$workspace/fixture_$i.cr"
             printf 'require "./fixture_%d"\n' "$i" >> "$driver"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -927,23 +927,23 @@ jobs:
       # same `class ThrottlerType_` / `class ClientType_` / etc., and
       # two reuse the top-level `def emit` / `def process`. `extend
       # self` lets unqualified calls like `emit(...)` inside the module
-      # body resolve to the module's own `def emit`. A single
-      # `require "set"` on the driver covers the 18 fixtures that need
-      # it (stripped from each wrapped copy); the driver then
-      # `require`s every fixture so each module body executes at
-      # program start. The `fixture_N.cr <- original-path` mapping is
-      # printed so failures still point back to the source.
+      # body resolve to the module's own `def emit`. Any
+      # `require "set"` from the original fixture is preserved inside
+      # its module so each fixture keeps its own dependencies; the
+      # driver then `require`s every fixture so each module body
+      # executes at program start. The `fixture_N.cr <- original-path`
+      # mapping is printed so failures still point back to the source.
       - name: Run Crystal files
         run: |-
           workspace=$(mktemp -d)
           driver="$workspace/run_all.cr"
-          printf 'require "set"\n' > "$driver"
+          : > "$driver"
           i=0
           while IFS= read -r -d '' f; do
             {
               printf 'module Fixture%d\n' "$i"
               printf 'extend self\n'
-              sed '/^require "set"$/d' "$f"
+              cat "$f"
               printf 'end\n'
             } > "$workspace/fixture_$i.cr"
             printf 'require "./fixture_%d"\n' "$i" >> "$driver"


### PR DESCRIPTION
## Summary
- Drop the top-level `require "set"` seeded into the batched Crystal driver and the `sed` strip that removed it from each wrapped fixture.
- Copy each fixture verbatim into its `module FixtureN` so any original `require "set"` is preserved per-fixture, keeping the single `crystal run` batching while letting each fixture own its dependencies.

## Test plan
- [ ] `lint-crystal` job passes on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it tweaks how Crystal fixtures are wrapped/required, so it could surface new compile-order or dependency issues in the `lint-crystal` job.
> 
> **Overview**
> Updates the `lint-crystal` workflow to stop seeding a global `require "set"` in the shared driver and instead preserve each fixture’s own `require "set"`.
> 
> When generating `fixture_N.cr`, the workflow now detects a fixture-level `require "set"`, hoists it above the `module FixtureN` wrapper, and strips it from the wrapped body so Crystal accepts it while keeping dependencies fixture-scoped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a217c378c6b1e44c728415c1d263b79b40a4ee40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->