### PR TITLE
Move include_delimiters=True unit tests to integration cases

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -85,42 +85,18 @@ def test_dict_python() -> None:
     assert result.code == expected
 
 
-def test_dict_include_delimiters() -> None:
-    """Wrapping a dict adds braces and indentation."""
-    result = literalize(
-        source=json.dumps(obj={"a": 1, "b": 2}),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        {
-            "a": 1,
-            "b": 2,
-        }"""
-    )
-    assert result.code == expected
-
-
-@pytest.mark.parametrize(
-    argnames="include_delimiters",
-    argvalues=[False, True],
-)
-def test_dict_empty(*, include_delimiters: bool) -> None:
-    """An empty dict produces the language's empty-dict literal when
-    delimiters are included, or an empty string without delimiters.
+def test_dict_empty_no_delimiters() -> None:
+    """An empty dict produces an empty string when delimiters are
+    excluded.
     """
     result = literalize(
         source=json.dumps(obj={}),
         input_format=InputFormat.JSON,
         language=PYTHON,
         pre_indent_level=0,
-        include_delimiters=include_delimiters,
+        include_delimiters=False,
     )
-    expected = "{}" if include_delimiters else ""
-    assert result.code == expected
+    assert result.code == ""
 
 
 def test_integers() -> None:
@@ -245,38 +221,6 @@ def test_indent_tabs() -> None:
     assert result.code == "\t\ttrue,\n\t\tfalse,"
 
 
-def test_include_delimiters() -> None:
-    """Wrapping adds brackets and indentation."""
-    result = literalize(
-        source=json.dumps(obj=[True, False]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        (
-            True,
-            False,
-        )"""
-    )
-    assert result.code == expected
-
-
-def test_include_delimiters_with_pre_indent_level() -> None:
-    """Wrapping respects the given pre_indent_level."""
-    result = literalize(
-        source=json.dumps(obj=[["a", 1.0]]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=1,
-        include_delimiters=True,
-    )
-    expected = '    (\n        ("a", 1.0),\n    )'
-    assert result.code == expected
-
-
 def test_indent_override() -> None:
     """User-provided indent overrides the language default."""
     language = Python(
@@ -298,23 +242,18 @@ def test_indent_override() -> None:
     assert result.code == expected
 
 
-@pytest.mark.parametrize(
-    argnames="include_delimiters",
-    argvalues=[False, True],
-)
-def test_empty_data(*, include_delimiters: bool) -> None:
-    """An empty list produces the language's empty-sequence literal when
-    delimiters are included, or an empty string without delimiters.
+def test_empty_list_no_delimiters() -> None:
+    """An empty list produces an empty string when delimiters are
+    excluded.
     """
     result = literalize(
         source=json.dumps(obj=[]),
         input_format=InputFormat.JSON,
         language=PYTHON,
         pre_indent_level=0,
-        include_delimiters=include_delimiters,
+        include_delimiters=False,
     )
-    expected = "()" if include_delimiters else ""
-    assert result.code == expected
+    assert result.code == ""
 
 
 @pytest.mark.parametrize(
@@ -357,18 +296,6 @@ def test_scalar_with_indent() -> None:
         include_delimiters=False,
     )
     assert result.code == "    42"
-
-
-def test_scalar_include_delimiters_ignored() -> None:
-    """Wrap is ignored for scalar values."""
-    result = literalize(
-        source="42",
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-    )
-    assert result.code == "42"
 
 
 def test_literalize_json_array() -> None:

--- a/tests/test_json5.py
+++ b/tests/test_json5.py
@@ -58,27 +58,6 @@ def test_dict_python() -> None:
     assert result.code == expected
 
 
-def test_dict_include_delimiters() -> None:
-    """Wrapping a dict adds braces and indentation."""
-    source = "{a: 1, b: 2}"
-    result = literalize(
-        source=source,
-        input_format=InputFormat.JSON5,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        {
-            "a": 1,
-            "b": 2,
-        }"""
-    )
-    assert result.code == expected
-
-
 def test_array() -> None:
     """JSON5 array renders as a tuple in Python."""
     source = "[1, 2, 3,]"

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -60,26 +60,6 @@ def test_dict_python() -> None:
     assert result.code == expected
 
 
-def test_dict_include_delimiters() -> None:
-    """Wrapping a dict adds braces and indentation."""
-    toml_string = "a = 1\nb = 2\n"
-    result = literalize(
-        source=toml_string,
-        input_format=InputFormat.TOML,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        {
-            "a": 1,
-            "b": 2,
-        }"""
-    )
-    assert result.code == expected
-
-
 def test_empty_table() -> None:
     """An empty TOML string produces an empty dict."""
     result = literalize(


### PR DESCRIPTION
## Summary
- Delete `include_delimiters=True` unit tests from `test_json.py`, `test_toml.py`, and `test_json5.py`; the integration golden-file suite already covers this with `simple_dict`, `simple_sequence`, `empty_dict`, `empty_list`, `scalar_int`, and the pre-indent cases.
- Convert the two parameterized empty-data tests in `test_json.py` to keep only the `include_delimiters=False` branch, which doesn't fit the integration pattern.

## Test plan
- [x] `pytest tests/` (479 unit tests pass)
- [x] `pytest tests/integration/` (542 tests + 13924 subtests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only deletes/adjusts test cases without changing production logic; main risk is reduced unit-level coverage if integration goldens don’t fully cover edge cases.
> 
> **Overview**
> Removes several unit tests in `tests/test_json.py`, `tests/test_json5.py`, and `tests/test_toml.py` that asserted `include_delimiters=True` wrapping/indent behavior for dicts, sequences, and scalars.
> 
> Simplifies the previously-parameterized empty dict/list JSON tests to keep only the `include_delimiters=False` assertions (empty output), dropping the `include_delimiters=True` branches from these unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff896df362f14c4b38f3b110c8d0da5db060890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->