### PR TITLE
Silence clang-tidy compile_commands.json warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -591,14 +591,16 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
         run: uv tool install clang-tidy
+      # Pass compile flags after `--` so clang-tidy treats them as the full
+      # compile command and skips searching for a compile_commands.json.
       - name: Run clang-tidy on C files
         run: |-
           find tests/integration/cases -name '*.c' -print0 > /tmp/files-c-tidy
-          xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c11 < /tmp/files-c-tidy
+          xargs -0 -P "$(nproc)" -n1 -I{} clang-tidy {} -- -std=c11 < /tmp/files-c-tidy
       - name: Run clang-tidy on C++ files
         run: |-
           find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-cpp-tidy
-          xargs -0 -P "$(nproc)" -n1 clang-tidy --extra-arg=-std=c++20 < /tmp/files-cpp-tidy
+          xargs -0 -P "$(nproc)" -n1 -I{} clang-tidy {} -- -std=c++20 < /tmp/files-cpp-tidy
 
   lint-cobol:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Pass `-std=c11` / `-std=c++20` after `--` in the `lint-clang-tidy` job so clang-tidy treats them as the full compile command and skips searching for `compile_commands.json`, eliminating the per-file "Could not auto-detect compilation database" warning.

## Test plan
- [ ] CI `lint-clang-tidy` job runs cleanly without compilation-database warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tweaks `clang-tidy` invocation; main risk is mis-specifying flags and changing lint behavior for C/C++ fixtures.
> 
> **Overview**
> Updates the `lint-clang-tidy` GitHub Actions job to pass `-std=c11`/`-std=c++20` *after* `--` (as part of the compile command) when running `clang-tidy` on C/C++ fixtures, avoiding per-file `compile_commands.json` auto-detection warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f13a75b543219765c3c477f42449f69e0e0c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->