### PR TITLE
Re-add per-file Crystal syntax check to lint-crystal

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -919,6 +919,13 @@ jobs:
         run: find tests/integration/cases -name '*.cr' -print0 > /tmp/files-to-lint
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
+      # Typecheck each fixture in isolation. The batched `crystal run`
+      # step below pre-loads `require "set"` on its driver and strips
+      # it from each wrapped fixture, so a fixture that uses `Set` but
+      # forgot `require "set"` would still compile there. This
+      # per-file pass is what catches that regression.
+      - name: Check Crystal syntax
+        run: xargs -0 -P "$(nproc)" -n1 crystal build --no-codegen < /tmp/files-to-lint
       # Compile every fixture in a single `crystal run` invocation to
       # pay Crystal's front-end + LLVM codegen + link cost once instead
       # of per fixture. Each fixture is wrapped in a unique


### PR DESCRIPTION
## Summary
- Add a `crystal build --no-codegen` pre-check step to `lint-crystal` so each fixture is typechecked in isolation.
- The batched `crystal run` step pre-loads `require "set"` on its driver and strips it from each wrapped fixture, so a fixture that uses `Set` without `require "set"` would still compile there. The per-file pass was dropped in 29240a382 when `crystal run` still typechecked each fixture on its own; the later batching commit 715eeea7a removed that signal, and this step restores it.

## Test plan
- [ ] `lint-crystal` job passes on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it can increase CI time and may surface new Crystal fixture failures that were previously masked by the batched driver.
> 
> **Overview**
> Restores a per-fixture Crystal compile/typecheck pass in `lint-crystal` by running `crystal build --no-codegen` on each `.cr` file before the existing batched `crystal run` step.
> 
> This makes CI catch missing per-file `require`s (notably `require "set"`) that the batched wrapper can hide due to its shared driver setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5063277ba9c89d5d7a04fa9290ceceda26dd07a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->