### PR TITLE
Run odin check from per-file tmpdirs to probe parallel hangs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -149,11 +149,19 @@ jobs:
           find tests/integration/cases -name '*.nix' -print0 > /tmp/files-nix
           xargs -0 -P "$(nproc)" -n1 nix-instantiate --parse < /tmp/files-nix > /dev/null
 
+      # Run each `odin check -file` from its own tmpdir to test
+      # whether the intermittent step hangs (since parallelization)
+      # come from concurrent invocations racing on per-CWD compiler
+      # temp files.
       - name: Lint Odin
         run: |-
           find tests/integration/cases -name '*.odin' -print0 > /tmp/files-odin
           cat > /tmp/check-odin.sh <<'SCRIPT'
-          odin check "$1" -file || exit 1
+          src=$(realpath "$1")
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cd "$tmpdir" || exit 1
+          odin check "$src" -file || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/check-odin.sh < /tmp/files-odin
 


### PR DESCRIPTION
## Summary
- `lint-fast` has hung at the Lint Odin step roughly 1 in 7 runs since #1624 parallelized `odin check` — successful runs finish in 2–4 s, hangs run to the 30-minute job timeout.
- Run each `odin check -file` from its own `mktemp -d` cwd (mirroring the Lint Fortran step) to test whether concurrent invocations are racing on per-CWD compiler temp files.
- Diagnostic only: if hangs disappear we have the root cause and can decide on a permanent fix.

## Test plan
- [ ] Watch lint-fast across the next several runs; confirm the hang stops recurring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it can affect lint reliability and runtime by changing the working directory used for each parallel `odin check` invocation.
> 
> **Overview**
> Updates the `lint-fast` GitHub Actions workflow so the **Odin lint step** runs each `odin check -file` from its own `mktemp` working directory (using `realpath` to the source file), instead of invoking checks from a shared CWD.
> 
> This is intended to diagnose/avoid intermittent hangs when `odin check` runs in parallel, by isolating any per-directory temporary/compiler artifacts between workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89678c2fd9176ca7a0a239f43834d5a20b65c7c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->