### PR TITLE
Isolate lint-odin into its own serial job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,10 +63,6 @@ jobs:
           luaVersion: '5.4'
       - name: Install Nix
         uses: cachix/install-nix-action@v31
-      - name: Install Odin
-        uses: laytan/setup-odin@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Bash
         run: |-
@@ -149,21 +145,26 @@ jobs:
           find tests/integration/cases -name '*.nix' -print0 > /tmp/files-nix
           xargs -0 -P "$(nproc)" -n1 nix-instantiate --parse < /tmp/files-nix > /dev/null
 
-      # Run each `odin check -file` from its own tmpdir to test
-      # whether the intermittent step hangs (since parallelization)
-      # come from concurrent invocations racing on per-CWD compiler
-      # temp files.
+  # Split out from lint-fast because `odin check` intermittently hangs
+  # in CI; isolating it means a hang only stalls this job instead of
+  # blocking every other lint-fast language behind the same timeout.
+  lint-odin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Odin
+        uses: laytan/setup-odin@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # Run serially: parallel `odin check` invocations are the
+      # suspected cause of the intermittent hangs, so feed fixtures
+      # one at a time until the upstream issue is understood.
       - name: Lint Odin
         run: |-
           find tests/integration/cases -name '*.odin' -print0 > /tmp/files-odin
-          cat > /tmp/check-odin.sh <<'SCRIPT'
-          src=$(realpath "$1")
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          cd "$tmpdir" || exit 1
-          odin check "$src" -file || exit 1
-          SCRIPT
-          xargs -0 -P "$(nproc)" -n1 bash /tmp/check-odin.sh < /tmp/files-odin
+          xargs -0 -n1 odin check -file < /tmp/files-odin
 
   # Fixture languages whose interpreter is a quick `apt-get install`.
   # Grouped so the apt-get cost is paid once for the whole group.
@@ -1251,6 +1252,7 @@ jobs:
     needs:
       - pre-commit
       - lint-fast
+      - lint-odin
       - lint-apt-basics
       - lint-go-installed
       - lint-npm-installed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Lint Odin
         run: |-
           find tests/integration/cases -name '*.odin' -print0 > /tmp/files-odin
-          xargs -0 -n1 odin check -file < /tmp/files-odin
+          xargs -0 -I{} odin check {} -file < /tmp/files-odin
 
   # Fixture languages whose interpreter is a quick `apt-get install`.
   # Grouped so the apt-get cost is paid once for the whole group.


### PR DESCRIPTION
## Summary
- Split `Lint Odin` out of `lint-fast` into a dedicated `lint-odin` job so its intermittent CI hang only stalls itself instead of every other fast-language step.
- Reverted the recent parallelisation + per-file `mktemp -d` wrapper; `odin check -file` now runs serially via `xargs -0 -n1`, since concurrent invocations are the suspected hang trigger.
- Comments on the new job explain both the isolation rationale and why it is not parallelised.

## Test plan
- [ ] CI: `lint-odin` and `lint-fast` both pass on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just reshapes CI execution; main impact is CI duration/parallelism and the possibility of missed flakes if the new serial `odin check` invocation behaves differently from the prior wrapper.
> 
> **Overview**
> Moves Odin linting out of `lint-fast` into a dedicated `lint-odin` GitHub Actions job so intermittent `odin check` hangs only stall that job.
> 
> Changes the Odin step to run **serially** (removing the per-file tempdir wrapper and parallel `xargs`) and wires `completion-lint` to also depend on `lint-odin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c982fe58b5488b5399704ae8ee1d6ba76d0eef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->