### PR TITLE
Add format_call_ref_identifier hook with identity default

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1204,6 +1204,20 @@ class Language(Protocol):
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
+    @property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the form
+        required by this language's call expression syntax.
+
+        Called after :func:`~literalizer.literalize_call`'s ``ref_case``
+        normalization, so *name* is already in the requested identifier
+        case.  Most languages emit ref identifiers bare and use
+        :data:`identity_call_ref_identifier`.  Languages where variable
+        references carry a sigil (e.g. PHP ``$name``, Perl ``$name``)
+        override this to prepend the sigil.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
     @staticmethod
     def wrap_in_file(
         content: str,
@@ -1259,6 +1273,21 @@ def _identity_call_target(name: str, /) -> str:
 
 identity_call_target: Callable[[str], str] = _identity_call_target
 """Shared callable for languages that need no call-target rewriting."""
+
+
+def _identity_call_ref_identifier(name: str, /) -> str:
+    """Return *name* unchanged."""
+    return name
+
+
+identity_call_ref_identifier: Callable[[str], str] = (
+    _identity_call_ref_identifier
+)
+"""Shared callable for languages that need no ``$ref`` identifier
+rewriting.  Languages that decorate ref identifiers (e.g. PHP's
+``$name`` or Perl's ``$name``) override
+:attr:`Language.format_call_ref_identifier` instead.
+"""
 
 
 def _no_type_hint_preamble(

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1515,8 +1515,8 @@ def _format_single_call_arg(
     ref_name = _extract_call_arg_ref_name(value=value)
     if ref_name is not None:
         if ref_case is not None:
-            return ref_case.convert(name=ref_name)
-        return ref_name
+            ref_name = ref_case.convert(name=ref_name)
+        return language.format_call_ref_identifier(ref_name)
     return wrap_arg(
         value,
         _format_value(

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -463,6 +464,13 @@ class Ada(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -496,6 +497,13 @@ class Bash(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -536,6 +537,13 @@ class C(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -432,6 +433,13 @@ class Clojure(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -613,6 +614,13 @@ class Cobol(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -454,6 +455,13 @@ class CommonLisp(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_type_hint_preamble,
@@ -1323,6 +1324,13 @@ class Cpp(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _cpp_date_type(self) -> str:

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -529,6 +530,13 @@ class Crystal(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -76,6 +76,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -864,6 +865,13 @@ class CSharp(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _date_tp(self) -> type:

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -506,6 +507,13 @@ class D(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -702,6 +703,13 @@ class Dart(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _date_tp(self) -> type:

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -704,6 +705,13 @@ class Dhall(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -502,6 +503,13 @@ class Elixir(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -728,6 +729,13 @@ class Elm(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def null_literal(self) -> str:

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -544,6 +545,13 @@ class Erlang(metaclass=LanguageCls):
         syntax.
         """
         return _erlang_format_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -38,6 +38,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -524,6 +525,13 @@ class Forth(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -590,6 +591,13 @@ class Fortran(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _format_entry(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -611,6 +612,13 @@ class FSharp(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _entry_formatter(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     no_call_stub,
     no_type_hint_preamble,
     no_validate_spec_for_data,
@@ -911,6 +912,13 @@ class Gleam(metaclass=LanguageCls):
         syntax.
         """
         return _gleam_format_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def null_literal(self) -> str:

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -637,6 +638,13 @@ class Go(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _init_element_to_type(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -474,6 +475,13 @@ class Groovy(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_data_preamble,
     no_type_hint_preamble,
@@ -1517,3 +1518,10 @@ class Haskell(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -415,6 +416,13 @@ class Hcl(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -68,6 +68,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_type_hint_preamble,
@@ -1114,6 +1115,13 @@ class Java(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _suffix_is_auto(self) -> bool:

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -538,6 +539,13 @@ class JavaScript(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -425,6 +426,13 @@ class Json5(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -456,6 +457,13 @@ class Jsonnet(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -63,6 +63,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -556,6 +557,13 @@ class Julia(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -76,6 +76,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_type_hint_preamble,
@@ -911,6 +912,13 @@ class Kotlin(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _date_type_name(self) -> str | None:

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -467,6 +468,13 @@ class Lua(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -551,6 +552,13 @@ class Matlab(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -681,6 +682,13 @@ class Mojo(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -962,6 +963,13 @@ class Nim(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -507,6 +508,13 @@ class Nix(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -412,6 +413,13 @@ class Norg(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -602,6 +603,13 @@ class ObjectiveC(metaclass=LanguageCls):
         ``k``-prefixed const global emitted by :func:`_objc_call_stub`.
         """
         return _objc_format_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -582,6 +583,13 @@ class OCaml(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def null_literal(self) -> str:

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -445,6 +446,13 @@ class Occam(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -507,6 +508,13 @@ class Odin(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -505,6 +506,13 @@ class Perl(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -514,6 +515,13 @@ class Php(metaclass=LanguageCls):
         form.
         """
         return _php_format_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def format_call_preamble_stub(

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -434,6 +435,13 @@ class PowerShell(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -825,6 +826,13 @@ class PureScript(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -1014,6 +1015,13 @@ class Python(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -503,6 +504,13 @@ class R(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -443,6 +444,13 @@ class Racket(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -492,6 +493,13 @@ class Raku(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -531,6 +532,13 @@ class Ruby(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -1373,6 +1374,13 @@ class Rust(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -639,6 +640,13 @@ class Scala(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -407,6 +408,13 @@ class Scheme(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -618,6 +619,13 @@ class Sml(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -66,6 +66,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -797,6 +798,13 @@ class Swift(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -502,6 +503,13 @@ class SystemVerilog(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -455,6 +456,13 @@ class Tcl(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -442,6 +443,13 @@ class Toml(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -716,6 +717,13 @@ class TypeScript(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -472,6 +473,13 @@ class V(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -545,6 +546,13 @@ class VisualBasic(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def _element_to_type(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -421,6 +422,13 @@ class Wren(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -413,6 +414,13 @@ class Yaml(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -543,6 +544,13 @@ class Zig(metaclass=LanguageCls):
         syntax.
         """
         return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -453,6 +453,7 @@ def test_protocol_properties_accessible(
     assert callable(spec.format_call_stub)
     assert callable(spec.format_call_preamble_stub)
     assert callable(spec.format_call_target)
+    assert callable(spec.format_call_ref_identifier)
     assert callable(spec.format_variable_declaration)
     assert callable(spec.format_variable_assignment)
     assert callable(spec.type_hint_collection_preamble_lines)


### PR DESCRIPTION
## Summary
- Introduces a `format_call_ref_identifier` property on the `Language` Protocol so each language can rewrite `{"$ref": "name"}` identifiers (e.g. to prepend a sigil) in `literalize_call` output.
- Adds a shared `identity_call_ref_identifier` default and wires it into every one of the 62 language classes.
- Routes the new hook through `_format_single_call_arg` after `ref_case` normalization; with all languages on the identity default the emitted output is byte-identical to before.

## Test plan
- [x] `pytest --cov=src/ --cov=tests --cov-fail-under 100` (1164 passed, 100% coverage)
- [x] `ruff check` / `ruff format --check` on changed files
- [x] All `call_ref_args*` integration goldens pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged for all languages by default (identity transform), with the main impact being a new required `Language` hook that custom specs must implement.
> 
> **Overview**
> Adds a new `Language.format_call_ref_identifier` hook (plus shared `identity_call_ref_identifier`) so `literalize_call` can rewrite `{"$ref": "name"}` identifiers in a language-specific way.
> 
> Routes `$ref` argument rendering through this hook in `_format_single_call_arg` after optional `ref_case` normalization, updates all built-in language specs to return the identity implementation, and extends `test_languages` to assert the new callable exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb9f97d2c07671a2a15615eb2aa21eb094ff1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->