### PR TITLE
Add Perl call-ref renaming with scalar sigil

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- ``Perl`` ``literalize_call`` output now prepends Perl's scalar ``$``
+  sigil to ``{"$ref": "name"}`` identifiers via a
+  ``format_call_ref_identifier`` override, so a ref to ``my_var``
+  renders as ``$my_var`` at the call site and lines up with the
+  ``my $my_var = ...`` declaration site.  Generated files now pass
+  ``perl -c`` under ``use strict`` and ``Perl`` is no longer excluded
+  from the integration suite's ref-declaration golden cases.
 - Added ``literalize_call`` support for ``Matlab``.  ``Matlab.CallStyles``
   now has a ``POSITIONAL`` member backed by a :class:`PositionalCallStyle`,
   and ``format_call_stub`` emits ``name = @(varargin) [];`` assignments so

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,8 @@ Changelog
 Next
 ----
 
-- ``Perl`` ``literalize_call`` output now prepends Perl's scalar ``$``
-  sigil to ``{"$ref": "name"}`` identifiers via a
+- ``Perl`` ``literalize_call`` output now emits Perl's scalar ``$``
+  sigil before each ``{"$ref": "name"}`` identifier via a
   ``format_call_ref_identifier`` override, so a ref to ``my_var``
   renders as ``$my_var`` at the call site and lines up with the
   ``my $my_var = ...`` declaration site.  Generated files now pass

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -62,7 +62,6 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
-    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -91,6 +90,12 @@ def _perl_call_stub(
     """
     parts = name.split(sep=".")
     return tuple(f"sub {part} {{}}" for part in parts)
+
+
+@beartype
+def _perl_format_call_ref_identifier(name: str, /) -> str:
+    """Prepend Perl's scalar ``$`` sigil to a ``$ref`` identifier."""
+    return f"${name}"
 
 
 @beartype
@@ -512,7 +517,7 @@ class Perl(metaclass=LanguageCls):
         """Rewrite a ``{"$ref": "name"}`` identifier into the
         language's call expression syntax.
         """
-        return identity_call_ref_identifier
+        return _perl_format_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/tests/integration/cases/call_ref_args/Perl_call.pl
+++ b/tests/integration/cases/call_ref_args/Perl_call.pl
@@ -1,0 +1,13 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+my $my_other = [
+    4,
+    5,
+    6,
+];
+process($my_var, 42);
+process($my_other, 7);

--- a/tests/integration/cases/call_ref_args_converted/Perl_call.pl
+++ b/tests/integration/cases/call_ref_args_converted/Perl_call.pl
@@ -1,0 +1,13 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+my $my_other = [
+    4,
+    5,
+    6,
+];
+process($my_var, 42);
+process($my_other, 7);

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Perl_call.pl
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Perl_call.pl
@@ -1,0 +1,13 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+my $my_other = [
+    4,
+    5,
+    6,
+];
+process($my_var, 42);
+process($my_other, 7);

--- a/tests/integration/cases/call_ref_args_converted_whole/Perl_call.pl
+++ b/tests/integration/cases/call_ref_args_converted_whole/Perl_call.pl
@@ -1,0 +1,7 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+process($my_var);

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -55,7 +55,6 @@ from literalizer.languages import (
     Nim,
     OCaml,
     Odin,
-    Perl,
     Php,
     PureScript,
     Python,
@@ -2409,13 +2408,6 @@ _REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
         # ``wrap_in_file`` wraps content in ``[ … ]`` as an expression
         # list; variable declarations don't fit the shape.
         Jsonnet,
-        # Variables declare with a ``my $name`` sigil that ``$ref``
-        # does not emit at the call site.  The default ``perl -c``
-        # tolerates the unquoted identifier (interpreting it as the
-        # string ``"my_var"``), but the call no longer references the
-        # declared variable, so the golden misrepresents the feature
-        # and the file fails ``use strict``.
-        Perl,
         # Variables declare with a ``$`` sigil that ``$ref`` does not
         # emit at the call site — undefined-constant error at runtime.
         Php,


### PR DESCRIPTION
## Summary
- Override `Perl.format_call_ref_identifier` to prepend the scalar `$` sigil so a `{"$ref": "name"}` marker renders as `$name` at the call site, lining up with the `my $name = ...` declaration site.
- Drop `Perl` from `_REF_CASE_INCOMPATIBLE` and add the four `call_ref_args*/Perl_call.pl` goldens (each passes `perl -c` under `use strict` and runs cleanly under `perl`).

Closes #1645.

## Test plan
- [x] `uv run pytest tests/` — 1172 passed, 0 failed
- [x] `find tests/integration/cases -name '*.pl' | xargs -n1 perl -c` — all syntax OK
- [x] `find tests/integration/cases -name '*.pl' | xargs -n1 perl` — all execute cleanly
- [x] `uv run -m pylint *.py src/ tests/ docs/` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated Perl call rendering tweak plus new/reenabled integration goldens; main risk is minor output breakage for existing Perl `$ref` call sites expecting bare identifiers.
> 
> **Overview**
> Perl `literalize_call` now formats `{"$ref": "name"}` arguments as scalar variables by prefixing a `$` at the call site via a `format_call_ref_identifier` override.
> 
> This re-enables Perl in the integration suite’s ref-declaration call cases and adds Perl golden fixtures for the `call_ref_args*` scenarios to ensure generated `.pl` files typecheck cleanly under `use strict`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b889740b2ba3015e01cafc31355a7cb24a3337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->