### PR TITLE
Add literalize_call support for Matlab

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- Added ``literalize_call`` support for ``Matlab``.  ``Matlab.CallStyles``
+  now has a ``POSITIONAL`` member backed by a :class:`PositionalCallStyle`,
+  and ``format_call_stub`` emits ``name = @(varargin) [];`` assignments so
+  every target (including dotted paths like ``app.client.fetch``) is a
+  bound function handle before it is invoked.  MATLAB's auto-vivifying
+  struct-field assignment means a single line defines the entire chain
+  regardless of depth, so the stub is one statement per call target.
 - ``lint-purescript`` in ``.github/workflows/lint.yml`` now runs each
   PureScript fixture end-to-end.  A new ``Run PureScript files`` step
   compiles each fixture with ``purs compile`` and loads the resulting

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -34,8 +34,6 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_concat_control
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
-    CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -46,6 +44,7 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -165,6 +164,27 @@ def _format_containers_map_entry(
     if formatted_value.startswith("{") and formatted_value.endswith("}"):
         formatted_value = f"{{{formatted_value}}}"
     return formatted_value
+
+
+@beartype
+def _matlab_call_stub(
+    name: str,
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return MATLAB stub declarations for a call name.
+
+    MATLAB scripts have no concept of forward declarations, so every
+    name referenced in a call expression must be bound first.  Simple
+    targets become anonymous function handles that accept any
+    arguments and return ``[]`` (MATLAB's null literal, usable as both
+    a value and a discarded result).  Dotted targets rely on MATLAB's
+    ``a.b.c = value`` syntax auto-vivifying intermediate ``struct``
+    fields, so the stub is a single assignment irrespective of depth.
+    """
+    anon = "@(varargin) []"
+    return (f"{name} = {anon};",)
 
 
 @beartype
@@ -380,6 +400,8 @@ class Matlab(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Matlab call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -470,9 +492,7 @@ class Matlab(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+    call_style: CallStyles = CallStyles.POSITIONAL
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:
@@ -511,7 +531,7 @@ class Matlab(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _matlab_call_stub
 
     @cached_property
     def format_call_preamble_stub(
@@ -519,6 +539,11 @@ class Matlab(metaclass=LanguageCls):
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
         return no_call_stub
+
+    @cached_property
+    def call_style_config(self) -> PositionalCallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_call_target(self) -> Callable[[str], str]:

--- a/tests/integration/cases/call_deep_dotted_method/Matlab_call.m
+++ b/tests/integration/cases/call_deep_dotted_method/Matlab_call.m
@@ -1,0 +1,4 @@
+obj.api.client.post = @(varargin) [];
+obj.api.client.post("hello")
+obj.api.client.post(42)
+obj.api.client.post(true)

--- a/tests/integration/cases/call_deep_dotted_transformed/Matlab_call.m
+++ b/tests/integration/cases/call_deep_dotted_transformed/Matlab_call.m
@@ -1,0 +1,5 @@
+app.client.fetch = @(varargin) [];
+emit = @(varargin) [];
+emit(app.client.fetch("hello"))
+emit(app.client.fetch(42))
+emit(app.client.fetch(true))

--- a/tests/integration/cases/call_dotted_method/Matlab_call.m
+++ b/tests/integration/cases/call_dotted_method/Matlab_call.m
@@ -1,0 +1,4 @@
+app.client.fetch = @(varargin) [];
+app.client.fetch("hello")
+app.client.fetch(42)
+app.client.fetch(true)

--- a/tests/integration/cases/call_keyword_args/Matlab_call.m
+++ b/tests/integration/cases/call_keyword_args/Matlab_call.m
@@ -1,0 +1,4 @@
+throttler.check = @(varargin) [];
+emit = @(varargin) [];
+emit(throttler.check("user_1", 1000.0))
+emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_mixed_type_dicts/Matlab_call.m
+++ b/tests/integration/cases/call_mixed_type_dicts/Matlab_call.m
@@ -1,0 +1,3 @@
+app.mgr.op = @(varargin) [];
+app.mgr.op(struct('type', "create", 'pr_id', "pr_1", 'draft', true))
+app.mgr.op(struct('type', "create", 'pr_id', "pr_2"))

--- a/tests/integration/cases/call_multi_args/Matlab_call.m
+++ b/tests/integration/cases/call_multi_args/Matlab_call.m
@@ -1,0 +1,3 @@
+process = @(varargin) [];
+process(1, 42)
+process(2, 100)

--- a/tests/integration/cases/call_per_element_false/Matlab_call.m
+++ b/tests/integration/cases/call_per_element_false/Matlab_call.m
@@ -1,0 +1,2 @@
+process = @(varargin) [];
+process(1)

--- a/tests/integration/cases/call_ref_args/Matlab_call.m
+++ b/tests/integration/cases/call_ref_args/Matlab_call.m
@@ -1,0 +1,13 @@
+process = @(varargin) [];
+my_var = {
+    1,
+    2,
+    3
+};
+my_other = {
+    4,
+    5,
+    6
+};
+process(my_var, 42)
+process(my_other, 7)

--- a/tests/integration/cases/call_ref_args_converted/Matlab_call.m
+++ b/tests/integration/cases/call_ref_args_converted/Matlab_call.m
@@ -1,0 +1,13 @@
+process = @(varargin) [];
+myVar = {
+    1,
+    2,
+    3
+};
+myOther = {
+    4,
+    5,
+    6
+};
+process(myVar, 42)
+process(myOther, 7)

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Matlab_call.m
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Matlab_call.m
@@ -1,0 +1,13 @@
+process = @(varargin) [];
+myVar = {
+    1,
+    2,
+    3
+};
+myOther = {
+    4,
+    5,
+    6
+};
+process(myVar, 42)
+process(myOther, 7)

--- a/tests/integration/cases/call_ref_args_converted_whole/Matlab_call.m
+++ b/tests/integration/cases/call_ref_args_converted_whole/Matlab_call.m
@@ -1,0 +1,7 @@
+process = @(varargin) [];
+myVar = {
+    1,
+    2,
+    3
+};
+process(myVar)

--- a/tests/integration/cases/call_scalar_args/Matlab_call.m
+++ b/tests/integration/cases/call_scalar_args/Matlab_call.m
@@ -1,0 +1,4 @@
+process = @(varargin) [];
+process("hello")
+process(42)
+process(true)

--- a/tests/integration/cases/call_transform_no_wrapper/Matlab_call.m
+++ b/tests/integration/cases/call_transform_no_wrapper/Matlab_call.m
@@ -1,0 +1,4 @@
+process = @(varargin) [];
+process("hello")
+process(42)
+process(true)

--- a/tests/integration/cases/call_wrap_in_file/Matlab_call.m
+++ b/tests/integration/cases/call_wrap_in_file/Matlab_call.m
@@ -1,0 +1,3 @@
+process = @(varargin) [];
+process(1, 2)
+process(3, 4)


### PR DESCRIPTION
Define Matlab positional call style and emit function-handle call stubs so simple and dotted targets are bound before invocation. Add MATLAB call goldens across integration call cases and document the feature in the changelog.

Closes #1129

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `literalize_call` behavior for MATLAB, including generated stubs for call targets (notably dotted paths), which could affect call-output correctness across multiple fixtures. Changes are localized to the MATLAB language spec and integration goldens.
> 
> **Overview**
> Adds **`literalize_call` support for `Matlab`** by defining `Matlab.CallStyles.POSITIONAL` and wiring MATLAB into the call-style config path.
> 
> Updates MATLAB call generation to emit a per-target stub assignment (`name = @(varargin) [];`) so both simple and **dotted call targets** are bound before invocation, and adds MATLAB golden outputs across existing integration call cases. Documentation is updated in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faba1e496eb32ffca9bc24aabb70abe82f61b70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->