### PR TITLE
Run lint-mojo on Ubicloud's 16 GB runner and parallelize

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,3 @@
 ---
 self-hosted-runner:
-  labels: [ubicloud-standard-4]
+  labels: [blacksmith-4vcpu-ubuntu-2404]

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,3 @@
 ---
 self-hosted-runner:
-  labels: [blacksmith-4vcpu-ubuntu-2404]
+  labels: [ubicloud-standard-4]

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+---
+self-hosted-runner:
+  labels: [ubicloud-standard-4]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -969,8 +969,14 @@ jobs:
           done < /tmp/files-to-lint
           crystal run "$driver"
 
+  # Mojo reserves ~3.6 GB of virtual address space per invocation
+  # (upstream: modular/modular#6433), so ubuntu-latest's 7 GB runner
+  # crashes in libKGENCompilerRTShared.so before producing any output —
+  # and even with overcommit + swap workarounds it could only run
+  # serially. Ubicloud's 16 GB runner comfortably fits `$(nproc)`
+  # parallel invocations without the workarounds.
   lint-mojo:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     steps:
       - uses: actions/checkout@v6
         with:
@@ -985,35 +991,8 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install Mojo
         run: uv tool install mojo-compiler
-      # Mojo reserves ~3.6 GB of virtual address space per invocation
-      # (upstream: modular/modular#6433). On the 7 GB GitHub runner the
-      # kernel's default overcommit heuristic refuses the allocation and
-      # Mojo crashes in libKGENCompilerRTShared.so before producing any
-      # output. Allow overcommit and add a 4 GB swap file so the kernel
-      # has enough headroom to accept the reservation — Mojo only
-      # actually touches ~320 MB of it.
-      - name: Expand memory headroom for Mojo
-        # The GitHub runner already ships a /swapfile mounted as swap, so
-        # add a second file at a fresh path instead of overwriting it.
-        run: |-
-          sudo sysctl -w vm.overcommit_memory=1
-          sudo fallocate -l 4G /mnt/extra-swapfile
-          sudo chmod 600 /mnt/extra-swapfile
-          sudo mkswap /mnt/extra-swapfile
-          sudo swapon /mnt/extra-swapfile
-      # Lift the per-process virtual-address cap so the shell and each
-      # `mojo run` child inherit an unlimited `RLIMIT_AS`. Keep the
-      # executions serial: each invocation reserves ~3.6 GB virtual,
-      # so running one per core on a 7 GB runner still crashes even
-      # with overcommit + swap enabled. Recommended by the upstream
-      # bug author in HomericIntelligence/ProjectOdyssey#5274.
-      # Local tracking: https://github.com/adamtheturtle/literalizer/issues/1574
       - name: Check Mojo syntax
-        run: |-
-          ulimit -v unlimited
-          while IFS= read -r -d '' f; do
-            mojo run --Werror "$GITHUB_WORKSPACE/$f"
-          done < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 mojo run --Werror < /tmp/files-to-lint
 
   lint-nim:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -973,10 +973,10 @@ jobs:
   # (upstream: modular/modular#6433), so ubuntu-latest's 7 GB runner
   # crashes in libKGENCompilerRTShared.so before producing any output —
   # and even with overcommit + swap workarounds it could only run
-  # serially. Ubicloud's 16 GB runner comfortably fits `$(nproc)`
+  # serially. Blacksmith's 16 GB runner comfortably fits `$(nproc)`
   # parallel invocations without the workarounds.
   lint-mojo:
-    runs-on: ubicloud-standard-4
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -973,10 +973,10 @@ jobs:
   # (upstream: modular/modular#6433), so ubuntu-latest's 7 GB runner
   # crashes in libKGENCompilerRTShared.so before producing any output —
   # and even with overcommit + swap workarounds it could only run
-  # serially. Blacksmith's 16 GB runner comfortably fits `$(nproc)`
+  # serially. Ubicloud's 16 GB runner comfortably fits `$(nproc)`
   # parallel invocations without the workarounds.
   lint-mojo:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubicloud-standard-4
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Moves `lint-mojo` from `ubuntu-latest` (7 GB) to Ubicloud's `ubicloud-standard-4` (16 GB) so Mojo's ~3.6 GB per-invocation virtual-address reservation (modular/modular#6433) fits comfortably.
- Drops the overcommit, 4 GB swap file, and `ulimit -v unlimited` workarounds; replaces the serial `while` loop with `xargs -0 -P "\$(nproc)" -n1`.
- Registers the `ubicloud-standard-4` label in a new `.github/actionlint.yaml` so actionlint accepts the custom runner.

## Test plan
- [ ] Install the Ubicloud Managed Runners GitHub App on \`adamtheturtle/literalizer\` before merging — otherwise the job will queue indefinitely.
- [ ] Confirm the \`lint-mojo\` job picks up an \`ubicloud-standard-4\` runner and passes without the removed workarounds.