### PR TITLE
Use textwrap.dedent for indented multiline strings

### DIFF
--- a/check_purescript_syntax.py
+++ b/check_purescript_syntax.py
@@ -4,21 +4,26 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 from pathlib import Path
 
 
 def main() -> None:
     """Check syntax of a single PureScript file."""
-    prelude_purs_content = """\
-module Prelude where
-foreign import negate :: forall a. a -> a
-foreign import div :: forall a. a -> a -> a
-infixl 7 div as /
-"""
-    prelude_js_content = """\
-export const negate = x => -x;
-export const div = x => y => x / y;
-"""
+    prelude_purs_content = textwrap.dedent(
+        text="""\
+        module Prelude where
+        foreign import negate :: forall a. a -> a
+        foreign import div :: forall a. a -> a -> a
+        infixl 7 div as /
+        """,
+    )
+    prelude_js_content = textwrap.dedent(
+        text="""\
+        export const negate = x => -x;
+        export const div = x => y => x / y;
+        """,
+    )
     filename = sys.argv[1]
     purs_path: str = shutil.which(cmd="purs") or "purs"
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_json5.py
+++ b/tests/test_json5.py
@@ -144,13 +144,15 @@ def test_trailing_commas() -> None:
 
 def test_comments_stripped() -> None:
     """JSON5 comments are stripped during parsing."""
-    source = """\
-{
-    // This is a comment
-    name: "alice",
-    /* block comment */
-    age: 30,
-}"""
+    source = textwrap.dedent(
+        text="""\
+        {
+            // This is a comment
+            name: "alice",
+            /* block comment */
+            age: 30,
+        }""",
+    )
     result = literalize(
         source=source,
         input_format=InputFormat.JSON5,


### PR DESCRIPTION
## Summary
- Wrap the `source` literal in `tests/test_json5.py::test_comments_stripped` with `textwrap.dedent` so the JSON5 input lines up with the surrounding test body, matching the pattern used elsewhere in the file.
- Wrap the `prelude_purs_content` and `prelude_js_content` literals in `check_purescript_syntax.py` with `textwrap.dedent` so the PureScript/JS prelude content sits at the function body's indent level instead of column 0.

## Test plan
- [x] `uv run pytest tests/test_json5.py`
- [x] `uv run ruff check` and `uv run ruff format --check` on the modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatting-only change: wraps a few multiline string literals with `textwrap.dedent`, with no behavior changes expected beyond whitespace normalization.
> 
> **Overview**
> Updates `check_purescript_syntax.py` to build the temporary PureScript/JS prelude strings via `textwrap.dedent` (and imports `textwrap`), keeping the literals indented with the surrounding code while preserving their on-disk contents.
> 
> Updates `tests/test_json5.py` to construct the JSON5 `source` in `test_comments_stripped` using `textwrap.dedent` so the test input can be indented consistently with other multiline fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5380b7210ee58ea50ef467b2f3e6e5ca5db11673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->