### PR TITLE
Parallelize gforth invocations in lint-forth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -174,9 +174,7 @@ jobs:
       - name: Lint Forth
         run: |-
           find tests/integration/cases -name '*.fth' -print0 > /tmp/files-forth
-          while IFS= read -r -d '' f; do
-            gforth "$f" -e bye || exit 1
-          done < /tmp/files-forth
+          xargs -0 -P "$(nproc)" -I{} gforth {} -e bye < /tmp/files-forth
 
       - name: Lint Tcl
         run: |-


### PR DESCRIPTION
## Summary
- Replace the serial `while` loop driving `gforth` in the `lint-forth` step with `xargs -0 -P "$(nproc)" -I{}`, so Forth fixtures are checked across all available CPUs.
- Matches the pattern already used for the neighbouring Scheme/Lua/Nix lints (and the Swift parallelization from #1478 cited in the issue).

Closes #1494

## Test plan
- [ ] CI `lint-apt-basics` job runs `Lint Forth` successfully and faster than before.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; the main risk is that running multiple `gforth` processes concurrently could expose any unexpected shared-state or temp-file collisions in fixtures.
> 
> **Overview**
> Speeds up the CI `Lint Forth` step by replacing the serial per-file `gforth` loop with a parallel `xargs -P "$(nproc)"` invocation, aligning Forth linting with the other fixture-language lints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892646a34a6017ca6886b2ed55dd84e5116f7994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->