### PR TITLE
Inject target-function stub in literalize_call(wrap_in_file=True)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- ``literalize_call(..., wrap_in_file=True)`` now injects a no-op
+  stub for the ``target_function`` into the wrapped file, so the
+  generated source compiles against strict checkers on its own.
+  Callers that supply a ``call_transform`` are still responsible for
+  providing a definition for the wrapper function the transform
+  introduces.
 - ``C`` generated output now routes positive integers above
   ``LLONG_MAX`` (e.g. ``2**63``) through a new ``unsigned long long``
   union field instead of narrowing them into the signed ``long long``

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -29,6 +29,7 @@ from literalizer._language import (
     PositionalCallStyle,
     PostfixCallStyle,
     PrefixCallStyle,
+    StubReturn,
 )
 from literalizer._parsing import InputFormat, parse_input
 from literalizer._preamble import compute_preamble
@@ -1807,8 +1808,13 @@ def literalize_call(
             becomes a separate call.  If ``False``, the whole
             literalized value is passed as a single argument.
         wrap_in_file: If ``True``, assemble :attr:`code` as a
-            complete, valid source file using the language's
-            ``wrap_in_file`` method and prepend :attr:`preamble`.
+            complete, self-contained source file using the language's
+            ``wrap_in_file`` method and prepend :attr:`preamble`.  A
+            no-op stub for *target_function* is also injected so the
+            generated file does not reference an undefined name; when
+            a *call_transform* is supplied the wrapper name it
+            introduces is not stubbed — callers that transform calls
+            are responsible for providing that definition themselves.
             When set, :attr:`preamble` and :attr:`body_preamble`
             on the result are empty tuples (their content has been
             folded into :attr:`code`).
@@ -1827,6 +1833,7 @@ def literalize_call(
         case _ as style:
             pass
 
+    raw_target_function = target_function
     target_function = language.format_call_target(target_function)
 
     data_for_preamble = _strip_call_arg_refs_for_preamble(
@@ -1870,13 +1877,29 @@ def literalize_call(
     )
 
     if wrap_in_file:
+        # Emit a no-op stub for ``target_function`` so the wrapped file
+        # compiles on its own.  ``StubReturn.VALUE`` is used whenever a
+        # ``call_transform`` consumes the call's return value; otherwise
+        # the call result is discarded and a void stub suffices.
+        stub_return = (
+            StubReturn.VALUE if call_transform is not None else StubReturn.VOID
+        )
+        body_stubs = language.format_call_stub(
+            raw_target_function, parameter_names, stub_return
+        )
+        preamble_stubs = language.format_call_preamble_stub(
+            raw_target_function, parameter_names, stub_return
+        )
         wrapped = language.wrap_in_file(
             content=result,
             variable_name="",
-            body_preamble=computed.body,
+            body_preamble=body_stubs + computed.body,
         )
-        if preamble:
-            wrapped = "\n".join(preamble) + "\n" + wrapped
+        # Stubs follow the language's static preamble (e.g. Go's
+        # ``package main`` must come first).
+        full_preamble = preamble + preamble_stubs
+        if full_preamble:
+            wrapped = "\n".join(full_preamble) + "\n" + wrapped
         return LiteralizeResult(
             declaration_code=wrapped,
             preamble=(),

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -475,17 +475,14 @@ def test_python_no_any_import_when_all_defaults_overridden() -> None:
     assert not result.preamble
 
 
-def test_literalize_call_wrap_in_file() -> None:
-    """Literalize_call with wrap_in_file returns a complete file.
-
-    Integration tests compose ``wrap_in_file`` manually around
-    ``literalize_call(..., wrap_in_file=False)`` so they can stub the
-    target function; this unit test keeps coverage on the
-    ``wrap_in_file=True`` branch of :func:`literalize_call` itself.
+def test_literalize_call_wrap_in_file_emits_stubs() -> None:
+    """``wrap_in_file=True`` produces a self-contained file that
+    defines the ``target_function`` so the output compiles on its own.
     """
-    # Go has a static preamble ("package main") — covers the preamble
-    # prepend branch.
-    result = literalize_call(
+    # Go: stub lands in the file-scope preamble (Go can't declare
+    # functions inside ``main``).  The static ``package main`` preamble
+    # is also prepended.
+    go_result = literalize_call(
         source="[[1, 2]]",
         input_format=InputFormat.JSON,
         language=Go(),
@@ -493,12 +490,22 @@ def test_literalize_call_wrap_in_file() -> None:
         parameter_names=["a", "b"],
         wrap_in_file=True,
     )
-    expected = "package main\n\nfunc main() {\nprocess(1, 2);\n}"
-    assert result.code == expected
-    assert not result.preamble
-    assert not result.body_preamble
-    # Python has no static preamble — covers the no-preamble branch.
-    result_no_preamble = literalize_call(
+    expected_go = textwrap.dedent(
+        text="""\
+        package main
+        func process(args ...any) any { return nil }
+
+        func main() {
+        process(1, 2);
+        }""",
+    )
+    assert go_result.code == expected_go
+    assert not go_result.preamble
+    assert not go_result.body_preamble
+    # Python: stub lands inside the wrapper (no language wrapper here,
+    # so it sits above the call) and covers the no-static-preamble
+    # branch.
+    py_result = literalize_call(
         source="[[1, 2]]",
         input_format=InputFormat.JSON,
         language=Python(),
@@ -506,8 +513,37 @@ def test_literalize_call_wrap_in_file() -> None:
         parameter_names=["a", "b"],
         wrap_in_file=True,
     )
-    assert result_no_preamble.code == "process(a=1, b=2)"
-    assert not result_no_preamble.preamble
+    expected_py = textwrap.dedent(
+        text="""\
+        def process(*_args: object, **_kwargs: object) -> object: ...
+        process(a=1, b=2)""",
+    )
+    assert py_result.code == expected_py
+    assert not py_result.preamble
+
+
+def test_literalize_call_wrap_in_file_transform_stub_returns_value() -> None:
+    """When ``call_transform`` consumes the call result, the stub
+    returns a value instead of ``void``.
+    """
+    result = literalize_call(
+        source="[[1, 2]]",
+        input_format=InputFormat.JSON,
+        language=Python(),
+        target_function="process",
+        parameter_names=["a", "b"],
+        call_transform=lambda c: f"emit({c})",
+        wrap_in_file=True,
+    )
+    # ``process`` still gets a value-returning stub; ``emit`` is out of
+    # scope here — callers that use ``call_transform`` are responsible
+    # for providing their own wrapper definition.
+    expected = textwrap.dedent(
+        text="""\
+        def process(*_args: object, **_kwargs: object) -> object: ...
+        emit(process(a=1, b=2))""",
+    )
+    assert result.code == expected
 
 
 def test_both_variable_forms_without_wrap_in_file_raises() -> None:


### PR DESCRIPTION
## Summary
- `literalize_call(..., wrap_in_file=True)` now injects a no-op stub for `target_function` into the wrapped file using the language's existing `format_call_stub` / `format_call_preamble_stub` hooks. Before this change, the wrapped file called an undefined function and only survived lint tools that don't resolve names (e.g. `gofmt -e`). Now it compiles against strict checkers on its own.
- `StubReturn.VALUE` is used when a `call_transform` consumes the call result; `StubReturn.VOID` otherwise. The wrapper name the transform introduces is not stubbed — callers that transform calls remain responsible for providing that definition.
- Updated the existing unit test in `tests/test_languages.py` to assert the new output (Go: stub in file-scope preamble after `package main`; Python: stub directly above the call). Added a second test covering the `StubReturn.VALUE` / `call_transform` path.

## Test plan
- [x] `uv run pytest -n auto --cov-fail-under 100 --cov=src/ --cov=tests .` — 1020 passed, 100% coverage
- [x] `uv run ty check`, `uv run pyrefly check`, `uv run mypy` — all clean
- [x] Pre-push hooks (mypy, pyright, ty, pyrefly, pyright-verifytypes) pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated source for `literalize_call` in `wrap_in_file` mode by adding stub declarations and adjusting preamble ordering, which could affect downstream snapshot/golden tests and consumers relying on exact output.
> 
> **Overview**
> **`literalize_call(..., wrap_in_file=True)` now generates fully self-contained source files** by injecting a no-op stub for the `target_function` using each language’s `format_call_stub` / `format_call_preamble_stub` hooks.
> 
> When a `call_transform` is provided, the stub is generated with `StubReturn.VALUE` (so the transformed expression can consume the call result); otherwise it uses `StubReturn.VOID`. Preamble assembly is adjusted so stubs appear after the language’s static preamble (e.g. Go’s `package main`).
> 
> Tests are updated to assert the new wrapped-file output for Go and Python, and a new test covers the value-returning stub behavior under `call_transform`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbba1b45f8bf9623a1d7f9250d98433e32703a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->