### PR TITLE
Replace substring assertions with exact equality in tests

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -493,9 +493,8 @@ def test_literalize_call_wrap_in_file() -> None:
         parameter_names=["a", "b"],
         wrap_in_file=True,
     )
-    assert "package main" in result.code
-    assert "func main()" in result.code
-    assert "process(" in result.code
+    expected = "package main\n\nfunc main() {\nprocess(1, 2);\n}"
+    assert result.code == expected
     assert not result.preamble
     assert not result.body_preamble
     # Python has no static preamble — covers the no-preamble branch.
@@ -507,7 +506,7 @@ def test_literalize_call_wrap_in_file() -> None:
         parameter_names=["a", "b"],
         wrap_in_file=True,
     )
-    assert "process(" in result_no_preamble.code
+    assert result_no_preamble.code == "process(a=1, b=2)"
     assert not result_no_preamble.preamble
 
 
@@ -756,7 +755,7 @@ def test_literalize_call_arg_ref_all_refs() -> None:
         target_function="combine",
         parameter_names=["x", "y"],
     )
-    assert "combine(a, b)" in result.code
+    assert result.code == "combine(a, b);"
 
 
 def test_literalize_call_arg_ref_top_level_element() -> None:
@@ -771,8 +770,7 @@ def test_literalize_call_arg_ref_top_level_element() -> None:
         target_function="run",
         parameter_names=["x"],
     )
-    assert "run(a)" in result.code
-    assert "run(b)" in result.code
+    assert result.code == "run(a);\nrun(b);"
 
 
 def test_literalize_call_arg_ref_per_element_false() -> None:
@@ -787,7 +785,7 @@ def test_literalize_call_arg_ref_per_element_false() -> None:
         parameter_names=["body"],
         per_element=False,
     )
-    assert "publish(body=payload)" in result.code
+    assert result.code == "publish(body=payload)"
 
 
 def test_literalize_call_arg_ref_non_ref_dict_still_literalized() -> None:
@@ -802,7 +800,7 @@ def test_literalize_call_arg_ref_non_ref_dict_still_literalized() -> None:
         target_function="process",
         parameter_names=["data"],
     )
-    assert 'process(data={"$ref": "x", "extra": 1})' in two_key.code
+    assert two_key.code == 'process(data={"$ref": "x", "extra": 1})'
     non_string_ref = literalize_call(
         source='[[{"$ref": 42}]]',
         input_format=InputFormat.JSON,
@@ -810,7 +808,7 @@ def test_literalize_call_arg_ref_non_ref_dict_still_literalized() -> None:
         target_function="process",
         parameter_names=["data"],
     )
-    assert 'process(data={"$ref": 42})' in non_string_ref.code
+    assert non_string_ref.code == 'process(data={"$ref": 42})'
 
 
 def test_literalize_call_arg_ref_parameter_count_still_validated() -> None:

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -435,14 +435,14 @@ def test_rust_lazy_static_preamble_includes_lazy_lock() -> None:
     """``LAZY_STATIC`` adds ``use std::sync::LazyLock;`` to the
     preamble.
     """
-    assert "use std::sync::LazyLock;" in RUST_LAZY_STATIC.static_preamble
+    assert RUST_LAZY_STATIC.static_preamble == ("use std::sync::LazyLock;",)
 
 
 def test_rust_static_preamble_excludes_lazy_lock() -> None:
     """Non-``LAZY_STATIC`` declaration styles emit no ``LazyLock``
     import.
     """
-    assert "use std::sync::LazyLock;" not in RUST_CONST.static_preamble
+    assert RUST_CONST.static_preamble == ()
 
 
 def test_rust_lazy_static_config_formatter_raises_if_called_directly() -> None:


### PR DESCRIPTION
## Summary
- Swap `assert X in Y` / `assert X not in Y` for exact `==` comparisons in `tests/test_languages.py` and `tests/test_variables.py` so tests pin down the full expected output instead of a loose substring match.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_languages.py tests/test_variables.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that make expectations stricter and may expose previously-ignored formatting differences.
> 
> **Overview**
> These tests now pin **exact rendered output** instead of using loose `in`/`not in` substring assertions.
> 
> In `tests/test_languages.py`, `literalize_call` expectations are updated to full-string matches for wrapped-file output and `$ref` argument rendering (including exact semicolons/newlines). In `tests/test_variables.py`, Rust `static_preamble` checks are tightened to exact tuple equality for `LAZY_STATIC` vs non-`LAZY_STATIC` styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3310cd68bf5ed5e7719612934e60ed0d1eda8a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->