### PR TITLE
Wrap CommonLisp call-ref identifiers in earmuffs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,8 @@ Next
 - ``CommonLisp`` now wraps ``{"$ref": "name"}`` identifiers in earmuffs
   (``*name*``) at the call site so they resolve to the matching
   ``defparameter`` declaration.  ``CommonLisp`` is no longer skipped by
-  the ``literalize_call`` ref-args integration tests, which now lint
-  cleanly under SBCL.
+  the ``literalize_call`` reference-argument integration tests, which
+  now lint cleanly under SBCL.
 - Added ``literalize_call`` support for ``Matlab``.  ``Matlab.CallStyles``
   now has a ``POSITIONAL`` member backed by a :class:`PositionalCallStyle`,
   and ``format_call_stub`` emits ``name = @(varargin) [];`` assignments so

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- ``CommonLisp`` now wraps ``{"$ref": "name"}`` identifiers in earmuffs
+  (``*name*``) at the call site so they resolve to the matching
+  ``defparameter`` declaration.  ``CommonLisp`` is no longer skipped by
+  the ``literalize_call`` ref-args integration tests, which now lint
+  cleanly under SBCL.
 - Added ``literalize_call`` support for ``Matlab``.  ``Matlab.CallStyles``
   now has a ``POSITIONAL`` member backed by a :class:`PositionalCallStyle`,
   and ``format_call_stub`` emits ``name = @(varargin) [];`` assignments so

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -74,8 +74,8 @@ def _format_common_lisp_call_ref_identifier(name: str, /) -> str:
     """Wrap a ``$ref`` identifier in Common Lisp earmuffs.
 
     The ``DEFPARAMETER`` declaration style binds variables as
-    ``*name*``, so the call site must reference the same earmuffed
-    name to resolve to the bound value.
+    ``*name*``, so the call site must wrap the bare name in the
+    matching ``*...*`` markers to resolve to the bound value.
     """
     return f"*{name}*"
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -49,7 +49,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -69,6 +68,16 @@ def _format_cons_entry(
 ) -> str:
     """Format a Common Lisp association-list entry as a ``cons`` pair."""
     return f"(cons {key} {formatted_value})"
+
+
+def _format_common_lisp_call_ref_identifier(name: str, /) -> str:
+    """Wrap a ``$ref`` identifier in Common Lisp earmuffs.
+
+    The ``DEFPARAMETER`` declaration style binds variables as
+    ``*name*``, so the call site must reference the same earmuffed
+    name to resolve to the bound value.
+    """
+    return f"*{name}*"
 
 
 def _common_lisp_call_stub(
@@ -461,7 +470,7 @@ class CommonLisp(metaclass=LanguageCls):
         """Rewrite a ``{"$ref": "name"}`` identifier into the
         language's call expression syntax.
         """
-        return identity_call_ref_identifier
+        return _format_common_lisp_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/tests/integration/cases/call_ref_args/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_ref_args/CommonLisp_call.lisp
@@ -1,0 +1,13 @@
+(defun process (&rest args) (declare (ignore args)) nil)
+(defparameter *my_var* (list
+    1
+    2
+    3
+))
+(defparameter *my_other* (list
+    4
+    5
+    6
+))
+(process :data *my_var* :count 42)
+(process :data *my_other* :count 7)

--- a/tests/integration/cases/call_ref_args_converted/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_ref_args_converted/CommonLisp_call.lisp
@@ -1,0 +1,13 @@
+(defun process (&rest args) (declare (ignore args)) nil)
+(defparameter *my-var* (list
+    1
+    2
+    3
+))
+(defparameter *my-other* (list
+    4
+    5
+    6
+))
+(process :data *my-var* :count 42)
+(process :data *my-other* :count 7)

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/CommonLisp_call.lisp
@@ -1,0 +1,13 @@
+(defun process (&rest args) (declare (ignore args)) nil)
+(defparameter *my-var* (list
+    1
+    2
+    3
+))
+(defparameter *my-other* (list
+    4
+    5
+    6
+))
+(process :data *my-var* :count 42)
+(process :data *my-other* :count 7)

--- a/tests/integration/cases/call_ref_args_converted_whole/CommonLisp_call.lisp
+++ b/tests/integration/cases/call_ref_args_converted_whole/CommonLisp_call.lisp
@@ -1,0 +1,7 @@
+(defun process (&rest args) (declare (ignore args)) nil)
+(defparameter *my-var* (list
+    1
+    2
+    3
+))
+(process :data *my-var*)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -36,7 +36,6 @@ from literalizer.exceptions import (
 from literalizer.languages import (
     ALL_LANGUAGES,
     C,
-    CommonLisp,
     Crystal,
     CSharp,
     Dart,
@@ -2391,10 +2390,6 @@ def test_format_enumeration_properties(
 # name-mangling gaps.
 _REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
     {
-        # ``defparameter`` adds ``*name*`` earmuffs at the declaration
-        # site, but ``$ref`` emits the bare name at the call site —
-        # unbound variable at load.
-        CommonLisp,
         # Variables are capitalized at the declaration site (``My_var =
         # ...``) but ``$ref`` emits the bare name, which Erlang parses
         # as a lowercase atom rather than the declared variable.


### PR DESCRIPTION
## Summary

- Override `format_call_ref_identifier` on `CommonLisp` to wrap `{"$ref": "name"}` identifiers in earmuffs (`*name*`) so call sites resolve to the matching `defparameter` declaration.
- Drop `CommonLisp` from `_REF_CASE_INCOMPATIBLE` and add the four `CommonLisp_call.lisp` golden files (verified to load cleanly under SBCL).

Closes #1643

## Test plan

- [x] `pytest` (full suite passes locally)
- [x] SBCL `--load` exits 0 on each new golden
- [x] `ruff check` / `mypy` / `pyrefly` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated change to Common Lisp call-ref formatting plus new/updated integration goldens; main risk is minor output differences for existing Common Lisp `literalize_call` users relying on bare ref names.
> 
> **Overview**
> **Common Lisp call refs now match declarations.** `CommonLisp.format_call_ref_identifier` is overridden to wrap `{"$ref": "name"}` call arguments as `*name*`, aligning call-site refs with `defparameter`’s earmuffed bindings.
> 
> **Integration coverage expanded.** Common Lisp is removed from the ref-arg incompatibility skip list and new `CommonLisp_call.lisp` golden files are added for ref-argument cases (including identifier-case conversion variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a42f83563bec5cf63b305f9f6fb87e0b2dbff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->