### PR TITLE
Run C# fixtures in lint.yml to catch runtime errors

### DIFF
--- a/.github/scripts/lint-csharp/Program.cs
+++ b/.github/scripts/lint-csharp/Program.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -43,6 +45,56 @@ for (var i = 0; i < paths.Count; i++)
         {
             Console.Error.WriteLine($"  {diag}");
         }
+        continue;
+    }
+
+    var assembly = Assembly.Load(ms.ToArray());
+    try
+    {
+        // Top-level-statement fixtures compile to a synthetic
+        // `<Program>$.<Main>$` whose body is the statement list, so
+        // invoking the entry point runs their `var my_data = ...`
+        // initializers.
+        var entryPoint = assembly.EntryPoint;
+        if (entryPoint is not null)
+        {
+            var parameters = entryPoint.GetParameters();
+            object?[]? entryArgs = parameters.Length == 0
+                ? null
+                : new object?[] { Array.Empty<string>() };
+            entryPoint.Invoke(obj: null, parameters: entryArgs);
+        }
+        // `class Check { ... Main() {} }` fixtures declare `my_data`
+        // as a field whose initializer only runs when the class is
+        // constructed; their `Main` is empty, so the entry point
+        // alone never exercises the initializer. Force the static
+        // cctor and — when there's a parameterless ctor — construct
+        // an instance so instance field initializers run too.
+        var checkType = assembly.GetType("Check");
+        if (checkType is not null)
+        {
+            RuntimeHelpers.RunClassConstructor(checkType.TypeHandle);
+            if (checkType.GetConstructor(Type.EmptyTypes) is not null)
+            {
+                Activator.CreateInstance(checkType);
+            }
+        }
+    }
+    catch (Exception ex)
+    {
+        allOk = false;
+        // `RunClassConstructor` wraps cctor failures in
+        // `TypeInitializationException`, and `MethodInfo.Invoke` wraps
+        // callee failures in `TargetInvocationException`; peel both
+        // layers so the reported error points at the fixture's actual
+        // runtime failure.
+        var inner = ex;
+        while (inner is TargetInvocationException or TypeInitializationException
+            && inner.InnerException is not null)
+        {
+            inner = inner.InnerException;
+        }
+        Console.Error.WriteLine($"{path}: C# runtime error: {inner}");
     }
 }
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -338,6 +338,9 @@ jobs:
         run: dotnet publish .github/scripts/lint-vb/lint-vb.csproj -c Release -o /tmp/lint-vb
           --nologo
 
+      # The host compiles each fixture into an in-memory assembly and
+      # invokes its entry point, so emit-success and runtime errors
+      # (e.g. undefined members on an unstubbed object) both fail here.
       - name: Lint CSharp
         run: |-
           find tests/integration/cases -name '*.cs' -print0 > /tmp/files-cs

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -80,6 +80,7 @@ from literalizer._language import (
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_spec_for_data,
+    prepend_body_preamble,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -277,17 +278,49 @@ def _csharp_call_stub(
 ) -> tuple[str, ...]:
     """Return C# stub declarations for a call name.
 
-    For a single-name target the stub is a free function whose
-    parameter list matches the count of ``params``; for a dotted
-    target an ``ExpandoObject`` root is emitted so dynamic dispatch
-    absorbs any number of arguments.
+    For a single-name target the stub is a static method whose
+    parameter list matches the given names; for a dotted target a
+    chain of nested stub classes is emitted so ``a.b.c.d(...)``
+    dispatches to a real method whose body returns ``null``.  Every
+    argument is spelled out by name with a ``null`` default so
+    named-argument call styles bind to real parameters instead of
+    failing at runtime.
     """
+    param_list = ", ".join(f"object {p} = null" for p in params)
     parts = name.split(sep=".")
     if len(parts) == 1:
-        param_list = ", ".join(f"dynamic _a{i}" for i in range(len(params)))
-        return (f"dynamic {parts[0]}({param_list}) => null;",)
+        return (f"static object {parts[0]}({param_list}) => null;",)
     root = parts[0]
-    return (f"dynamic {root} = new System.Dynamic.ExpandoObject();",)
+    method = parts[-1]
+    fields = parts[1:-1]
+    if not fields:
+        type_name = f"{root.title()}Type_"
+        return (
+            f"class {type_name} {{"
+            f" public object {method}({param_list}) => null; }}",
+            f"static {type_name} {root} = new {type_name}();",
+        )
+    lines: list[str] = []
+    inner_type = f"{fields[-1].title()}Type_"
+    lines.append(
+        f"class {inner_type} {{"
+        f" public object {method}({param_list}) => null; }}"
+    )
+    prev_type = inner_type
+    for i in range(len(fields) - 2, -1, -1):
+        curr_type = f"{fields[i].title()}Type_"
+        lines.append(
+            f"class {curr_type} {{"
+            f" public {prev_type} {fields[i + 1]} = new {prev_type}(); }}"
+        )
+        prev_type = curr_type
+    root_type = f"{root.title()}Type_"
+    lines.append(
+        f"class {root_type} {{"
+        f" public {prev_type} {fields[0]} = new {prev_type}(); }}"
+    )
+    lines.append(f"static {root_type} {root} = new {root_type}();")
+    return tuple(lines)
 
 
 @beartype
@@ -641,9 +674,18 @@ class CSharp(metaclass=LanguageCls):
         When *content* starts with a class-field modifier keyword (one
         of the visibility or storage keywords that C# only accepts on
         class members) the declaration is placed inside a ``class
-        Check`` body with a ``Main`` entry point; otherwise it's
-        emitted as a top-level statement, which is the only context
-        where ``var`` declarations are valid.
+        Check`` body with a ``Main`` entry point.
+
+        When *body_preamble* carries call-stub declarations (``class
+        Foo_ { ... }`` and ``static Foo_ foo = new Foo_();``) the whole
+        file is wrapped in ``class Check { ...stubs... static void
+        Main() { ...content... } }``.  C# requires type declarations to
+        follow top-level statements, so stubs cannot sit before
+        top-level calls — wrapping them as class members sidesteps
+        that ordering rule.
+
+        Otherwise the content is emitted as a top-level statement,
+        which is the only context where ``var`` declarations are valid.
         """
         first_token = (
             content.lstrip().split(sep=" ", maxsplit=1)[0]
@@ -666,6 +708,29 @@ class CSharp(metaclass=LanguageCls):
                 f"{content}\n"
                 "    public static void Main() {}\n"
                 "}"
+            )
+        stub_prefixes = ("class ", "static ")
+        stub_lines = tuple(
+            line for line in body_preamble if line.startswith(stub_prefixes)
+        )
+        other_lines = tuple(
+            line
+            for line in body_preamble
+            if not line.startswith(stub_prefixes)
+        )
+        if stub_lines:
+            stub_block = "\n".join(stub_lines) + "\n"
+            body = prepend_body_preamble(
+                content=content,
+                body_preamble=other_lines,
+            )
+            return (
+                f"class Check {{\n"
+                f"{stub_block}"
+                f"    public static void Main() {{\n"
+                f"{body}\n"
+                f"    }}\n"
+                f"}}"
             )
         return wrap_in_file_noop(
             content=content,

--- a/tests/integration/cases/call_deep_dotted_method/CSharp_call.cs
+++ b/tests/integration/cases/call_deep_dotted_method/CSharp_call.cs
@@ -1,5 +1,12 @@
 using System;
-dynamic obj = new System.Dynamic.ExpandoObject();
+class Check {
+class ClientType_ { public object post(object data = null) => null; }
+class ApiType_ { public ClientType_ client = new ClientType_(); }
+class ObjType_ { public ApiType_ api = new ApiType_(); }
+static ObjType_ obj = new ObjType_();
+    public static void Main() {
 obj.api.client.post("hello");
 obj.api.client.post(42);
 obj.api.client.post(true);
+    }
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/CSharp_call.cs
+++ b/tests/integration/cases/call_deep_dotted_transformed/CSharp_call.cs
@@ -1,6 +1,12 @@
 using System;
-dynamic app = new System.Dynamic.ExpandoObject();
-dynamic emit(dynamic _a0) => null;
+class Check {
+class ClientType_ { public object fetch(object payload = null) => null; }
+class AppType_ { public ClientType_ client = new ClientType_(); }
+static AppType_ app = new AppType_();
+static object emit(object _arg = null) => null;
+    public static void Main() {
 emit(app.client.fetch("hello"));
 emit(app.client.fetch(42));
 emit(app.client.fetch(true));
+    }
+}

--- a/tests/integration/cases/call_dotted_method/CSharp_call.cs
+++ b/tests/integration/cases/call_dotted_method/CSharp_call.cs
@@ -1,5 +1,11 @@
 using System;
-dynamic app = new System.Dynamic.ExpandoObject();
+class Check {
+class ClientType_ { public object fetch(object payload = null) => null; }
+class AppType_ { public ClientType_ client = new ClientType_(); }
+static AppType_ app = new AppType_();
+    public static void Main() {
 app.client.fetch("hello");
 app.client.fetch(42);
 app.client.fetch(true);
+    }
+}

--- a/tests/integration/cases/call_keyword/CSharp_call.cs
+++ b/tests/integration/cases/call_keyword/CSharp_call.cs
@@ -1,5 +1,10 @@
 using System;
-dynamic throttler = new System.Dynamic.ExpandoObject();
-dynamic emit(dynamic _a0) => null;
+class Check {
+class ThrottlerType_ { public object check(object user_id = null, object ts = null) => null; }
+static ThrottlerType_ throttler = new ThrottlerType_();
+static object emit(object _arg = null) => null;
+    public static void Main() {
 emit(throttler.check(user_id: "user_1", ts: 1000.0));
 emit(throttler.check(user_id: "user_2", ts: 2000.5));
+    }
+}

--- a/tests/integration/cases/call_keyword_args/CSharp_call.cs
+++ b/tests/integration/cases/call_keyword_args/CSharp_call.cs
@@ -1,5 +1,10 @@
 using System;
-dynamic throttler = new System.Dynamic.ExpandoObject();
-dynamic emit(dynamic _a0) => null;
+class Check {
+class ThrottlerType_ { public object check(object user_id = null, object ts = null) => null; }
+static ThrottlerType_ throttler = new ThrottlerType_();
+static object emit(object _arg = null) => null;
+    public static void Main() {
 emit(throttler.check("user_1", 1000.0));
 emit(throttler.check("user_2", 2000.5));
+    }
+}

--- a/tests/integration/cases/call_mixed_type_dicts/CSharp_call.cs
+++ b/tests/integration/cases/call_mixed_type_dicts/CSharp_call.cs
@@ -1,5 +1,11 @@
 using System.Collections.Generic;
 using System;
-dynamic app = new System.Dynamic.ExpandoObject();
+class Check {
+class MgrType_ { public object op(object operation = null) => null; }
+class AppType_ { public MgrType_ mgr = new MgrType_(); }
+static AppType_ app = new AppType_();
+    public static void Main() {
 app.mgr.op(new Dictionary<string, object> {["type"] = "create", ["pr_id"] = "pr_1", ["draft"] = true});
 app.mgr.op(new Dictionary<string, object> {["type"] = "create", ["pr_id"] = "pr_2"});
+    }
+}

--- a/tests/integration/cases/call_multi_args/CSharp_call.cs
+++ b/tests/integration/cases/call_multi_args/CSharp_call.cs
@@ -1,4 +1,8 @@
 using System;
-dynamic process(dynamic _a0, dynamic _a1) => null;
+class Check {
+static object process(object value = null, object count = null) => null;
+    public static void Main() {
 process(1, 42);
 process(2, 100);
+    }
+}

--- a/tests/integration/cases/call_per_element_false/CSharp_call.cs
+++ b/tests/integration/cases/call_per_element_false/CSharp_call.cs
@@ -1,2 +1,6 @@
-dynamic process(dynamic _a0) => null;
+class Check {
+static object process(object data = null) => null;
+    public static void Main() {
 process(1);
+    }
+}

--- a/tests/integration/cases/call_ref_args/CSharp_call.cs
+++ b/tests/integration/cases/call_ref_args/CSharp_call.cs
@@ -1,5 +1,7 @@
 using System;
-dynamic process(dynamic _a0, dynamic _a1) => null;
+class Check {
+static object process(object data = null, object count = null) => null;
+    public static void Main() {
 var my_var = (
     1,
     2,
@@ -12,3 +14,5 @@ var my_other = (
 );
 process(my_var, 42);
 process(my_other, 7);
+    }
+}

--- a/tests/integration/cases/call_scalar_args/CSharp_call.cs
+++ b/tests/integration/cases/call_scalar_args/CSharp_call.cs
@@ -1,5 +1,9 @@
 using System;
-dynamic process(dynamic _a0) => null;
+class Check {
+static object process(object value = null) => null;
+    public static void Main() {
 process("hello");
 process(42);
 process(true);
+    }
+}

--- a/tests/integration/cases/call_transform_no_wrapper/CSharp_call.cs
+++ b/tests/integration/cases/call_transform_no_wrapper/CSharp_call.cs
@@ -1,5 +1,9 @@
 using System;
-dynamic process(dynamic _a0) => null;
+class Check {
+static object process(object value = null) => null;
+    public static void Main() {
 process("hello");
 process(42);
 process(true);
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #1411. The Roslyn host at `.github/scripts/lint-csharp/Program.cs` only validated `Emit` success, so runtime failures (undefined member access on an empty `ExpandoObject`, uninitialized static/instance fields, etc.) slipped past CI.
- The host now invokes the emitted assembly's entry point and forces `Check.cctor` plus instance construction, so top-level-statement fixtures and `class Check { ... Main() {} }` fixtures alike actually execute their initializers.
- The C# call-stub emitter (`src/literalizer/languages/csharp.py`) was switched from `dynamic x = new ExpandoObject()` to Java/Kotlin-style typed stub classes, and `wrap_in_file` wraps call scenarios in `class Check { ...stubs... static void Main() { ...calls... } }` because C# requires type declarations to follow top-level statements.
- All 11 `tests/integration/cases/call_*/CSharp_call.cs` fixtures were regenerated via `pytest --regen-all`; the 6 previously unrunnable ones now execute end-to-end.

## Test plan

- [x] `uv run --extra=dev pytest tests/` — 1021 passed, 13924 subtests passed.
- [x] Built the Roslyn host locally and piped all 319 `.cs` fixtures through it — exit 0, no runtime errors.
- [x] `prek` pre-commit + pre-push hooks pass on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now executes emitted C# fixture assemblies (not just compile-check), which can introduce new lint failures and alters the fixture execution surface. The C# call-stub codegen was reworked (dynamic-to-typed stubs + wrapping), which could affect generated fixture correctness across call scenarios.
> 
> **Overview**
> C# fixture linting now runs the compiled in-memory assembly to catch *runtime* failures (e.g., missing stub members), not just `Roslyn.Emit` success, and reports unwrapped underlying exceptions for clearer failures.
> 
> C# call-stub generation switches from `dynamic ExpandoObject`-based dispatch to emitted typed stub classes with explicit (named, defaulted) parameters, and call fixtures are wrapped into a `class Check` with a `Main` so stub type declarations can coexist with executable call statements.
> 
> Integration C# call fixtures were regenerated to match the new stub/wrapping strategy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8221baa7c3c1db3d9136ce688850a7ede1dc5bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->