### PR TITLE
Delete include_delimiters=False unit tests covered by integration

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -8,7 +8,6 @@ import pytest
 
 from literalizer import (
     InputFormat,
-    Language,
     NewVariable,
     literalize,
 )
@@ -20,40 +19,19 @@ from literalizer.exceptions import (
 )
 from literalizer.languages import (
     Cpp,
-    CSharp,
     Dhall,
     Go,
-    JavaScript,
     Mojo,
     Nix,
     Python,
     R,
-    Ruby,
 )
 
-CPP = Cpp(
-    date_format=Cpp.date_formats.CPP,
-    datetime_format=Cpp.datetime_formats.CPP,
-    bytes_format=Cpp.bytes_formats.HEX,
-    sequence_format=Cpp.sequence_formats.INITIALIZER_LIST,
-)
-CSHARP = CSharp(
-    date_format=CSharp.date_formats.CSHARP,
-    datetime_format=CSharp.datetime_formats.CSHARP,
-    bytes_format=CSharp.bytes_formats.HEX,
-    sequence_format=CSharp.sequence_formats.ARRAY,
-)
 GO = Go(
     date_format=Go.date_formats.GO,
     datetime_format=Go.datetime_formats.GO,
     bytes_format=Go.bytes_formats.HEX,
     sequence_format=Go.sequence_formats.SLICE,
-)
-JAVASCRIPT = JavaScript(
-    date_format=JavaScript.date_formats.JS,
-    datetime_format=JavaScript.datetime_formats.JS,
-    bytes_format=JavaScript.bytes_formats.HEX,
-    sequence_format=JavaScript.sequence_formats.ARRAY,
 )
 PYTHON = Python(
     date_format=Python.date_formats.PYTHON,
@@ -62,12 +40,6 @@ PYTHON = Python(
     sequence_format=Python.sequence_formats.TUPLE,
     set_format=Python.set_formats.SET,
     variable_type_hints=Python.variable_type_hints_formats.AUTO,
-)
-RUBY = Ruby(
-    date_format=Ruby.date_formats.RUBY,
-    datetime_format=Ruby.datetime_formats.RUBY,
-    bytes_format=Ruby.bytes_formats.HEX,
-    sequence_format=Ruby.sequence_formats.ARRAY,
 )
 
 
@@ -97,104 +69,6 @@ def test_dict_empty_no_delimiters() -> None:
         include_delimiters=False,
     )
     assert result.code == ""
-
-
-def test_integers() -> None:
-    """Integer values are rendered literally."""
-    result = literalize(
-        source=json.dumps(obj=[42, 0, -7]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        42,
-        0,
-        -7,"""
-    )
-    assert result.code == expected
-
-
-def test_floats() -> None:
-    """Float values are rendered literally."""
-    result = literalize(
-        source=json.dumps(obj=[1000.0, 3.14]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    expected = textwrap.dedent(
-        text="""\
-        1000.0,
-        3.14,"""
-    )
-    assert result.code == expected
-
-
-def test_string_escaping() -> None:
-    """Special characters in strings are properly escaped."""
-    result = literalize(
-        source=json.dumps(obj=['say "hi"', "a\\b", "line1\nline2"]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    lines = result.code.split(sep="\n")
-    assert lines[0] == '"say \\"hi\\"",'
-    assert lines[1] == '"a\\\\b",'
-    assert lines[2] == '"line1\\nline2",'
-
-
-def test_nested_arrays() -> None:
-    """Nested arrays are rendered recursively."""
-    result = literalize(
-        source=json.dumps(obj=[[[1, 2], [3, 4]]]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    assert result.code == "((1, 2), (3, 4)),"
-
-
-def test_dicts() -> None:
-    """Dicts inside a list are rendered inline."""
-    result = literalize(
-        source=json.dumps(obj=[{"name": "alice", "age": 30}]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    assert result.code == '{"name": "alice", "age": 30},'
-
-
-def test_nested_dict_in_sequence() -> None:
-    """A dict nested inside a sequence is rendered inline."""
-    result = literalize(
-        source=json.dumps(obj=[["a", {"x": 1}]]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    assert result.code == '("a", {"x": 1}),'
-
-
-def test_nested_sequence_in_dict() -> None:
-    """A sequence nested inside a dict is rendered inline."""
-    result = literalize(
-        source=json.dumps(obj=[{"items": [1, 2]}]),
-        input_format=InputFormat.JSON,
-        language=PYTHON,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    assert result.code == '{"items": (1, 2)},'
 
 
 def test_indent_spaces() -> None:
@@ -254,36 +128,6 @@ def test_empty_list_no_delimiters() -> None:
         include_delimiters=False,
     )
     assert result.code == ""
-
-
-@pytest.mark.parametrize(
-    argnames=("json_string", "language", "expected"),
-    argvalues=[
-        ("42", PYTHON, "42"),
-        ("3.14", PYTHON, "3.14"),
-        ('"hello"', PYTHON, '"hello"'),
-        ("true", PYTHON, "True"),
-        ("false", PYTHON, "False"),
-        ("null", PYTHON, "None"),
-        ("true", JAVASCRIPT, "true"),
-        ("null", CSHARP, "(object?)null"),
-        ("null", GO, "nil"),
-        ("null", RUBY, "nil"),
-        ("null", CPP, "nullptr"),
-    ],
-)
-def test_scalar(
-    *, json_string: str, language: Language, expected: str
-) -> None:
-    """Scalar values are formatted as native literals."""
-    result = literalize(
-        source=json_string,
-        input_format=InputFormat.JSON,
-        language=language,
-        pre_indent_level=0,
-        include_delimiters=False,
-    )
-    assert result.code == expected
 
 
 def test_scalar_with_indent() -> None:


### PR DESCRIPTION
## Summary

- Delete eight tests from `tests/test_json.py` whose data shapes are already exercised by the integration golden-file suite (`int_list`, `float_list`, `nested_sequence`, `sequence_of_dicts`, `scalar_*`, etc.).
- The `include_delimiters=False` branch is a trivial strip of the `=True` output, adequately verified by the remaining unit tests that cover unique aspects (empty data, non-zero `pre_indent_level`, parse errors).

## Test plan

- [x] `uv run pytest tests/` — 458 unit tests pass
- [x] `uv run pytest tests/integration` — 542 tests, 13924 subtests pass
- [x] `uv run ruff check`, `mypy`, `pyright`, `pylint` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only delete/trim test coverage and do not modify production code. Main risk is reduced unit-level regression detection for scalar/sequence formatting across some languages.
> 
> **Overview**
> Removes several `tests/test_json.py` unit tests that exercised scalar and common collection shapes (ints/floats/strings, nested arrays/dicts, and multi-language scalar formatting) with `include_delimiters=False`, relying on the integration golden tests for those cases.
> 
> Cleans up unused language fixtures/imports (e.g., `CSharp`, `JavaScript`, `Ruby`, and `Language`) while retaining targeted unit coverage for indentation, empty collections, and JSON parse error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b3118110ee2691d8d6a0ed9b802d7ecb87ec05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->