### PR TITLE
Add Erlang call-ref renaming support (closes #1644)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- ``Erlang`` now capitalizes ``{"$ref": "name"}`` call arguments so
+  they reference the declared variable instead of parsing as a
+  lowercase atom, matching the existing ``My_var = ...`` capitalization
+  on the declaration site.  ``Erlang.format_variable_declaration`` now
+  emits the trailing ``,`` separator itself so multiple declarations can
+  precede a call; :meth:`Erlang.wrap_in_file` is adjusted accordingly
+  and the rendered output is unchanged for the single-declaration case.
 - Added ``literalize_call`` support for ``Matlab``.  ``Matlab.CallStyles``
   now has a ``POSITIONAL`` member backed by a :class:`PositionalCallStyle`,
   and ``format_call_stub`` emits ``name = @(varargin) [];`` assignments so

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -79,7 +79,7 @@ def _format_variable_declaration(
 ) -> str:
     """Format an Erlang variable declaration.
 
-    The trailing ``,`` is Erlang's intra-body statement separator so
+    The trailing ``,`` is Erlang's in-body statement separator so
     multiple declarations can be concatenated (e.g. between ``$ref``
     variable bindings and the following call); :meth:`Erlang.wrap_in_file`
     rewrites the final ``,`` to ``.`` when closing the ``x/0`` clause.

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -54,7 +54,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -78,9 +77,15 @@ def _format_variable_declaration(
     _data: Value,
     _modifiers: frozenset[enum.Enum],
 ) -> str:
-    """Format an Erlang variable declaration."""
+    """Format an Erlang variable declaration.
+
+    The trailing ``,`` is Erlang's intra-body statement separator so
+    multiple declarations can be concatenated (e.g. between ``$ref``
+    variable bindings and the following call); :meth:`Erlang.wrap_in_file`
+    rewrites the final ``,`` to ``.`` when closing the ``x/0`` clause.
+    """
     erlang_name = name[0].upper() + name[1:]
-    return f"{erlang_name} = {value}"
+    return f"{erlang_name} = {value},"
 
 
 @beartype
@@ -111,6 +116,19 @@ def _erlang_format_call_target(name: str, /) -> str:
     if "." in name:
         return f"'{name}'"
     return name
+
+
+@beartype
+def _erlang_format_call_ref_identifier(name: str, /) -> str:
+    """Capitalize a ``$ref`` name so it matches the declaration site.
+
+    :func:`_format_variable_declaration` writes ``my_var = ...`` as
+    ``My_var = ...`` because Erlang variables must start with an
+    uppercase letter; ref arguments need the same transformation or
+    they parse as lowercase atoms instead of the bound variable.
+    Slicing rather than indexing keeps the empty-name path safe.
+    """
+    return name[:1].upper() + name[1:]
 
 
 @beartype
@@ -417,7 +435,7 @@ class Erlang(metaclass=LanguageCls):
                 f"-module(check).\n"
                 f"-export([x/0]).\n"
                 f"x() ->\n"
-                f"{indented},\n"
+                f"{indented}\n"
                 f"    {erlang_varname}."
             )
         trimmed = content.rstrip().removesuffix(",")
@@ -548,10 +566,10 @@ class Erlang(metaclass=LanguageCls):
 
     @cached_property
     def format_call_ref_identifier(self) -> Callable[[str], str]:
-        """Rewrite a ``{"$ref": "name"}`` identifier into the
-        language's call expression syntax.
+        """Capitalize a ``{"$ref": "name"}`` identifier so the call
+        site references the declared Erlang variable.
         """
-        return identity_call_ref_identifier
+        return _erlang_format_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/tests/integration/cases/call_ref_args/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args/Erlang_call.erl
@@ -1,0 +1,16 @@
+-module(check).
+-export([x/0]).
+process(_, _) -> ok.
+x() ->
+    My_var = [
+        1,
+        2,
+        3
+    ],
+    My_other = [
+        4,
+        5,
+        6
+    ],
+    process(My_var, 42),
+    process(My_other, 7).

--- a/tests/integration/cases/call_ref_args_converted/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args_converted/Erlang_call.erl
@@ -1,0 +1,16 @@
+-module(check).
+-export([x/0]).
+process(_, _) -> ok.
+x() ->
+    My_var = [
+        1,
+        2,
+        3
+    ],
+    My_other = [
+        4,
+        5,
+        6
+    ],
+    process(My_var, 42),
+    process(My_other, 7).

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Erlang_call.erl
@@ -1,0 +1,16 @@
+-module(check).
+-export([x/0]).
+process(_, _) -> ok.
+x() ->
+    My_var = [
+        1,
+        2,
+        3
+    ],
+    My_other = [
+        4,
+        5,
+        6
+    ],
+    process(My_var, 42),
+    process(My_other, 7).

--- a/tests/integration/cases/call_ref_args_converted_whole/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args_converted_whole/Erlang_call.erl
@@ -1,0 +1,10 @@
+-module(check).
+-export([x/0]).
+process(_) -> ok.
+x() ->
+    My_var = [
+        1,
+        2,
+        3
+    ],
+    process(My_var).

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -42,7 +42,6 @@ from literalizer.languages import (
     Dart,
     Dhall,
     Elm,
-    Erlang,
     Fortran,
     FSharp,
     Gleam,
@@ -2395,10 +2394,6 @@ _REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
         # site, but ``$ref`` emits the bare name at the call site —
         # unbound variable at load.
         CommonLisp,
-        # Variables are capitalized at the declaration site (``My_var =
-        # ...``) but ``$ref`` emits the bare name, which Erlang parses
-        # as a lowercase atom rather than the declared variable.
-        Erlang,
         # ``wrap_in_file`` places content inside ``main = do``; a
         # multi-line ``name = value`` binding needs ``let`` in a
         # do-block, which the harness does not inject.


### PR DESCRIPTION
## Summary
- Adds an ``Erlang.format_call_ref_identifier`` override that capitalizes ``{"$ref": "name"}`` arguments so they reference the declared ``My_var`` variables instead of parsing as lowercase atoms.
- Shifts the intra-body ``,`` separator from ``Erlang.wrap_in_file`` into ``_format_variable_declaration`` so multiple declarations can precede a call, leaving single-declaration output byte-identical.
- Drops Erlang from ``_REF_CASE_INCOMPATIBLE`` and adds four ``call_ref_args*`` goldens (each compiles cleanly under ``erlc -Werror``).

## Test plan
- [x] ``pytest --cov=src --cov-fail-under=100`` (1172 passed, 100% coverage)
- [x] ``ruff check`` and ``ruff format --check`` on touched files
- [x] ``erlc -Werror`` on all four new Erlang goldens and every existing ``.erl`` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Erlang code generation for both variable declarations and `literalize_call` output, which could subtly affect rendered syntax/termination in wrapped files. Risk is limited to Erlang targets and is covered by new integration goldens.
> 
> **Overview**
> **Erlang `literalize_call` now correctly references `$ref` variables.** Call-site `{"$ref": "name"}` identifiers are capitalized via a new `Erlang.format_call_ref_identifier` hook so they match Erlang’s uppercase variable declarations (avoiding accidental lowercase atom parsing).
> 
> **Statement termination handling was shifted into declarations.** `Erlang.format_variable_declaration` now emits the trailing `,` separator itself, and `Erlang.wrap_in_file` was adjusted so multi-declaration + call sequences render correctly while keeping single-declaration output unchanged.
> 
> Integration coverage was updated by adding Erlang golden fixtures for the `call_ref_args*` cases and removing Erlang from the `_REF_CASE_INCOMPATIBLE` exclusion set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b39ac1eb740a6a399091f0366c6037423ee1f9a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->