### PR TITLE
Delete more include_delimiters=True unit tests covered by integration

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -312,26 +312,6 @@ def test_literalize_json_array() -> None:
     assert result.code == expected
 
 
-def test_literalize_json_object() -> None:
-    """``literalize_json`` parses a JSON object string."""
-    json_string = '{"a": 1, "b": true}'
-    result = literalize(
-        source=json_string,
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        {
-            "a": 1,
-            "b": True,
-        }"""
-    )
-    assert result.code == expected
-
-
 def test_literalize_json_invalid() -> None:
     """``literalize_json`` raises on invalid JSON."""
     with pytest.raises(expected_exception=JSONParseError):

--- a/tests/test_json5.py
+++ b/tests/test_json5.py
@@ -335,31 +335,3 @@ def test_scalar_types(
         variable_form=None,
     )
     assert result.code == expected
-
-
-def test_scalar_string() -> None:
-    """A bare JSON5 string renders as a scalar."""
-    source = '"hello"'
-    result = literalize(
-        source=source,
-        input_format=InputFormat.JSON5,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-    )
-    assert result.code == '"hello"'
-
-
-def test_scalar_number() -> None:
-    """A bare JSON5 number renders as a scalar."""
-    source = "42"
-    result = literalize(
-        source=source,
-        input_format=InputFormat.JSON5,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=None,
-    )
-    assert result.code == "42"


### PR DESCRIPTION
## Summary
- Remove `test_literalize_json_object` from `tests/test_json.py` — dict wrapping with `include_delimiters=True` is covered by the integration `simple_dict` golden case, and JSON object parsing is still exercised by `test_dict_python`.
- Remove `test_scalar_string` / `test_scalar_number` from `tests/test_json5.py` — the scalar wrap-ignored behavior is covered by the integration `scalar_*` golden cases.

## Test plan
- [x] `uv run pytest tests/test_json.py tests/test_json5.py tests/integration/test_integration.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only deletes a few redundant unit tests; no production logic changes.
> 
> **Overview**
> Removes redundant unit tests for JSON and JSON5 literalization that were duplicating coverage already provided by integration golden cases.
> 
> Specifically drops the JSON object `include_delimiters=True` test in `tests/test_json.py` and the bare JSON5 scalar string/number tests in `tests/test_json5.py`, keeping invalid-parse coverage intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 008dfd5c32191609d86baece1083bf047ff4a3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->