### PR TITLE
Run Racket files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1113,6 +1113,8 @@ jobs:
       - uses: Bogdanp/setup-racket@v1.15
       - name: Check Racket syntax
         run: xargs -0 raco make < /tmp/files-to-lint
+      - name: Run Racket files
+        run: xargs -0 -P "$(nproc)" -n1 racket < /tmp/files-to-lint
 
   lint-raku:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add a `Run Racket files` step to the `lint-racket` job so each fixture actually executes, not just gets compiled by `raco make`.
- Matches the pattern already used by lint-bash, lint-ruby, lint-javascript, lint-go, lint-julia, and lint-perl.

Closes #1431

## Test plan
- Ran `racket` against every `tests/integration/cases/**/*.rkt` fixture locally; all 245 fixtures ran clean, so no stubs were needed.
- CI will exercise the new step.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds runtime execution of Racket fixtures; main impact is potentially longer lint time or newly surfaced fixture failures.
> 
> **Overview**
> The `lint-racket` GitHub Actions job now **runs each `*.rkt` fixture** (in parallel via `xargs -P "$(nproc)"`) after compiling with `raco make`, so CI can catch Racket runtime errors that syntax/bytecode compilation alone would miss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c99ed2f273afd4fcc96dc26a28977e5a49dcd4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->