### PR TITLE
Batch lint-elixir into a single BEAM invocation

### DIFF
--- a/.github/scripts/lint-elixir.exs
+++ b/.github/scripts/lint-elixir.exs
@@ -1,0 +1,36 @@
+paths =
+  IO.read(:stdio, :eof)
+  |> String.split("\0", trim: true)
+
+# Fixtures all declare `defmodule Check`, so each iteration redefines the
+# same module name. Silence the "redefining module" compiler warning and
+# purge the previous bytecode between fixtures so the new definition is
+# the one actually invoked.
+Code.put_compiler_option(:ignore_module_conflict, true)
+
+failed =
+  Enum.reduce(paths, false, fn path, acc ->
+    result =
+      try do
+        Code.compile_file(path)
+        Check.x()
+        acc
+      rescue
+        e ->
+          IO.puts(
+            :stderr,
+            "FAIL #{path}:\n#{Exception.format(:error, e, __STACKTRACE__)}"
+          )
+          true
+      catch
+        kind, reason ->
+          IO.puts(:stderr, "FAIL #{path}:\n#{inspect({kind, reason})}")
+          true
+      end
+
+    :code.purge(Check)
+    :code.delete(Check)
+    result
+  end)
+
+System.halt(if failed, do: 1, else: 0)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -455,23 +455,15 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 uv run --no-project python check_gleam_syntax.py < /tmp/files-gleam
 
       # Fixtures only declare `defmodule Check` with a `def x` body, so
-      # `elixir` compiles the module but never invokes it. Append a call
-      # to `Check.x()` so the function body — and any references inside
-      # it — actually executes.
+      # `elixir` compiles the module but never invokes it. The script
+      # compiles each fixture, calls `Check.x()` to force the body to
+      # execute, and purges the module between fixtures — all inside a
+      # single BEAM VM, paying the cold-start cost once instead of twice
+      # per fixture (serial `elixirc` + `elixir` loops).
       - name: Lint Elixir
         run: |-
           find tests/integration/cases -name '*.ex' -print0 > /tmp/files-elixir
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            cp "$f" "$tmpdir/check.ex"
-            (cd "$tmpdir" && elixirc check.ex) || exit 1
-          done < /tmp/files-elixir
-          while IFS= read -r -d '' f; do
-            tmpdir=$(mktemp -d)
-            cp "$f" "$tmpdir/check.ex"
-            printf '\nCheck.x()\n' >> "$tmpdir/check.ex"
-            (cd "$tmpdir" && elixir check.ex) || exit 1
-          done < /tmp/files-elixir
+          elixir .github/scripts/lint-elixir.exs < /tmp/files-elixir
 
       # Compile every fixture in a single erlc invocation to pay the
       # BEAM VM startup cost once. Erlang requires the module name to


### PR DESCRIPTION
## Summary

- Extract the `Lint Elixir` step into `.github/scripts/lint-elixir.exs`, which compiles each fixture with `Code.compile_file/1`, calls `Check.x()` to force the body to execute, and purges the `Check` module between fixtures so the next can redefine it — all inside one BEAM VM.
- Replace the two serial `while` loops (one `elixirc` per fixture, then one `elixir` per fixture — two cold BEAM starts each) with a single `elixir .github/scripts/lint-elixir.exs < /tmp/files-elixir` invocation.
- Mirrors the batching done for Groovy (#1481) and Dart (#1479).

Closes #1487.

## Test plan

- [x] Local run against all 144 `.ex` fixtures completes in ~0.9s (previously ~9.6s for just the first loop over 35 fixtures, extrapolating to ~80s for the full two-loop run).
- [x] Injected a runtime `raise` and a syntax error into dummy fixtures to confirm the script prints `FAIL <path>` with a stack trace, keeps going through remaining fixtures, and exits non-zero.
- [ ] `lint-beam` passes on CI.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow refactor limited to CI linting; main risk is subtle module caching/purge behavior causing false pass/fail in Elixir fixture checks.
> 
> **Overview**
> Elixir fixture linting is refactored to run **all `.ex` fixtures in one `elixir` process** via a new `.github/scripts/lint-elixir.exs` driver, instead of two per-file loops (`elixirc` then `elixir`).
> 
> The script compiles each fixture, executes `Check.x()` to surface runtime/undefined-reference errors, and purges `Check` between fixtures while aggregating failures and exiting non-zero if any fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02843cc560f15c111c7c94257c0bdecde0bdc3d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->