### PR TITLE
Prebuild objc_main.o once for lint-objectivec fixture links

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1442,17 +1442,21 @@ jobs:
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang -fsyntax-only -Werror -include-pch
           /tmp/pch.h.pch < /tmp/files-to-lint
       # Fixtures define `check_(void)` with no main entry point, so
-      # compile each alongside a tiny wrapper that calls it. Link
-      # against Foundation and execute to surface runtime errors. Each
-      # invocation gets a private tmpdir so parallel builds don't clobber
-      # each other's output binary.
+      # compile each alongside a tiny wrapper that calls it. Compile
+      # `objc_main.m` once up front so each fixture link reuses the
+      # object instead of re-parsing the same TU. Link against Foundation
+      # and execute to surface runtime errors. Each invocation gets a
+      # private tmpdir so parallel builds don't clobber each other's
+      # output binary.
+      - name: Build objc_main object
+        run: clang -c .github/scripts/objc_main.m -o /tmp/objc_main.o
       - name: Run Objective-C files
         run: |-
           cat > /tmp/run-objc.sh <<'SCRIPT'
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
           clang -framework Foundation -Werror -include-pch /tmp/pch.h.pch "$1" \
-            .github/scripts/objc_main.m -o "$tmpdir/out" || exit 1
+            /tmp/objc_main.o -o "$tmpdir/out" || exit 1
           "$tmpdir/out" || exit 1
           SCRIPT
           xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 bash /tmp/run-objc.sh < /tmp/files-to-lint


### PR DESCRIPTION
## Summary
- Compile `.github/scripts/objc_main.m` once to `/tmp/objc_main.o` in a new lint-objectivec step, then link each fixture against the prebuilt object instead of recompiling the same TU alongside every fixture.

Closes #1586

## Test plan
- [ ] CI `lint-objectivec` job passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow optimization, but it changes how Objective-C fixtures are linked/executed in CI and could fail if the object build/link flags diverge from prior behavior.
> 
> **Overview**
> Speeds up the `lint-objectivec` GitHub Actions job by compiling `.github/scripts/objc_main.m` once into `/tmp/objc_main.o` and reusing that object when linking each Objective-C fixture.
> 
> Updates the run script to link fixtures against the prebuilt object (instead of recompiling `objc_main.m` per fixture) while keeping the existing PCH-based syntax check and per-fixture execution behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6ff934ade8c8093fa1c7f1919a4c06748b37f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->