### PR TITLE
Remove default for narrowed_empty_form

### DIFF
--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -130,6 +130,7 @@ of the protocol's nested enum classes and attributes.
                uses_typed_literal_for_scalars=False,
                requires_uniform_record_shapes=False,
                declared_type=None,
+               narrowed_empty_form=None,
            )
 
        sequence_formats = SequenceFormats

--- a/src/literalizer/_formatters/format_factories.py
+++ b/src/literalizer/_formatters/format_factories.py
@@ -87,6 +87,7 @@ def _build_sequence_format_config(
         uses_typed_literal_for_scalars=False,
         requires_uniform_record_shapes=False,
         declared_type=None,
+        narrowed_empty_form=None,
     )
 
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -31,7 +31,7 @@ class SequenceFormatConfig:
     uses_typed_literal_for_scalars: bool
     requires_uniform_record_shapes: bool
     declared_type: str | None
-    narrowed_empty_form: Callable[[Sequence[list[Value]]], str] | None = None
+    narrowed_empty_form: Callable[[Sequence[list[Value]]], str] | None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -182,6 +182,7 @@ class Ada(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -197,6 +197,7 @@ class Bash(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -253,6 +253,7 @@ class C(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):
@@ -615,6 +616,7 @@ class C(metaclass=LanguageCls):
                 fmt.requires_uniform_record_shapes
             ),
             declared_type=fmt.declared_type,
+            narrowed_empty_form=None,
         )
 
     @cached_property

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -151,6 +151,7 @@ class Clojure(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -327,6 +327,7 @@ class Cobol(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -169,6 +169,7 @@ class CommonLisp(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -307,6 +307,7 @@ def _make_initializer_list_config(
         uses_typed_literal_for_scalars=False,
         requires_uniform_record_shapes=False,
         declared_type=None,
+        narrowed_empty_form=None,
     )
 
 
@@ -329,6 +330,7 @@ def _make_array_config(
         uses_typed_literal_for_scalars=False,
         requires_uniform_record_shapes=False,
         declared_type=None,
+        narrowed_empty_form=None,
     )
 
 

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -212,6 +212,7 @@ class Crystal(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="{"),
@@ -226,6 +227,7 @@ class Crystal(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -205,6 +205,7 @@ class D(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -292,6 +292,7 @@ class Dart(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="("),
@@ -306,6 +307,7 @@ class Dart(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -403,6 +403,7 @@ class Dhall(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=True,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -181,6 +181,7 @@ class Elixir(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="{"),
@@ -195,6 +196,7 @@ class Elixir(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -459,6 +459,7 @@ class Elm(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="Val",
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -239,6 +239,7 @@ class Erlang(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="{"),
@@ -253,6 +254,7 @@ class Erlang(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -244,6 +244,7 @@ class Forth(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -289,6 +289,7 @@ class Fortran(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):
@@ -646,6 +647,7 @@ class Fortran(metaclass=LanguageCls):
                 fmt.requires_uniform_record_shapes
             ),
             declared_type=fmt.declared_type,
+            narrowed_empty_form=None,
         )
 
     @cached_property

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -310,6 +310,7 @@ class FSharp(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="Val",
+            narrowed_empty_form=None,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="[|"),
@@ -324,6 +325,7 @@ class FSharp(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="Val array",
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -554,6 +554,7 @@ class Gleam(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="#("),
@@ -568,6 +569,7 @@ class Gleam(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -312,6 +312,7 @@ class Go(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -184,6 +184,7 @@ class Groovy(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -987,6 +987,7 @@ class Haskell(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="Val",
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="("),
@@ -1001,6 +1002,7 @@ class Haskell(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -125,6 +125,7 @@ class Hcl(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -669,6 +669,7 @@ class Java(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         LIST = SequenceFormatConfig(
             sequence_open=_list_of_open,
@@ -683,6 +684,7 @@ class Java(metaclass=LanguageCls):
             empty_sequence="List.of()",
             preamble_lines=("import java.util.List;",),
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -180,6 +180,7 @@ class JavaScript(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -160,6 +160,7 @@ class Json5(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -178,6 +178,7 @@ class Jsonnet(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -212,6 +212,7 @@ class Julia(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="("),
@@ -226,6 +227,7 @@ class Julia(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -496,6 +496,7 @@ class Kotlin(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="arrayOf<Any?>("),
@@ -510,6 +511,7 @@ class Kotlin(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=_kotlin_tuple_open,
@@ -524,6 +526,7 @@ class Kotlin(metaclass=LanguageCls):
             empty_sequence=None,
             preamble_lines=(),
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -187,6 +187,7 @@ class Lua(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -257,6 +257,7 @@ class Matlab(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -498,6 +498,7 @@ class Nim(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=True,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="["),
@@ -512,6 +513,7 @@ class Nim(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -228,6 +228,7 @@ class Nix(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -134,6 +134,7 @@ class Norg(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -321,6 +321,7 @@ class ObjectiveC(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -277,6 +277,7 @@ class OCaml(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="val_t",
+            narrowed_empty_form=None,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="[|"),
@@ -291,6 +292,7 @@ class OCaml(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="val_t array",
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -144,6 +144,7 @@ class Occam(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -185,6 +185,7 @@ class Odin(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -206,6 +206,7 @@ class Perl(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -203,6 +203,7 @@ class Php(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -151,6 +151,7 @@ class PowerShell(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -551,6 +551,7 @@ class PureScript(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="Val",
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -597,6 +597,7 @@ class Python(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         LIST = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="["),
@@ -611,6 +612,7 @@ class Python(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
         @property

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -224,6 +224,7 @@ class R(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -152,6 +152,7 @@ class Racket(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -183,6 +183,7 @@ class Raku(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -211,6 +211,7 @@ class Ruby(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -285,6 +285,7 @@ class Scala(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         SEQ = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="Seq("),
@@ -299,6 +300,7 @@ class Scala(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         ARRAY = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="Array("),
@@ -313,6 +315,7 @@ class Scala(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -125,6 +125,7 @@ class Scheme(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -329,6 +329,7 @@ class Sml(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type="val_t",
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -202,6 +202,7 @@ class SystemVerilog(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -179,6 +179,7 @@ class Tcl(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -166,6 +166,7 @@ class Toml(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -298,6 +298,7 @@ class TypeScript(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
         TUPLE = SequenceFormatConfig(
             sequence_open=fixed_open(open_str="["),
@@ -312,6 +313,7 @@ class TypeScript(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -152,6 +152,7 @@ class V(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -596,6 +596,7 @@ class VisualBasic(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     @cached_property

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -136,6 +136,7 @@ class Wren(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -142,6 +142,7 @@ class Yaml(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -217,6 +217,7 @@ class Zig(metaclass=LanguageCls):
             uses_typed_literal_for_scalars=False,
             requires_uniform_record_shapes=False,
             declared_type=None,
+            narrowed_empty_form=None,
         )
 
     class SetFormats(enum.Enum):


### PR DESCRIPTION
## Summary
- Removed the `= None` default from `SequenceFormatConfig.narrowed_empty_form` so every call site must specify it explicitly.
- Added `narrowed_empty_form=None` to all existing `SequenceFormatConfig(...)` constructions across the language modules and format factories that previously relied on the default.

## Test plan
- [x] `pytest tests/test_languages.py tests/test_class_enum_access.py` (302 passed)
- [x] `pytest tests/test_json.py tests/test_yaml.py tests/test_toml.py tests/test_roundtrip.py` (107 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk, mechanical API change that touches many language spec files to pass an explicit `narrowed_empty_form` value; primary risk is missed call sites causing runtime/type errors.
> 
> **Overview**
> Removes the implicit default for `SequenceFormatConfig.narrowed_empty_form`, making it a required constructor argument.
> 
> Updates the sequence format factory and all built-in language `SequenceFormatConfig(...)` definitions (plus the custom language example in `docs/source/languages.rst`) to explicitly pass `narrowed_empty_form=None` where no special empty-form handling is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68c6c859b1404dd641d0f18517a5a234da30be94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->