### PR TITLE
Add PHP call-ref identifier formatter

### DIFF
--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -64,7 +64,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -81,6 +80,11 @@ def _php_format_call_target(name: str, /) -> str:
     if len(parts) == 1:
         return name
     return "$" + parts[0] + "".join(f"->{p}" for p in parts[1:])
+
+
+def _php_format_call_ref_identifier(name: str, /) -> str:
+    """Prepend PHP's ``$`` variable sigil to a call-ref identifier."""
+    return f"${name}"
 
 
 def _php_call_stub(
@@ -518,10 +522,10 @@ class Php(metaclass=LanguageCls):
 
     @cached_property
     def format_call_ref_identifier(self) -> Callable[[str], str]:
-        """Rewrite a ``{"$ref": "name"}`` identifier into the
-        language's call expression syntax.
+        """Prepend PHP's ``$`` sigil so a ``{"$ref": "name"}`` argument
+        renders as ``$name`` at the call site.
         """
-        return identity_call_ref_identifier
+        return _php_format_call_ref_identifier
 
     @cached_property
     def format_call_preamble_stub(

--- a/tests/integration/cases/call_ref_args/Php_call.php
+++ b/tests/integration/cases/call_ref_args/Php_call.php
@@ -1,0 +1,14 @@
+<?php
+function process($data, $count) {}
+$my_var = [
+    1,
+    2,
+    3,
+];
+$my_other = [
+    4,
+    5,
+    6,
+];
+process(data: $my_var, count: 42);
+process(data: $my_other, count: 7);

--- a/tests/integration/cases/call_ref_args_converted/Php_call.php
+++ b/tests/integration/cases/call_ref_args_converted/Php_call.php
@@ -1,0 +1,14 @@
+<?php
+function process($data, $count) {}
+$my_var = [
+    1,
+    2,
+    3,
+];
+$my_other = [
+    4,
+    5,
+    6,
+];
+process(data: $my_var, count: 42);
+process(data: $my_other, count: 7);

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Php_call.php
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Php_call.php
@@ -1,0 +1,14 @@
+<?php
+function process($data, $count) {}
+$my_var = [
+    1,
+    2,
+    3,
+];
+$my_other = [
+    4,
+    5,
+    6,
+];
+process(data: $my_var, count: 42);
+process(data: $my_other, count: 7);

--- a/tests/integration/cases/call_ref_args_converted_whole/Php_call.php
+++ b/tests/integration/cases/call_ref_args_converted_whole/Php_call.php
@@ -1,0 +1,8 @@
+<?php
+function process($data) {}
+$my_var = [
+    1,
+    2,
+    3,
+];
+process(data: $my_var);

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -56,7 +56,6 @@ from literalizer.languages import (
     OCaml,
     Odin,
     Perl,
-    Php,
     PureScript,
     Python,
     Rust,
@@ -2416,9 +2415,6 @@ _REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
         # declared variable, so the golden misrepresents the feature
         # and the file fails ``use strict``.
         Perl,
-        # Variables declare with a ``$`` sigil that ``$ref`` does not
-        # emit at the call site — undefined-constant error at runtime.
-        Php,
     }
 )
 


### PR DESCRIPTION
Fixes https://github.com/adamtheturtle/literalizer/issues/1646

## Summary
- Implement PHP's `format_call_ref_identifier` hook so `{"$ref": "name"}` call arguments render as `$name`, matching PHP's variable sigil.
- Drop `Php` from the integration test's `_REF_CASE_INCOMPATIBLE` set now that ref-declaration goldens can lint and run cleanly, and add the four generated `call_ref_args*` PHP goldens.

## Test plan
- [x] `uv run --extra=dev pytest tests/test_languages.py tests/integration/test_integration.py` (878 passed)
- [x] `php -l` + `php` on each new golden (matches the `lint-fast` CI step locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)