### PR TITLE
Run Lua fixtures in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,6 +135,7 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.lua' -print0 > /tmp/files-lua
           xargs -0 luac -p < /tmp/files-lua
+          xargs -0 -P "$(nproc)" -n1 lua < /tmp/files-lua
 
       - name: Lint Nix
         run: |-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- ``lint-lua`` in ``.github/workflows/lint.yml`` now runs each Lua
+  fixture end-to-end via ``lua``, catching runtime errors (calls to
+  undefined functions, missing module imports, failed assertions)
+  that the existing ``luac -p`` parse-only step let through,
+  mirroring ``lint-bash`` / ``lint-javascript`` / ``lint-perl`` etc.
 - ``literalize_call(..., wrap_in_file=True)`` now injects a no-op
   stub for the ``target_function`` into the wrapped file, so the
   generated source compiles against strict checkers on its own.


### PR DESCRIPTION
## Summary

- Add a second xargs line to the `Lint Lua` step in `.github/workflows/lint.yml` that actually runs each fixture with `lua`, so runtime errors (calls to undefined functions, missing module imports, failed assertions) no longer slip past the `luac -p` parse-only check.
- Mirrors the pattern already used by `lint-bash`, `lint-ruby`, `lint-javascript`, `lint-go`, `lint-julia`, and — as of 1de640d0a — `lint-perl`.
- No fixture changes needed: all 261 `tests/integration/cases/**/*.lua` fixtures run end-to-end without stubs.

Closes #1420.

## Test plan

- [ ] `lint-fast` job in CI passes, with the new `xargs -0 -P "$(nproc)" -n1 lua < /tmp/files-lua` line exercising every fixture.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it may increase `lint-fast` runtime and surface previously-unnoticed Lua fixture runtime failures.
> 
> **Overview**
> **Lua linting in CI is tightened** by running every `tests/integration/cases/**/*.lua` fixture end-to-end via `lua` after the existing `luac -p` parse check (parallelized with `xargs -P`).
> 
> Updates `CHANGELOG.rst` to document that `lint-lua` now catches runtime errors (e.g., missing imports/undefined functions/assertion failures) that parsing alone could miss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1c9684f9406ac5c55954cfea2278dccd268637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->