### PR TITLE
Inline lint-haskell main wrapper into Check.hs

### DIFF
--- a/.github/scripts/haskell_main.hs
+++ b/.github/scripts/haskell_main.hs
@@ -1,6 +1,0 @@
-module Main where
-
-import Check
-
-main :: IO ()
-main = seq Check.my_data (return ())

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -581,10 +581,12 @@ jobs:
           xargs -0 -n1 ghc -fno-code -Wall -Werror -outputdir "$tmpdir" \
             < /tmp/files-to-lint
       # Most fixtures declare only `module Check` with a `my_data` val; GHC
-      # never evaluates its body unless a top-level expression references it,
-      # so compile alongside a small Main wrapper that forces `Check.my_data`.
-      # Fixtures that already define their own `main` compile with
-      # `-main-is Check` instead.
+      # never evaluates its body unless a top-level expression references
+      # it, so append a small `main` that forces `my_data`. Inlining the
+      # wrapper into Check skips compiling a separate Main TU per fixture
+      # in a single ghc invocation, where precompiling Main.o would still
+      # need a second ghc call to link against each fixture's Check.o.
+      # Fixtures that already define their own `main` use it as-is.
       - name: Run Haskell files
         run: |-
           # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
@@ -592,14 +594,12 @@ jobs:
             tmpdir=$(mktemp -d)
             trap "rm -rf \"$tmpdir\"" EXIT
             cp "$0" "$tmpdir/Check.hs"
-            if grep -qE "^main " "$0"; then
-              ghc -Wall -Werror -main-is Check -outputdir "$tmpdir" \
-                -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
-            else
-              cp .github/scripts/haskell_main.hs "$tmpdir/Main.hs"
-              ghc -Wall -Werror -outputdir "$tmpdir" \
-                -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
+            if ! grep -qE "^main " "$0"; then
+              printf "\nmain :: IO ()\nmain = seq my_data (return ())\n" \
+                >> "$tmpdir/Check.hs"
             fi
+            ghc -Wall -Werror -main-is Check -outputdir "$tmpdir" \
+              -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
             "$tmpdir/run" || exit 1
           ' < /tmp/files-to-lint
 


### PR DESCRIPTION
## Summary
- Append the `seq my_data (return ())` wrapper to each fixture's `Check` module instead of building it as a separate `Main` TU. Drops the per-fixture Main module compile from `lint-haskell`.
- Per the issue, the literal precompile-and-relink path was investigated but doesn't help on its own: GHC's interface check rejects reusing `Main.o` against each fixture's differing `Check.hi` under `--make`, and a manual link step adds a second `ghc` invocation per fixture (with full startup) that cancels the savings. Inlining sidesteps both costs in a single `ghc` call.
- Removes the now-unused `.github/scripts/haskell_main.hs`.

Closes #1587.

## Test plan
- [ ] CI `lint-haskell` job passes on all 176 `.hs` fixtures (167 no-own-main + 9 own-main).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it alters how Haskell fixtures are compiled/executed in CI and could surface new failures if `main` detection or module assumptions differ across fixtures.
> 
> **Overview**
> Updates the `lint-haskell` GitHub Actions job to **stop compiling a separate `Main` module per fixture** and instead append a tiny `main` definition directly to the copied `Check.hs` when the fixture doesn’t define one.
> 
> Removes the now-unused `.github/scripts/haskell_main.hs` helper and standardizes the run step to compile each fixture via a single `ghc ... -main-is Check` invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa670662fceec66d0d96273d09757e2abb0da261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->