### PR TITLE
Run Dart fixtures in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -801,17 +801,40 @@ jobs:
       # renamed to `fixture_N.dart` because several fixtures share a
       # basename (e.g. `Dart.dart`); the mapping is printed so failures
       # still point back to the original path.
-      - name: Check Dart syntax
+      #
+      # Fixtures only declare a top-level `final my_data = ...`, and
+      # Dart initializes top-level `final` lazily — `dart run` on a
+      # bare fixture would never evaluate its initializer. Generate a
+      # `main.dart` driver that imports every fixture and references
+      # each `my_data`, so one `dart run` forces all initializers to
+      # execute and surfaces runtime errors (e.g. a bad
+      # `DateTime.parse` argument). Paying Dart VM startup once across
+      # all fixtures keeps this step cheap.
+      - name: Check Dart syntax and run fixtures
         run: |-
           tmpdir=$(mktemp -d)
           printf 'name: check\nenvironment:\n  sdk: ^3.0.0\n' > "$tmpdir/pubspec.yaml"
+          driver="$tmpdir/main.dart"
+          : > "$driver"
           i=0
           while IFS= read -r -d '' f; do
             cp "$f" "$tmpdir/fixture_$i.dart"
+            printf 'import "fixture_%d.dart" as f%d;\n' "$i" "$i" >> "$driver"
             printf 'fixture_%s.dart <- %s\n' "$i" "$f"
             i=$((i+1))
           done < /tmp/files-to-lint
+          {
+            printf 'void main() {\n'
+            printf '  final sink = <Object?>[\n'
+            for ((j=0; j<i; j++)); do
+              printf '    f%d.my_data,\n' "$j"
+            done
+            printf '  ];\n'
+            printf "  if (sink.isEmpty) throw StateError('unreachable');\n"
+            printf '}\n'
+          } >> "$driver"
           dart analyze --fatal-infos "$tmpdir"
+          (cd "$tmpdir" && dart run main.dart)
 
   lint-julia:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `dart analyze` only performs static analysis, and Dart fixtures just declare a top-level `final my_data = ...` whose initializer is lazily evaluated, so even running a fixture directly would never execute it. Runtime errors (e.g. bad `DateTime.parse` arguments, undefined function calls) therefore slip past CI.
- Build a `main.dart` driver alongside the copied fixtures that imports each as `fN` and pushes every `my_data` into an `<Object?>[]` sink, forcing all initializers to run under a single `dart run`. Dart VM startup is still paid once, matching the existing batch-into-one-invocation pattern used by `lint-scala`, `lint-crystal` and `lint-erlang`.
- All 223 Dart fixtures under `tests/integration/cases/**` run end-to-end without stubs, so no fixture changes are needed.

Closes #1419

## Test plan

- [x] Locally ran `dart analyze --fatal-infos` against all 223 copied fixtures → `No issues found!`
- [x] Locally ran `dart run main.dart` against the generated driver → exit 0 in ~1.2s
- [x] Verified regressions are caught by temporarily replacing a fixture with `final my_data = undefined_function();` (compile error) and `final my_data = DateTime.parse("not a valid date");` (runtime `FormatException`)
- [x] `actionlint`, `check yaml`, `yamlfix`, and `zizmor` pass on the updated workflow
- [ ] CI green on this PR

Made-with: Cursor

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes CI linting behavior, though it may increase job time and introduce new failures by surfacing previously-missed runtime errors in fixtures.
> 
> **Overview**
> Enhances the `lint-dart` GitHub Actions job to **run** the generated Dart fixture package, not just `dart analyze`, by creating a `main.dart` driver that imports every copied `fixture_N.dart` and references each `my_data` to force lazy top-level initializers to execute.
> 
> The workflow still batches fixtures into one temp package/invocation, but now fails CI on runtime issues (e.g. invalid `DateTime.parse` inputs) via an added `(cd "$tmpdir" && dart run main.dart)` step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7637ef2b38540deccee5b460bf702116b82664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->