### PR TITLE
Run Java files in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,6 +86,11 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 node --check < /tmp/files-js
           xargs -0 -P "$(nproc)" -n1 node < /tmp/files-js
 
+      # The host compiles each fixture into an in-memory assembly, then
+      # reflectively constructs `Check` and invokes its `check()` method
+      # (or runs field initializers on field-only fixtures), so javac
+      # emit-success and runtime errors (e.g. bad `Instant.parse` input)
+      # both fail here.
       - name: Lint Java
         run: |-
           find tests/integration/cases -name '*.java' -print0 > /tmp/files-java

--- a/CheckJavaSyntax.java
+++ b/CheckJavaSyntax.java
@@ -1,4 +1,9 @@
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -8,9 +13,16 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
-// Compile each given Java source file with the in-process JavaCompiler
-// API so the compiler stays warm across fixtures instead of cold-starting
-// a JVM per file like the previous `javac` bash loop did.
+// Compile and execute each given Java source file with the in-process
+// JavaCompiler API and a private URLClassLoader so the compiler and JVM
+// stay warm across fixtures instead of cold-starting a JVM per file like
+// the previous `javac` bash loop did. Fixtures either expose a
+// `public static void check()` method (wrapping the literal in a method
+// body) or declare `my_data` as a field on `class Check`; either way the
+// host triggers static-init, constructs a `Check` instance to run any
+// instance-field initializers, and invokes `check()` when present, so
+// runtime errors (e.g. a bad `Instant.parse` argument) surface here
+// instead of passing silently.
 public class CheckJavaSyntax {
     public static void main(final String[] args) throws IOException {
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -37,9 +49,55 @@ public class CheckJavaSyntax {
                 if (!task.call()) {
                     System.err.println(filename + ": javac failed");
                     failed = true;
+                    continue;
+                }
+                if (!runFixture(filename, classDir)) {
+                    failed = true;
                 }
             }
         }
         System.exit(failed ? 1 : 0);
+    }
+
+    // Load `Check` from a private class loader rooted at *classDir*,
+    // construct an instance (forcing both static- and instance-field
+    // initializers), and invoke `check()` if the fixture defines one.
+    // `Check` is package-private in every fixture, so `setAccessible`
+    // is required before invoking members reflectively.
+    private static boolean runFixture(final String filename, final Path classDir) {
+        final URL[] urls;
+        try {
+            urls = new URL[] {classDir.toUri().toURL()};
+        } catch (final java.net.MalformedURLException e) {
+            System.err.println(filename + ": " + e);
+            return false;
+        }
+        try (final URLClassLoader loader = new URLClassLoader(urls)) {
+            final Class<?> checkClass = Class.forName("Check", true, loader);
+            final Constructor<?> constructor = checkClass.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            final Object instance = constructor.newInstance();
+            final Method checkMethod;
+            try {
+                checkMethod = checkClass.getDeclaredMethod("check");
+            } catch (final NoSuchMethodException e) {
+                // Field-only fixtures — constructing `Check` above
+                // already ran the field initializer.
+                return true;
+            }
+            checkMethod.setAccessible(true);
+            checkMethod.invoke(instance);
+            return true;
+        } catch (final ClassNotFoundException
+                | NoSuchMethodException
+                | IllegalAccessException
+                | InstantiationException
+                | IOException e) {
+            System.err.println(filename + ": " + e);
+            return false;
+        } catch (final InvocationTargetException e) {
+            System.err.println(filename + ": " + e.getCause());
+            return false;
+        }
     }
 }

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -20,7 +20,6 @@ from literalizer._formatters.collection_openers import (
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
-    datetime_iso_formatter,
     format_date_iso,
     format_datetime_iso,
 )
@@ -182,6 +181,23 @@ def _format_datetime_java_zoned(value: datetime.datetime) -> str:
         f"{value.hour}, {value.minute}, {value.second}, "
         f'{nanoseconds}, ZoneId.of("{timezone_name}"))'
     )
+
+
+@beartype
+def _format_datetime_java_instant(value: datetime.datetime) -> str:
+    """Format a datetime as a Java ``Instant.parse(...)`` call.
+
+    ``Instant.parse`` rejects strings without a timezone offset, so a
+    naive datetime (no :attr:`~datetime.datetime.tzinfo`) is rendered
+    with a trailing ``Z`` — Python's :meth:`~datetime.datetime.isoformat`
+    emits no offset for naive datetimes, which Java reads as invalid.
+    Treating naive values as UTC matches the ISO 8601 convention for
+    unqualified timestamps.
+    """
+    iso = value.isoformat()
+    if value.tzinfo is None:
+        iso += "Z"
+    return f'Instant.parse("{iso}")'
 
 
 @beartype
@@ -607,9 +623,7 @@ class Java(metaclass=LanguageCls):
         """Datetime formatting options for Java."""
 
         INSTANT = DatetimeFormatConfig(
-            formatter=datetime_iso_formatter(
-                template='Instant.parse("{iso}")',
-            ),
+            formatter=_format_datetime_java_instant,
             preamble_lines=("import java.time.Instant;",),
         )
         ZONED = DatetimeFormatConfig(

--- a/tests/integration/cases/dict_all_scalar_types/Java.java
+++ b/tests/integration/cases/dict_all_scalar_types/Java.java
@@ -9,7 +9,7 @@ var my_data = Map.ofEntries(
     Map.entry("f", 1.5),
     Map.entry("b", true),
     Map.entry("d", LocalDate.of(2024, 1, 15)),
-    Map.entry("dt", Instant.parse("2024-01-15T12:00:00")),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
     Map.entry("by", "48656c6c6f")
 );
     }

--- a/tests/integration/cases/dict_all_scalar_types/Java_combined.java
+++ b/tests/integration/cases/dict_all_scalar_types/Java_combined.java
@@ -9,7 +9,7 @@ var my_data = Map.ofEntries(
     Map.entry("f", 1.5),
     Map.entry("b", true),
     Map.entry("d", LocalDate.of(2024, 1, 15)),
-    Map.entry("dt", Instant.parse("2024-01-15T12:00:00")),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
     Map.entry("by", "48656c6c6f")
 );
 my_data = Map.ofEntries(
@@ -18,7 +18,7 @@ my_data = Map.ofEntries(
     Map.entry("f", 1.5),
     Map.entry("b", true),
     Map.entry("d", LocalDate.of(2024, 1, 15)),
-    Map.entry("dt", Instant.parse("2024-01-15T12:00:00")),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
     Map.entry("by", "48656c6c6f")
 );
     }

--- a/tests/integration/cases/scalar_datetime_midnight/Java.java
+++ b/tests/integration/cases/scalar_datetime_midnight/Java.java
@@ -1,6 +1,6 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T00:00:00");
+var my_data = Instant.parse("2024-01-15T00:00:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_midnight/Java_combined.java
+++ b/tests/integration/cases/scalar_datetime_midnight/Java_combined.java
@@ -1,7 +1,7 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T00:00:00");
-my_data = Instant.parse("2024-01-15T00:00:00");
+var my_data = Instant.parse("2024-01-15T00:00:00Z");
+my_data = Instant.parse("2024-01-15T00:00:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_naive/Java.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java.java
@@ -1,6 +1,6 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:00");
+var my_data = Instant.parse("2024-01-15T12:30:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_naive/Java_combined.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java_combined.java
@@ -1,7 +1,7 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:00");
-my_data = Instant.parse("2024-01-15T12:30:00");
+var my_data = Instant.parse("2024-01-15T12:30:00Z");
+my_data = Instant.parse("2024-01-15T12:30:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Java.java
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Java.java
@@ -1,6 +1,6 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:45.123456");
+var my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_combined.java
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_combined.java
@@ -1,7 +1,7 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:45.123456");
-my_data = Instant.parse("2024-01-15T12:30:45.123456");
+var my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
+my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
     }
 }


### PR DESCRIPTION
## Summary

- Extends the in-process `CheckJavaSyntax` host to **compile and execute** each fixture, reflectively constructing `Check` and invoking its `check()` method (or running field initializers on field-only fixtures), so `javac` emit-success and runtime errors both fail the step. Mirrors the pattern already used by `lint-csharp` / `lint-vb` and keeps the warm-compiler speedup of the single long-running host.
- Fixes a generator bug surfaced by running the fixtures: `Instant.parse` rejects strings without a timezone offset, but `DatetimeFormats.INSTANT` emitted `Instant.parse("2024-01-15T12:30:00")` for naive datetimes. New `_format_datetime_java_instant` appends `Z` when `tzinfo is None`, treating unqualified timestamps as UTC per ISO 8601.
- Regenerates the 8 affected Java golden files (`scalar_datetime_midnight`, `scalar_datetime_naive`, `scalar_datetime_seconds_microsecond`, `dict_all_scalar_types` — each for the default and `_combined` variants).

Fixes #1406.

## Test plan

- [x] `uv run pytest tests/integration/` — 682 passed, 13934 subtests passed.
- [x] `find tests/integration/cases -name '*.java' -print0 | xargs -0 java CheckJavaSyntax.java` — all 399 fixtures compile and execute; exit 0.
- [x] `prek run` across `pre-commit`, `pre-push`, and `manual` hook stages on all changed files — all hooks pass (ruff, yamlfix, actionlint, zizmor, mypy, pyright, ty, pyrefly, pylint, interrogate, deptry, docs build, …).
- [ ] CI green on this PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI lint behavior to execute Java fixtures (can introduce new failures/timeouts) and adjusts Java datetime literal generation, which affects golden outputs and potentially user-facing code generation.
> 
> **Overview**
> **Java fixture linting now catches runtime errors.** The `lint-fast` GitHub Action switches Java linting to run the `CheckJavaSyntax.java` host, which compiles each fixture and then loads and executes `Check` (running field initializers and invoking `check()` when present) so runtime failures surface in CI.
> 
> **Fixes Java `Instant.parse` output for naive datetimes.** The Java literalizer now appends `Z` for tz-naive datetimes when emitting `DatetimeFormats.INSTANT`, and the affected Java integration golden files are regenerated to include the timezone suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f89a0eca9599a8acdc382ee6ae08b65067b4753f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->