### PR TITLE
Add function call rendering to Gleam

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- Added ``literalize_call`` support for Gleam:
+  ``Gleam.format_call_preamble_stub`` emits module-level ``pub fn``
+  declarations with fresh type variables per parameter and a
+  ``panic`` body, and ``Gleam.format_call_target`` flattens dotted
+  targets (e.g. ``app.client.fetch``) to underscored identifiers
+  (``app_client_fetch``) because Gleam identifiers cannot contain
+  ``.``.  ``Gleam.CallStyles.POSITIONAL`` renders calls as
+  ``func(arg1, arg2)``.
 - ``ObjectiveC`` call stubs now emit ``k``-prefixed, title-cased root
   names for the ``static const struct`` globals that back dotted call
   targets, so a user-written ``throttler.check(...)`` literalizes to

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -42,7 +42,6 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -52,12 +51,12 @@ from literalizer._language import (
     HeterogeneousBehavior,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -319,6 +318,35 @@ _GLEAM_BYTES_FORMATTERS: dict[
     "HEX": _build_gleam_bytes_hex,
     "BASE64": _build_gleam_bytes_base64,
 }
+
+
+def _gleam_call_preamble_stub(
+    name: str,
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Gleam module-level function stubs for a call target.
+
+    Dotted names are flattened to underscored identifiers — Gleam
+    identifiers cannot contain ``.``, so ``app.client.fetch`` becomes
+    ``app_client_fetch``.  Each parameter gets a fresh type variable
+    so the stub is polymorphic across call sites that pass different
+    argument types.  Return type is ``Nil``; ``panic`` fills the body
+    so the stub unifies with any return-position type at the call
+    site.
+    """
+    flat_name = name.replace(".", "_")
+    letters = "abcdefghijklmnopqrstuvwxyz"
+    param_list = ", ".join(
+        f"_{p}: {letters[i]}" for i, p in enumerate(iterable=params)
+    )
+    return (f"pub fn {flat_name}({param_list}) -> Nil {{ panic }}",)
+
+
+def _gleam_format_call_target(name: str) -> str:
+    """Flatten a dotted call target to an underscored Gleam identifier."""
+    return name.replace(".", "_")
 
 
 @beartype
@@ -644,6 +672,8 @@ class Gleam(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Gleam call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -674,7 +704,8 @@ class Gleam(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
         indented = textwrap.indent(text=content, prefix="  ")
-        return f"\npub fn main() {{\n{indented}\n  let _ = {variable_name}\n}}"
+        use_line = f"\n  let _ = {variable_name}" if variable_name else ""
+        return f"\npub fn main() {{\n{indented}{use_line}\n}}"
 
     @staticmethod
     def wrap_combined_in_file(
@@ -710,6 +741,7 @@ class Gleam(metaclass=LanguageCls):
     string_format: StringFormats = StringFormats.DOUBLE
     trailing_comma: TrailingCommas = TrailingCommas.YES
     line_ending: LineEndings = LineEndings.NONE
+    call_style: CallStyles = CallStyles.POSITIONAL
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
@@ -727,9 +759,11 @@ class Gleam(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for Gleam's call style."""
+        return self.call_style.value
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:
@@ -770,14 +804,14 @@ class Gleam(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return no_call_stub
+        return _gleam_call_preamble_stub
 
     @cached_property
     def format_call_target(self) -> Callable[[str], str]:
         """Rewrite a dotted call target into the language's call
         syntax.
         """
-        return identity_call_target
+        return _gleam_format_call_target
 
     @cached_property
     def null_literal(self) -> str:

--- a/tests/integration/cases/call_deep_dotted_method/Gleam_call.gleam
+++ b/tests/integration/cases/call_deep_dotted_method/Gleam_call.gleam
@@ -1,0 +1,17 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn obj_api_client_post(_data: a) -> Nil { panic }
+
+pub fn main() {
+  obj_api_client_post(GStr("hello"))
+  obj_api_client_post(GInt(42))
+  obj_api_client_post(GBool(True))
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Gleam_call.gleam
+++ b/tests/integration/cases/call_deep_dotted_transformed/Gleam_call.gleam
@@ -1,0 +1,18 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn app_client_fetch(_payload: a) -> Nil { panic }
+pub fn emit(__arg: a) -> Nil { panic }
+
+pub fn main() {
+  emit(app_client_fetch(GStr("hello")))
+  emit(app_client_fetch(GInt(42)))
+  emit(app_client_fetch(GBool(True)))
+}

--- a/tests/integration/cases/call_dotted_method/Gleam_call.gleam
+++ b/tests/integration/cases/call_dotted_method/Gleam_call.gleam
@@ -1,0 +1,17 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn app_client_fetch(_payload: a) -> Nil { panic }
+
+pub fn main() {
+  app_client_fetch(GStr("hello"))
+  app_client_fetch(GInt(42))
+  app_client_fetch(GBool(True))
+}

--- a/tests/integration/cases/call_keyword_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_keyword_args/Gleam_call.gleam
@@ -1,0 +1,17 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn throttler_check(_user_id: a, _ts: b) -> Nil { panic }
+pub fn emit(__arg: a) -> Nil { panic }
+
+pub fn main() {
+  emit(throttler_check(GStr("user_1"), GFloat(1000.0)))
+  emit(throttler_check(GStr("user_2"), GFloat(2000.5)))
+}

--- a/tests/integration/cases/call_mixed_type_dicts/Gleam_call.gleam
+++ b/tests/integration/cases/call_mixed_type_dicts/Gleam_call.gleam
@@ -1,0 +1,16 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn app_mgr_op(_operation: a) -> Nil { panic }
+
+pub fn main() {
+  app_mgr_op(GDict([#("type", GStr("create")), #("pr_id", GStr("pr_1")), #("draft", GBool(True))]))
+  app_mgr_op(GDict([#("type", GStr("create")), #("pr_id", GStr("pr_2"))]))
+}

--- a/tests/integration/cases/call_multi_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_multi_args/Gleam_call.gleam
@@ -1,0 +1,16 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn process(_value: a, _count: b) -> Nil { panic }
+
+pub fn main() {
+  process(GInt(1), GInt(42))
+  process(GInt(2), GInt(100))
+}

--- a/tests/integration/cases/call_per_element_false/Gleam_call.gleam
+++ b/tests/integration/cases/call_per_element_false/Gleam_call.gleam
@@ -1,0 +1,15 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn process(_data: a) -> Nil { panic }
+
+pub fn main() {
+  process(GInt(1))
+}

--- a/tests/integration/cases/call_ref_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_ref_args/Gleam_call.gleam
@@ -1,0 +1,26 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn process(_data: a, _count: b) -> Nil { panic }
+
+pub fn main() {
+  let my_var = GList([
+    GInt(1),
+    GInt(2),
+    GInt(3),
+  ])
+  let my_other = GList([
+    GInt(4),
+    GInt(5),
+    GInt(6),
+  ])
+  process(my_var, GInt(42))
+  process(my_other, GInt(7))
+}

--- a/tests/integration/cases/call_scalar_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_scalar_args/Gleam_call.gleam
@@ -1,0 +1,17 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn process(_value: a) -> Nil { panic }
+
+pub fn main() {
+  process(GStr("hello"))
+  process(GInt(42))
+  process(GBool(True))
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Gleam_call.gleam
+++ b/tests/integration/cases/call_transform_no_wrapper/Gleam_call.gleam
@@ -1,0 +1,17 @@
+pub type GVal {
+  GNull
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GStr(String)
+  GList(List(GVal))
+  GDict(List(#(String, GVal)))
+  GSet(List(GVal))
+}
+pub fn process(_value: a) -> Nil { panic }
+
+pub fn main() {
+  process(GStr("hello"))
+  process(GInt(42))
+  process(GBool(True))
+}


### PR DESCRIPTION
## Summary
- Wire `Gleam` through `PositionalCallStyle` and implement `_gleam_call_preamble_stub` to emit module-level `pub fn` declarations with per-parameter type variables and a `panic` body so stubs are polymorphic across call sites.
- Flatten dotted call targets (`app.client.fetch` → `app_client_fetch`) via `_gleam_format_call_target` since Gleam identifiers cannot contain `.`, and fix `wrap_in_file` to omit the trailing `let _ = ` line when `variable_name` is empty.
- Add golden files for the ten `literalize_call` integration test cases and a CHANGELOG entry. Closes #1120.

## Test plan
- [x] `uv run pytest tests/ -q` (1031 tests + 13924 subtests pass)
- [x] Each generated `Gleam_call.gleam` compiles under `gleam 1.15.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Gleam code generation for call expressions (stub emission, call target rewriting, and wrapper output), which can affect generated fixtures and compilation behavior.
> 
> **Overview**
> Adds **`literalize_call` support for Gleam** by wiring in `PositionalCallStyle` and implementing `Gleam.format_call_preamble_stub` to emit module-scope `pub fn` stubs with per-parameter type variables and a `panic` body.
> 
> Updates Gleam call rendering to **flatten dotted targets** (`a.b.c` → `a_b_c`) via `Gleam.format_call_target`, and tweaks `Gleam.wrap_in_file` to omit the trailing `let _ = …` line when no `variable_name` is provided.
> 
> Adds/updates the CHANGELOG entry and introduces Gleam golden outputs for the `literalize_call` integration test cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbaa4bd12609fe39a62d9510eebb310f73efbbe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->