### PR TITLE
Enforce clang-tidy -Wimplicitly-unsigned-literal for ObjectiveC (#1461)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks: >
   -altera-struct-pack-align,
   -bugprone-narrowing-conversions,
   -clang-analyzer-deadcode.DeadStores,
-  -clang-diagnostic-implicitly-unsigned-literal,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-narrowing-conversions,
   -fuchsia-default-arguments-calls,


### PR DESCRIPTION
## Summary

- Drop ``-clang-diagnostic-implicitly-unsigned-literal`` from ``.clang-tidy``. It was added to unblock the ``scalar_int_very_large`` ObjectiveC fixture, but ``ObjectiveC.format_integer`` now wraps with the shared ULL overflow fallback, so the emitted literal is ``9223372036854775808ULL`` and the warning no longer fires.

Closes #1461

## Test plan

- [ ] CI ``lint-objectivec`` runs clang-tidy against the regenerated fixtures with the suppression removed and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; may cause new lint failures if any generated or handwritten code still emits implicitly-unsigned integer literals.
> 
> **Overview**
> Re-enables clang-tidy enforcement for `clang-diagnostic-implicitly-unsigned-literal` by removing it from the `.clang-tidy` ignore list, so this warning is now treated as an error during `WarningsAsErrors: '*'` lint runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b31d87724f828af21800d2901f3f81c8e9bd33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->