### PR TITLE
Remove defaults from _CallCaseConfig dataclass fields

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -684,10 +684,8 @@ class _CallCaseConfig:
     call_transform: Callable[[str], str] | None
     transform_stub_names: list[str]
     per_element: bool
-    call_style_type: type[literalizer.CallStyle] | None = None
-    ref_declarations: dict[str, str] = dataclasses.field(
-        default_factory=dict[str, str],
-    )
+    call_style_type: type[literalizer.CallStyle] | None
+    ref_declarations: dict[str, str]
 
 
 _CALL_STYLE_VARIANTS: list[tuple[str, type[literalizer.CallStyle]]] = [
@@ -705,6 +703,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=lambda c: f"emit({c})",
         transform_stub_names=["emit"],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_scalar_args",
@@ -713,6 +713,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=None,
         transform_stub_names=[],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_multi_args",
@@ -721,6 +723,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=None,
         transform_stub_names=[],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_dotted_method",
@@ -729,6 +733,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=None,
         transform_stub_names=[],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_deep_dotted_method",
@@ -737,6 +743,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=None,
         transform_stub_names=[],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_deep_dotted_transformed",
@@ -745,6 +753,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=lambda c: f"emit({c})",
         transform_stub_names=["emit"],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_transform_no_wrapper",
@@ -753,6 +763,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=lambda c: c,
         transform_stub_names=[],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_per_element_false",
@@ -761,6 +773,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=None,
         transform_stub_names=[],
         per_element=False,
+        call_style_type=None,
+        ref_declarations={},
     ),
     _CallCaseConfig(
         case_dir_name="call_ref_args",
@@ -769,6 +783,7 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=None,
         transform_stub_names=[],
         per_element=True,
+        call_style_type=None,
         ref_declarations={
             "my_var": "[1, 2, 3]",
             "my_other": "[4, 5, 6]",
@@ -781,6 +796,8 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
         call_transform=None,
         transform_stub_names=[],
         per_element=True,
+        call_style_type=None,
+        ref_declarations={},
     ),
     *[
         _CallCaseConfig(
@@ -791,6 +808,7 @@ _CALL_CASE_CONFIGS: list[_CallCaseConfig] = [
             transform_stub_names=["emit"],
             per_element=True,
             call_style_type=cls,
+            ref_declarations={},
         )
         for name, cls in _CALL_STYLE_VARIANTS
     ],


### PR DESCRIPTION
## Summary
- Remove the `None` and `default_factory=dict` defaults from `_CallCaseConfig.call_style_type` and `_CallCaseConfig.ref_declarations`
- Update every `_CallCaseConfig` instantiation in `tests/integration/test_integration.py` to pass both fields explicitly

## Test plan
- [ ] `pytest tests/integration/test_integration.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that makes `_CallCaseConfig` construction more explicit without changing production code paths.
> 
> **Overview**
> Removes default values for `_CallCaseConfig.call_style_type` and `_CallCaseConfig.ref_declarations`, making these fields required when defining `literalize_call` integration test cases.
> 
> Updates all `_CallCaseConfig` instances to pass `call_style_type` and `ref_declarations` explicitly (typically `None`/`{}`), reducing reliance on implicit dataclass defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86dd080b4fc0748251f051d6906eff6ee71e3b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->