### PR TITLE
Group trivial lint jobs to cut runner queueing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,9 +46,10 @@ jobs:
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()
 
-  # Fixture languages whose toolchains are preinstalled on ubuntu-latest.
-  # Grouped into one job because each sub-lint takes only seconds, so the
-  # runner startup cost is the dominant factor when they are split out.
+  # Fixture languages whose lint is a handful of seconds — either the
+  # toolchain is preinstalled on ubuntu-latest, or the install is quick
+  # enough that splitting them into separate runners would spend more
+  # time on runner startup than on linting.
   lint-fast:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -56,6 +57,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Install Lua
+        uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: '5.4'
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+      - name: Install Odin
+        uses: laytan/setup-odin@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Bash
         run: |-
@@ -68,13 +79,6 @@ jobs:
           find tests/integration/cases -name '*.rb' -print0 > /tmp/files-ruby
           xargs -0 -P "$(nproc)" -n1 ruby -c < /tmp/files-ruby
           xargs -0 -P "$(nproc)" -n1 ruby < /tmp/files-ruby
-
-      - name: Lint Go
-        run: |-
-          find tests/integration/cases -name '*.go' -print0 > /tmp/files-go
-          xargs -0 gofmt -e < /tmp/files-go
-          xargs -0 -P "$(nproc)" -n1 go vet < /tmp/files-go
-          xargs -0 -P "$(nproc)" -n1 go run < /tmp/files-go
 
       - name: Lint JavaScript
         run: |-
@@ -127,23 +131,22 @@ jobs:
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-fortran.sh < /tmp/files-fortran
 
-      - name: Lint Rust
+      - name: Lint Lua
         run: |-
-          find tests/integration/cases -name '*.rs' -print0 > /tmp/files-rust
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          cargo init "$tmpdir/chrono-check"
-          cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
-          cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
-          deps="$tmpdir/chrono-check/target/debug/deps"
-          chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
+          find tests/integration/cases -name '*.lua' -print0 > /tmp/files-lua
+          xargs -0 luac -p < /tmp/files-lua
+
+      - name: Lint Nix
+        run: |-
+          find tests/integration/cases -name '*.nix' -print0 > /tmp/files-nix
+          xargs -0 -P "$(nproc)" -n1 nix-instantiate --parse < /tmp/files-nix > /dev/null
+
+      - name: Lint Odin
+        run: |-
+          find tests/integration/cases -name '*.odin' -print0 > /tmp/files-odin
           while IFS= read -r -d '' f; do
-            rustc --edition 2021 \
-              -L "dependency=$deps" \
-              --extern "chrono=$chrono_rlib" \
-              "$f" -o "$tmpdir/out" 2>&1 || exit 1
-            "$tmpdir/out" || exit 1
-          done < /tmp/files-rust
+            odin check "$f" -file || exit 1
+          done < /tmp/files-odin
 
   # Fixture languages whose interpreter is a quick `apt-get install`.
   # Grouped so the apt-get cost is paid once for the whole group.
@@ -819,7 +822,7 @@ jobs:
         run: xargs -0 -P "$(nproc)" -n1 julia --startup-file=no --project=/tmp/julia-lint
           < /tmp/files-to-lint
 
-  lint-lua:
+  lint-go:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -827,13 +830,39 @@ jobs:
           persist-credentials: false
       - name: Find files to lint
         shell: bash
-        run: find tests/integration/cases -name '*.lua' -print0 > /tmp/files-to-lint
-      - name: Install Lua
-        uses: leafo/gh-actions-lua@v13
+        run: find tests/integration/cases -name '*.go' -print0 > /tmp/files-to-lint
+      - name: Check Go syntax
+        run: xargs -0 gofmt -e < /tmp/files-to-lint
+      - name: Check Go compilation
+        run: xargs -0 -P "$(nproc)" -n1 go vet < /tmp/files-to-lint
+      - name: Run Go files
+        run: xargs -0 -P "$(nproc)" -n1 go run < /tmp/files-to-lint
+
+  lint-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
         with:
-          luaVersion: '5.4'
-      - name: Check Lua syntax
-        run: xargs -0 luac -p < /tmp/files-to-lint
+          persist-credentials: false
+      - name: Find files to lint
+        shell: bash
+        run: find tests/integration/cases -name '*.rs' -print0 > /tmp/files-to-lint
+      - name: Check Rust syntax and run binaries
+        run: |-
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cargo init "$tmpdir/chrono-check"
+          cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
+          cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
+          deps="$tmpdir/chrono-check/target/debug/deps"
+          chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
+          while IFS= read -r -d '' f; do
+            rustc --edition 2021 \
+              -L "dependency=$deps" \
+              --extern "chrono=$chrono_rlib" \
+              "$f" -o "$tmpdir/out" 2>&1 || exit 1
+            "$tmpdir/out" || exit 1
+          done < /tmp/files-to-lint
 
   lint-r:
     runs-on: ubuntu-latest
@@ -1056,21 +1085,6 @@ jobs:
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-nim.sh < /tmp/files-to-lint
 
-  lint-nix:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.nix' -print0 > /tmp/files-to-lint
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-      - name: Check Nix syntax
-        run: xargs -0 -P "$(nproc)" -n1 nix-instantiate --parse < /tmp/files-to-lint
-          > /dev/null
-
   lint-racket:
     runs-on: ubuntu-latest
     steps:
@@ -1083,25 +1097,6 @@ jobs:
       - uses: Bogdanp/setup-racket@v1.15
       - name: Check Racket syntax
         run: xargs -0 raco make < /tmp/files-to-lint
-
-  lint-odin:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.odin' -print0 > /tmp/files-to-lint
-      - name: Install Odin
-        uses: laytan/setup-odin@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check Odin
-        run: |-
-          while IFS= read -r -d '' f; do
-            odin check "$f" -file || exit 1
-          done < /tmp/files-to-lint
 
   lint-raku:
     runs-on: ubuntu-latest
@@ -1256,17 +1251,16 @@ jobs:
       - lint-commonlisp
       - lint-scala
       - lint-dart
+      - lint-go
       - lint-julia
-      - lint-lua
       - lint-r
       - lint-d
       - lint-crystal
       - lint-mojo
       - lint-nim
-      - lint-nix
       - lint-racket
-      - lint-odin
       - lint-raku
+      - lint-rust
       - lint-zig
       - lint-systemverilog
       - lint-v

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,33 +46,469 @@ jobs:
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()
 
-  lint-bash:
+  # Fixture languages whose toolchains are preinstalled on ubuntu-latest.
+  # Grouped into one job because each sub-lint takes only seconds, so the
+  # runner startup cost is the dominant factor when they are split out.
+  lint-fast-native:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.sh' -print0 > /tmp/files-to-lint
-      - name: Check Bash syntax
-        run: xargs -0 bash -n < /tmp/files-to-lint
-      - name: Run Bash files
-        run: xargs -0 -P "$(nproc)" -n1 bash < /tmp/files-to-lint
 
-  lint-ruby:
+      - name: Lint Bash
+        run: |-
+          find tests/integration/cases -name '*.sh' -print0 > /tmp/files-bash
+          xargs -0 bash -n < /tmp/files-bash
+          xargs -0 -P "$(nproc)" -n1 bash < /tmp/files-bash
+
+      - name: Lint Ruby
+        run: |-
+          find tests/integration/cases -name '*.rb' -print0 > /tmp/files-ruby
+          xargs -0 -P "$(nproc)" -n1 ruby -c < /tmp/files-ruby
+          xargs -0 -P "$(nproc)" -n1 ruby < /tmp/files-ruby
+
+      - name: Lint Go
+        run: |-
+          find tests/integration/cases -name '*.go' -print0 > /tmp/files-go
+          xargs -0 gofmt -e < /tmp/files-go
+          xargs -0 -P "$(nproc)" -n1 go vet < /tmp/files-go
+          xargs -0 -P "$(nproc)" -n1 go run < /tmp/files-go
+
+      - name: Lint JavaScript
+        run: |-
+          find tests/integration/cases -name '*.js' -print0 > /tmp/files-js
+          xargs -0 -P "$(nproc)" -n1 node --check < /tmp/files-js
+          xargs -0 -P "$(nproc)" -n1 node < /tmp/files-js
+
+      - name: Lint Java
+        run: |-
+          find tests/integration/cases -name '*.java' -print0 > /tmp/files-java
+          xargs -0 java CheckJavaSyntax.java < /tmp/files-java
+
+      - name: Lint C
+        run: |-
+          find tests/integration/cases -name '*.c' -print0 > /tmp/files-c
+          xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-c
+
+      - name: Lint Php
+        run: |-
+          find tests/integration/cases -name '*.php' -print0 > /tmp/files-php
+          xargs -0 php -l < /tmp/files-php
+          xargs -0 -P "$(nproc)" -n1 php < /tmp/files-php
+
+      # Parse every fixture inside a single pwsh invocation so the .NET
+      # and PowerShell startup cost is paid once instead of per fixture.
+      - name: Lint PowerShell
+        run: |-
+          find tests/integration/cases -name '*.ps1' -print0 > /tmp/files-ps1
+          pwsh -NoProfile -NonInteractive -File .github/scripts/lint-powershell.ps1 < /tmp/files-ps1
+
+      # Every fixture defines its own `fval_m` module, and the syntax
+      # check leaves an `fval_m.mod` in the working directory (gfortran
+      # emits .mod files even under `-fsyntax-only`). gfortran would
+      # then reuse that stale .mod instead of recompiling each file's
+      # inline module, masking references to names defined only in the
+      # current file. Compile each file from inside a private tmpdir so
+      # the stale .mod is not on the module search path and parallel
+      # runs cannot clobber each other's output.
+      - name: Lint Fortran
+        run: |-
+          find tests/integration/cases -name '*.f90' -print0 > /tmp/files-fortran
+          xargs -0 gfortran -std=f2008 -ffree-line-length-none -fsyntax-only < /tmp/files-fortran
+          cat > /tmp/run-fortran.sh <<'SCRIPT'
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          src=$(realpath "$1")
+          cd "$tmpdir" || exit 1
+          gfortran -std=f2008 -ffree-line-length-none "$src" -o run || exit 1
+          ./run || exit 1
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-fortran.sh < /tmp/files-fortran
+
+  # Fixture languages whose interpreter is a quick `apt-get install`.
+  # Grouped so the apt-get cost is paid once for the whole group.
+  lint-apt-basics:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.rb' -print0 > /tmp/files-to-lint
-      - name: Check Ruby syntax
-        run: xargs -0 -P "$(nproc)" -n1 ruby -c < /tmp/files-to-lint
-      - name: Run Ruby files
-        run: xargs -0 -P "$(nproc)" -n1 ruby < /tmp/files-to-lint
+      - name: Install apt packages and Perl deps
+        run: |-
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gforth tcl guile-3.0 octave cpanminus
+          sudo cpanm --notest DateTime
+
+      - name: Lint Forth
+        run: |-
+          find tests/integration/cases -name '*.fth' -print0 > /tmp/files-forth
+          while IFS= read -r -d '' f; do
+            gforth "$f" -e bye || exit 1
+          done < /tmp/files-forth
+
+      - name: Lint Tcl
+        run: |-
+          find tests/integration/cases -name '*.tcl' -print0 > /tmp/files-tcl
+          xargs -0 -P "$(nproc)" -n1 tclsh < /tmp/files-tcl
+
+      - name: Lint Scheme
+        run: |-
+          find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme
+          xargs -0 -P "$(nproc)" -I{} guile --no-auto-compile -s {} < /tmp/files-scheme
+
+      # Octave is a practical CI substitute, but it does not support
+      # every MATLAB builtin. Skip files that use features Octave lacks:
+      #  - datetime(): not yet implemented in Octave
+      #  - ""-escaped quotes: Octave accepts some backslash escapes
+      #    (e.g. \") that MATLAB rejects, so the check would be misleading
+      - name: Lint Matlab
+        run: |-
+          find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab
+          while IFS= read -r -d '' f; do
+            if grep -q '""' "$f"; then
+              echo "Skipping Octave parse check for MATLAB-escaped quotes in $f"
+              continue
+            fi
+            if grep -qw 'datetime' "$f"; then
+              echo "Skipping $f — uses datetime(), which Octave does not implement"
+              continue
+            fi
+            octave --norc --no-gui "$f" || exit 1
+          done < /tmp/files-matlab
+
+      - name: Lint Perl
+        run: |-
+          find tests/integration/cases -name '*.pl' -print0 > /tmp/files-perl
+          xargs -0 -P "$(nproc)" -n1 perl -c < /tmp/files-perl
+          xargs -0 -P "$(nproc)" -n1 perl < /tmp/files-perl
+
+  # Fixture languages linted by small tools fetched via `go install`.
+  lint-go-installed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Go-sourced linters
+        run: |-
+          go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+          go install github.com/tmccombs/hcl2json@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Lint Jsonnet
+        run: |-
+          find tests/integration/cases -name '*.jsonnet' -print0 > /tmp/files-jsonnet
+          xargs -0 -P "$(nproc)" -n1 jsonnet < /tmp/files-jsonnet > /dev/null
+
+      - name: Lint Hcl
+        run: |-
+          find tests/integration/cases -name '*.hcl' -print0 > /tmp/files-hcl
+          xargs -0 -P "$(nproc)" -n1 hcl2json < /tmp/files-hcl > /dev/null
+
+  # Fixture languages linted by tools fetched via `npm install -g`.
+  lint-npm-installed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install npm-sourced linters
+        run: npm install -g json5 tree-sitter-cli
+
+      - name: Build tree-sitter-norg parser
+        run: |-
+          git clone --depth=1 https://github.com/nvim-neorg/tree-sitter-norg.git /tmp/tree-sitter-norg
+          cc -shared -fPIC -o /tmp/norg.so \
+            -I /tmp/tree-sitter-norg/src \
+            /tmp/tree-sitter-norg/src/parser.c \
+            -x c++ /tmp/tree-sitter-norg/src/scanner.cc \
+            -lstdc++
+
+      - name: Lint Json5
+        run: |-
+          find tests/integration/cases -name '*.json5' -print0 > /tmp/files-json5
+          xargs -0 -P "$(nproc)" -n1 json5 < /tmp/files-json5 > /dev/null
+
+      - name: Lint Norg
+        run: |-
+          find tests/integration/cases -name '*.norg' -print0 > /tmp/files-norg
+          xargs -0 tree-sitter parse --lib-path /tmp/norg.so --lang-name norg --quiet < /tmp/files-norg
+
+  # Fixture languages whose check is a small `uv run python ...` helper.
+  lint-uv-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install apt packages for Ada
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq gnat
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
+      - name: Lint Ada
+        run: |-
+          find tests/integration/cases -name '*.adb' -print0 > /tmp/files-ada
+          xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_ada_syntax.py < /tmp/files-ada
+
+      - name: Lint Occam
+        run: |-
+          find tests/integration/cases -name '*.occ' -print0 > /tmp/files-occam
+          xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_occam_syntax.py < /tmp/files-occam
+
+      - name: Lint Toml
+        run: |-
+          find tests/integration/cases -name '*.toml' -print0 > /tmp/files-toml
+          xargs -0 -P "$(nproc)" -n1 uv run --with 'tomli>=2.4.0' --no-project python check_toml_syntax.py < /tmp/files-toml
+
+      - name: Lint Yaml
+        run: |-
+          find tests/integration/cases -name '*.yaml' ! -name 'input.yaml' -print0 > /tmp/files-yaml
+          xargs -0 uvx yamllint --strict -d '{extends: default, rules: {document-start: disable, line-length: disable}}' -- < /tmp/files-yaml
+
+  # .NET-hosted linters. Run host builds in parallel-looking sequential
+  # steps so the .NET runtime startup is paid once for the whole job.
+  lint-dotnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Initialize .NET runtime
+        run: |
+          mkdir -p /tmp/.dotnet/shm
+          dotnet --info
+
+      # Build a small Roslyn host once, then feed every fixture through
+      # its stdin so the .NET runtime and C# compiler load once instead
+      # of per fixture. Replaces `dotnet build` per fixture, which paid
+      # MSBuild + NuGet restore + compiler startup each time.
+      - name: Build C# lint host
+        run: dotnet publish .github/scripts/lint-csharp/lint-csharp.csproj -c Release
+          -o /tmp/lint-csharp --nologo
+      # Build a small Roslyn host once, then feed every fixture through
+      # its stdin so the .NET runtime and VB compiler load once instead
+      # of per fixture.
+      - name: Build VB lint host
+        run: dotnet publish .github/scripts/lint-vb/lint-vb.csproj -c Release -o /tmp/lint-vb
+          --nologo
+
+      - name: Lint CSharp
+        run: |-
+          find tests/integration/cases -name '*.cs' -print0 > /tmp/files-cs
+          dotnet /tmp/lint-csharp/lint-csharp.dll < /tmp/files-cs
+
+      - name: Lint VisualBasic
+        run: |-
+          find tests/integration/cases -name '*.vb' -print0 > /tmp/files-vb
+          dotnet /tmp/lint-vb/lint-vb.dll < /tmp/files-vb
+
+      # Generate an FSX driver that `#load`s every fixture, then
+      # evaluate it in a single `dotnet fsi --exec` invocation so the
+      # .NET runtime and FSI compiler start up once instead of per
+      # fixture. Each fixture re-declares `module Check`; FSI shadows
+      # the previous definition, which is fine because the top-level
+      # bindings still execute at load time.
+      - name: Lint FSharp
+        run: |-
+          find tests/integration/cases \( -name '*.fs' -o -name '*.fsi' \) -print0 > /tmp/files-fs
+          driver=$(mktemp -d)/driver.fsx
+          while IFS= read -r -d '' f; do
+            printf '#load "%s"\n' "$(realpath "$f")"
+          done < /tmp/files-fs > "$driver"
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 \
+            dotnet fsi --nologo --exec "$driver"
+
+  # Fixture languages whose toolchain is a tarball download.
+  lint-curl-tarballs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install MLton
+        run: |
+          curl -fsSL https://github.com/MLton/mlton/releases/download/on-20241230-release/mlton-20241230-1.amd64-linux.ubuntu-24.04_static.tgz | tar xz -C /tmp
+          echo "/tmp/mlton-20241230-1.amd64-linux.ubuntu-24.04_static/bin" >> "$GITHUB_PATH"
+      - name: Install Dhall
+        run: |-
+          curl -fsSL https://github.com/dhall-lang/dhall-haskell/releases/download/1.42.2/dhall-1.42.2-x86_64-linux.tar.bz2 \
+            | tar -xj
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+      - name: Install Wren CLI
+        run: |
+          curl -fsSL https://github.com/wren-lang/wren-cli/releases/download/0.4.0/wren-cli-linux-0.4.0.zip -o /tmp/wren.zip
+          unzip -o /tmp/wren.zip -d /tmp/wren
+          sudo install /tmp/wren/wren-cli-linux-0.4.0/wren_cli /usr/local/bin/wren_cli
+
+      # Fixtures only declare `structure Check` with a `my_data` val;
+      # MLton never evaluates the body unless a top-level expression
+      # references it, so compile alongside a small force file that
+      # forces `Check.my_data` to be constructed.
+      - name: Lint Sml
+        run: |-
+          find tests/integration/cases -name '*.sml' -print0 > /tmp/files-sml
+          cat > /tmp/run-sml.sh <<'SCRIPT'
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cp "$1" "$tmpdir/check.sml"
+          cp .github/scripts/sml_force.sml "$tmpdir/force.sml"
+          cp .github/scripts/sml_main.mlb "$tmpdir/main.mlb"
+          mlton -output "$tmpdir/out" "$tmpdir/main.mlb" || exit 1
+          "$tmpdir/out" || exit 1
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-sml.sh < /tmp/files-sml
+
+      - name: Lint Dhall
+        run: |-
+          find tests/integration/cases -name '*.dhall' -print0 > /tmp/files-dhall
+          cat > /tmp/check-dhall.sh <<'SCRIPT'
+          dhall < "$1" > /dev/null
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/check-dhall.sh < /tmp/files-dhall
+
+      - name: Lint Wren
+        run: |-
+          find tests/integration/cases -name '*.wren' -print0 > /tmp/files-wren
+          xargs -0 -P "$(nproc)" -n1 wren_cli < /tmp/files-wren
+
+  # Erlang + Elixir share the BEAM runtime via setup-beam, so one
+  # install serves both syntax checks.
+  lint-beam:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Erlang and Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.18'
+          otp-version: '27'
+
+      # Fixtures only declare `defmodule Check` with a `def x` body, so
+      # `elixir` compiles the module but never invokes it. Append a call
+      # to `Check.x()` so the function body — and any references inside
+      # it — actually executes.
+      - name: Lint Elixir
+        run: |-
+          find tests/integration/cases -name '*.ex' -print0 > /tmp/files-elixir
+          while IFS= read -r -d '' f; do
+            tmpdir=$(mktemp -d)
+            cp "$f" "$tmpdir/check.ex"
+            (cd "$tmpdir" && elixirc check.ex) || exit 1
+          done < /tmp/files-elixir
+          while IFS= read -r -d '' f; do
+            tmpdir=$(mktemp -d)
+            cp "$f" "$tmpdir/check.ex"
+            printf '\nCheck.x()\n' >> "$tmpdir/check.ex"
+            (cd "$tmpdir" && elixir check.ex) || exit 1
+          done < /tmp/files-elixir
+
+      # Compile every fixture in a single erlc invocation to pay the
+      # BEAM VM startup cost once. Erlang requires the module name to
+      # match the filename, so fixtures (all declared `-module(check).`)
+      # are renamed to `fixture_N.erl` with the module declaration
+      # rewritten; the mapping is printed so failures still point back
+      # to the original path.
+      - name: Lint Erlang
+        run: |-
+          find tests/integration/cases -name '*.erl' -print0 > /tmp/files-erlang
+          tmpdir=$(mktemp -d)
+          i=0
+          while IFS= read -r -d '' f; do
+            name="fixture_$i"
+            sed "1s/^-module(check)\./-module($name)./" "$f" > "$tmpdir/$name.erl"
+            printf '%s.erl <- %s\n' "$name" "$f"
+            i=$((i+1))
+          done < /tmp/files-erlang
+          (cd "$tmpdir" && erlc -Werror fixture_*.erl)
+
+  # Small JVM-based lints that each do a quick action install.
+  lint-jvm-mini:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install clj-kondo
+        uses: DeLaGuardo/setup-clojure@13
+        with:
+          clj-kondo: latest
+      - name: Install Groovy
+        uses: wtfjoke/setup-groovy@v3
+        with:
+          groovy-version: 4.x
+
+      - name: Lint Clojure
+        run: |-
+          find tests/integration/cases -name '*.clj' -print0 > /tmp/files-clj
+          xargs -0 clj-kondo --lint < /tmp/files-clj
+
+      # Parse and run every fixture inside a single Groovy JVM via
+      # GroovyShell, so the compiler stays warm across iterations
+      # instead of cold-starting groovyc/groovy per file. A fresh
+      # GroovyShell per fixture keeps classloaders isolated, since
+      # some fixtures declare top-level classes with shared names.
+      - name: Lint Groovy
+        run: |-
+          find tests/integration/cases -name '*.groovy' -print0 > /tmp/files-groovy
+          groovy .github/scripts/lint-groovy.groovy < /tmp/files-groovy
+
+  # Haskell + PureScript share the Haskell toolchain.
+  lint-haskell-family:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: latest
+      - uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: latest
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
+      # Most fixtures declare only `module Check` with a `my_data` val;
+      # GHC never evaluates its body unless a top-level expression
+      # references it, so compile alongside a small Main wrapper that
+      # forces `Check.my_data`. Fixtures that already define their own
+      # `main` compile with `-main-is Check` instead.
+      - name: Lint Haskell
+        run: |-
+          find tests/integration/cases -name '*.hs' -print0 > /tmp/files-haskell
+          tmpdir=$(mktemp -d)
+          xargs -0 -n1 ghc -fno-code -Wall -Werror -outputdir "$tmpdir" < /tmp/files-haskell
+          # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
+          xargs -0 -P "$(nproc)" -n1 bash -c '
+            tmpdir=$(mktemp -d)
+            trap "rm -rf \"$tmpdir\"" EXIT
+            cp "$0" "$tmpdir/Check.hs"
+            if grep -qE "^main " "$0"; then
+              ghc -Wall -Werror -main-is Check -outputdir "$tmpdir" \
+                -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
+            else
+              cp .github/scripts/haskell_main.hs "$tmpdir/Main.hs"
+              ghc -Wall -Werror -outputdir "$tmpdir" \
+                -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
+            fi
+            "$tmpdir/run" || exit 1
+          ' < /tmp/files-haskell
+
+      - name: Lint PureScript
+        run: |-
+          find tests/integration/cases -name '*.purs' -print0 > /tmp/files-purescript
+          xargs -0 -P "$(nproc)" -n 1 uv run --no-project python check_purescript_syntax.py < /tmp/files-purescript
 
   lint-gleam:
     runs-on: ubuntu-latest
@@ -108,87 +544,6 @@ jobs:
         run: xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_gleam_syntax.py
           < /tmp/files-to-lint
 
-  lint-go:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.go' -print0 > /tmp/files-to-lint
-      - name: Check Go syntax
-        run: xargs -0 gofmt -e < /tmp/files-to-lint
-      - name: Check Go compilation
-        run: xargs -0 -P "$(nproc)" -n1 go vet < /tmp/files-to-lint
-      - name: Run Go files
-        run: xargs -0 -P "$(nproc)" -n1 go run < /tmp/files-to-lint
-
-  lint-groovy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.groovy' -print0 > /tmp/files-to-lint
-      - name: Install Groovy
-        uses: wtfjoke/setup-groovy@v3
-        with:
-          groovy-version: 4.x
-      # Parse and run every fixture inside a single Groovy JVM via
-      # GroovyShell, so the compiler stays warm across iterations
-      # instead of cold-starting groovyc/groovy per file. A fresh
-      # GroovyShell per fixture keeps classloaders isolated, since
-      # some fixtures declare top-level classes with shared names.
-      - name: Check and run Groovy files
-        run: groovy .github/scripts/lint-groovy.groovy < /tmp/files-to-lint
-
-  lint-javascript:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.js' -print0 > /tmp/files-to-lint
-      - name: Check JavaScript syntax
-        run: xargs -0 -P "$(nproc)" -n1 node --check < /tmp/files-to-lint
-      - name: Run JavaScript files
-        run: xargs -0 -P "$(nproc)" -n1 node < /tmp/files-to-lint
-
-  lint-json5:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.json5' -print0 > /tmp/files-to-lint
-      - name: Install json5
-        run: npm install -g json5
-      - name: Check JSON5 syntax
-        run: xargs -0 -P "$(nproc)" -n1 json5 < /tmp/files-to-lint > /dev/null
-
-  lint-jsonnet:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.jsonnet' -print0 > /tmp/files-to-lint
-      - name: Install jsonnet
-        run: |-
-          go install github.com/google/go-jsonnet/cmd/jsonnet@latest
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-      - name: Check Jsonnet syntax
-        run: xargs -0 -P "$(nproc)" -n1 jsonnet < /tmp/files-to-lint > /dev/null
-
   lint-typescript:
     runs-on: ubuntu-latest
     steps:
@@ -203,30 +558,6 @@ jobs:
       - name: Check TypeScript syntax
         run: xargs -0 -P "$(nproc)" -n1 tsc --noEmit --noResolve --skipLibCheck --lib
           es2015 < /tmp/files-to-lint
-
-  lint-java:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.java' -print0 > /tmp/files-to-lint
-      - name: Check Java syntax
-        run: xargs -0 java CheckJavaSyntax.java < /tmp/files-to-lint
-
-  lint-c:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.c' -print0 > /tmp/files-to-lint
-      - name: Check C syntax
-        run: xargs -0 clang -fsyntax-only -std=c11 < /tmp/files-to-lint
 
   lint-c-tidy:
     runs-on: ubuntu-latest
@@ -400,63 +731,6 @@ jobs:
       - name: Run Swift files
         run: xargs -0 -P "$(nproc)" -n1 swift < /tmp/files-to-lint
 
-  lint-csharp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.cs' -print0 > /tmp/files-to-lint
-      - name: Initialize .NET runtime
-        run: |
-          mkdir -p /tmp/.dotnet/shm
-          dotnet --info
-      # Build a small Roslyn host once, then feed every fixture through
-      # its stdin so the .NET runtime and C# compiler load once instead
-      # of per fixture. Replaces `dotnet build` per fixture, which paid
-      # MSBuild + NuGet restore + compiler startup each time.
-      - name: Build C# lint host
-        run: dotnet publish .github/scripts/lint-csharp/lint-csharp.csproj -c Release
-          -o /tmp/lint-csharp --nologo
-      - name: Check C# syntax
-        run: dotnet /tmp/lint-csharp/lint-csharp.dll < /tmp/files-to-lint
-
-  lint-elixir:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.ex' -print0 > /tmp/files-to-lint
-      - name: Install Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          elixir-version: '1.18'
-          otp-version: '27'
-      - name: Check Elixir syntax
-        run: |-
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            cp "$f" "$tmpdir/check.ex"
-            (cd "$tmpdir" && elixirc check.ex) || exit 1
-          done < /tmp/files-to-lint
-      # Fixtures only declare `defmodule Check` with a `def x` body, so
-      # `elixir` compiles the module but never invokes it. Append a call
-      # to `Check.x()` so the function body — and any references inside
-      # it — actually executes.
-      - name: Run Elixir files
-        run: |-
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            cp "$f" "$tmpdir/check.ex"
-            printf '\nCheck.x()\n' >> "$tmpdir/check.ex"
-            (cd "$tmpdir" && elixir check.ex) || exit 1
-          done < /tmp/files-to-lint
-
   lint-elm:
     runs-on: ubuntu-latest
     steps:
@@ -483,68 +757,6 @@ jobs:
       - name: Run Elm files
         run: xargs -0 uv run --no-project python run_elm.py < /tmp/files-to-lint
 
-  lint-erlang:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.erl' -print0 > /tmp/files-to-lint
-      - name: Install Erlang
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: '27'
-          install-rebar: false
-          install-hex: false
-      # Compile every fixture in a single erlc invocation to pay the
-      # BEAM VM startup cost once. Erlang requires the module name to
-      # match the filename, so fixtures (all declared `-module(check).`)
-      # are renamed to `fixture_N.erl` with the module declaration
-      # rewritten; the mapping is printed so failures still point back
-      # to the original path.
-      - name: Check Erlang syntax
-        run: |-
-          tmpdir=$(mktemp -d)
-          i=0
-          while IFS= read -r -d '' f; do
-            name="fixture_$i"
-            sed "1s/^-module(check)\./-module($name)./" "$f" > "$tmpdir/$name.erl"
-            printf '%s.erl <- %s\n' "$name" "$f"
-            i=$((i+1))
-          done < /tmp/files-to-lint
-          (cd "$tmpdir" && erlc -Werror fixture_*.erl)
-
-  lint-fsharp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases \( -name '*.fs' -o -name '*.fsi' \) -print0
-          > /tmp/files-to-lint
-      - name: Initialize .NET runtime
-        run: |
-          mkdir -p /tmp/.dotnet/shm
-          dotnet --info
-      # Generate an FSX driver that `#load`s every fixture, then
-      # evaluate it in a single `dotnet fsi --exec` invocation so
-      # the .NET runtime and FSI compiler start up once instead of
-      # per fixture. Each fixture re-declares `module Check`; FSI
-      # shadows the previous definition, which is fine because the
-      # top-level bindings still execute at load time.
-      - name: Check F# syntax
-        run: |-
-          driver=$(mktemp -d)/driver.fsx
-          while IFS= read -r -d '' f; do
-            printf '#load "%s"\n' "$(realpath "$f")"
-          done < /tmp/files-to-lint > "$driver"
-          DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 \
-            dotnet fsi --nologo --exec "$driver"
-
   lint-ocaml:
     runs-on: ubuntu-latest
     steps:
@@ -562,46 +774,6 @@ jobs:
         run: |-
           tmpdir=$(mktemp -d)
           xargs -0 -n1 opam exec -- ocamlopt -c -o "$tmpdir/check.o" < /tmp/files-to-lint
-
-  lint-haskell:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.hs' -print0 > /tmp/files-to-lint
-      - uses: haskell-actions/setup@v2
-        with:
-          ghc-version: latest
-      - name: Check Haskell syntax
-        run: |-
-          tmpdir=$(mktemp -d)
-          xargs -0 -n1 ghc -fno-code -Wall -Werror -outputdir "$tmpdir" \
-            < /tmp/files-to-lint
-      # Most fixtures declare only `module Check` with a `my_data` val; GHC
-      # never evaluates its body unless a top-level expression references it,
-      # so compile alongside a small Main wrapper that forces `Check.my_data`.
-      # Fixtures that already define their own `main` compile with
-      # `-main-is Check` instead.
-      - name: Run Haskell files
-        run: |-
-          # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
-          xargs -0 -P "$(nproc)" -n1 bash -c '
-            tmpdir=$(mktemp -d)
-            trap "rm -rf \"$tmpdir\"" EXIT
-            cp "$0" "$tmpdir/Check.hs"
-            if grep -qE "^main " "$0"; then
-              ghc -Wall -Werror -main-is Check -outputdir "$tmpdir" \
-                -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
-            else
-              cp .github/scripts/haskell_main.hs "$tmpdir/Main.hs"
-              ghc -Wall -Werror -outputdir "$tmpdir" \
-                -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
-            fi
-            "$tmpdir/run" || exit 1
-          ' < /tmp/files-to-lint
 
   lint-commonlisp:
     runs-on: ubuntu-latest
@@ -623,40 +795,6 @@ jobs:
           --load {}
           --quit
           < /tmp/files-to-lint
-
-  lint-hcl:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.hcl' -print0 > /tmp/files-to-lint
-      - name: Install hcl2json
-        run: |-
-          go install github.com/tmccombs/hcl2json@latest
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-      - name: Check HCL syntax
-        run: >-
-          xargs -0 -P "$(nproc)" -n1 hcl2json
-          < /tmp/files-to-lint > /dev/null
-
-  lint-clojure:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.clj' -print0 > /tmp/files-to-lint
-      - name: Install clj-kondo
-        uses: DeLaGuardo/setup-clojure@13
-        with:
-          clj-kondo: latest
-      - name: Check Clojure syntax
-        run: xargs -0 clj-kondo --lint < /tmp/files-to-lint
 
   lint-scala:
     runs-on: ubuntu-latest
@@ -722,27 +860,6 @@ jobs:
           done < /tmp/files-to-lint
           dart analyze --fatal-infos "$tmpdir"
 
-  lint-dhall:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.dhall' -print0 > /tmp/files-to-lint
-      - name: Install dhall
-        run: |-
-          curl -fsSL https://github.com/dhall-lang/dhall-haskell/releases/download/1.42.2/dhall-1.42.2-x86_64-linux.tar.bz2 \
-            | tar -xj
-          echo "$PWD/bin" >> "$GITHUB_PATH"
-      - name: Check Dhall syntax
-        run: |-
-          cat > /tmp/check-dhall.sh <<'SCRIPT'
-          dhall < "$1" > /dev/null
-          SCRIPT
-          xargs -0 -P "$(nproc)" -n1 bash /tmp/check-dhall.sh < /tmp/files-to-lint
-
   lint-julia:
     runs-on: ubuntu-latest
     steps:
@@ -763,25 +880,6 @@ jobs:
         run: xargs -0 -P "$(nproc)" -n1 julia --startup-file=no --project=/tmp/julia-lint
           < /tmp/files-to-lint
 
-  lint-perl:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.pl' -print0 > /tmp/files-to-lint
-      - name: Install Perl dependencies
-        run: |-
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq cpanminus
-          sudo cpanm --notest DateTime
-      - name: Check Perl syntax
-        run: xargs -0 -P "$(nproc)" -n1 perl -c < /tmp/files-to-lint
-      - name: Run Perl files
-        run: xargs -0 -P "$(nproc)" -n1 perl < /tmp/files-to-lint
-
   lint-lua:
     runs-on: ubuntu-latest
     steps:
@@ -797,34 +895,6 @@ jobs:
           luaVersion: '5.4'
       - name: Check Lua syntax
         run: xargs -0 luac -p < /tmp/files-to-lint
-
-  lint-tcl:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.tcl' -print0 > /tmp/files-to-lint
-      - name: Install Tcl
-        run: sudo apt-get update && sudo apt-get install -y tcl
-      - name: Check Tcl syntax
-        run: xargs -0 -P "$(nproc)" -n1 tclsh < /tmp/files-to-lint
-
-  lint-php:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.php' -print0 > /tmp/files-to-lint
-      - name: Check PHP syntax
-        run: xargs -0 php -l < /tmp/files-to-lint
-      - name: Run PHP files
-        run: xargs -0 -P "$(nproc)" -n1 php < /tmp/files-to-lint
 
   lint-r:
     runs-on: ubuntu-latest
@@ -858,59 +928,6 @@ jobs:
           compiler: dmd-latest
       - name: Check D syntax
         run: xargs -0 -P "$(nproc)" -n1 dmd -o- -c < /tmp/files-to-lint
-
-  lint-powershell:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.ps1' -print0 > /tmp/files-to-lint
-      # Parse every fixture inside a single pwsh invocation so the .NET
-      # and PowerShell startup cost is paid once instead of per fixture.
-      - name: Check PowerShell syntax
-        run: pwsh -NoProfile -NonInteractive -File .github/scripts/lint-powershell.ps1
-          < /tmp/files-to-lint
-
-  lint-ada:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.adb' -print0 > /tmp/files-to-lint
-      - name: Install GNAT
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq gnat
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check Ada syntax
-        run: xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_ada_syntax.py
-          < /tmp/files-to-lint
-
-  lint-occam:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.occ' -print0 > /tmp/files-to-lint
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check Occam-pi syntax
-        run: xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_occam_syntax.py
-          < /tmp/files-to-lint
 
   lint-crystal:
     runs-on: ubuntu-latest
@@ -955,36 +972,6 @@ jobs:
             i=$((i+1))
           done < /tmp/files-to-lint
           crystal run "$driver"
-
-  lint-matlab:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-to-lint
-      - name: Install Octave
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq octave
-      # Octave is a practical CI substitute, but it does not support
-      # every MATLAB builtin.  Skip files that use features Octave lacks:
-      #  - datetime(): not yet implemented in Octave
-      #  - ""-escaped quotes: Octave accepts some backslash escapes
-      #    (e.g. \") that MATLAB rejects, so the check would be misleading
-      - name: Check MATLAB syntax (Octave-compatible files)
-        run: |-
-          while IFS= read -r -d '' f; do
-            if grep -q '""' "$f"; then
-              echo "Skipping Octave parse check for MATLAB-escaped quotes in $f"
-              continue
-            fi
-            if grep -qw 'datetime' "$f"; then
-              echo "Skipping $f — uses datetime(), which Octave does not implement"
-              continue
-            fi
-            octave --norc --no-gui "$f" || exit 1
-          done < /tmp/files-to-lint
 
   lint-mojo:
     runs-on: ubuntu-latest
@@ -1145,50 +1132,6 @@ jobs:
         run: xargs -0 -P "$(nproc)" -n1 nix-instantiate --parse < /tmp/files-to-lint
           > /dev/null
 
-  lint-norg:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.norg' -print0 > /tmp/files-to-lint
-      - name: Install tree-sitter CLI
-        run: npm install tree-sitter-cli
-      - name: Build tree-sitter-norg parser
-        run: |-
-          git clone --depth=1 https://github.com/nvim-neorg/tree-sitter-norg.git /tmp/tree-sitter-norg
-          cc -shared -fPIC -o /tmp/norg.so \
-            -I /tmp/tree-sitter-norg/src \
-            /tmp/tree-sitter-norg/src/parser.c \
-            -x c++ /tmp/tree-sitter-norg/src/scanner.cc \
-            -lstdc++
-      - name: Check Norg syntax
-        run: xargs -0 npx tree-sitter parse --lib-path /tmp/norg.so --lang-name norg
-          --quiet < /tmp/files-to-lint
-
-  lint-purescript:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.purs' -print0 > /tmp/files-to-lint
-      - uses: purescript-contrib/setup-purescript@main
-        with:
-          purescript: latest
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check PureScript syntax
-        run: xargs -0 -P "$(nproc)" -n 1 uv run --no-project python check_purescript_syntax.py
-          < /tmp/files-to-lint
-
   lint-racket:
     runs-on: ubuntu-latest
     steps:
@@ -1220,50 +1163,6 @@ jobs:
           while IFS= read -r -d '' f; do
             odin check "$f" -file || exit 1
           done < /tmp/files-to-lint
-
-  lint-sml:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.sml' -print0 > /tmp/files-to-lint
-      - name: Install MLton
-        run: |
-          curl -fsSL https://github.com/MLton/mlton/releases/download/on-20241230-release/mlton-20241230-1.amd64-linux.ubuntu-24.04_static.tgz | tar xz -C /tmp
-          echo "/tmp/mlton-20241230-1.amd64-linux.ubuntu-24.04_static/bin" >> "$GITHUB_PATH"
-      # Fixtures only declare `structure Check` with a `my_data` val;
-      # MLton never evaluates the body unless a top-level expression
-      # references it, so compile alongside a small force file that
-      # forces `Check.my_data` to be constructed.
-      - name: Run SML files
-        run: |-
-          cat > /tmp/run-sml.sh <<'SCRIPT'
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          cp "$1" "$tmpdir/check.sml"
-          cp .github/scripts/sml_force.sml "$tmpdir/force.sml"
-          cp .github/scripts/sml_main.mlb "$tmpdir/main.mlb"
-          mlton -output "$tmpdir/out" "$tmpdir/main.mlb" || exit 1
-          "$tmpdir/out" || exit 1
-          SCRIPT
-          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-sml.sh < /tmp/files-to-lint
-
-  lint-scheme:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.scm' -print0 > /tmp/files-to-lint
-      - name: Install Guile
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq guile-3.0
-      - name: Check Scheme syntax
-        run: xargs -0 -P "$(nproc)" -I{} guile --no-auto-compile -s {} < /tmp/files-to-lint
 
   lint-raku:
     runs-on: ubuntu-latest
@@ -1297,42 +1196,6 @@ jobs:
       - name: Check Zig
         run: xargs -0 -P "$(nproc)" -n1 zig build-obj -fno-emit-bin < /tmp/files-to-lint
 
-  lint-toml:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.toml' -print0 > /tmp/files-to-lint
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check TOML syntax
-        run: xargs -0 -P "$(nproc)" -n1 uv run --with 'tomli>=2.4.0' --no-project
-          python check_toml_syntax.py < /tmp/files-to-lint
-
-  lint-yaml:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.yaml' ! -name 'input.yaml' -print0
-          > /tmp/files-to-lint
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check YAML syntax
-        run: |-
-          xargs -0 uvx yamllint --strict -d '{extends: default, rules: {document-start: disable, line-length: disable}}' -- < /tmp/files-to-lint
-
   lint-systemverilog:
     runs-on: ubuntu-latest
     steps:
@@ -1348,7 +1211,7 @@ jobs:
         run: xargs -0 -P "$(nproc)" -n1 verilator --lint-only --language 1800-2017
           -Wno-REALCVT < /tmp/files-to-lint
 
-  lint-visualbasic:
+  lint-v:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -1356,70 +1219,20 @@ jobs:
           persist-credentials: false
       - name: Find files to lint
         shell: bash
-        run: find tests/integration/cases -name '*.vb' -print0 > /tmp/files-to-lint
-      - name: Initialize .NET runtime
+        run: find tests/integration/cases -name '*.v' -print0 > /tmp/files-to-lint
+      - name: Install V
         run: |
-          mkdir -p /tmp/.dotnet/shm
-          dotnet --info
-      # Build a small Roslyn host once, then feed every fixture through
-      # its stdin so the .NET runtime and VB compiler load once instead
-      # of per fixture. Replaces `dotnet build` per fixture, which paid
-      # MSBuild + NuGet restore + compiler startup each time.
-      - name: Build VB lint host
-        run: dotnet publish .github/scripts/lint-vb/lint-vb.csproj -c Release -o /tmp/lint-vb
-          --nologo
-      - name: Check and run VB.NET files
-        run: dotnet /tmp/lint-vb/lint-vb.dll < /tmp/files-to-lint
-
-  lint-forth:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
+          git clone --depth=1 https://github.com/vlang/v /tmp/vlang
+          cd /tmp/vlang && make
+          sudo ln -s /tmp/vlang/v /usr/local/bin/v
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.fth' -print0 > /tmp/files-to-lint
-      - name: Install Gforth
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq gforth
-      - name: Check Forth syntax
-        run: |-
-          while IFS= read -r -d '' f; do
-            gforth "$f" -e bye || exit 1
-          done < /tmp/files-to-lint
-
-  lint-fortran:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.f90' -print0 > /tmp/files-to-lint
-      - name: Check Fortran syntax
-        run: xargs -0 gfortran -std=f2008 -ffree-line-length-none -fsyntax-only <
-          /tmp/files-to-lint
-      # Every fixture defines its own `fval_m` module, and the syntax
-      # check above leaves an `fval_m.mod` in the working directory
-      # (gfortran emits .mod files even under `-fsyntax-only`). gfortran
-      # would then reuse that stale .mod instead of recompiling each
-      # file's inline module, masking references to names defined only
-      # in the current file. Compile each file from inside a private
-      # tmpdir so the stale .mod is not on the module search path and
-      # parallel runs cannot clobber each other's output.
-      - name: Run Fortran files
-        run: |-
-          cat > /tmp/run-fortran.sh <<'SCRIPT'
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          src=$(realpath "$1")
-          cd "$tmpdir" || exit 1
-          gfortran -std=f2008 -ffree-line-length-none "$src" -o run || exit 1
-          ./run || exit 1
-          SCRIPT
-          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-fortran.sh < /tmp/files-to-lint
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Check V syntax
+        run: xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_v_syntax.py
+          < /tmp/files-to-lint
 
   lint-objectivec:
     runs-on: macos-latest
@@ -1482,60 +1295,21 @@ jobs:
       - name: Run clang-tidy
         run: xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 clang-tidy < /tmp/files-to-lint
 
-  lint-wren:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.wren' -print0 > /tmp/files-to-lint
-      - name: Install Wren CLI
-        run: |
-          curl -fsSL https://github.com/wren-lang/wren-cli/releases/download/0.4.0/wren-cli-linux-0.4.0.zip -o /tmp/wren.zip
-          unzip -o /tmp/wren.zip -d /tmp/wren
-          sudo install /tmp/wren/wren-cli-linux-0.4.0/wren_cli /usr/local/bin/wren_cli
-      - name: Run Wren files
-        run: xargs -0 -P "$(nproc)" -n1 wren_cli < /tmp/files-to-lint
-
-  lint-v:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.v' -print0 > /tmp/files-to-lint
-      - name: Install V
-        run: |
-          git clone --depth=1 https://github.com/vlang/v /tmp/vlang
-          cd /tmp/vlang && make
-          sudo ln -s /tmp/vlang/v /usr/local/bin/v
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check V syntax
-        run: xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_v_syntax.py
-          < /tmp/files-to-lint
-
   completion-lint:
     needs:
       - pre-commit
-      - lint-bash
-      - lint-ruby
+      - lint-fast-native
+      - lint-apt-basics
+      - lint-go-installed
+      - lint-npm-installed
+      - lint-uv-scripts
+      - lint-dotnet
+      - lint-curl-tarballs
+      - lint-beam
+      - lint-jvm-mini
+      - lint-haskell-family
       - lint-gleam
-      - lint-go
-      - lint-groovy
-      - lint-javascript
-      - lint-json5
-      - lint-jsonnet
       - lint-typescript
-      - lint-java
-      - lint-c
       - lint-c-tidy
       - lint-cobol
       - lint-cpp
@@ -1543,50 +1317,25 @@ jobs:
       - lint-kotlin
       - lint-rust
       - lint-swift
-      - lint-csharp
-      - lint-elixir
       - lint-elm
-      - lint-erlang
-      - lint-fsharp
       - lint-ocaml
-      - lint-haskell
       - lint-commonlisp
-      - lint-hcl
-      - lint-clojure
       - lint-scala
       - lint-dart
-      - lint-dhall
       - lint-julia
-      - lint-perl
       - lint-lua
-      - lint-tcl
-      - lint-php
       - lint-r
       - lint-d
-      - lint-ada
-      - lint-occam
       - lint-crystal
-      - lint-matlab
       - lint-mojo
       - lint-nim
       - lint-nix
-      - lint-norg
-      - lint-purescript
       - lint-racket
       - lint-odin
       - lint-raku
-      - lint-scheme
-      - lint-sml
       - lint-zig
-      - lint-toml
-      - lint-v
-      - lint-wren
-      - lint-yaml
-      - lint-powershell
       - lint-systemverilog
-      - lint-visualbasic
-      - lint-forth
-      - lint-fortran
+      - lint-v
       - lint-objectivec
       - lint-objectivec-tidy
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,6 +127,24 @@ jobs:
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-fortran.sh < /tmp/files-fortran
 
+      - name: Lint Rust
+        run: |-
+          find tests/integration/cases -name '*.rs' -print0 > /tmp/files-rust
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cargo init "$tmpdir/chrono-check"
+          cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
+          cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
+          deps="$tmpdir/chrono-check/target/debug/deps"
+          chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
+          while IFS= read -r -d '' f; do
+            rustc --edition 2021 \
+              -L "dependency=$deps" \
+              --extern "chrono=$chrono_rlib" \
+              "$f" -o "$tmpdir/out" 2>&1 || exit 1
+            "$tmpdir/out" || exit 1
+          done < /tmp/files-rust
+
   # Fixture languages whose interpreter is a quick `apt-get install`.
   # Grouped so the apt-get cost is paid once for the whole group.
   lint-apt-basics:
@@ -215,7 +233,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Install npm-sourced linters
-        run: npm install -g json5 tree-sitter-cli
+        run: npm install -g json5 tree-sitter-cli typescript elm-format elm
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
 
       - name: Build tree-sitter-norg parser
         run: |-
@@ -235,6 +258,20 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.norg' -print0 > /tmp/files-norg
           xargs -0 tree-sitter parse --lib-path /tmp/norg.so --lang-name norg --quiet < /tmp/files-norg
+
+      - name: Lint TypeScript
+        run: |-
+          find tests/integration/cases -name '*.ts' -print0 > /tmp/files-ts
+          xargs -0 -P "$(nproc)" -n1 tsc --noEmit --noResolve --skipLibCheck --lib es2015 < /tmp/files-ts
+
+      - name: Lint Elm
+        run: |-
+          find tests/integration/cases -name '*.elm' -print0 > /tmp/files-elm
+          while IFS= read -r -d '' f; do
+            elm-format --stdin < "$f" > /dev/null || exit 1
+          done < /tmp/files-elm
+          xargs -0 uv run --no-project python check_elm_syntax.py < /tmp/files-elm
+          xargs -0 uv run --no-project python run_elm.py < /tmp/files-elm
 
   # Fixture languages whose check is a small `uv run python ...` helper.
   lint-uv-scripts:
@@ -377,19 +414,41 @@ jobs:
           find tests/integration/cases -name '*.wren' -print0 > /tmp/files-wren
           xargs -0 -P "$(nproc)" -n1 wren_cli < /tmp/files-wren
 
-  # Erlang + Elixir share the BEAM runtime via setup-beam, so one
-  # install serves both syntax checks.
+  # Erlang + Elixir + Gleam all share the BEAM runtime via setup-beam,
+  # so one install serves all three.
   lint-beam:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Install Erlang and Elixir
+      - name: Install Erlang, Elixir and Gleam
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.18'
+          gleam-version: latest
           otp-version: '27'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Populate the shared Hex package cache once up front. Parallel
+      # `gleam deps download` invocations would otherwise race on the
+      # cache and fail with "Unable to locate Hex package contents.tar.gz"
+      # when one worker is mid-download and another reads the partial
+      # file.
+      - name: Prime Gleam Hex cache
+        run: |-
+          tmpdir=$(mktemp -d)
+          cp .github/scripts/lint-gleam.toml "$tmpdir/gleam.toml"
+          mkdir "$tmpdir/src"
+          (cd "$tmpdir" && gleam deps download)
+
+      - name: Lint Gleam
+        run: |-
+          find tests/integration/cases -name '*.gleam' -print0 > /tmp/files-gleam
+          xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_gleam_syntax.py < /tmp/files-gleam
 
       # Fixtures only declare `defmodule Check` with a `def x` body, so
       # `elixir` compiles the module but never invokes it. Append a call
@@ -510,67 +569,15 @@ jobs:
           find tests/integration/cases -name '*.purs' -print0 > /tmp/files-purescript
           xargs -0 -P "$(nproc)" -n 1 uv run --no-project python check_purescript_syntax.py < /tmp/files-purescript
 
-  lint-gleam:
+  # Ubuntu's packaged clang-tidy is several releases behind and is the
+  # dominant cost of this job on runners. Pull a recent build from PyPI
+  # via uv instead. Shared across C and C++ since it's the same tool.
+  lint-clang-tidy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.gleam' -print0 > /tmp/files-to-lint
-      - name: Install Gleam
-        uses: erlef/setup-beam@v1
-        with:
-          gleam-version: latest
-          otp-version: 27
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      # Populate the shared Hex package cache once up front. Parallel
-      # `gleam deps download` invocations would otherwise race on the
-      # cache and fail with "Unable to locate Hex package contents.tar.gz"
-      # when one worker is mid-download and another reads the partial
-      # file.
-      - name: Prime Gleam Hex cache
-        run: |-
-          tmpdir=$(mktemp -d)
-          cp .github/scripts/lint-gleam.toml "$tmpdir/gleam.toml"
-          mkdir "$tmpdir/src"
-          (cd "$tmpdir" && gleam deps download)
-      - name: Check Gleam compiles
-        run: xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_gleam_syntax.py
-          < /tmp/files-to-lint
-
-  lint-typescript:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.ts' -print0 > /tmp/files-to-lint
-      - name: Install TypeScript
-        run: npm install -g typescript
-      - name: Check TypeScript syntax
-        run: xargs -0 -P "$(nproc)" -n1 tsc --noEmit --noResolve --skipLibCheck --lib
-          es2015 < /tmp/files-to-lint
-
-  lint-c-tidy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.c' -print0 > /tmp/files-to-lint
-      # Ubuntu's packaged clang-tidy is several releases behind and is
-      # the dominant cost of this job on runners. Pull a recent build
-      # from PyPI via uv instead.
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -578,8 +585,14 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
         run: uv tool install clang-tidy
-      - name: Run clang-tidy
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c11 < /tmp/files-to-lint
+      - name: Run clang-tidy on C files
+        run: |-
+          find tests/integration/cases -name '*.c' -print0 > /tmp/files-c-tidy
+          xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c11 < /tmp/files-c-tidy
+      - name: Run clang-tidy on C++ files
+        run: |-
+          find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-cpp-tidy
+          xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-cpp-tidy
 
   lint-cobol:
     runs-on: ubuntu-latest
@@ -633,28 +646,6 @@ jobs:
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-cpp.sh < /tmp/files-to-lint
 
-  lint-cpp-tidy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-to-lint
-      # Ubuntu's packaged clang-tidy is several releases behind and is
-      # the dominant cost of this job on runners. Pull a recent build
-      # from PyPI via uv instead.
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Install clang-tidy
-        run: uv tool install clang-tidy
-      - name: Run clang-tidy
-        run: xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-to-lint
-
   lint-kotlin:
     runs-on: ubuntu-latest
     steps:
@@ -680,32 +671,6 @@ jobs:
       - name: Check Kotlin syntax
         run: kotlin .github/scripts/lint-kotlin.main.kts < /tmp/files-to-lint
 
-  lint-rust:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.rs' -print0 > /tmp/files-to-lint
-      - name: Check Rust syntax and run binaries
-        run: |-
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          cargo init "$tmpdir/chrono-check"
-          cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
-          cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
-          deps="$tmpdir/chrono-check/target/debug/deps"
-          chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
-          while IFS= read -r -d '' f; do
-            rustc --edition 2021 \
-              -L "dependency=$deps" \
-              --extern "chrono=$chrono_rlib" \
-              "$f" -o "$tmpdir/out" 2>&1 || exit 1
-            "$tmpdir/out" || exit 1
-          done < /tmp/files-to-lint
-
   lint-swift:
     runs-on: ubuntu-latest
     steps:
@@ -730,32 +695,6 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 bash /tmp/check-swift.sh < /tmp/files-to-lint
       - name: Run Swift files
         run: xargs -0 -P "$(nproc)" -n1 swift < /tmp/files-to-lint
-
-  lint-elm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.elm' -print0 > /tmp/files-to-lint
-      - name: Install elm-format and elm
-        run: npm install -g elm-format elm
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-      - name: Check Elm formatting
-        run: |-
-          while IFS= read -r -d '' f; do
-            elm-format --stdin < "$f" > /dev/null || exit 1
-          done < /tmp/files-to-lint
-      - name: Check Elm compiles
-        run: xargs -0 uv run --no-project python check_elm_syntax.py < /tmp/files-to-lint
-      - name: Run Elm files
-        run: xargs -0 uv run --no-project python run_elm.py < /tmp/files-to-lint
 
   lint-ocaml:
     runs-on: ubuntu-latest
@@ -1308,16 +1247,11 @@ jobs:
       - lint-beam
       - lint-jvm-mini
       - lint-haskell-family
-      - lint-gleam
-      - lint-typescript
-      - lint-c-tidy
+      - lint-clang-tidy
       - lint-cobol
       - lint-cpp
-      - lint-cpp-tidy
       - lint-kotlin
-      - lint-rust
       - lint-swift
-      - lint-elm
       - lint-ocaml
       - lint-commonlisp
       - lint-scala

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
   # Fixture languages whose toolchains are preinstalled on ubuntu-latest.
   # Grouped into one job because each sub-lint takes only seconds, so the
   # runner startup cost is the dominant factor when they are split out.
-  lint-fast-native:
+  lint-fast:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1237,7 +1237,7 @@ jobs:
   completion-lint:
     needs:
       - pre-commit
-      - lint-fast-native
+      - lint-fast
       - lint-apt-basics
       - lint-go-installed
       - lint-npm-installed

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -22,8 +22,16 @@ def fixture_lint_workflow(
 def test_all_languages_have_lint_workflow(
     lint_workflow: dict[str, Any],
 ) -> None:
-    """Every language has a lint job in the lint workflow."""
+    """Every language is covered by a ``Lint <Class>`` step or
+    ``lint-<class>`` job.
+    """
     job_ids: set[str] = set(lint_workflow["jobs"])
+    step_names: set[str] = set()
+    for job in lint_workflow["jobs"].values():
+        steps: list[dict[str, Any]] = job.get("steps") or []
+        for step in steps:
+            if "name" in step:
+                step_names.add(step["name"])
 
     # Python is linted by the "build" job (pre-commit hooks),
     # not a dedicated lint workflow.
@@ -31,12 +39,16 @@ def test_all_languages_have_lint_workflow(
         {"Python"},
     )
 
-    expected_jobs = {
-        f"lint-{lang_cls.__name__.lower()}"
-        for lang_cls in ALL_LANGUAGES
-        if lang_cls.__name__ not in no_dedicated_workflow
-    }
-    assert expected_jobs <= job_ids
+    for lang_cls in ALL_LANGUAGES:
+        name = lang_cls.__name__
+        if name in no_dedicated_workflow:
+            continue
+        has_dedicated_job = f"lint-{name.lower()}" in job_ids
+        has_named_step = f"Lint {name}" in step_names
+        assert has_dedicated_job or has_named_step, (
+            f"No lint coverage for {name}: "
+            f"expected job 'lint-{name.lower()}' or step 'Lint {name}'"
+        )
 
 
 def test_all_lint_jobs_in_completion_gate(


### PR DESCRIPTION
## Summary
- Consolidates 34 tiny single-language lint jobs into 10 grouped jobs (`lint-fast-native`, `lint-apt-basics`, `lint-go-installed`, `lint-npm-installed`, `lint-uv-scripts`, `lint-dotnet`, `lint-curl-tarballs`, `lint-beam`, `lint-jvm-mini`, `lint-haskell-family`), cutting ubuntu-latest lint jobs per run from 63 to 39.
- Under GitHub Pro's 40-concurrent cap, the queueing tail collapses from ~32 jobs to ~7, so Lint wall-clock should drop from ~13 min to ~5 min.
- Each language gets one `Lint <ClassName>` step; the `test_all_languages_have_lint_workflow` meta-test now checks that naming convention instead of a hardcoded job mapping.

## Test plan
- [x] `uv run --extra=dev pytest tests/test_meta.py`
- [x] `uv run --extra=dev prek run --files .github/workflows/lint.yml tests/test_meta.py` (actionlint, yamllint, yamlfix, zizmor, etc.)
- [ ] Push and observe the next Lint run's wall-clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of the GitHub Actions lint workflow; risk is mainly CI regressions from missed/incorrectly grouped language steps or tool installation order, not runtime/product behavior.
> 
> **Overview**
> Refactors `.github/workflows/lint.yml` to **collapse many per-language fixture lint jobs into a smaller set of grouped jobs** (e.g. `lint-fast`, `lint-apt-basics`, `lint-go-installed`, `lint-npm-installed`, `lint-uv-scripts`, `lint-dotnet`, `lint-curl-tarballs`, `lint-beam`, `lint-jvm-mini`, `lint-haskell-family`, plus shared `lint-clang-tidy`) while keeping the remaining heavier language jobs separate.
> 
> Updates the `completion-lint` gate to depend on the new grouped jobs, and adjusts `tests/test_meta.py` to accept lint coverage via either a dedicated `lint-<language>` job **or** a `Lint <Language>` step name within grouped jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d557300adbe21bb6209df479706e6bc8922447cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->