### PR TITLE
Speed up recursive formatting without removing beartype

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -229,7 +229,9 @@ def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
         return set_cfg.empty_set
     sorted_items = sorted(value, key=lambda v: (type(v).__name__, repr(v)))
     items_as_values: list[Value] = list(sorted_items)
-    formatted = [_format_scalar(value=v, spec=spec) for v in sorted_items]
+    formatted = [
+        _format_scalar_unchecked(value=v, spec=spec) for v in sorted_items
+    ]
     entries = [
         spec.format_set_entry(v, item)
         for v, item in zip(sorted_items, formatted, strict=True)
@@ -279,7 +281,7 @@ def _format_ordered_map_value(
                 parent_id=parent_id,
                 wrap_ids=wrap_ids,
                 raw_value=v,
-                formatted_value=_format_dict_entry_value(
+                formatted_value=_format_dict_entry_value_unchecked(
                     value=v,
                     spec=spec,
                     wrap_ids=wrap_ids,
@@ -333,7 +335,7 @@ def _format_dict_value(
     )
     pairs = [
         _build_dict_entry(
-            key_str=_format_value(
+            key_str=_format_value_unchecked(
                 value=k,
                 spec=spec,
                 dict_open_override=None,
@@ -345,7 +347,7 @@ def _format_dict_value(
                 parent_id=parent_id,
                 wrap_ids=wrap_ids,
                 raw_value=v,
-                formatted_value=_format_dict_entry_value(
+                formatted_value=_format_dict_entry_value_unchecked(
                     value=v,
                     spec=spec,
                     wrap_ids=wrap_ids,
@@ -387,14 +389,14 @@ def _format_dict_entry_value(
     across sibling entries share a widened type).
     """
     if isinstance(value, list):
-        return _format_list_value(
+        return _format_list_value_unchecked(
             value=value,
             spec=spec,
             wrap_ids=wrap_ids,
             sequence_open_override=outer_sequence_override,
             child_sequence_open_overrides=position_overrides,
         )
-    return _format_value(
+    return _format_value_unchecked(
         value=value,
         spec=spec,
         dict_open_override=None,
@@ -673,7 +675,7 @@ def _format_list_value(
                 parent_id=parent_id,
                 wrap_ids=wrap_ids,
                 raw_value=v,
-                formatted_value=_format_value(
+                formatted_value=_format_value_unchecked(
                     value=v,
                     spec=spec,
                     dict_open_override=dict_open_override,
@@ -740,22 +742,22 @@ def _format_value(
     """
     match value:
         case ordereddict():
-            return _format_ordered_map_value(
+            return _format_ordered_map_value_unchecked(
                 value=value,
                 spec=spec,
                 wrap_ids=wrap_ids,
             )
         case dict():
-            return _format_dict_value(
+            return _format_dict_value_unchecked(
                 value=value,
                 spec=spec,
                 open_override=dict_open_override,
                 wrap_ids=wrap_ids,
             )
         case set():
-            return _format_set_value(value=value, spec=spec)
+            return _format_set_value_unchecked(value=value, spec=spec)
         case list():
-            return _format_list_value(
+            return _format_list_value_unchecked(
                 value=value,
                 spec=spec,
                 wrap_ids=wrap_ids,
@@ -763,7 +765,16 @@ def _format_value(
                 child_sequence_open_overrides=(),
             )
         case _:
-            return _format_scalar(value=value, spec=spec)
+            return _format_scalar_unchecked(value=value, spec=spec)
+
+
+_format_scalar_unchecked = _format_scalar.__wrapped__
+_format_set_value_unchecked = _format_set_value.__wrapped__
+_format_ordered_map_value_unchecked = _format_ordered_map_value.__wrapped__
+_format_dict_value_unchecked = _format_dict_value.__wrapped__
+_format_dict_entry_value_unchecked = _format_dict_entry_value.__wrapped__
+_format_list_value_unchecked = _format_list_value.__wrapped__
+_format_value_unchecked = _format_value.__wrapped__
 
 
 @beartype
@@ -852,7 +863,7 @@ def _format_collection_lines(
             )
             formatted_entries: list[str] = []
             for k, v in entries:
-                formatted_key = _format_value(
+                formatted_key = _format_value_unchecked(
                     value=k,
                     spec=spec,
                     dict_open_override=None,
@@ -863,7 +874,7 @@ def _format_collection_lines(
                     parent_id=parent_id,
                     wrap_ids=wrap_ids,
                     raw_value=v,
-                    formatted_value=_format_dict_entry_value(
+                    formatted_value=_format_dict_entry_value_unchecked(
                         value=v,
                         spec=spec,
                         wrap_ids=wrap_ids,
@@ -900,7 +911,7 @@ def _format_collection_lines(
             formatted_entries = [
                 spec.format_set_entry(
                     item,
-                    _format_value(
+                    _format_value_unchecked(
                         value=item,
                         spec=spec,
                         dict_open_override=None,
@@ -933,7 +944,7 @@ def _format_collection_lines(
                         parent_id=parent_id,
                         wrap_ids=wrap_ids,
                         raw_value=element,
-                        formatted_value=_format_value(
+                        formatted_value=_format_value_unchecked(
                             value=element,
                             spec=spec,
                             dict_open_override=dict_open_override,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Sequence
-from typing import Any, assert_never, cast
+from typing import assert_never, cast
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.compat import ordereddict
@@ -154,6 +154,11 @@ VariableForm = NewVariable | ExistingVariable | BothVariableForms
 @beartype
 def _format_scalar(*, value: Scalar, spec: Language) -> str:
     """Format a scalar JSON value as a native language literal."""
+    return _format_scalar_impl(value=value, spec=spec)
+
+
+def _format_scalar_impl(*, value: Scalar, spec: Language) -> str:
+    """Format a scalar JSON value as a native language literal."""
     match value:
         case None:
             result = spec.null_literal
@@ -223,15 +228,18 @@ def _build_dict_entry(
 @beartype
 def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
     """Format a set value as a native language literal."""
+    return _format_set_value_impl(value=value, spec=spec)
+
+
+def _format_set_value_impl(*, value: set[Scalar], spec: Language) -> str:
+    """Format a set value as a native language literal."""
     set_cfg = spec.set_format_config
 
     if not value and set_cfg.empty_set is not None:
         return set_cfg.empty_set
     sorted_items = sorted(value, key=lambda v: (type(v).__name__, repr(v)))
     items_as_values: list[Value] = list(sorted_items)
-    formatted = [
-        _format_scalar_unchecked(value=v, spec=spec) for v in sorted_items
-    ]
+    formatted = [_format_scalar_impl(value=v, spec=spec) for v in sorted_items]
     entries = [
         spec.format_set_entry(v, item)
         for v, item in zip(sorted_items, formatted, strict=True)
@@ -242,6 +250,20 @@ def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
 
 @beartype
 def _format_ordered_map_value(
+    *,
+    value: ordereddict,
+    spec: Language,
+    wrap_ids: frozenset[int],
+) -> str:
+    """Format an ordered map as a native language literal."""
+    return _format_ordered_map_value_impl(
+        value=value,
+        spec=spec,
+        wrap_ids=wrap_ids,
+    )
+
+
+def _format_ordered_map_value_impl(
     *,
     value: ordereddict,
     spec: Language,
@@ -269,7 +291,7 @@ def _format_ordered_map_value(
     )
     pairs = [
         spec.format_ordered_map_entry(
-            _format_value(
+            _format_value_impl(
                 value=k,
                 spec=spec,
                 dict_open_override=None,
@@ -281,7 +303,7 @@ def _format_ordered_map_value(
                 parent_id=parent_id,
                 wrap_ids=wrap_ids,
                 raw_value=v,
-                formatted_value=_format_dict_entry_value_unchecked(
+                formatted_value=_format_dict_entry_value_impl(
                     value=v,
                     spec=spec,
                     wrap_ids=wrap_ids,
@@ -300,6 +322,22 @@ def _format_ordered_map_value(
 
 @beartype
 def _format_dict_value(
+    *,
+    value: dict[str, Value],
+    spec: Language,
+    open_override: str | None,
+    wrap_ids: frozenset[int],
+) -> str:
+    """Format a dict as a native language literal."""
+    return _format_dict_value_impl(
+        value=value,
+        spec=spec,
+        open_override=open_override,
+        wrap_ids=wrap_ids,
+    )
+
+
+def _format_dict_value_impl(
     *,
     value: dict[str, Value],
     spec: Language,
@@ -335,7 +373,7 @@ def _format_dict_value(
     )
     pairs = [
         _build_dict_entry(
-            key_str=_format_value_unchecked(
+            key_str=_format_value_impl(
                 value=k,
                 spec=spec,
                 dict_open_override=None,
@@ -347,7 +385,7 @@ def _format_dict_value(
                 parent_id=parent_id,
                 wrap_ids=wrap_ids,
                 raw_value=v,
-                formatted_value=_format_dict_entry_value_unchecked(
+                formatted_value=_format_dict_entry_value_impl(
                     value=v,
                     spec=spec,
                     wrap_ids=wrap_ids,
@@ -388,15 +426,38 @@ def _format_dict_entry_value(
     immediate child lists (so nested sequences at matching positions
     across sibling entries share a widened type).
     """
+    return _format_dict_entry_value_impl(
+        value=value,
+        spec=spec,
+        wrap_ids=wrap_ids,
+        outer_sequence_override=outer_sequence_override,
+        position_overrides=position_overrides,
+    )
+
+
+_KEEP_TYPED_WRAPPERS: tuple[Callable[..., str], ...] = (
+    _format_dict_entry_value,
+)
+
+
+def _format_dict_entry_value_impl(
+    *,
+    value: Value,
+    spec: Language,
+    wrap_ids: frozenset[int],
+    outer_sequence_override: str | None,
+    position_overrides: Sequence[str | None],
+) -> str:
+    """Unchecked implementation for dict entry values."""
     if isinstance(value, list):
-        return _format_list_value_unchecked(
+        return _format_list_value_impl(
             value=value,
             spec=spec,
             wrap_ids=wrap_ids,
             sequence_open_override=outer_sequence_override,
             child_sequence_open_overrides=position_overrides,
         )
-    return _format_value_unchecked(
+    return _format_value_impl(
         value=value,
         spec=spec,
         dict_open_override=None,
@@ -651,6 +712,24 @@ def _format_list_value(
     openers for child lists, so nested sequences at matching positions
     across sibling containers can share a widened type.
     """
+    return _format_list_value_impl(
+        value=value,
+        spec=spec,
+        wrap_ids=wrap_ids,
+        sequence_open_override=sequence_open_override,
+        child_sequence_open_overrides=child_sequence_open_overrides,
+    )
+
+
+def _format_list_value_impl(
+    *,
+    value: list[Value],
+    spec: Language,
+    wrap_ids: frozenset[int],
+    sequence_open_override: str | None,
+    child_sequence_open_overrides: Sequence[str | None],
+) -> str:
+    """Unchecked implementation for list formatting."""
     sequence_cfg = spec.sequence_format_config
 
     # When a parent has widened this position's opener, skip the
@@ -675,7 +754,7 @@ def _format_list_value(
                 parent_id=parent_id,
                 wrap_ids=wrap_ids,
                 raw_value=v,
-                formatted_value=_format_value_unchecked(
+                formatted_value=_format_value_impl(
                     value=v,
                     spec=spec,
                     dict_open_override=dict_open_override,
@@ -742,22 +821,22 @@ def _format_value(
     """
     match value:
         case ordereddict():
-            return _format_ordered_map_value_unchecked(
+            return _format_ordered_map_value(
                 value=value,
                 spec=spec,
                 wrap_ids=wrap_ids,
             )
         case dict():
-            return _format_dict_value_unchecked(
+            return _format_dict_value(
                 value=value,
                 spec=spec,
                 open_override=dict_open_override,
                 wrap_ids=wrap_ids,
             )
         case set():
-            return _format_set_value_unchecked(value=value, spec=spec)
+            return _format_set_value(value=value, spec=spec)
         case list():
-            return _format_list_value_unchecked(
+            return _format_list_value(
                 value=value,
                 spec=spec,
                 wrap_ids=wrap_ids,
@@ -765,32 +844,44 @@ def _format_value(
                 child_sequence_open_overrides=(),
             )
         case _:
-            return _format_scalar_unchecked(value=value, spec=spec)
+            return _format_scalar(value=value, spec=spec)
 
 
-_format_scalar_unchecked: Callable[..., str] = cast(
-    "Callable[..., str]", cast("Any", _format_scalar).__wrapped__
-)
-_format_set_value_unchecked: Callable[..., str] = cast(
-    "Callable[..., str]", cast("Any", _format_set_value).__wrapped__
-)
-_format_ordered_map_value_unchecked: Callable[..., str] = cast(
-    "Callable[..., str]",
-    cast("Any", _format_ordered_map_value).__wrapped__,
-)
-_format_dict_value_unchecked: Callable[..., str] = cast(
-    "Callable[..., str]", cast("Any", _format_dict_value).__wrapped__
-)
-_format_dict_entry_value_unchecked: Callable[..., str] = cast(
-    "Callable[..., str]",
-    cast("Any", _format_dict_entry_value).__wrapped__,
-)
-_format_list_value_unchecked: Callable[..., str] = cast(
-    "Callable[..., str]", cast("Any", _format_list_value).__wrapped__
-)
-_format_value_unchecked: Callable[..., str] = cast(
-    "Callable[..., str]", cast("Any", _format_value).__wrapped__
-)
+def _format_value_impl(
+    *,
+    value: Value,
+    spec: Language,
+    dict_open_override: str | None,
+    wrap_ids: frozenset[int],
+    sequence_open_override: str | None,
+) -> str:
+    """Unchecked implementation for generic value formatting."""
+    match value:
+        case ordereddict():
+            return _format_ordered_map_value_impl(
+                value=value,
+                spec=spec,
+                wrap_ids=wrap_ids,
+            )
+        case dict():
+            return _format_dict_value_impl(
+                value=value,
+                spec=spec,
+                open_override=dict_open_override,
+                wrap_ids=wrap_ids,
+            )
+        case set():
+            return _format_set_value_impl(value=value, spec=spec)
+        case list():
+            return _format_list_value_impl(
+                value=value,
+                spec=spec,
+                wrap_ids=wrap_ids,
+                sequence_open_override=sequence_open_override,
+                child_sequence_open_overrides=(),
+            )
+        case _:
+            return _format_scalar_impl(value=value, spec=spec)
 
 
 @beartype
@@ -879,7 +970,7 @@ def _format_collection_lines(
             )
             formatted_entries: list[str] = []
             for k, v in entries:
-                formatted_key = _format_value_unchecked(
+                formatted_key = _format_value_impl(
                     value=k,
                     spec=spec,
                     dict_open_override=None,
@@ -890,7 +981,7 @@ def _format_collection_lines(
                     parent_id=parent_id,
                     wrap_ids=wrap_ids,
                     raw_value=v,
-                    formatted_value=_format_dict_entry_value_unchecked(
+                    formatted_value=_format_dict_entry_value_impl(
                         value=v,
                         spec=spec,
                         wrap_ids=wrap_ids,
@@ -927,7 +1018,7 @@ def _format_collection_lines(
             formatted_entries = [
                 spec.format_set_entry(
                     item,
-                    _format_value_unchecked(
+                    _format_value_impl(
                         value=item,
                         spec=spec,
                         dict_open_override=None,
@@ -960,7 +1051,7 @@ def _format_collection_lines(
                         parent_id=parent_id,
                         wrap_ids=wrap_ids,
                         raw_value=element,
-                        formatted_value=_format_value_unchecked(
+                        formatted_value=_format_value_impl(
                             value=element,
                             spec=spec,
                             dict_open_override=dict_open_override,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Sequence
-from typing import assert_never, cast
+from typing import Any, assert_never, cast
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.compat import ordereddict
@@ -768,13 +768,29 @@ def _format_value(
             return _format_scalar_unchecked(value=value, spec=spec)
 
 
-_format_scalar_unchecked = _format_scalar.__wrapped__
-_format_set_value_unchecked = _format_set_value.__wrapped__
-_format_ordered_map_value_unchecked = _format_ordered_map_value.__wrapped__
-_format_dict_value_unchecked = _format_dict_value.__wrapped__
-_format_dict_entry_value_unchecked = _format_dict_entry_value.__wrapped__
-_format_list_value_unchecked = _format_list_value.__wrapped__
-_format_value_unchecked = _format_value.__wrapped__
+_format_scalar_unchecked: Callable[..., str] = cast(
+    "Callable[..., str]", cast("Any", _format_scalar).__wrapped__
+)
+_format_set_value_unchecked: Callable[..., str] = cast(
+    "Callable[..., str]", cast("Any", _format_set_value).__wrapped__
+)
+_format_ordered_map_value_unchecked: Callable[..., str] = cast(
+    "Callable[..., str]",
+    cast("Any", _format_ordered_map_value).__wrapped__,
+)
+_format_dict_value_unchecked: Callable[..., str] = cast(
+    "Callable[..., str]", cast("Any", _format_dict_value).__wrapped__
+)
+_format_dict_entry_value_unchecked: Callable[..., str] = cast(
+    "Callable[..., str]",
+    cast("Any", _format_dict_entry_value).__wrapped__,
+)
+_format_list_value_unchecked: Callable[..., str] = cast(
+    "Callable[..., str]", cast("Any", _format_list_value).__wrapped__
+)
+_format_value_unchecked: Callable[..., str] = cast(
+    "Callable[..., str]", cast("Any", _format_value).__wrapped__
+)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- speed up literal formatting hot paths by routing internal recursive formatter calls through unchecked aliases to avoid repeated beartype wrapper overhead
- keep beartype on formatter entry points and public APIs so runtime validation behavior remains intact
- add explicit typing around unchecked aliases so strict static checks continue to pass

## Test plan
- [x] `uv run --extra dev pytest tests/test_json.py tests/test_yaml.py -q`
- [x] `uv run --extra dev pytest tests/benchmarks/test_bench_literalize.py -q`
- [x] `uv run --extra dev mypy src/literalizer/_literalize.py`
- [x] `uv run --extra dev pyright src/literalizer/_literalize.py`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core recursive literal formatting paths; although intended to be behavior-preserving, routing through unchecked helpers could subtly change type-validation coverage or edge-case formatting if a call site is missed.
> 
> **Overview**
> Speeds up literal formatting by splitting several `@beartype`-decorated formatting helpers into a validated wrapper plus an unchecked `*_impl` function, then routing internal recursive calls through the `*_impl` variants to avoid repeated `beartype` overhead.
> 
> This refactors scalar/set/dict/ordered-map/list and generic value formatting to consistently use the unchecked implementations for nested formatting, while keeping `beartype` on the external entry points and adding a small typed wrapper-retention tuple (`_KEEP_TYPED_WRAPPERS`) to satisfy static checking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b8ec9fd44dee1309002c6875e4b09cc0973a7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->