### PR TITLE
Extract duplicated set-sorting key lambda

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -2,13 +2,15 @@
 
 import dataclasses
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
 from beartype import beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 from ruamel.yaml.tokens import CommentToken
 from tomlkit.items import Comment, Table, Whitespace
 from tomlkit.toml_document import TOMLDocument
+
+from literalizer._types import Scalar, set_sort_key
 
 
 @dataclasses.dataclass(frozen=True)
@@ -163,10 +165,9 @@ def extract_yaml_comments(
     # CommentedSet elements are emitted in sorted order by _literalize,
     # so reorder to match that sort key to keep comments aligned.
     if isinstance(ruamel_data, CommentedSet):
-        output_keys: list[object] = sorted(
-            keys,
-            key=lambda v: (type(v).__name__, repr(v)),
-        )
+        scalar_keys = cast("list[Scalar]", keys)
+        sorted_scalars = sorted(scalar_keys, key=set_sort_key)
+        output_keys: list[object] = list(sorted_scalars)
     else:
         output_keys = keys
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -152,6 +152,17 @@ VariableForm = NewVariable | ExistingVariable | BothVariableForms
 
 
 @beartype
+def _set_sort_key(value: Scalar) -> tuple[str, str]:
+    """Return a stable sort key for set elements.
+
+    Sets are unordered, so we sort by type name and then ``repr`` to get
+    a deterministic output that also copes with heterogeneous element
+    types that may not be mutually comparable.
+    """
+    return (type(value).__name__, repr(value))
+
+
+@beartype
 def _format_scalar(*, value: Scalar, spec: Language) -> str:
     """Format a scalar JSON value as a native language literal."""
     match value:
@@ -227,7 +238,7 @@ def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
 
     if not value and set_cfg.empty_set is not None:
         return set_cfg.empty_set
-    sorted_items = sorted(value, key=lambda v: (type(v).__name__, repr(v)))
+    sorted_items = sorted(value, key=_set_sort_key)
     items_as_values: list[Value] = list(sorted_items)
     formatted = [_format_scalar(value=v, spec=spec) for v in sorted_items]
     entries = [
@@ -779,20 +790,19 @@ def _wrap_body(
     ci = spec.indent if spec.indent_closing_delimiter else ""
     close_prefix = f"{line_prefix}{ci}"
     match data:
-        case dict() if is_ordered_map:
-            ordered_map_cfg = spec.ordered_map_format_config
-            open_str = ordered_map_cfg.ordered_map_open(data)
-            opening = f"{line_prefix}{open_str}"
-            closing = f"{close_prefix}{ordered_map_cfg.close}"
-        case dict():
-            dict_cfg = spec.dict_format_config
-            opening = f"{line_prefix}{dict_cfg.dict_open(data)}"
-            closing = f"{close_prefix}{dict_cfg.close}"
-        case set():
-            sorted_set: list[Value] = sorted(
-                data,
-                key=lambda v: (type(v).__name__, repr(v)),
-            )
+        case dict() as dict_data:
+            if is_ordered_map:
+                ordered_map_cfg = spec.ordered_map_format_config
+                open_str = ordered_map_cfg.ordered_map_open(dict_data)
+                opening = f"{line_prefix}{open_str}"
+                closing = f"{close_prefix}{ordered_map_cfg.close}"
+            else:
+                dict_cfg = spec.dict_format_config
+                opening = f"{line_prefix}{dict_cfg.dict_open(dict_data)}"
+                closing = f"{close_prefix}{dict_cfg.close}"
+        case set() as set_data:
+            sorted_items = sorted(set_data, key=_set_sort_key)
+            sorted_set: list[Value] = list(sorted_items)
             set_cfg = spec.set_format_config
             opening = f"{line_prefix}{set_cfg.set_open(sorted_set)}"
             closing = f"{close_prefix}{set_cfg.close}"
@@ -893,10 +903,7 @@ def _format_collection_lines(
                 spec=spec,
             )
         case set() as set_data:
-            sorted_items = sorted(
-                set_data,
-                key=lambda v: (type(v).__name__, repr(v)),
-            )
+            sorted_items = sorted(set_data, key=_set_sort_key)
             formatted_entries = [
                 spec.format_set_entry(
                     item,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -35,7 +35,7 @@ from literalizer._language import (
 )
 from literalizer._parsing import InputFormat, parse_input
 from literalizer._preamble import compute_preamble
-from literalizer._types import Scalar, Value
+from literalizer._types import Scalar, Value, set_sort_key
 from literalizer.exceptions import (
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
@@ -152,17 +152,6 @@ VariableForm = NewVariable | ExistingVariable | BothVariableForms
 
 
 @beartype
-def _set_sort_key(value: Scalar) -> tuple[str, str]:
-    """Return a stable sort key for set elements.
-
-    Sets are unordered, so we sort by type name and then ``repr`` to get
-    a deterministic output that also copes with heterogeneous element
-    types that may not be mutually comparable.
-    """
-    return (type(value).__name__, repr(value))
-
-
-@beartype
 def _format_scalar(*, value: Scalar, spec: Language) -> str:
     """Format a scalar JSON value as a native language literal."""
     match value:
@@ -238,7 +227,7 @@ def _format_set_value(*, value: set[Scalar], spec: Language) -> str:
 
     if not value and set_cfg.empty_set is not None:
         return set_cfg.empty_set
-    sorted_items = sorted(value, key=_set_sort_key)
+    sorted_items = sorted(value, key=set_sort_key)
     items_as_values: list[Value] = list(sorted_items)
     formatted = [_format_scalar(value=v, spec=spec) for v in sorted_items]
     entries = [
@@ -801,7 +790,7 @@ def _wrap_body(
                 opening = f"{line_prefix}{dict_cfg.dict_open(dict_data)}"
                 closing = f"{close_prefix}{dict_cfg.close}"
         case set() as set_data:
-            sorted_items = sorted(set_data, key=_set_sort_key)
+            sorted_items = sorted(set_data, key=set_sort_key)
             sorted_set: list[Value] = list(sorted_items)
             set_cfg = spec.set_format_config
             opening = f"{line_prefix}{set_cfg.set_open(sorted_set)}"
@@ -903,7 +892,7 @@ def _format_collection_lines(
                 spec=spec,
             )
         case set() as set_data:
-            sorted_items = sorted(set_data, key=_set_sort_key)
+            sorted_items = sorted(set_data, key=set_sort_key)
             formatted_entries = [
                 spec.format_set_entry(
                     item,

--- a/src/literalizer/_types.py
+++ b/src/literalizer/_types.py
@@ -3,10 +3,26 @@
 import datetime
 import enum
 
+from beartype import beartype
+
 type Scalar = (
     str | int | float | bool | None | datetime.date | datetime.datetime | bytes
 )
 type Value = Scalar | list[Value] | dict[str, Value] | set[Scalar]
+
+
+@beartype
+def set_sort_key(value: Scalar) -> tuple[str, str]:
+    """Return a stable sort key for set elements.
+
+    Sets are unordered, so we sort by type name and then ``repr`` to get
+    a deterministic output that also copes with heterogeneous element
+    types that may not be mutually comparable.
+
+    Shared so that any code that needs to match the order emitted by the
+    core set formatters (e.g. comment extraction) uses the same key.
+    """
+    return (type(value).__name__, repr(value))
 
 
 class ValueKind(enum.Enum):

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -73,7 +73,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value, ValueKind
+from literalizer._types import Value, ValueKind, set_sort_key
 
 
 class _CppModifiers(enum.Enum):
@@ -390,11 +390,9 @@ def _compute_cpp_type(
                 type_ctx=type_ctx,
             )
             return f"std::vector<{inner_type}>"
-        case set():
-            sorted_items: list[Value] = sorted(
-                item,
-                key=lambda v: (type(v).__name__, repr(v)),
-            )
+        case set() as set_item:
+            sorted_scalars = sorted(set_item, key=set_sort_key)
+            sorted_items: list[Value] = list(sorted_scalars)
             inner_type = _compute_element_type_for_items(
                 items=sorted_items,
                 type_ctx=type_ctx,
@@ -521,11 +519,9 @@ def _needs_variant_type(
     Used to determine whether ``#include <variant>`` is needed.
     """
     match data:
-        case set():
-            sorted_items: list[Value] = sorted(
-                data,
-                key=lambda v: (type(v).__name__, repr(v)),
-            )
+        case set() as set_data:
+            sorted_scalars = sorted(set_data, key=set_sort_key)
+            sorted_items: list[Value] = list(sorted_scalars)
             return _items_need_variant(
                 items=sorted_items,
                 element_to_type=element_to_type,


### PR DESCRIPTION
## Summary

- Extract the `lambda v: (type(v).__name__, repr(v))` key function that was duplicated in `_format_set_value`, `_wrap_body`, and `_format_collection_lines` into a single module-level `_set_sort_key` helper in `_literalize.py`, with a docstring explaining why sets are sorted this way.
- Flatten `_wrap_body`'s `match` so the `is_ordered_map` branching happens inside the `case dict()` branch instead of as a pattern guard; this lets mypy/pyright narrow the `set` arm to `set[Scalar]` so the extracted helper type-checks.

Closes #1185.

## Test plan

- [x] `uv run pytest tests --ignore=tests/benchmarks --ignore=tests/integration` (468 passed)
- [x] `uv run mypy src/literalizer/_literalize.py`
- [x] `uv run pyright src/literalizer/_literalize.py`
- [x] `uv run ty check src/literalizer/_literalize.py`
- [x] `uv run pyrefly check src/literalizer/_literalize.py`
- [x] CI

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes deterministic set ordering; primary risk is subtle ordering changes affecting emitted set literals or comment alignment across languages.
> 
> **Overview**
> Unifies deterministic set element ordering by introducing `set_sort_key` in `_types.py` and reusing it across set formatting paths (including YAML `CommentedSet` comment alignment and C++ set-related type inference/preamble checks).
> 
> Refactors `_wrap_body`’s pattern matching to avoid guarded cases, enabling better type narrowing for the set branch while preserving existing open/close formatting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5172912e528c19bdb1b60dc9ec9aef3015072e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->