### PR TITLE
Run Java fixtures in lint to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,11 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 node --check < /tmp/files-js
           xargs -0 -P "$(nproc)" -n1 node < /tmp/files-js
 
+      # The host compiles each fixture into an in-memory assembly, then
+      # reflectively constructs `Check` and invokes its `check()` method
+      # (or runs field initializers on field-only fixtures), so javac
+      # emit-success and runtime errors (e.g. bad `Instant.parse` input)
+      # both fail here.
       - name: Lint Java
         run: |-
           find tests/integration/cases -name '*.java' -print0 > /tmp/files-java

--- a/CheckJavaSyntax.java
+++ b/CheckJavaSyntax.java
@@ -1,4 +1,9 @@
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -8,9 +13,16 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
-// Compile each given Java source file with the in-process JavaCompiler
-// API so the compiler stays warm across fixtures instead of cold-starting
-// a JVM per file like the previous `javac` bash loop did.
+// Compile and execute each given Java source file with the in-process
+// JavaCompiler API and a private URLClassLoader so the compiler and JVM
+// stay warm across fixtures instead of cold-starting a JVM per file like
+// the previous `javac` bash loop did. Fixtures either expose a
+// `public static void check()` method (wrapping the literal in a method
+// body) or declare `my_data` as a field on `class Check`; either way the
+// host triggers static-init, constructs a `Check` instance to run any
+// instance-field initializers, and invokes `check()` when present, so
+// runtime errors (e.g. a bad `Instant.parse` argument) surface here
+// instead of passing silently.
 public class CheckJavaSyntax {
     public static void main(final String[] args) throws IOException {
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -37,9 +49,55 @@ public class CheckJavaSyntax {
                 if (!task.call()) {
                     System.err.println(filename + ": javac failed");
                     failed = true;
+                    continue;
+                }
+                if (!runFixture(filename, classDir)) {
+                    failed = true;
                 }
             }
         }
         System.exit(failed ? 1 : 0);
+    }
+
+    // Load `Check` from a private class loader rooted at *classDir*,
+    // construct an instance (forcing both static- and instance-field
+    // initializers), and invoke `check()` if the fixture defines one.
+    // `Check` is package-private in every fixture, so `setAccessible`
+    // is required before invoking members reflectively.
+    private static boolean runFixture(final String filename, final Path classDir) {
+        final URL[] urls;
+        try {
+            urls = new URL[] {classDir.toUri().toURL()};
+        } catch (final java.net.MalformedURLException e) {
+            System.err.println(filename + ": " + e);
+            return false;
+        }
+        try (final URLClassLoader loader = new URLClassLoader(urls)) {
+            final Class<?> checkClass = Class.forName("Check", true, loader);
+            final Constructor<?> constructor = checkClass.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            final Object instance = constructor.newInstance();
+            final Method checkMethod;
+            try {
+                checkMethod = checkClass.getDeclaredMethod("check");
+            } catch (final NoSuchMethodException e) {
+                // Field-only fixtures — constructing `Check` above
+                // already ran the field initializer.
+                return true;
+            }
+            checkMethod.setAccessible(true);
+            checkMethod.invoke(instance);
+            return true;
+        } catch (final ClassNotFoundException
+                | NoSuchMethodException
+                | IllegalAccessException
+                | InstantiationException
+                | IOException e) {
+            System.err.println(filename + ": " + e);
+            return false;
+        } catch (final InvocationTargetException e) {
+            System.err.println(filename + ": " + e.getCause());
+            return false;
+        }
     }
 }

--- a/CheckJavaSyntax.java
+++ b/CheckJavaSyntax.java
@@ -88,15 +88,14 @@ public class CheckJavaSyntax {
             checkMethod.setAccessible(true);
             checkMethod.invoke(instance);
             return true;
-        } catch (final ClassNotFoundException
-                | NoSuchMethodException
-                | IllegalAccessException
-                | InstantiationException
-                | IOException e) {
-            System.err.println(filename + ": " + e);
-            return false;
         } catch (final InvocationTargetException e) {
             System.err.println(filename + ": " + e.getCause());
+            return false;
+        } catch (final Throwable t) {
+            // Includes `ExceptionInInitializerError` (extends `Error`)
+            // raised when a static field initializer throws during
+            // `Class.forName`, e.g. a bad `Instant.parse` argument.
+            System.err.println(filename + ": " + t);
             return false;
         }
     }

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -20,7 +20,6 @@ from literalizer._formatters.collection_openers import (
 )
 from literalizer._formatters.format_dates import (
     date_ymd_formatter,
-    datetime_iso_formatter,
     format_date_iso,
     format_datetime_iso,
 )
@@ -183,6 +182,23 @@ def _format_datetime_java_zoned(value: datetime.datetime) -> str:
         f"{value.hour}, {value.minute}, {value.second}, "
         f'{nanoseconds}, ZoneId.of("{timezone_name}"))'
     )
+
+
+@beartype
+def _format_datetime_java_instant(value: datetime.datetime) -> str:
+    """Format a datetime as a Java ``Instant.parse(...)`` call.
+
+    ``Instant.parse`` rejects strings without a timezone offset, so a
+    naive datetime (no :attr:`~datetime.datetime.tzinfo`) is rendered
+    with a trailing ``Z`` — Python's :meth:`~datetime.datetime.isoformat`
+    emits no offset for naive datetimes, which Java reads as invalid.
+    Treating naive values as UTC matches the ISO 8601 convention for
+    unqualified timestamps.
+    """
+    iso = value.isoformat()
+    if value.tzinfo is None:
+        iso += "Z"
+    return f'Instant.parse("{iso}")'
 
 
 @beartype
@@ -608,9 +624,7 @@ class Java(metaclass=LanguageCls):
         """Datetime formatting options for Java."""
 
         INSTANT = DatetimeFormatConfig(
-            formatter=datetime_iso_formatter(
-                template='Instant.parse("{iso}")',
-            ),
+            formatter=_format_datetime_java_instant,
             preamble_lines=("import java.time.Instant;",),
         )
         ZONED = DatetimeFormatConfig(

--- a/tests/integration/cases/dict_all_scalar_types/Java.java
+++ b/tests/integration/cases/dict_all_scalar_types/Java.java
@@ -9,7 +9,7 @@ var my_data = Map.ofEntries(
     Map.entry("f", 1.5),
     Map.entry("b", true),
     Map.entry("d", LocalDate.of(2024, 1, 15)),
-    Map.entry("dt", Instant.parse("2024-01-15T12:00:00")),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
     Map.entry("by", "48656c6c6f")
 );
     }

--- a/tests/integration/cases/dict_all_scalar_types/Java_combined.java
+++ b/tests/integration/cases/dict_all_scalar_types/Java_combined.java
@@ -9,7 +9,7 @@ var my_data = Map.ofEntries(
     Map.entry("f", 1.5),
     Map.entry("b", true),
     Map.entry("d", LocalDate.of(2024, 1, 15)),
-    Map.entry("dt", Instant.parse("2024-01-15T12:00:00")),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
     Map.entry("by", "48656c6c6f")
 );
 my_data = Map.ofEntries(
@@ -18,7 +18,7 @@ my_data = Map.ofEntries(
     Map.entry("f", 1.5),
     Map.entry("b", true),
     Map.entry("d", LocalDate.of(2024, 1, 15)),
-    Map.entry("dt", Instant.parse("2024-01-15T12:00:00")),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
     Map.entry("by", "48656c6c6f")
 );
     }

--- a/tests/integration/cases/scalar_datetime_midnight/Java.java
+++ b/tests/integration/cases/scalar_datetime_midnight/Java.java
@@ -1,6 +1,6 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T00:00:00");
+var my_data = Instant.parse("2024-01-15T00:00:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_midnight/Java_combined.java
+++ b/tests/integration/cases/scalar_datetime_midnight/Java_combined.java
@@ -1,7 +1,7 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T00:00:00");
-my_data = Instant.parse("2024-01-15T00:00:00");
+var my_data = Instant.parse("2024-01-15T00:00:00Z");
+my_data = Instant.parse("2024-01-15T00:00:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_naive/Java.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java.java
@@ -1,6 +1,6 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:00");
+var my_data = Instant.parse("2024-01-15T12:30:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_naive/Java_combined.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java_combined.java
@@ -1,7 +1,7 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:00");
-my_data = Instant.parse("2024-01-15T12:30:00");
+var my_data = Instant.parse("2024-01-15T12:30:00Z");
+my_data = Instant.parse("2024-01-15T12:30:00Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Java.java
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Java.java
@@ -1,6 +1,6 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:45.123456");
+var my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
     }
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_combined.java
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_combined.java
@@ -1,7 +1,7 @@
 import java.time.Instant;
 class Check {
     public static void check() {
-var my_data = Instant.parse("2024-01-15T12:30:45.123456");
-my_data = Instant.parse("2024-01-15T12:30:45.123456");
+var my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
+my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
     }
 }


### PR DESCRIPTION
Takes over #1638.

## Summary

- Extends the in-process `CheckJavaSyntax` host to **compile and execute** each fixture, reflectively constructing `Check` and invoking its `check()` method (or running field initializers on field-only fixtures), so `javac` emit-success and runtime errors both fail the step. Mirrors the pattern used by `lint-csharp` / `lint-vb` and keeps the warm-compiler speedup of the single long-running host.
- Fixes a generator bug surfaced by running the fixtures: `Instant.parse` rejects strings without a timezone offset, but `DatetimeFormats.INSTANT` emitted `Instant.parse("2024-01-15T12:30:00")` for naive datetimes. New `_format_datetime_java_instant` appends `Z` when `tzinfo is None`, treating unqualified timestamps as UTC per ISO 8601.
- Regenerates the 8 affected Java golden files.
- Catches `Throwable` rather than only `Exception` subclasses in the fixture runner, so an `ExceptionInInitializerError` from a static field initializer (e.g. a bad `Instant.parse`) is reported per fixture instead of crashing the runner loop. Addresses Cursor Bugbot finding on #1638.

Fixes #1406.

## Test plan

- [x] `find tests/integration/cases -name '*.java' -print0 | xargs -0 java CheckJavaSyntax.java` — all 399 fixtures compile and execute; exit 0.
- [x] Manual repro of `ExceptionInInitializerError` confirms the loop now continues to the next fixture instead of aborting.
- [ ] CI green on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now compiles and *runs* all Java fixtures, which can introduce new failures and increases reliance on reflective execution in the lint job. Generator changes affect emitted Java datetime literals and could impact downstream golden expectations.
> 
> **Overview**
> **Java fixture linting now executes code, not just compiles it.** `CheckJavaSyntax.java` is extended to compile each fixture to a temp output dir, load `Check` via an isolated `URLClassLoader`, construct it (triggering static/instance initializers), and invoke `check()` when present; the workflow’s Java lint step is updated accordingly and documented to fail on runtime errors.
> 
> **Fixes Java datetime emission for `Instant.parse`.** The Java generator now appends `Z` for naive datetimes so `Instant.parse(...)` receives a timezone-qualified ISO string, and the affected Java integration golden fixtures are regenerated to include the trailing `Z`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd5d9c9493527e70ef8e3a7af3792ea4e04ef96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->