### PR TITLE
Re-enable clang-tidy narrowing-conversions checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,11 +2,9 @@
 Checks: >
   *,
   -altera-struct-pack-align,
-  -bugprone-narrowing-conversions,
   -clang-analyzer-deadcode.DeadStores,
   -clang-diagnostic-implicitly-unsigned-literal,
   -cppcoreguidelines-avoid-magic-numbers,
-  -cppcoreguidelines-narrowing-conversions,
   -fuchsia-default-arguments-calls,
   -google-objc-function-naming,
   -google-runtime-int,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ Changelog
 Next
 ----
 
+- ``C`` generated output now routes positive integers above
+  ``LLONG_MAX`` (e.g. ``2**63``) through a new ``unsigned long long``
+  union field instead of narrowing them into the signed ``long long``
+  field.  The ``CVal`` union gains a ``u`` member alongside ``i``, and
+  a new ``uint_field`` constructor argument lets users rename it.
+  clang-tidy's ``bugprone-narrowing-conversions`` and
+  ``cppcoreguidelines-narrowing-conversions`` checks, previously
+  suppressed in ``.clang-tidy`` because the union-initializer literal
+  silently truncated those values, are now enforced for both ``C``
+  and ``Cpp`` output.
+- ``Cpp`` generated output now wraps the ``INFINITY`` and ``NAN``
+  ``<cmath>`` macros in ``static_cast<double>`` (with the negation
+  applied outside the cast for ``-INFINITY``) so that brace-init of
+  ``std::vector<double>`` does not trip clang-tidy's
+  narrowing-conversions check on the implicit ``float``-to-``double``
+  conversion.
 - ``ObjectiveC`` call stubs now emit ``k``-prefixed, title-cased root
   names for the ``static const struct`` globals that back dotted call
   targets, so a user-written ``throttler.check(...)`` literalizes to

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -30,6 +30,7 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_integers import (
+    I64_MAX,
     format_integer_hex,
     make_long_suffix_formatter,
     make_overflow_fallback_formatter,
@@ -69,6 +70,7 @@ def _apply_format_c_entry(
     original: Value,
     formatted: str,
     int_field: str,
+    uint_field: str,
     float_field: str,
     string_field: str,
 ) -> str:
@@ -79,6 +81,11 @@ def _apply_format_c_entry(
         case bool():
             return formatted
         case int():
+            # Values above ``LLONG_MAX`` cannot be assigned to the signed
+            # ``long long`` field without an implementation-defined
+            # narrowing conversion; route them to the unsigned field.
+            if original > I64_MAX:
+                return f"((CVal){{.{uint_field} = {formatted}}})"
             return f"((CVal){{.{int_field} = {formatted}}})"
         case float():
             return f"((CVal){{.{float_field} = {formatted}}})"
@@ -90,6 +97,7 @@ def _apply_format_c_entry(
 def _make_format_c_entry(
     *,
     int_field: str,
+    uint_field: str,
     float_field: str,
     string_field: str,
 ) -> collections.abc.Callable[[Value, str], str]:
@@ -103,6 +111,7 @@ def _make_format_c_entry(
             original=original,
             formatted=formatted,
             int_field=int_field,
+            uint_field=uint_field,
             float_field=float_field,
             string_field=string_field,
         )
@@ -453,6 +462,7 @@ class C(metaclass=LanguageCls):
     indent: str = "    "
     bool_field: str = "b"
     int_field: str = "i"
+    uint_field: str = "u"
     float_field: str = "f"
     string_field: str = "s"
     array_field: str = "a"
@@ -533,6 +543,7 @@ class C(metaclass=LanguageCls):
         """
         return _make_format_c_entry(
             int_field=self.int_field,
+            uint_field=self.uint_field,
             float_field=self.float_field,
             string_field=self.string_field,
         )
@@ -731,6 +742,7 @@ class C(metaclass=LanguageCls):
             "    union {",
             f"        _Bool {self.bool_field};",
             f"        long long {self.int_field};",
+            f"        unsigned long long {self.uint_field};",
             f"        double {self.float_field};",
             f"        const char *{self.string_field};",
             f"        const CVal *{self.array_field};",

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1037,9 +1037,9 @@ class Cpp(metaclass=LanguageCls):
     class FloatFormats(
         FloatSpecialsMixin,
         enum.Enum,
-        positive_infinity="INFINITY",
-        negative_infinity="-INFINITY",
-        nan="NAN",
+        positive_infinity="static_cast<double>(INFINITY)",
+        negative_infinity="-static_cast<double>(INFINITY)",
+        nan="static_cast<double>(NAN)",
     ):
         """Float format options."""
 

--- a/tests/integration/cases/binary/C.c
+++ b/tests/integration/cases/binary/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/binary/C_bytes_format_base64.c
+++ b/tests/integration/cases/binary/C_bytes_format_base64.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/binary/C_combined.c
+++ b/tests/integration/cases/binary/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/bool_list/C.c
+++ b/tests/integration/cases/bool_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/bool_list/C_combined.c
+++ b/tests/integration/cases/bool_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_deep_dotted_method/C_call.c
+++ b/tests/integration/cases/call_deep_dotted_method/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_deep_dotted_transformed/C_call.c
+++ b/tests/integration/cases/call_deep_dotted_transformed/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_dotted_method/C_call.c
+++ b/tests/integration/cases/call_dotted_method/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_keyword_args/C_call.c
+++ b/tests/integration/cases/call_keyword_args/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_mixed_type_dicts/C_call.c
+++ b/tests/integration/cases/call_mixed_type_dicts/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_multi_args/C_call.c
+++ b/tests/integration/cases/call_multi_args/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_per_element_false/C_call.c
+++ b/tests/integration/cases/call_per_element_false/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_ref_args/C_call.c
+++ b/tests/integration/cases/call_ref_args/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_scalar_args/C_call.c
+++ b/tests/integration/cases/call_scalar_args/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/call_transform_no_wrapper/C_call.c
+++ b/tests/integration/cases/call_transform_no_wrapper/C_call.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_block_scalar_not_comment/C.c
+++ b/tests/integration/cases/comment_block_scalar_not_comment/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_block_scalar_not_comment/C_combined.c
+++ b/tests/integration/cases/comment_block_scalar_not_comment/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar/C.c
+++ b/tests/integration/cases/comment_scalar/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar/C_combined.c
+++ b/tests/integration/cases/comment_scalar/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar_document_markers/C.c
+++ b/tests/integration/cases/comment_scalar_document_markers/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar_document_markers/C_combined.c
+++ b/tests/integration/cases/comment_scalar_document_markers/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar_inline/C.c
+++ b/tests/integration/cases/comment_scalar_inline/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar_inline/C_combined.c
+++ b/tests/integration/cases/comment_scalar_inline/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/C.c
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/C_combined.c
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments/C.c
+++ b/tests/integration/cases/comments/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments/C_combined.c
+++ b/tests/integration/cases/comments/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments/C_comment_block.c
+++ b/tests/integration/cases/comments/C_comment_block.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_bang_in_double_quote/C.c
+++ b/tests/integration/cases/comments_bang_in_double_quote/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_bang_in_double_quote/C_combined.c
+++ b/tests/integration/cases/comments_bang_in_double_quote/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_double_hash/C.c
+++ b/tests/integration/cases/comments_double_hash/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_double_hash/C_combined.c
+++ b/tests/integration/cases/comments_double_hash/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_empty_line/C.c
+++ b/tests/integration/cases/comments_empty_line/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_empty_line/C_combined.c
+++ b/tests/integration/cases/comments_empty_line/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_escaped_quote/C.c
+++ b/tests/integration/cases/comments_escaped_quote/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_escaped_quote/C_combined.c
+++ b/tests/integration/cases/comments_escaped_quote/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_escaped_single_quote/C.c
+++ b/tests/integration/cases/comments_escaped_single_quote/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_escaped_single_quote/C_combined.c
+++ b/tests/integration/cases/comments_escaped_single_quote/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_multi_line/C.c
+++ b/tests/integration/cases/comments_multi_line/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_multi_line/C_combined.c
+++ b/tests/integration/cases/comments_multi_line/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_nested_mapping/C.c
+++ b/tests/integration/cases/comments_nested_mapping/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_nested_mapping/C_combined.c
+++ b/tests/integration/cases/comments_nested_mapping/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_sequence_before/C.c
+++ b/tests/integration/cases/comments_sequence_before/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_sequence_before/C_combined.c
+++ b/tests/integration/cases/comments_sequence_before/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_sequence_inline/C.c
+++ b/tests/integration/cases/comments_sequence_inline/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_sequence_inline/C_combined.c
+++ b/tests/integration/cases/comments_sequence_inline/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_trailing/C.c
+++ b/tests/integration/cases/comments_trailing/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_trailing/C_combined.c
+++ b/tests/integration/cases/comments_trailing/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_vb_before_dim/C.c
+++ b/tests/integration/cases/comments_vb_before_dim/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/comments_vb_before_dim/C_combined.c
+++ b/tests/integration/cases/comments_vb_before_dim/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/date_list/C.c
+++ b/tests/integration/cases/date_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/date_list/C_combined.c
+++ b/tests/integration/cases/date_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/date_set/C.c
+++ b/tests/integration/cases/date_set/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/date_set/C_combined.c
+++ b/tests/integration/cases/date_set/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dates/C.c
+++ b/tests/integration/cases/dates/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dates/C_combined.c
+++ b/tests/integration/cases/dates/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/datetime_list/C.c
+++ b/tests/integration/cases/datetime_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/datetime_list/C_combined.c
+++ b/tests/integration/cases/datetime_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/deep_nesting/C.c
+++ b/tests/integration/cases/deep_nesting/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/deep_nesting/C_combined.c
+++ b/tests/integration/cases/deep_nesting/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_all_null_trailing_comment/C.c
+++ b/tests/integration/cases/dict_all_null_trailing_comment/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_all_null_trailing_comment/C_combined.c
+++ b/tests/integration/cases/dict_all_null_trailing_comment/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_all_scalar_types/C.c
+++ b/tests/integration/cases/dict_all_scalar_types/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_all_scalar_types/C_combined.c
+++ b/tests/integration/cases/dict_all_scalar_types/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_mixed_int_widths/C.c
+++ b/tests/integration/cases/dict_mixed_int_widths/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_mixed_int_widths/C_combined.c
+++ b/tests/integration/cases/dict_mixed_int_widths/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_mixed_scalars/C.c
+++ b/tests/integration/cases/dict_mixed_scalars/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_mixed_scalars/C_combined.c
+++ b/tests/integration/cases/dict_mixed_scalars/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_null_leading_comment/C.c
+++ b/tests/integration/cases/dict_null_leading_comment/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_null_leading_comment/C_combined.c
+++ b/tests/integration/cases/dict_null_leading_comment/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_null_middle_inline_comment/C.c
+++ b/tests/integration/cases/dict_null_middle_inline_comment/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_null_middle_inline_comment/C_combined.c
+++ b/tests/integration/cases/dict_null_middle_inline_comment/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_null_trailing_inline_comment/C.c
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_null_trailing_inline_comment/C_combined.c
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_control_char_keys/C.c
+++ b/tests/integration/cases/dict_with_control_char_keys/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_control_char_keys/C_combined.c
+++ b/tests/integration/cases/dict_with_control_char_keys/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_hyphen_keys/C.c
+++ b/tests/integration/cases/dict_with_hyphen_keys/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_hyphen_keys/C_combined.c
+++ b/tests/integration/cases/dict_with_hyphen_keys/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_list_value/C.c
+++ b/tests/integration/cases/dict_with_list_value/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_list_value/C_combined.c
+++ b/tests/integration/cases/dict_with_list_value/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_nulls/C.c
+++ b/tests/integration/cases/dict_with_nulls/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/dict_with_nulls/C_combined.c
+++ b/tests/integration/cases/dict_with_nulls/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_dict/C.c
+++ b/tests/integration/cases/empty_dict/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_dict/C_combined.c
+++ b/tests/integration/cases/empty_dict/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_dicts_in_sequence/C.c
+++ b/tests/integration/cases/empty_dicts_in_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_dicts_in_sequence/C_combined.c
+++ b/tests/integration/cases/empty_dicts_in_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_list/C.c
+++ b/tests/integration/cases/empty_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_list/C_combined.c
+++ b/tests/integration/cases/empty_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_sequence/C.c
+++ b/tests/integration/cases/empty_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_sequence/C_combined.c
+++ b/tests/integration/cases/empty_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_set/C.c
+++ b/tests/integration/cases/empty_set/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/empty_set/C_combined.c
+++ b/tests/integration/cases/empty_set/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_list/C.c
+++ b/tests/integration/cases/float_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_list/C_combined.c
+++ b/tests/integration/cases/float_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_list/C_float_format_fixed.c
+++ b/tests/integration/cases/float_list/C_float_format_fixed.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_list/C_float_format_scientific.c
+++ b/tests/integration/cases/float_list/C_float_format_scientific.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_negative_zero/C.c
+++ b/tests/integration/cases/float_negative_zero/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_negative_zero/C_combined.c
+++ b/tests/integration/cases/float_negative_zero/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_scientific_notation/C.c
+++ b/tests/integration/cases/float_scientific_notation/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_scientific_notation/C_combined.c
+++ b/tests/integration/cases/float_scientific_notation/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_scientific_notation/C_float_format_fixed_s.c
+++ b/tests/integration/cases/float_scientific_notation/C_float_format_fixed_s.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_scientific_notation/C_float_format_scientific_s.c
+++ b/tests/integration/cases/float_scientific_notation/C_float_format_scientific_s.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_special_values/C.c
+++ b/tests/integration/cases/float_special_values/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_special_values/C_combined.c
+++ b/tests/integration/cases/float_special_values/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_special_values/C_float_format_fixed_v.c
+++ b/tests/integration/cases/float_special_values/C_float_format_fixed_v.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_special_values/C_float_format_scientific_v.c
+++ b/tests/integration/cases/float_special_values/C_float_format_scientific_v.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/float_special_values/Cpp.cpp
+++ b/tests/integration/cases/float_special_values/Cpp.cpp
@@ -3,8 +3,8 @@
 #include <vector>
 void check_() {
 auto my_data = std::vector<double>{
-    INFINITY,
-    -INFINITY,
-    NAN,
+    static_cast<double>(INFINITY),
+    -static_cast<double>(INFINITY),
+    static_cast<double>(NAN),
 };
 }

--- a/tests/integration/cases/float_special_values/Cpp_combined.cpp
+++ b/tests/integration/cases/float_special_values/Cpp_combined.cpp
@@ -3,13 +3,13 @@
 #include <vector>
 void check_() {
 auto my_data = std::vector<double>{
-    INFINITY,
-    -INFINITY,
-    NAN,
+    static_cast<double>(INFINITY),
+    -static_cast<double>(INFINITY),
+    static_cast<double>(NAN),
 };
 my_data = std::vector<double>{
-    INFINITY,
-    -INFINITY,
-    NAN,
+    static_cast<double>(INFINITY),
+    -static_cast<double>(INFINITY),
+    static_cast<double>(NAN),
 };
 }

--- a/tests/integration/cases/float_special_values/Cpp_float_format_fixed_v.cpp
+++ b/tests/integration/cases/float_special_values/Cpp_float_format_fixed_v.cpp
@@ -3,8 +3,8 @@
 #include <vector>
 void check_() {
 auto my_data = std::vector<double>{
-    INFINITY,
-    -INFINITY,
-    NAN,
+    static_cast<double>(INFINITY),
+    -static_cast<double>(INFINITY),
+    static_cast<double>(NAN),
 };
 }

--- a/tests/integration/cases/float_special_values/Cpp_float_format_scientific_v.cpp
+++ b/tests/integration/cases/float_special_values/Cpp_float_format_scientific_v.cpp
@@ -3,8 +3,8 @@
 #include <vector>
 void check_() {
 auto my_data = std::vector<double>{
-    INFINITY,
-    -INFINITY,
-    NAN,
+    static_cast<double>(INFINITY),
+    -static_cast<double>(INFINITY),
+    static_cast<double>(NAN),
 };
 }

--- a/tests/integration/cases/int_key_dict/C.c
+++ b/tests/integration/cases/int_key_dict/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_key_dict/C_combined.c
+++ b/tests/integration/cases/int_key_dict/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list/C.c
+++ b/tests/integration/cases/int_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list/C_combined.c
+++ b/tests/integration/cases/int_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list/C_integer_format_hex.c
+++ b/tests/integration/cases/int_list/C_integer_format_hex.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list/C_numeric_literal_suffix_auto.c
+++ b/tests/integration/cases/int_list/C_numeric_literal_suffix_auto.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_large/C.c
+++ b/tests/integration/cases/int_list_large/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_large/C_combined.c
+++ b/tests/integration/cases/int_list_large/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_large/C_integer_format_hex_large.c
+++ b/tests/integration/cases/int_list_large/C_integer_format_hex_large.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_large/C_numeric_literal_suffix_auto_large.c
+++ b/tests/integration/cases/int_list_large/C_numeric_literal_suffix_auto_large.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_with_zero/C.c
+++ b/tests/integration/cases/int_list_with_zero/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_with_zero/C_combined.c
+++ b/tests/integration/cases/int_list_with_zero/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_with_zero/C_integer_format_hex_zero.c
+++ b/tests/integration/cases/int_list_with_zero/C_integer_format_hex_zero.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_list_with_zero/C_numeric_literal_suffix_auto_zero.c
+++ b/tests/integration/cases/int_list_with_zero/C_numeric_literal_suffix_auto_zero.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_set/C.c
+++ b/tests/integration/cases/int_set/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/int_set/C_combined.c
+++ b/tests/integration/cases/int_set/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_number_dict/C.c
+++ b/tests/integration/cases/mixed_number_dict/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_number_dict/C_combined.c
+++ b/tests/integration/cases/mixed_number_dict/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_number_list/C.c
+++ b/tests/integration/cases/mixed_number_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_number_list/C_combined.c
+++ b/tests/integration/cases/mixed_number_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_set/C.c
+++ b/tests/integration/cases/mixed_set/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_set/C_combined.c
+++ b/tests/integration/cases/mixed_set/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/C.c
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/C_combined.c
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested/C.c
+++ b/tests/integration/cases/nested/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested/C_combined.c
+++ b/tests/integration/cases/nested/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_bool_list/C.c
+++ b/tests/integration/cases/nested_bool_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_bool_list/C_combined.c
+++ b/tests/integration/cases/nested_bool_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_collection_multi_space_string/C.c
+++ b/tests/integration/cases/nested_collection_multi_space_string/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_collection_multi_space_string/C_combined.c
+++ b/tests/integration/cases/nested_collection_multi_space_string/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_deep_empty/C.c
+++ b/tests/integration/cases/nested_deep_empty/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_deep_empty/C_combined.c
+++ b/tests/integration/cases/nested_deep_empty/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_deep_mixed/C.c
+++ b/tests/integration/cases/nested_deep_mixed/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_deep_mixed/C_combined.c
+++ b/tests/integration/cases/nested_deep_mixed/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_empty_inner/C.c
+++ b/tests/integration/cases/nested_empty_inner/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_empty_inner/C_combined.c
+++ b/tests/integration/cases/nested_empty_inner/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_float_list/C.c
+++ b/tests/integration/cases/nested_float_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_float_list/C_combined.c
+++ b/tests/integration/cases/nested_float_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_float_list/C_float_format_fixed_n.c
+++ b/tests/integration/cases/nested_float_list/C_float_format_fixed_n.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_float_list/C_float_format_scientific_n.c
+++ b/tests/integration/cases/nested_float_list/C_float_format_scientific_n.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_list_of_dicts/C.c
+++ b/tests/integration/cases/nested_list_of_dicts/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_list_of_dicts/C_combined.c
+++ b/tests/integration/cases/nested_list_of_dicts/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_dict/C.c
+++ b/tests/integration/cases/nested_mixed_dict/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_dict/C_combined.c
+++ b/tests/integration/cases/nested_mixed_dict/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_inner/C.c
+++ b/tests/integration/cases/nested_mixed_inner/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_inner/C_combined.c
+++ b/tests/integration/cases/nested_mixed_inner/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_set/C.c
+++ b/tests/integration/cases/nested_mixed_set/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_set/C_combined.c
+++ b/tests/integration/cases/nested_mixed_set/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_types/C.c
+++ b/tests/integration/cases/nested_mixed_types/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_mixed_types/C_combined.c
+++ b/tests/integration/cases/nested_mixed_types/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_sequence/C.c
+++ b/tests/integration/cases/nested_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_sequence/C_combined.c
+++ b/tests/integration/cases/nested_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_sequences/C.c
+++ b/tests/integration/cases/nested_sequences/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/nested_sequences/C_combined.c
+++ b/tests/integration/cases/nested_sequences/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/no_comment/C.c
+++ b/tests/integration/cases/no_comment/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/no_comment/C_combined.c
+++ b/tests/integration/cases/no_comment/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map/C.c
+++ b/tests/integration/cases/ordered_map/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map/C_combined.c
+++ b/tests/integration/cases/ordered_map/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map_in_sequence/C.c
+++ b/tests/integration/cases/ordered_map_in_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map_in_sequence/C_combined.c
+++ b/tests/integration/cases/ordered_map_in_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map_int_keys/C.c
+++ b/tests/integration/cases/ordered_map_int_keys/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map_int_keys/C_combined.c
+++ b/tests/integration/cases/ordered_map_int_keys/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map_nested_values/C.c
+++ b/tests/integration/cases/ordered_map_nested_values/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/ordered_map_nested_values/C_combined.c
+++ b/tests/integration/cases/ordered_map_nested_values/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/pair_sequence/C.c
+++ b/tests/integration/cases/pair_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/pair_sequence/C_combined.c
+++ b/tests/integration/cases/pair_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_bool/C.c
+++ b/tests/integration/cases/scalar_bool/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_bool/C_combined.c
+++ b/tests/integration/cases/scalar_bool/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_date/C.c
+++ b/tests/integration/cases/scalar_date/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_date/C_combined.c
+++ b/tests/integration/cases/scalar_date/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime/C.c
+++ b/tests/integration/cases/scalar_datetime/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime/C_combined.c
+++ b/tests/integration/cases/scalar_datetime/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_microsecond/C.c
+++ b/tests/integration/cases/scalar_datetime_microsecond/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_microsecond/C_combined.c
+++ b/tests/integration/cases/scalar_datetime_microsecond/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_midnight/C.c
+++ b/tests/integration/cases/scalar_datetime_midnight/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_midnight/C_combined.c
+++ b/tests/integration/cases/scalar_datetime_midnight/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_naive/C.c
+++ b/tests/integration/cases/scalar_datetime_naive/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_naive/C_combined.c
+++ b/tests/integration/cases/scalar_datetime_naive/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_non_utc/C.c
+++ b/tests/integration/cases/scalar_datetime_non_utc/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_non_utc/C_combined.c
+++ b/tests/integration/cases/scalar_datetime_non_utc/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/C.c
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/C_combined.c
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_float/C.c
+++ b/tests/integration/cases/scalar_float/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_float/C_combined.c
+++ b/tests/integration/cases/scalar_float/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_int/C.c
+++ b/tests/integration/cases/scalar_int/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_int/C_combined.c
+++ b/tests/integration/cases/scalar_int/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_int_large/C.c
+++ b/tests/integration/cases/scalar_int_large/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_int_large/C_combined.c
+++ b/tests/integration/cases/scalar_int_large/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_int_negative_large/C.c
+++ b/tests/integration/cases/scalar_int_negative_large/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_int_negative_large/C_combined.c
+++ b/tests/integration/cases/scalar_int_negative_large/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_int_very_large/C.c
+++ b/tests/integration/cases/scalar_int_very_large/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;
@@ -14,6 +15,6 @@ struct CVal {
 };
 struct CKV { const char *k; CVal v; };
 void check_(void) {
-CVal my_data = ((CVal){.i = 9223372036854775808ULL});
+CVal my_data = ((CVal){.u = 9223372036854775808ULL});
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_int_very_large/C_combined.c
+++ b/tests/integration/cases/scalar_int_very_large/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;
@@ -14,7 +15,7 @@ struct CVal {
 };
 struct CKV { const char *k; CVal v; };
 void check_(void) {
-CVal my_data = ((CVal){.i = 9223372036854775808ULL});
-my_data = ((CVal){.i = 9223372036854775808ULL});
+CVal my_data = ((CVal){.u = 9223372036854775808ULL});
+my_data = ((CVal){.u = 9223372036854775808ULL});
     (void)my_data;
 }

--- a/tests/integration/cases/scalar_null/C.c
+++ b/tests/integration/cases/scalar_null/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_null/C_combined.c
+++ b/tests/integration/cases/scalar_null/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_null_with_comment/C.c
+++ b/tests/integration/cases/scalar_null_with_comment/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_null_with_comment/C_combined.c
+++ b/tests/integration/cases/scalar_null_with_comment/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_string/C.c
+++ b/tests/integration/cases/scalar_string/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalar_string/C_combined.c
+++ b/tests/integration/cases/scalar_string/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalars/C.c
+++ b/tests/integration/cases/scalars/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/scalars/C_combined.c
+++ b/tests/integration/cases/scalars/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/sequence_of_dicts/C.c
+++ b/tests/integration/cases/sequence_of_dicts/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/sequence_of_dicts/C_combined.c
+++ b/tests/integration/cases/sequence_of_dicts/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/set/C.c
+++ b/tests/integration/cases/set/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/set/C_combined.c
+++ b/tests/integration/cases/set/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/set_comments/C.c
+++ b/tests/integration/cases/set_comments/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/set_comments/C_combined.c
+++ b/tests/integration/cases/set_comments/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/set_comments_unsorted_order/C.c
+++ b/tests/integration/cases/set_comments_unsorted_order/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/set_comments_unsorted_order/C_combined.c
+++ b/tests/integration/cases/set_comments_unsorted_order/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/sibling_list_values_nested/C.c
+++ b/tests/integration/cases/sibling_list_values_nested/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/sibling_list_values_nested/C_combined.c
+++ b/tests/integration/cases/sibling_list_values_nested/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/sibling_list_values_uniform_inner/C.c
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/sibling_list_values_uniform_inner/C_combined.c
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/simple_dict/C.c
+++ b/tests/integration/cases/simple_dict/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/simple_dict/C_combined.c
+++ b/tests/integration/cases/simple_dict/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/simple_dict/C_field_names_custom.c
+++ b/tests/integration/cases/simple_dict/C_field_names_custom.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool bl;
         long long integer;
+        unsigned long long uinteger;
         double fp;
         const char *str;
         const CVal *arr;

--- a/tests/integration/cases/simple_sequence/C.c
+++ b/tests/integration/cases/simple_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/simple_sequence/C_combined.c
+++ b/tests/integration/cases/simple_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/simple_sequence/C_field_names_custom.c
+++ b/tests/integration/cases/simple_sequence/C_field_names_custom.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool bl;
         long long integer;
+        unsigned long long uinteger;
         double fp;
         const char *str;
         const CVal *arr;

--- a/tests/integration/cases/simple_sequence/C_trailing_comma_no.c
+++ b/tests/integration/cases/simple_sequence/C_trailing_comma_no.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_control_chars/C.c
+++ b/tests/integration/cases/string_control_chars/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_control_chars/C_combined.c
+++ b/tests/integration/cases/string_control_chars/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/C.c
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/C_combined.c
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_list/C.c
+++ b/tests/integration/cases/string_list/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_list/C_combined.c
+++ b/tests/integration/cases/string_list/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_backslash/C.c
+++ b/tests/integration/cases/string_with_backslash/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_backslash/C_combined.c
+++ b/tests/integration/cases/string_with_backslash/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_dollar/C.c
+++ b/tests/integration/cases/string_with_dollar/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_dollar/C_combined.c
+++ b/tests/integration/cases/string_with_dollar/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_dollar_brace/C.c
+++ b/tests/integration/cases/string_with_dollar_brace/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_dollar_brace/C_combined.c
+++ b/tests/integration/cases/string_with_dollar_brace/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_hash/C.c
+++ b/tests/integration/cases/string_with_hash/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_hash/C_combined.c
+++ b/tests/integration/cases/string_with_hash/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_percent/C.c
+++ b/tests/integration/cases/string_with_percent/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/string_with_percent/C_combined.c
+++ b/tests/integration/cases/string_with_percent/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/triple_sequence/C.c
+++ b/tests/integration/cases/triple_sequence/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/triple_sequence/C_combined.c
+++ b/tests/integration/cases/triple_sequence/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/type_hints/C.c
+++ b/tests/integration/cases/type_hints/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/type_hints/C_combined.c
+++ b/tests/integration/cases/type_hints/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/C.c
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/C_combined.c
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/uniform_string_dicts_in_seq/C.c
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/C.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/cases/uniform_string_dicts_in_seq/C_combined.c
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/C_combined.c
@@ -6,6 +6,7 @@ struct CVal {
     union {
         _Bool b;
         long long i;
+        unsigned long long u;
         double f;
         const char *s;
         const CVal *a;

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -186,6 +186,7 @@ _FIELD_NAME_OVERRIDES: dict[literalizer.LanguageCls, dict[str, str]] = {
     C: {
         "bool_field": "bl",
         "int_field": "integer",
+        "uint_field": "uinteger",
         "float_field": "fp",
         "string_field": "str",
         "array_field": "arr",


### PR DESCRIPTION
## Summary

Closes #1463. Re-enables `bugprone-narrowing-conversions` and `cppcoreguidelines-narrowing-conversions` in `.clang-tidy` and fixes the two narrowing issues that fell out:

- The `C` generator now adds an `unsigned long long u` field (with a new `uint_field` constructor argument) to the `CVal` union and routes positive integers above `LLONG_MAX` to it, instead of silently truncating into the signed `long long` field.
- The `Cpp` generator now wraps `INFINITY`/`NAN` in `static_cast<double>` (with negation outside the cast for `-INFINITY`) so `std::vector<double>` brace-init does not trip the check on the implicit `float`-to-`double` conversion.

## Test plan

- [x] `uv run pytest tests/` passes (1021 passed)
- [x] `clang-tidy` on all `tests/integration/cases/*.c` and `*.cpp` files reports no narrowing diagnostics
- [x] `clang -fsyntax-only -std=c11 -Werror` and `clang++ -fsyntax-only -std=c++20 -Werror` both succeed across all regenerated fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes generated C/C++ literal output semantics for large integers and special floats, and adds a new configurable `uint_field` parameter that could affect downstream consumers relying on exact emitted code.
> 
> **Overview**
> Re-enables clang-tidy’s `bugprone-narrowing-conversions` and `cppcoreguidelines-narrowing-conversions` checks by removing their exclusions from `.clang-tidy`.
> 
> Updates the C generator to avoid narrowing for integers above `LLONG_MAX` by adding an `unsigned long long` union member (configurable via new `uint_field`) and emitting those values through that field.
> 
> Updates the C++ generator to wrap `INFINITY`/`NAN` in `static_cast<double>(...)` (with negation applied outside the cast) to prevent brace-init narrowing warnings; integration fixtures and field-name override tests are regenerated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55237ea5f0556b2084119f8553f8e0ed562b3a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->