### PR TITLE
Run TypeScript fixtures in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
   # time on runner startup than on linting.
   lint-fast:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
   # time on runner startup than on linting.
   lint-fast:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -234,7 +234,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install npm-sourced linters
-        run: npm install -g json5 tree-sitter-cli typescript elm-format elm
+        run: npm install -g json5 tree-sitter-cli typescript tsx elm-format elm
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -264,6 +264,8 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.ts' -print0 > /tmp/files-ts
           xargs -0 -P "$(nproc)" -n1 tsc --noEmit --noResolve --skipLibCheck --lib es2015 < /tmp/files-ts
+      - name: Run TypeScript files
+        run: xargs -0 -P "$(nproc)" -n1 tsx < /tmp/files-ts
 
       - name: Lint Elm
         run: |-

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -83,9 +83,20 @@ def _ts_call_stub(
     _stub_return: StubReturn,
     /,
 ) -> tuple[str, ...]:
-    """Return TypeScript stub declarations for a call name."""
+    """Return TypeScript stub declarations for a call name.
+
+    Mirrors :func:`_js_call_stub`: dotted roots become a ``Proxy`` that
+    returns a callable ``Proxy`` for any attribute access, so nested
+    member calls succeed; bare roots become a no-op function. The ``:
+    any`` annotation keeps the stub accepted by the type checker
+    regardless of how the fixture uses it.
+    """
     root = name.split(sep=".", maxsplit=1)[0]
-    return (f"declare const {root}: any;",)
+    if "." in name:
+        proxy = "new Proxy(function(){}, {get: g})"
+        handler = f"get: function g() {{ return {proxy}; }}"
+        return (f"const {root}: any = new Proxy({{}}, {{{handler}}});",)
+    return (f"const {root}: any = () => {{}};",)
 
 
 @beartype

--- a/tests/integration/cases/call_deep_dotted_method/TypeScript_call.ts
+++ b/tests/integration/cases/call_deep_dotted_method/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const obj: any;
+const obj: any = new Proxy({}, {get: function g() { return new Proxy(function(){}, {get: g}); }});
 obj.api.client.post({ data: "hello" });
 obj.api.client.post({ data: 42 });
 obj.api.client.post({ data: true });

--- a/tests/integration/cases/call_deep_dotted_transformed/TypeScript_call.ts
+++ b/tests/integration/cases/call_deep_dotted_transformed/TypeScript_call.ts
@@ -1,5 +1,5 @@
-declare const app: any;
-declare const emit: any;
+const app: any = new Proxy({}, {get: function g() { return new Proxy(function(){}, {get: g}); }});
+const emit: any = () => {};
 emit(app.client.fetch({ payload: "hello" }));
 emit(app.client.fetch({ payload: 42 }));
 emit(app.client.fetch({ payload: true }));

--- a/tests/integration/cases/call_dotted_method/TypeScript_call.ts
+++ b/tests/integration/cases/call_dotted_method/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const app: any;
+const app: any = new Proxy({}, {get: function g() { return new Proxy(function(){}, {get: g}); }});
 app.client.fetch({ payload: "hello" });
 app.client.fetch({ payload: 42 });
 app.client.fetch({ payload: true });

--- a/tests/integration/cases/call_keyword_args/TypeScript_call.ts
+++ b/tests/integration/cases/call_keyword_args/TypeScript_call.ts
@@ -1,5 +1,5 @@
-declare const throttler: any;
-declare const emit: any;
+const throttler: any = new Proxy({}, {get: function g() { return new Proxy(function(){}, {get: g}); }});
+const emit: any = () => {};
 emit(throttler.check({ user_id: "user_1", ts: 1000.0 }));
 emit(throttler.check({ user_id: "user_2", ts: 2000.5 }));
 export {};

--- a/tests/integration/cases/call_mixed_type_dicts/TypeScript_call.ts
+++ b/tests/integration/cases/call_mixed_type_dicts/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const app: any;
+const app: any = new Proxy({}, {get: function g() { return new Proxy(function(){}, {get: g}); }});
 app.mgr.op({ operation: {"type": "create", "pr_id": "pr_1", "draft": true} });
 app.mgr.op({ operation: {"type": "create", "pr_id": "pr_2"} });
 export {};

--- a/tests/integration/cases/call_multi_args/TypeScript_call.ts
+++ b/tests/integration/cases/call_multi_args/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 process({ value: 1, count: 42 });
 process({ value: 2, count: 100 });
 export {};

--- a/tests/integration/cases/call_per_element_false/TypeScript_call.ts
+++ b/tests/integration/cases/call_per_element_false/TypeScript_call.ts
@@ -1,3 +1,3 @@
-declare const process: any;
+const process: any = () => {};
 process({ data: 1 });
 export {};

--- a/tests/integration/cases/call_positional/TypeScript_call.ts
+++ b/tests/integration/cases/call_positional/TypeScript_call.ts
@@ -1,5 +1,5 @@
-declare const throttler: any;
-declare const emit: any;
+const throttler: any = new Proxy({}, {get: function g() { return new Proxy(function(){}, {get: g}); }});
+const emit: any = () => {};
 emit(throttler.check("user_1", 1000.0));
 emit(throttler.check("user_2", 2000.5));
 export {};

--- a/tests/integration/cases/call_ref_args/TypeScript_call.ts
+++ b/tests/integration/cases/call_ref_args/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 const my_var = [
   1,
   2,

--- a/tests/integration/cases/call_ref_args_converted/TypeScript_call.ts
+++ b/tests/integration/cases/call_ref_args_converted/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 const myVar = [
   1,
   2,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/TypeScript_call.ts
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 const myVar = [
   1,
   2,

--- a/tests/integration/cases/call_ref_args_converted_whole/TypeScript_call.ts
+++ b/tests/integration/cases/call_ref_args_converted_whole/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 const myVar = [
   1,
   2,

--- a/tests/integration/cases/call_scalar_args/TypeScript_call.ts
+++ b/tests/integration/cases/call_scalar_args/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 process({ value: "hello" });
 process({ value: 42 });
 process({ value: true });

--- a/tests/integration/cases/call_transform_no_wrapper/TypeScript_call.ts
+++ b/tests/integration/cases/call_transform_no_wrapper/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 process({ value: "hello" });
 process({ value: 42 });
 process({ value: true });

--- a/tests/integration/cases/call_wrap_in_file/TypeScript_call.ts
+++ b/tests/integration/cases/call_wrap_in_file/TypeScript_call.ts
@@ -1,4 +1,4 @@
-declare const process: any;
+const process: any = () => {};
 process({ a: 1, b: 2 });
 process({ a: 3, b: 4 });
 export {};


### PR DESCRIPTION
## Summary

- `tsc --noEmit` only performs static type-checking, and the TS call fixtures used `declare const X: any;` stubs that exist solely at the type level — at runtime the bound name is undefined and any use would throw. Runtime errors (e.g. calls to undefined functions, invalid member access on stub-only objects) therefore slipped past CI.
- Add a `Run TypeScript files` step that executes each fixture via `tsx`, matching the pattern already used by `lint-javascript`, `lint-ruby`, `lint-go`, `lint-perl`, and others.
- Rewrite `_ts_call_stub` to mirror `_js_call_stub`: dotted roots become a `Proxy` whose attribute access returns a callable `Proxy`, and bare roots become a no-op arrow function. Both are annotated `: any` so the stub remains accepted by the type checker regardless of how the fixture uses it.
- Regenerate the 14 `TypeScript_call.ts` golden files so every fixture under `tests/integration/cases/**` runs end-to-end without per-fixture edits.

Closes #1405

## Test plan

- [x] Locally ran `tsc --noEmit --noResolve --skipLibCheck --lib es2015` against all 483 `.ts` fixtures → 0 type errors
- [x] Locally ran `tsx <file>` against all 483 `.ts` fixtures → 0 runtime errors
- [x] Verified regressions are caught: before regenerating, the old `declare const` stubs produced `ReferenceError: emit is not defined` / `TypeError: process is not a function` on the 14 `call_*/TypeScript_call.ts` fixtures under `tsx`
- [x] `uv run --extra=dev pytest tests/` → `1154 passed, 372 skipped, 13934 subtests passed`
- [x] `prek run` on the changed files: `actionlint`, `yamlfix`, `ruff`, `zizmor`, `vulture`, `interrogate`, etc. all pass
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI linting to execute all TypeScript fixtures and updates TypeScript stub generation, which could introduce new failures/timeouts in the lint workflow and alter generated golden outputs.
> 
> **Overview**
> Adds **runtime execution of TypeScript fixtures in CI** by installing `tsx` and running each `.ts` fixture after `tsc --noEmit`, and bumps `lint-fast` job timeout to 30 minutes.
> 
> Updates TypeScript call stubs (`_ts_call_stub`) to emit *runtime-safe* stubs: dotted call roots become a nested-attribute `Proxy` and bare roots become a no-op function, then regenerates the affected `TypeScript_call.ts` golden fixtures to match the new stub output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ce3b2f37c74a4164c860cdce25deb2a80b2281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->