### PR TITLE
Pin mojo-compiler to 0.25.6.0 to probe CI flake

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -984,7 +984,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install Mojo
-        run: uv tool install mojo-compiler
+        run: uv tool install 'mojo-compiler==0.25.6.0'
       # Mojo reserves ~3.6 GB of virtual address space per invocation
       # (upstream: modular/modular#6433). On the 7 GB GitHub runner the
       # kernel's default overcommit heuristic refuses the allocation and


### PR DESCRIPTION
## Summary
- Pin `mojo-compiler` to `0.25.6.0` (oldest available on PyPI, Sep 2025) in the `lint-mojo` CI job to test whether the virtual-address-reservation flake (modular/modular#6433, tracked in #1574) is avoided by an older Mojo release.

## Test plan
- [ ] Observe `lint-mojo` runs on this branch and compare failure rate against main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adjusts a CI tool installation version; the main impact is potential changes in Mojo lint behavior or flake rate in `lint-mojo`.
> 
> **Overview**
> **CI change only:** the `lint-mojo` job now installs a pinned `mojo-compiler==0.25.6.0` via `uv tool install` instead of using the latest available version, to help investigate Mojo-related CI flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c026b8a70efa6c6de98c5c7a00900bdbbb3895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->