### PR TITLE
Extract duplicated comment_line_prefix calculation

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1156,16 +1156,15 @@ def _literalize_pre_form(
         include_delimiters=include_delimiters,
     )
 
+    comment_line_prefix = (
+        line_prefix + language.indent if include_delimiters else line_prefix
+    )
+
     resolved: ResolvedComments | None = None
     if input_format is InputFormat.YAML and parsed.yaml_needs_comment_resolve:
         comment_cfg = language.comment_config
         cp = comment_cfg.prefix
         cs = comment_cfg.suffix
-        comment_line_prefix = (
-            line_prefix + language.indent
-            if include_delimiters
-            else line_prefix
-        )
         resolved = resolve_yaml_comments(
             yaml_string=source,
             raw_data=parsed.raw_data,
@@ -1180,11 +1179,6 @@ def _literalize_pre_form(
         result = resolved.result
     elif input_format is InputFormat.TOML:
         comment_cfg = language.comment_config
-        comment_line_prefix = (
-            line_prefix + language.indent
-            if include_delimiters
-            else line_prefix
-        )
         resolved = resolve_toml_comments(
             toml_doc=parsed.raw_data,
             base=result,


### PR DESCRIPTION
Hoists the `comment_line_prefix` ternary out of the YAML and TOML branches in `_literalize.py` so it is computed once. Closes #1192.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only hoists a duplicated `comment_line_prefix` calculation; behavior should remain identical aside from potential edge cases if either branch previously diverged unintentionally.
> 
> **Overview**
> Moves the `comment_line_prefix` calculation in `_literalize_pre_form` out of the YAML and TOML branches so it’s computed once and reused for both comment-resolution paths.
> 
> This reduces duplicated logic while keeping YAML/TOML comment resolution inputs the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c02bcb1e6def867ab496979b500a62eb5b851a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->