### PR TITLE
Run Racket lint files to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1105,6 +1105,8 @@ jobs:
       - uses: Bogdanp/setup-racket@v1.15
       - name: Check Racket syntax
         run: xargs -0 raco make < /tmp/files-to-lint
+      - name: Run Racket files
+        run: xargs -0 -P "$(nproc)" -n1 racket < /tmp/files-to-lint
 
   lint-raku:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a "Run Racket files" step to the `lint-racket` job in `.github/workflows/lint.yml` so every `*.rkt` fixture is actually executed, mirroring the pattern used by `lint-go`, `lint-julia`, `lint-perl`, etc.
- `raco make` compiles `#lang racket` modules but does not invoke them, so calls to undefined functions and failed assertions slip past CI. The new step runs each fixture with `racket` (reusing the bytecode that `raco make` already produced).
- Closes #1431.

## Test plan

- [x] Installed `minimal-racket` locally and ran `racket <file>` against every fixture under `tests/integration/cases/**/*.rkt` (245 files); all pass end-to-end, so no stubs are required.
- [x] `prek run --files .github/workflows/lint.yml` passes (`actionlint`, `yamlfix`, `zizmor`, etc.).
- [ ] CI `lint-racket` job passes on this PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it may increase CI time and cause previously unexecuted Racket fixtures to start failing due to runtime errors.
> 
> **Overview**
> The `lint-racket` job now **runs** each Racket fixture with `racket` (in parallel) after the existing `raco make` compilation step, so CI fails on runtime errors that compilation alone would miss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 593533390b7b341d7d81de904554f232ea94f636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->