### PR TITLE
Fix IndexError in Gleam call stub for 27+ parameters

### DIFF
--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -320,6 +320,21 @@ _GLEAM_BYTES_FORMATTERS: dict[
 }
 
 
+def _gleam_type_var(index: int) -> str:
+    """Return a unique lowercase identifier for a type variable.
+
+    Indices ``0``..``25`` map to ``a``..``z``; higher indices append a
+    numeric suffix (``a1``..``z1``, ``a2``..``z2``, ...).  The numeric
+    suffix avoids collisions with Gleam reserved words like ``as`` and
+    ``fn`` that could otherwise appear in a pure-letter scheme.
+    """
+    letter = chr(ord("a") + index % 26)
+    group = index // 26
+    if group == 0:
+        return letter
+    return f"{letter}{group}"
+
+
 def _gleam_call_preamble_stub(
     name: str,
     params: Sequence[str],
@@ -337,9 +352,9 @@ def _gleam_call_preamble_stub(
     site.
     """
     flat_name = name.replace(".", "_")
-    letters = "abcdefghijklmnopqrstuvwxyz"
     param_list = ", ".join(
-        f"_{p}: {letters[i]}" for i, p in enumerate(iterable=params)
+        f"_{p}: {_gleam_type_var(index=i)}"
+        for i, p in enumerate(iterable=params)
     )
     return (f"pub fn {flat_name}({param_list}) -> Nil {{ panic }}",)
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -22,6 +22,7 @@ from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     HeterogeneousBehavior,
     LanguageCls,
+    StubReturn,
 )
 from literalizer._types import Value
 from literalizer.exceptions import (
@@ -36,6 +37,7 @@ from literalizer.languages import (
     Dart,
     Fortran,
     FSharp,
+    Gleam,
     Go,
     Java,
     JavaScript,
@@ -509,6 +511,23 @@ def test_literalize_call_wrap_in_file() -> None:
     )
     assert "process(" in result_no_preamble.code
     assert not result_no_preamble.preamble
+
+
+def test_gleam_call_preamble_stub_many_parameters() -> None:
+    """Gleam call stubs handle more than 26 parameters.
+
+    ``_gleam_type_var`` falls back to numeric suffixes past the 26-letter
+    alphabet, so a 27-parameter call must emit a ``z`` for the last
+    single-letter slot and an ``a1`` for the next one.
+    """
+    params = [f"p{i}" for i in range(27)]
+    (line,) = Gleam().format_call_preamble_stub(
+        "target",
+        params,
+        StubReturn.VOID,
+    )
+    assert "_p25: z" in line
+    assert "_p26: a1" in line
 
 
 def test_both_variable_forms_without_wrap_in_file_raises() -> None:


### PR DESCRIPTION
## Summary
- `_gleam_call_preamble_stub` indexed into a fixed 26-letter alphabet to generate per-parameter type variables, crashing with `IndexError` once a call target had 27+ params.
- Replaced the lookup with a `_gleam_type_var` helper that maps indices 0–25 to `a`–`z` (unchanged output for existing cases) and higher indices to `a1`, `b1`, …, avoiding Gleam keyword collisions like `as` / `fn` that a pure-letter scheme would produce.
- Addresses the Cursor Bugbot comment on #1598.

## Test plan
- [x] `uv run pytest tests/` (1010 passed, 371 skipped)
- [x] Hand-rendered a 30-param stub — emits valid Gleam, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to Gleam call preamble stub generation and adds a targeted unit test for 27+ parameters.
> 
> **Overview**
> Fixes Gleam call preamble stub generation to support call targets with more than 26 parameters by introducing `_gleam_type_var()` and using it instead of indexing a fixed alphabet.
> 
> Adds a regression test ensuring a 27-parameter stub emits `z` for the 26th type var and `a1` for the 27th, preventing the previous `IndexError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0a06a5f55a0f2240d942cd2d1fe63106c18fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->