### PR TITLE
Fix pyrefly pre-push hook collecting zero files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,9 +301,14 @@ plugins = [ "mypy_strict_kwargs" ]
 follow_untyped_imports = true
 
 [tool.pyrefly]
+# Without this, pyrefly's built-in default `project-excludes` (e.g.
+# `**/__pycache__`, `**/venv/**/*`, the project's `site-packages`) are
+# appended to ours and combine with the `.gitignore`-based ignore files to
+# match our entire include pattern (`**/*.py*`), causing pyrefly to report
+# "no files matched" and fail the pre-push hook.
+disable-project-excludes-heuristics = true
 errors.non-exhaustive-match = "error"
 errors.unused-ignore = "error"
-project_excludes = []
 search_path = [ ".", "src" ]
 
 [tool.pyright]


### PR DESCRIPTION
## Summary

- `pyrefly check` (and therefore the `pyrefly` / `pyrefly-docs` pre-push hooks) was exiting `1` on a clean `main` with `"No Python files matched"`, because pyrefly appends its built-in default `project-excludes` (`**/node_modules`, `**/__pycache__`, `**/venv/**/*`, the project's `site-packages`) to ours. Combined with the `.gitignore`-based ignore files, those defaults matched our entire include pattern (`**/*.py*`).
- Set `disable-project-excludes-heuristics = true` under `[tool.pyrefly]` so `project-excludes` starts empty (per the [pyrefly docs](https://pyrefly.org/en/docs/configuration/#disable-project-excludes-heuristics)). The now-redundant `project_excludes = []` line is removed.
- Added a comment explaining why the flag is needed so future readers don't re-introduce the same footgun.

Closes #1618.

## Test plan

- [x] `uv run --extra=dev pyrefly check` exits `0` (`0 errors (1 suppressed)`).
- [x] `uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="pyrefly check"` exits `0`.
- [x] The `pyrefly` pre-push hook runs cleanly on push (see `git push` output).
- [ ] Full pre-push / CI run is green.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects static analysis and pre-push hooks, not runtime behavior.
> 
> **Overview**
> Ensures `pyrefly check` (and related pre-push hooks) no longer fails with “no files matched” by setting `disable-project-excludes-heuristics = true` under `[tool.pyrefly]`.
> 
> Removes the now-redundant `project_excludes = []` and adds an inline comment documenting why the flag is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069725245e5fbfedb102219497dea11705aa0680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->