### PR TITLE
Run PowerShell fixtures in lint.yml to catch runtime errors

### DIFF
--- a/.github/scripts/run-powershell.ps1
+++ b/.github/scripts/run-powershell.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+$stream = [Console]::OpenStandardInput()
+$buffer = New-Object System.IO.MemoryStream
+$stream.CopyTo($buffer)
+$paths = [System.Text.Encoding]::UTF8.GetString($buffer.ToArray()) -split "`0" |
+    Where-Object { $_ }
+$failed = $false
+foreach ($p in $paths) {
+    try {
+        $block = [scriptblock]::Create((Get-Content -Raw -LiteralPath $p))
+        & $block
+    } catch {
+        [Console]::Error.WriteLine("FAIL ${p}: $($_.Exception.Message)")
+        $failed = $true
+    }
+}
+if ($failed) { exit 1 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -104,10 +104,17 @@ jobs:
 
       # Parse every fixture inside a single pwsh invocation so the .NET
       # and PowerShell startup cost is paid once instead of per fixture.
+      # The run step reuses the same trick: one pwsh process iterates
+      # every fixture, executing its script block in a child scope so
+      # `$my_data` (and anything else) does not leak between fixtures.
       - name: Lint PowerShell
         run: |-
           find tests/integration/cases -name '*.ps1' -print0 > /tmp/files-ps1
           pwsh -NoProfile -NonInteractive -File .github/scripts/lint-powershell.ps1 < /tmp/files-ps1
+
+      - name: Run PowerShell files
+        run: pwsh -NoProfile -NonInteractive -File .github/scripts/run-powershell.ps1
+          < /tmp/files-ps1
 
       # Every fixture defines its own `fval_m` module, and the syntax
       # check leaves an `fval_m.mod` in the working directory (gfortran


### PR DESCRIPTION
## Summary

- The existing `Lint PowerShell` step only builds a scriptblock per fixture via `[scriptblock]::Create(...)`, which validates parse but never executes the body. Undefined cmdlets, missing module imports, and failed assertions therefore slip past CI.
- Add a `Run PowerShell files` step that invokes each fixture's scriptblock in a child scope (`& $block`), mirroring the parse+run pattern already used by `lint-bash`, `lint-ruby`, `lint-javascript`, `lint-go`, `lint-julia`, and `lint-perl`.
- The run step reuses the same single-pwsh-invocation trick as the parse step, so the .NET + PowerShell startup cost is still paid once instead of per fixture. `$ErrorActionPreference = 'Stop'` promotes non-terminating errors to failures, and `& $block` gives each fixture a child scope so `$my_data` doesn't leak between fixtures.

Closes #1424.

## Test plan

- [x] Ran both steps locally against all 232 `*.ps1` fixtures under `tests/integration/cases/**` with pwsh 7.4.15 — all pass end-to-end, no stubs needed (every fixture only assigns `$my_data`).
- [x] Confirmed a synthetic fixture calling an undefined cmdlet passes the existing parse step but fails the new run step with `FAIL <path>: The term '...' is not recognized as a name of a cmdlet, ...`.
- [x] `actionlint`, `yamlfix`, and `zizmor --strict-collection .github` all clean.
- [ ] CI passes on this PR.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions to *run* repository PowerShell fixtures, which can introduce new CI failures or longer runtimes if any fixture has side effects or environment assumptions.
> 
> **Overview**
> The lint workflow now **executes** all `tests/integration/cases/**/*.ps1` fixtures in CI (in addition to the existing parse-only check) so runtime issues like missing cmdlets/imports and failing assertions are caught.
> 
> Adds `.github/scripts/run-powershell.ps1`, which reads the null-delimited fixture list from stdin, runs each file in a child scope via `& [scriptblock]::Create(...)`, and fails the job if any fixture throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420a4ddb6491a02c4ef288f5b0878fe48dcfed0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->