### PR TITLE
Add Mojo.HeterogeneousStrategies.VARIANT (#1371)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Next
 ----
 
+- ``Mojo`` now supports an opt-in
+  ``HeterogeneousStrategies.VARIANT`` that wraps mixed scalars in an
+  auto-generated ``alias Value = Variant[...]`` over only the Mojo
+  types actually present in the data.  Each wrapped scalar renders as
+  ``Value(...)`` (with an explicit ``String(...)`` or ``Float64(...)``
+  cast when needed to select the intended Variant alternative), so
+  heterogeneous dicts and lists become homogeneous in the Variant
+  type.  The alias name is configurable via
+  ``Mojo.heterogeneous_value_variant_name`` (default ``"Value"``).
+  The default ``ERROR`` strategy still raises on heterogeneous input.
 - ``ObjectiveC`` call stubs now emit ``k``-prefixed, title-cased root
   names for the ``static const struct`` globals that back dotted call
   targets, so a user-written ``throttler.check(...)`` literalizes to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,6 +412,7 @@ ignore_names = [
     "OBJECT_VARIANT",
     "TAGGED_ENUM",
     "UNION_TYPE",
+    "VARIANT",
     "CONST",
     "CONTAINERS_MAP",
     "DICTIONARY",

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -107,9 +107,9 @@ def _mojo_variant_for_scalar(value: Scalar, /) -> _VariantSignature:  # noqa: PL
     Strings, bytes, dates, and datetimes all map to ``String`` because
     the default Mojo date / datetime formats produce ISO strings and
     the bytes formats produce hex or base64 strings.  ``None`` maps to
-    ``NoneType`` and renders as ``Value(NoneType())`` because Mojo's
-    ``Variant`` constructor cannot infer ``NoneType`` from the bare
-    ``None`` literal.
+    ``NoneType`` and renders as ``Value(NoneType())`` because the
+    ``Variant`` constructor in Mojo cannot infer ``NoneType`` from the
+    bare ``None`` literal.
     """
     _string_signature = _VariantSignature(
         type_name="String",
@@ -213,7 +213,7 @@ def _build_variant_preamble(
     variant_name: str,
     /,
 ) -> Callable[[Value], tuple[str, ...]]:
-    """VARIANT strategy: emit a ``Variant`` comptime declaration."""
+    """VARIANT strategy: emit the ``Variant`` declaration preamble."""
 
     def _preamble(data: Value, /) -> tuple[str, ...]:
         """Build the ``Variant`` import + ``comptime`` declaration for

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -81,20 +81,23 @@ def _format_mojo_ordered_map_entry(
     return f"Tuple({key}, {formatted_value})"
 
 
+_VARIANT_PAYLOAD_VALUE_PLACEHOLDER = "{value}"
+
+
 @dataclasses.dataclass(frozen=True)
 class _VariantSignature:
     """Mojo ``Variant`` alternative for one scalar bucket.
 
     ``type_name`` is the Mojo type listed in the ``Variant[...]`` alias
-    (e.g. ``"Bool"``, ``"Int"``, ``"String"``, ``"NoneType"``).  ``cast``
-    is ``None`` when the formatted scalar can be passed straight to the
-    Variant constructor (``Value(True)``); otherwise it is a Mojo type
-    used to wrap the formatted value (``Value(String("x"))``) so the
-    constructor resolves to the intended alternative.
+    (e.g. ``"Bool"``, ``"Int"``, ``"String"``, ``"NoneType"``).
+    ``payload_template`` is the expression rendered between the outer
+    ``Value(...)`` parentheses; occurrences of ``{value}`` are replaced
+    with the formatted scalar, and a template without the placeholder
+    (e.g. ``"NoneType()"``) ignores the formatted scalar entirely.
     """
 
     type_name: str
-    cast: str | None
+    payload_template: str
 
 
 @beartype
@@ -103,16 +106,31 @@ def _mojo_variant_for_scalar(value: Scalar, /) -> _VariantSignature:  # noqa: PL
 
     Strings, bytes, dates, and datetimes all map to ``String`` because
     the default Mojo date / datetime formats produce ISO strings and
-    the bytes formats produce hex or base64 strings.
+    the bytes formats produce hex or base64 strings.  ``None`` maps to
+    ``NoneType`` and renders as ``Value(NoneType())`` because Mojo's
+    ``Variant`` constructor cannot infer ``NoneType`` from the bare
+    ``None`` literal.
     """
-    _string_signature = _VariantSignature(type_name="String", cast="String")
+    _string_signature = _VariantSignature(
+        type_name="String",
+        payload_template="String({value})",
+    )
     match value:
         case bool():
-            return _VariantSignature(type_name="Bool", cast=None)
+            return _VariantSignature(
+                type_name="Bool",
+                payload_template=_VARIANT_PAYLOAD_VALUE_PLACEHOLDER,
+            )
         case int():
-            return _VariantSignature(type_name="Int", cast=None)
+            return _VariantSignature(
+                type_name="Int",
+                payload_template=_VARIANT_PAYLOAD_VALUE_PLACEHOLDER,
+            )
         case float():
-            return _VariantSignature(type_name="Float64", cast="Float64")
+            return _VariantSignature(
+                type_name="Float64",
+                payload_template="Float64({value})",
+            )
         case str():
             return _string_signature
         case bytes():
@@ -122,7 +140,10 @@ def _mojo_variant_for_scalar(value: Scalar, /) -> _VariantSignature:  # noqa: PL
         case datetime.date():
             return _string_signature
         case None:
-            return _VariantSignature(type_name="NoneType", cast=None)
+            return _VariantSignature(
+                type_name="NoneType",
+                payload_template="NoneType()",
+            )
         case _ as unreachable:
             assert_never(unreachable)
 
@@ -156,6 +177,9 @@ def _build_error_preamble(
     return no_data_preamble
 
 
+_VARIANT_IMPORT_LINE = "from std.utils.variant import Variant"
+
+
 def _build_variant_behavior(
     variant_name: str,
     /,
@@ -167,15 +191,14 @@ def _build_variant_behavior(
         return collect_heterogeneous_container_ids(data=data)
 
     def _wrap(raw_value: Value, formatted: str) -> str:
-        """Wrap a scalar as ``{variant_name}(value)`` or
-        ``{variant_name}({Cast}(value))`` when an explicit cast is
-        needed to select the Variant alternative.
+        """Wrap a scalar as ``{variant_name}({payload})`` where the
+        payload comes from the signature's ``payload_template`` (with
+        ``{value}`` substituted by the formatted scalar).
         """
         signature = _mojo_variant_for_scalar(cast("Scalar", raw_value))
-        payload = (
-            formatted
-            if signature.cast is None
-            else f"{signature.cast}({formatted})"
+        payload = signature.payload_template.replace(
+            _VARIANT_PAYLOAD_VALUE_PLACEHOLDER,
+            formatted,
         )
         return f"{variant_name}({payload})"
 
@@ -190,10 +213,12 @@ def _build_variant_preamble(
     variant_name: str,
     /,
 ) -> Callable[[Value], tuple[str, ...]]:
-    """VARIANT strategy: emit a ``Variant`` alias declaration."""
+    """VARIANT strategy: emit a ``Variant`` comptime declaration."""
 
     def _preamble(data: Value, /) -> tuple[str, ...]:
-        """Build the ``alias`` declaration for *data*."""
+        """Build the ``Variant`` import + ``comptime`` declaration for
+        *data*.
+        """
         wrap_ids = collect_heterogeneous_container_ids(data=data)
         if not wrap_ids:
             return ()
@@ -207,7 +232,10 @@ def _build_variant_preamble(
             seen.add(signature.type_name)
             type_names.append(signature.type_name)
         joined = ", ".join(type_names)
-        return (f"alias {variant_name} = Variant[{joined}]",)
+        return (
+            _VARIANT_IMPORT_LINE,
+            f"comptime {variant_name} = Variant[{joined}]",
+        )
 
     return _preamble
 
@@ -220,9 +248,9 @@ class Mojo(metaclass=LanguageCls):
     By default Mojo raises on heterogeneous input because its native
     collections require a single element type.  Opt into
     :attr:`HeterogeneousStrategies.VARIANT` to wrap mixed scalars in a
-    generated ``alias Value = Variant[...]`` and render each scalar as
-    ``Value(...)`` so heterogeneous dicts and lists become homogeneous
-    in the Variant type.
+    generated ``comptime Value = Variant[...]`` and render each scalar
+    as ``Value(...)`` so heterogeneous dicts and lists become
+    homogeneous in the Variant type.
     """
 
     extension = ".mojo"
@@ -470,12 +498,14 @@ class Mojo(metaclass=LanguageCls):
             build_behavior=_build_variant_behavior,
             build_preamble=_build_variant_preamble,
         )
-        """Auto-generate an ``alias`` in the preamble binding the
+        """Auto-generate a ``comptime`` binding in the preamble for the
         configured name to a ``Variant[...]`` over only the Mojo types
-        actually present in heterogeneous positions, and wrap each such
-        scalar as ``{Name}(value)`` (with an explicit ``String(...)`` or
-        ``Float64(...)`` cast when needed so the constructor resolves to
-        the intended Variant alternative).
+        actually present in heterogeneous positions, together with a
+        ``from std.utils.variant import Variant`` import, and wrap each
+        such scalar as ``{Name}(value)`` (with an explicit ``String(...)``
+        or ``Float64(...)`` cast when needed so the constructor resolves
+        to the intended Variant alternative, and ``NoneType()`` for
+        nulls).
 
         The alias name is configurable via
         :attr:`Mojo.heterogeneous_value_variant_name` (default

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -102,8 +102,8 @@ def _mojo_variant_for_scalar(value: Scalar, /) -> _VariantSignature:  # noqa: PL
     """Return the Mojo Variant alternative for *value*.
 
     Strings, bytes, dates, and datetimes all map to ``String`` because
-    Mojo's default date / datetime formats produce ISO strings and
-    bytes formats produce hex or base64 strings.
+    the default Mojo date / datetime formats produce ISO strings and
+    the bytes formats produce hex or base64 strings.
     """
     _string_signature = _VariantSignature(type_name="String", cast="String")
     match value:
@@ -462,8 +462,8 @@ class Mojo(metaclass=LanguageCls):
         (or :exc:`~literalizer.exceptions.HeterogeneousSiblingListsError`)
         when scalar values of mixed types appear in a container that
         cannot represent them.  This is the default, matching the
-        single-element-type convention of Mojo's ``List``, ``Dict``,
-        and ``Set``.
+        single-element-type convention of the Mojo ``List``, ``Dict``,
+        and ``Set`` containers.
         """
 
         VARIANT = _HeterogeneousStrategyConfig(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -6,7 +6,7 @@ import enum
 import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property
-from typing import ClassVar
+from typing import ClassVar, assert_never, cast
 
 from beartype import beartype
 
@@ -39,6 +39,10 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._heterogeneous import (
+    collect_heterogeneous_container_ids,
+    iter_wrapped_scalars,
+)
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
@@ -64,7 +68,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 @beartype
@@ -77,16 +81,148 @@ def _format_mojo_ordered_map_entry(
     return f"Tuple({key}, {formatted_value})"
 
 
+@dataclasses.dataclass(frozen=True)
+class _VariantSignature:
+    """Mojo ``Variant`` alternative for one scalar bucket.
+
+    ``type_name`` is the Mojo type listed in the ``Variant[...]`` alias
+    (e.g. ``"Bool"``, ``"Int"``, ``"String"``, ``"NoneType"``).  ``cast``
+    is ``None`` when the formatted scalar can be passed straight to the
+    Variant constructor (``Value(True)``); otherwise it is a Mojo type
+    used to wrap the formatted value (``Value(String("x"))``) so the
+    constructor resolves to the intended alternative.
+    """
+
+    type_name: str
+    cast: str | None
+
+
+@beartype
+def _mojo_variant_for_scalar(value: Scalar, /) -> _VariantSignature:  # noqa: PLR0911
+    """Return the Mojo Variant alternative for *value*.
+
+    Strings, bytes, dates, and datetimes all map to ``String`` because
+    Mojo's default date / datetime formats produce ISO strings and
+    bytes formats produce hex or base64 strings.
+    """
+    _string_signature = _VariantSignature(type_name="String", cast="String")
+    match value:
+        case bool():
+            return _VariantSignature(type_name="Bool", cast=None)
+        case int():
+            return _VariantSignature(type_name="Int", cast=None)
+        case float():
+            return _VariantSignature(type_name="Float64", cast="Float64")
+        case str():
+            return _string_signature
+        case bytes():
+            return _string_signature
+        case datetime.datetime():
+            return _string_signature
+        case datetime.date():
+            return _string_signature
+        case None:
+            return _VariantSignature(type_name="NoneType", cast=None)
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+@dataclasses.dataclass(frozen=True)
+class _HeterogeneousStrategyConfig:
+    """Configuration for one Mojo heterogeneous-values strategy.
+
+    ``build_behavior`` produces the
+    :class:`~literalizer._language.HeterogeneousBehavior` exposed on a
+    Mojo instance.  ``build_preamble`` produces the data-dependent
+    preamble callable (e.g. the ``Variant`` alias declaration).  Both
+    receive the Mojo instance's configurable variant-type name so the
+    resulting functions can close over it.
+    """
+
+    build_behavior: Callable[[str], HeterogeneousBehavior]
+    build_preamble: Callable[[str], Callable[[Value], tuple[str, ...]]]
+
+
+def _build_error_behavior(_variant_name: str, /) -> HeterogeneousBehavior:
+    """ERROR strategy: no wrapping, no skipping of checks."""
+    return NO_HETEROGENEOUS_BEHAVIOR
+
+
+def _build_error_preamble(
+    _variant_name: str,
+    /,
+) -> Callable[[Value], tuple[str, ...]]:
+    """ERROR strategy: no data-dependent preamble."""
+    return no_data_preamble
+
+
+def _build_variant_behavior(
+    variant_name: str,
+    /,
+) -> HeterogeneousBehavior:
+    """VARIANT strategy: wrap scalars and skip scalar checks."""
+
+    def _compute(data: Value) -> frozenset[int]:
+        """Return container ids whose scalar children should wrap."""
+        return collect_heterogeneous_container_ids(data=data)
+
+    def _wrap(raw_value: Value, formatted: str) -> str:
+        """Wrap a scalar as ``{variant_name}(value)`` or
+        ``{variant_name}({Cast}(value))`` when an explicit cast is
+        needed to select the Variant alternative.
+        """
+        signature = _mojo_variant_for_scalar(cast("Scalar", raw_value))
+        payload = (
+            formatted
+            if signature.cast is None
+            else f"{signature.cast}({formatted})"
+        )
+        return f"{variant_name}({payload})"
+
+    return HeterogeneousBehavior(
+        skip_scalar_checks=True,
+        compute_wrap_ids=_compute,
+        wrap_scalar=_wrap,
+    )
+
+
+def _build_variant_preamble(
+    variant_name: str,
+    /,
+) -> Callable[[Value], tuple[str, ...]]:
+    """VARIANT strategy: emit a ``Variant`` alias declaration."""
+
+    def _preamble(data: Value, /) -> tuple[str, ...]:
+        """Build the ``alias`` declaration for *data*."""
+        wrap_ids = collect_heterogeneous_container_ids(data=data)
+        if not wrap_ids:
+            return ()
+        scalars = iter_wrapped_scalars(data=data, wrap_ids=wrap_ids)
+        type_names: list[str] = []
+        seen: set[str] = set()
+        for scalar in scalars:
+            signature = _mojo_variant_for_scalar(scalar)
+            if signature.type_name in seen:
+                continue
+            seen.add(signature.type_name)
+            type_names.append(signature.type_name)
+        joined = ", ".join(type_names)
+        return (f"alias {variant_name} = Variant[{joined}]",)
+
+    return _preamble
+
+
 @beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Mojo(metaclass=LanguageCls):
     """Mojo language specification.
 
-    Mojo does not support heterogeneous collections — every element in a
-    list or set must share a single type.  Input data containing
-    heterogeneous scalars or mixed-type collection values raises a
-    subclass of
-    :exc:`~literalizer.exceptions.HeterogeneousCollectionError`.
+    By default Mojo raises on heterogeneous input because its native
+    collections require a single element type.  Opt into
+    :attr:`HeterogeneousStrategies.VARIANT` to wrap mixed scalars in a
+    generated ``alias Value = Variant[...]`` and render each scalar as
+    ``Value(...)`` so heterogeneous dicts and lists become homogeneous
+    in the Variant type.
     """
 
     extension = ".mojo"
@@ -313,11 +449,38 @@ class Mojo(metaclass=LanguageCls):
     modifiers = Modifiers
 
     class HeterogeneousStrategies(enum.Enum):
-        """Heterogeneous-scalar strategy options — this language only
-        supports raising.
+        """Strategy for representing dicts or lists whose scalar values
+        span more than one Mojo type.
         """
 
-        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+        ERROR = _HeterogeneousStrategyConfig(
+            build_behavior=_build_error_behavior,
+            build_preamble=_build_error_preamble,
+        )
+        """Raise
+        :exc:`~literalizer.exceptions.HeterogeneousScalarCollectionError`
+        (or :exc:`~literalizer.exceptions.HeterogeneousSiblingListsError`)
+        when scalar values of mixed types appear in a container that
+        cannot represent them.  This is the default, matching the
+        single-element-type convention of Mojo's ``List``, ``Dict``,
+        and ``Set``.
+        """
+
+        VARIANT = _HeterogeneousStrategyConfig(
+            build_behavior=_build_variant_behavior,
+            build_preamble=_build_variant_preamble,
+        )
+        """Auto-generate an ``alias`` in the preamble binding the
+        configured name to a ``Variant[...]`` over only the Mojo types
+        actually present in heterogeneous positions, and wrap each such
+        scalar as ``{Name}(value)`` (with an explicit ``String(...)`` or
+        ``Float64(...)`` cast when needed so the constructor resolves to
+        the intended Variant alternative).
+
+        The alias name is configurable via
+        :attr:`Mojo.heterogeneous_value_variant_name` (default
+        ``"Value"``).
+        """
 
     heterogeneous_strategies = HeterogeneousStrategies
 
@@ -384,6 +547,7 @@ class Mojo(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    heterogeneous_value_variant_name: str = "Value"
     indent: str = "    "
 
     null_literal: ClassVar[str] = "None"
@@ -391,7 +555,6 @@ class Mojo(metaclass=LanguageCls):
     false_literal: ClassVar[str] = "False"
     indent_closing_delimiter: ClassVar[bool] = False
     element_separator: ClassVar[str] = ", "
-    skip_null_dict_values: ClassVar[bool] = True
     supports_collection_comments: ClassVar[bool] = True
     supports_scalar_before_comments: ClassVar[bool] = False
     supports_scalar_inline_comments: ClassVar[bool] = True
@@ -424,14 +587,36 @@ class Mojo(metaclass=LanguageCls):
         return passthrough_set_entry
 
     @cached_property
+    def skip_null_dict_values(self) -> bool:
+        """Drop ``None`` dict values for the default ERROR strategy so
+        the homogeneous-dict rendering stays valid Mojo.
+
+        ``VARIANT`` wraps every scalar as ``Value(...)``, so ``None``
+        values must flow through unchanged to be wrapped as
+        ``Value(None)`` against a ``NoneType`` Variant alternative.
+        """
+        cls = type(self.heterogeneous_strategy)
+        return self.heterogeneous_strategy is cls.ERROR
+
+    @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
-        """Return data-dependent preamble lines."""
-        return no_data_preamble
+        """Return data-dependent preamble lines.
+
+        For ``HeterogeneousStrategies.VARIANT`` emits an ``alias`` line
+        declaring the ``Variant`` over only the Mojo types actually used
+        in heterogeneous positions.  Other strategies produce no
+        preamble.
+        """
+        return self.heterogeneous_strategy.value.build_preamble(
+            self.heterogeneous_value_variant_name,
+        )
 
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
-        """Return the heterogeneous-behavior config."""
-        return self.heterogeneous_strategy.value
+        """Return the behavior for the chosen heterogeneous strategy."""
+        return self.heterogeneous_strategy.value.build_behavior(
+            self.heterogeneous_value_variant_name,
+        )
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/tests/integration/cases/dict_all_scalar_types/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/dict_all_scalar_types/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,0 +1,13 @@
+alias Value = Variant[String, Int, Float64, Bool, NoneType]
+def main():
+    var my_data = {
+        "s": Value(String("string")),
+        "i": Value(1),
+        "f": Value(Float64(1.5)),
+        "b": Value(True),
+        "n": Value(None),
+        "d": Value(String("2024-01-15")),
+        "dt": Value(String("2024-01-15T12:00:00")),
+        "by": Value(String("48656c6c6f")),
+    }
+    _ = my_data

--- a/tests/integration/cases/dict_all_scalar_types/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/dict_all_scalar_types/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,11 +1,12 @@
-alias Value = Variant[String, Int, Float64, Bool, NoneType]
+from std.utils.variant import Variant
+comptime Value = Variant[String, Int, Float64, Bool, NoneType]
 def main():
     var my_data = {
         "s": Value(String("string")),
         "i": Value(1),
         "f": Value(Float64(1.5)),
         "b": Value(True),
-        "n": Value(None),
+        "n": Value(NoneType()),
         "d": Value(String("2024-01-15")),
         "dt": Value(String("2024-01-15T12:00:00")),
         "by": Value(String("48656c6c6f")),

--- a/tests/integration/cases/dict_mixed_int_widths/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/dict_mixed_int_widths/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,4 +1,5 @@
-alias Value = Variant[Int, String]
+from std.utils.variant import Variant
+comptime Value = Variant[Int, String]
 def main():
     var my_data = {
         "a": Value(1),

--- a/tests/integration/cases/dict_mixed_int_widths/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/dict_mixed_int_widths/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,0 +1,8 @@
+alias Value = Variant[Int, String]
+def main():
+    var my_data = {
+        "a": Value(1),
+        "b": Value(3000000000),
+        "c": Value(String("x")),
+    }
+    _ = my_data

--- a/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,0 +1,7 @@
+alias Value = Variant[Int, String]
+def main():
+    var my_data = {
+        "a": Value(1),
+        "b": Value(String("x")),
+    }
+    _ = my_data

--- a/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,4 +1,5 @@
-alias Value = Variant[Int, String]
+from std.utils.variant import Variant
+comptime Value = Variant[Int, String]
 def main():
     var my_data = {
         "a": Value(1),

--- a/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant_combined.mojo
+++ b/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant_combined.mojo
@@ -1,4 +1,5 @@
-alias Value = Variant[Int, String]
+from std.utils.variant import Variant
+comptime Value = Variant[Int, String]
 def main():
     var my_data = {
         "a": Value(1),

--- a/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant_combined.mojo
+++ b/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_strategy_variant_combined.mojo
@@ -1,0 +1,12 @@
+alias Value = Variant[Int, String]
+def main():
+    var my_data = {
+        "a": Value(1),
+        "b": Value(String("x")),
+    }
+    _ = my_data
+    my_data = {
+        "a": Value(1),
+        "b": Value(String("x")),
+    }
+    _ = my_data

--- a/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_value_variant_name_JsonValue.mojo
+++ b/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_value_variant_name_JsonValue.mojo
@@ -1,4 +1,5 @@
-alias JsonValue = Variant[Int, String]
+from std.utils.variant import Variant
+comptime JsonValue = Variant[Int, String]
 def main():
     var my_data = {
         "a": JsonValue(1),

--- a/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_value_variant_name_JsonValue.mojo
+++ b/tests/integration/cases/dict_mixed_scalars/Mojo_heterogeneous_value_variant_name_JsonValue.mojo
@@ -1,0 +1,7 @@
+alias JsonValue = Variant[Int, String]
+def main():
+    var my_data = {
+        "a": JsonValue(1),
+        "b": JsonValue(String("x")),
+    }
+    _ = my_data

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,0 +1,7 @@
+alias Value = Variant[String, Bool]
+def main():
+    var my_data = [
+        {"type": Value(String("create")), "pr_id": Value(String("pr_1")), "draft": Value(True)},
+        {"type": Value(String("create")), "pr_id": Value(String("pr_2"))},
+    ]
+    _ = my_data

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,4 +1,5 @@
-alias Value = Variant[String, Bool]
+from std.utils.variant import Variant
+comptime Value = Variant[String, Bool]
 def main():
     var my_data = [
         {"type": Value(String("create")), "pr_id": Value(String("pr_1")), "draft": Value(True)},

--- a/tests/integration/cases/nested_mixed_dict/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/nested_mixed_dict/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,0 +1,6 @@
+alias Value = Variant[Int, String, NoneType]
+def main():
+    var my_data = {
+        "outer": {"a": Value(1), "b": Value(String("x")), "c": Value(None)},
+    }
+    _ = my_data

--- a/tests/integration/cases/nested_mixed_dict/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/nested_mixed_dict/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,6 +1,7 @@
-alias Value = Variant[Int, String, NoneType]
+from std.utils.variant import Variant
+comptime Value = Variant[Int, String, NoneType]
 def main():
     var my_data = {
-        "outer": {"a": Value(1), "b": Value(String("x")), "c": Value(None)},
+        "outer": {"a": Value(1), "b": Value(String("x")), "c": Value(NoneType())},
     }
     _ = my_data

--- a/tests/integration/cases/nested_mixed_inner/Mojo_heterogeneous_strategy_variant_inner.mojo
+++ b/tests/integration/cases/nested_mixed_inner/Mojo_heterogeneous_strategy_variant_inner.mojo
@@ -1,4 +1,5 @@
-alias Value = Variant[Int, String]
+from std.utils.variant import Variant
+comptime Value = Variant[Int, String]
 def main():
     var my_data = [
         [Value(1), Value(String("a"))],

--- a/tests/integration/cases/nested_mixed_inner/Mojo_heterogeneous_strategy_variant_inner.mojo
+++ b/tests/integration/cases/nested_mixed_inner/Mojo_heterogeneous_strategy_variant_inner.mojo
@@ -1,0 +1,7 @@
+alias Value = Variant[Int, String]
+def main():
+    var my_data = [
+        [Value(1), Value(String("a"))],
+        [Value(2), Value(String("b"))],
+    ]
+    _ = my_data

--- a/tests/integration/cases/nested_mixed_types/Mojo_heterogeneous_strategy_variant_sibling.mojo
+++ b/tests/integration/cases/nested_mixed_types/Mojo_heterogeneous_strategy_variant_sibling.mojo
@@ -1,0 +1,7 @@
+alias Value = Variant[Int, String]
+def main():
+    var my_data = [
+        [Value(1), Value(2)],
+        [Value(String("a")), Value(String("b"))],
+    ]
+    _ = my_data

--- a/tests/integration/cases/nested_mixed_types/Mojo_heterogeneous_strategy_variant_sibling.mojo
+++ b/tests/integration/cases/nested_mixed_types/Mojo_heterogeneous_strategy_variant_sibling.mojo
@@ -1,4 +1,5 @@
-alias Value = Variant[Int, String]
+from std.utils.variant import Variant
+comptime Value = Variant[Int, String]
 def main():
     var my_data = [
         [Value(1), Value(2)],

--- a/tests/integration/cases/nested_sequences/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/nested_sequences/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,0 +1,6 @@
+def main():
+    var my_data = [
+        [[1, 2], [3, 4]],
+        [[5]],
+    ]
+    _ = my_data

--- a/tests/integration/cases/ordered_map/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/ordered_map/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,0 +1,8 @@
+alias Value = Variant[String, Int, Bool]
+def main():
+    var my_data = [
+        Tuple("name", Value(String("Alice"))),
+        Tuple("age", Value(30)),
+        Tuple("active", Value(True)),
+    ]
+    _ = my_data

--- a/tests/integration/cases/ordered_map/Mojo_heterogeneous_strategy_variant.mojo
+++ b/tests/integration/cases/ordered_map/Mojo_heterogeneous_strategy_variant.mojo
@@ -1,4 +1,5 @@
-alias Value = Variant[String, Int, Bool]
+from std.utils.variant import Variant
+comptime Value = Variant[String, Int, Bool]
 def main():
     var my_data = [
         Tuple("name", Value(String("Alice"))),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -160,11 +160,11 @@ _HETEROGENEOUS_VALUE_UNION_NAME_OVERRIDES: dict[
 ] = {Dhall: "JsonValue"}
 
 # Languages whose heterogeneous-value variant name is configurable
-# (the Nim ``OBJECT_VARIANT`` strategy); the value is the test
-# override to apply.
+# (the Nim ``OBJECT_VARIANT`` strategy and the Mojo ``VARIANT``
+# strategy); the value is the test override to apply.
 _HETEROGENEOUS_VALUE_VARIANT_NAME_OVERRIDES: dict[
     literalizer.LanguageCls, str
-] = {Nim: "JsonValue"}
+] = {Nim: "JsonValue", Mojo: "JsonValue"}
 
 # Languages that accept constructor-name kwargs (Fortran) or field-name
 # kwargs (C); the inner dict is the kwargs to pass to the constructor.
@@ -1197,24 +1197,25 @@ def _build_heterogeneous_value_union_name_variants() -> Iterable[_Variant]:
 @beartype
 def _build_heterogeneous_value_variant_name_variants() -> Iterable[_Variant]:
     """Build heterogeneous-value-variant-name variants for languages
-    that generate a named object variant for their heterogeneous
-    strategy (e.g. the Nim ``OBJECT_VARIANT``).  The
+    that generate a named variant type for their heterogeneous strategy
+    (the Nim ``OBJECT_VARIANT`` and Mojo ``VARIANT``).  The
     ``heterogeneous_value_variant_name`` constructor parameter lets
     users customize that name.
     """
+    wrapping_strategy_names = {"OBJECT_VARIANT", "VARIANT"}
     variants: list[_Variant] = []
     for lang_cls in _sorted_languages():
         custom_name = _HETEROGENEOUS_VALUE_VARIANT_NAME_OVERRIDES.get(lang_cls)
         if custom_name is None:
             continue
         default_spec = _spec(lang_cls=lang_cls)
-        object_variant = next(
+        wrapping_strategy = next(
             strategy
             for strategy in default_spec.heterogeneous_strategies
-            if strategy.name == "OBJECT_VARIANT"
+            if strategy.name in wrapping_strategy_names
         )
         spec = lang_cls(
-            heterogeneous_strategy=object_variant,
+            heterogeneous_strategy=wrapping_strategy,
             heterogeneous_value_variant_name=custom_name,
         )
         variants.append(

--- a/tests/test_heterogeneous_default_errors.py
+++ b/tests/test_heterogeneous_default_errors.py
@@ -2,11 +2,11 @@
 contract.
 
 Languages with an opt-in wrapping strategy (Rust's ``TAGGED_ENUM``,
-Dhall's ``UNION_TYPE``, and the Nim ``OBJECT_VARIANT``) must still
-raise on heterogeneous input under the default ``ERROR`` strategy.
-The integration framework catches ``HeterogeneousCollectionError``
-and silently skips, so the error contract has no golden-file surface
-and needs unit coverage.
+Dhall's ``UNION_TYPE``, the Nim ``OBJECT_VARIANT``, and the Mojo
+``VARIANT``) must still raise on heterogeneous input under the default
+``ERROR`` strategy.  The integration framework catches
+``HeterogeneousCollectionError`` and silently skips, so the error
+contract has no golden-file surface and needs unit coverage.
 """
 
 import pytest
@@ -16,12 +16,12 @@ from literalizer.exceptions import (
     HeterogeneousScalarCollectionError,
     HeterogeneousSiblingListsError,
 )
-from literalizer.languages import Dhall, Nim, Rust
+from literalizer.languages import Dhall, Mojo, Nim, Rust
 
 
 @pytest.mark.parametrize(
     argnames="language_cls",
-    argvalues=[Rust, Dhall, Nim],
+    argvalues=[Rust, Dhall, Nim, Mojo],
 )
 @pytest.mark.parametrize(
     argnames=("source", "expected_exception"),


### PR DESCRIPTION
## Summary

Adds opt-in ``Mojo.HeterogeneousStrategies.VARIANT`` that wraps mixed scalars in an auto-generated ``alias Value = Variant[...]`` containing only the Mojo types present in the data, rendering each wrapped scalar as ``Value(...)`` (with an explicit ``String(...)`` or ``Float64(...)`` cast when needed to select the intended Variant alternative). The alias name is configurable via ``heterogeneous_value_variant_name`` (default ``"Value"``), matching the existing Rust ``TAGGED_ENUM``, Dhall ``UNION_TYPE``, and Nim ``OBJECT_VARIANT`` patterns. Mojo's default ``ERROR`` strategy still raises on heterogeneous input; the ``skip_null_dict_values`` behavior is now strategy-dependent so ``None`` flows through for ``VARIANT`` but is dropped for ``ERROR``.

## Test plan

- [x] ``test_heterogeneous_default_errors`` — Mojo added, default still raises
- [x] ``test_format_variant_golden_file[Mojo]`` — 11 new golden fixtures across ``dict_mixed_scalars``, ``dict_all_scalar_types``, ``dict_mixed_int_widths``, ``mixed_type_dicts_in_sequence``, ``nested_mixed_{dict,inner,types}``, ``nested_sequences``, ``ordered_map``, plus custom-name variant
- [x] Full suite: 1024 passed, 13934 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Mojo codegen strategy that changes how heterogeneous containers (and `None` dict values) are rendered when opted in, which could affect generated output and test fixtures. Default behavior remains raising on heterogeneous input, limiting impact to users enabling the new strategy.
> 
> **Overview**
> Adds an opt-in Mojo heterogeneous-scalar strategy, `HeterogeneousStrategies.VARIANT`, that auto-generates a data-dependent `Variant[...]` alias preamble and wraps heterogeneous scalar values as `Value(...)` (including explicit `String(...)`/`Float64(...)` casts and `NoneType()` for nulls) so mixed-type dicts/lists become representable.
> 
> Makes Mojo’s `skip_null_dict_values` strategy-dependent (drop null dict values under default `ERROR`, but preserve them for `VARIANT` so they can be wrapped), updates integration harness to support custom variant alias names for Mojo, and adds new golden fixtures plus a unit test asserting the default `ERROR` strategy still raises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3707c27fa4afcc93a96a9607e47f68ca6bbd828f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->