### PR TITLE
Add literalize_call support to Erlang

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- ``Erlang`` now supports ``literalize_call``.  Calls use positional
+  argument syntax (``f(A, B)``); dotted targets like
+  ``app.client.fetch`` are emitted as quoted-atom function names
+  (``'app.client.fetch'(...)``) since Erlang atoms do not allow
+  unquoted dots.  Call stubs are emitted as module-level function
+  definitions placed between ``-export`` and ``x()``, and ``x()``
+  separates call statements with ``,`` terminated by ``.``.
 - ``ObjectiveC`` call stubs now emit ``k``-prefixed, title-cased root
   names for the ``static const struct`` globals that back dotted call
   targets, so a user-written ``throttler.check(...)`` literalizes to

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -38,7 +38,6 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -48,12 +47,12 @@ from literalizer._language import (
     HeterogeneousBehavior,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -97,6 +96,39 @@ def _format_datetime_erlang(value: datetime.datetime) -> str:
         f"{{{{{value.year}, {value.month}, {value.day}}}, "
         f"{{{value.hour}, {value.minute}, {value.second}}}}}"
     )
+
+
+@beartype
+def _erlang_format_call_target(name: str, /) -> str:
+    """Rewrite a call target for Erlang.
+
+    Dotted names like ``app.client.fetch`` are wrapped in single
+    quotes so they form a valid Erlang atom; bare names pass
+    through unchanged.
+    """
+    if "." in name:
+        return f"'{name}'"
+    return name
+
+
+@beartype
+def _erlang_call_stub(
+    name: str,
+    params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return an Erlang module-level function stub for a call name.
+
+    Dotted names like ``app.client.fetch`` are emitted as a quoted
+    atom so the generated function name is syntactically valid.  A
+    single stub is emitted per call name; unused arguments use the
+    ``_`` pattern so no per-argument naming is needed.
+    """
+    body = "ok" if stub_return is StubReturn.VOID else "undefined"
+    target = _erlang_format_call_target(name)
+    arg_list = ", ".join("_" for _ in params)
+    return (f"{target}({arg_list}) -> {body}.",)
 
 
 @beartype
@@ -331,6 +363,8 @@ class Erlang(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Erlang call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -355,20 +389,39 @@ class Erlang(metaclass=LanguageCls):
         variable_name: str,
         body_preamble: tuple[str, ...],
     ) -> str:
-        """Wrap an Erlang variable binding in a module function."""
-        content = prepend_body_preamble(
-            content=content,
-            body_preamble=body_preamble,
-        )
-        erlang_varname = variable_name[0].upper() + variable_name[1:]
-        indented = textwrap.indent(text=content, prefix="    ")
-        return (
-            f"-module(check).\n"
-            f"-export([x/0]).\n"
-            f"x() ->\n"
-            f"{indented},\n"
-            f"    {erlang_varname}."
-        )
+        """Wrap an Erlang snippet in a module function.
+
+        For the variable form, *body_preamble* lines are prepended
+        inside ``x()`` and the function returns the bound variable.
+        For the call form (empty *variable_name*), *body_preamble*
+        lines are treated as module-level function definitions
+        placed between ``-export`` and ``x()``; the call statements
+        in *content* are terminated with ``,`` via
+        :attr:`statement_terminator` and the trailing ``,`` is
+        rewritten to ``.`` so ``x()`` ends on a valid clause.
+        """
+        if variable_name:
+            body = prepend_body_preamble(
+                content=content,
+                body_preamble=body_preamble,
+            )
+            erlang_varname = variable_name[0].upper() + variable_name[1:]
+            indented = textwrap.indent(text=body, prefix="    ")
+            return (
+                f"-module(check).\n"
+                f"-export([x/0]).\n"
+                f"x() ->\n"
+                f"{indented},\n"
+                f"    {erlang_varname}."
+            )
+        trimmed = content.rstrip().removesuffix(",")
+        indented = textwrap.indent(text=trimmed, prefix="    ")
+        parts = ["-module(check).", "-export([x/0])."]
+        if body_preamble:
+            parts.extend(body_preamble)
+        parts.append("x() ->")
+        parts.append(f"{indented}.")
+        return "\n".join(parts)
 
     @staticmethod
     def wrap_combined_in_file(
@@ -402,6 +455,7 @@ class Erlang(metaclass=LanguageCls):
     numeric_style: NumericStyles = NumericStyles.OVERLOADED
     string_format: StringFormats = StringFormats.DOUBLE
     trailing_comma: TrailingCommas = TrailingCommas.NO
+    call_style: CallStyles = CallStyles.POSITIONAL
     line_ending: LineEndings = LineEndings.SEMICOLON
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
@@ -417,13 +471,10 @@ class Erlang(metaclass=LanguageCls):
     supports_collection_comments: ClassVar[bool] = True
     supports_scalar_before_comments: ClassVar[bool] = False
     supports_scalar_inline_comments: ClassVar[bool] = False
-    statement_terminator: ClassVar[str] = ""
+    statement_terminator: ClassVar[str] = ","
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -465,11 +516,16 @@ class Erlang(metaclass=LanguageCls):
         return no_type_hint_preamble
 
     @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for Erlang's call style."""
+        return self.call_style.value
+
+    @cached_property
     def format_call_stub(
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _erlang_call_stub
 
     @cached_property
     def format_call_preamble_stub(
@@ -483,7 +539,7 @@ class Erlang(metaclass=LanguageCls):
         """Rewrite a dotted call target into the language's call
         syntax.
         """
-        return identity_call_target
+        return _erlang_format_call_target
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -417,8 +417,7 @@ class Erlang(metaclass=LanguageCls):
         trimmed = content.rstrip().removesuffix(",")
         indented = textwrap.indent(text=trimmed, prefix="    ")
         parts = ["-module(check).", "-export([x/0])."]
-        if body_preamble:
-            parts.extend(body_preamble)
+        parts.extend(body_preamble)
         parts.append("x() ->")
         parts.append(f"{indented}.")
         return "\n".join(parts)

--- a/tests/integration/cases/call_deep_dotted_method/Erlang_call.erl
+++ b/tests/integration/cases/call_deep_dotted_method/Erlang_call.erl
@@ -1,0 +1,7 @@
+-module(check).
+-export([x/0]).
+'obj.api.client.post'(_) -> ok.
+x() ->
+    'obj.api.client.post'("hello"),
+    'obj.api.client.post'(42),
+    'obj.api.client.post'(true).

--- a/tests/integration/cases/call_deep_dotted_transformed/Erlang_call.erl
+++ b/tests/integration/cases/call_deep_dotted_transformed/Erlang_call.erl
@@ -1,0 +1,8 @@
+-module(check).
+-export([x/0]).
+'app.client.fetch'(_) -> undefined.
+emit(_) -> ok.
+x() ->
+    emit('app.client.fetch'("hello")),
+    emit('app.client.fetch'(42)),
+    emit('app.client.fetch'(true)).

--- a/tests/integration/cases/call_dotted_method/Erlang_call.erl
+++ b/tests/integration/cases/call_dotted_method/Erlang_call.erl
@@ -1,0 +1,7 @@
+-module(check).
+-export([x/0]).
+'app.client.fetch'(_) -> ok.
+x() ->
+    'app.client.fetch'("hello"),
+    'app.client.fetch'(42),
+    'app.client.fetch'(true).

--- a/tests/integration/cases/call_keyword_args/Erlang_call.erl
+++ b/tests/integration/cases/call_keyword_args/Erlang_call.erl
@@ -1,0 +1,7 @@
+-module(check).
+-export([x/0]).
+'throttler.check'(_, _) -> undefined.
+emit(_) -> ok.
+x() ->
+    emit('throttler.check'("user_1", 1000.0)),
+    emit('throttler.check'("user_2", 2000.5)).

--- a/tests/integration/cases/call_mixed_type_dicts/Erlang_call.erl
+++ b/tests/integration/cases/call_mixed_type_dicts/Erlang_call.erl
@@ -1,0 +1,6 @@
+-module(check).
+-export([x/0]).
+'app.mgr.op'(_) -> ok.
+x() ->
+    'app.mgr.op'(#{"type" => "create", "pr_id" => "pr_1", "draft" => true}),
+    'app.mgr.op'(#{"type" => "create", "pr_id" => "pr_2"}).

--- a/tests/integration/cases/call_multi_args/Erlang_call.erl
+++ b/tests/integration/cases/call_multi_args/Erlang_call.erl
@@ -1,0 +1,6 @@
+-module(check).
+-export([x/0]).
+process(_, _) -> ok.
+x() ->
+    process(1, 42),
+    process(2, 100).

--- a/tests/integration/cases/call_per_element_false/Erlang_call.erl
+++ b/tests/integration/cases/call_per_element_false/Erlang_call.erl
@@ -1,0 +1,5 @@
+-module(check).
+-export([x/0]).
+process(_) -> ok.
+x() ->
+    process(1).

--- a/tests/integration/cases/call_scalar_args/Erlang_call.erl
+++ b/tests/integration/cases/call_scalar_args/Erlang_call.erl
@@ -1,0 +1,7 @@
+-module(check).
+-export([x/0]).
+process(_) -> ok.
+x() ->
+    process("hello"),
+    process(42),
+    process(true).

--- a/tests/integration/cases/call_transform_no_wrapper/Erlang_call.erl
+++ b/tests/integration/cases/call_transform_no_wrapper/Erlang_call.erl
@@ -1,0 +1,7 @@
+-module(check).
+-export([x/0]).
+process(_) -> undefined.
+x() ->
+    process("hello"),
+    process(42),
+    process(true).

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,6 +41,7 @@ from literalizer.languages import (
     Dart,
     Dhall,
     Elm,
+    Erlang,
     Fortran,
     FSharp,
     Gleam,
@@ -2261,6 +2262,10 @@ _REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
         # site, but ``$ref`` emits the bare name at the call site —
         # unbound variable at load.
         CommonLisp,
+        # Variables are capitalized at the declaration site (``My_var =
+        # ...``) but ``$ref`` emits the bare name, which Erlang parses
+        # as a lowercase atom rather than the declared variable.
+        Erlang,
         # ``wrap_in_file`` places content inside ``main = do``; a
         # multi-line ``name = value`` binding needs ``let`` in a
         # do-block, which the harness does not inject.


### PR DESCRIPTION
## Summary

- Implements `literalize_call` for `Erlang` (closes #1117).  Positional-style calls; dotted targets like `app.client.fetch` become quoted atoms (`'app.client.fetch'(...)`) since Erlang atoms can't contain unquoted dots.  Call stubs are emitted as module-level function definitions between `-export` and `x()`, and `x()` separates statements with `,` terminated by `.`.
- Adds `Erlang` to `_REF_CASE_INCOMPATIBLE` because variables are capitalized at the declaration site (`My_var = ...`) but `$ref` emits the bare name.
- Adds 9 `Erlang_call.erl` golden fixtures (all compile under `erlc -Werror`) and a CHANGELOG entry.

## Test plan

- [x] `uv run pytest tests/` — 1030 passed, 371 skipped, 13924 subtests passed
- [x] `erlc -Werror` on all new Erlang goldens
- [x] `uv run ruff check .` and `uv run ty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Erlang code generation semantics (statement termination and file wrapping) and adds new call-stub/target rewriting logic that could affect existing Erlang golden outputs.
> 
> **Overview**
> Adds `literalize_call` support for `Erlang`, including positional call rendering, quoted-atom handling for dotted call targets (e.g. `'app.client.fetch'(...)`), and module-level function stubs that return `ok`/`undefined` based on `StubReturn`.
> 
> Updates Erlang wrapping so call-mode output can inject stubs at module scope and emit call statements separated by `,` and terminated with `.`. Integration coverage is expanded with new Erlang call golden fixtures, and `Erlang` is marked `_REF_CASE_INCOMPATIBLE` for ref-argument tests due to variable-name casing mismatches; CHANGELOG is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a697f8e9e3a59bf453de741dbc8550a404c1b370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->