### PR TITLE
Pass cases_dir into integration test discovery functions

### DIFF
--- a/tests/integration/case_discovery.py
+++ b/tests/integration/case_discovery.py
@@ -67,9 +67,10 @@ def cases_with_non_trivial_dict_keys(
 
 @functools.cache
 @beartype
-def discover_cases() -> list[tuple[str, literalizer.LanguageCls]]:
+def discover_cases(
+    cases_dir: Path,
+) -> list[tuple[str, literalizer.LanguageCls]]:
     """Return ``(case_name, lang_cls)`` tuples."""
-    cases_dir = Path(__file__).parent / "cases"
     call_case_dirs = frozenset(cfg.case_dir_name for cfg in CALL_CASE_CONFIGS)
     non_trivial_key_cases = cases_with_non_trivial_dict_keys(
         cases_dir=cases_dir,
@@ -91,7 +92,9 @@ def discover_cases() -> list[tuple[str, literalizer.LanguageCls]]:
 
 @functools.cache
 @beartype
-def group_cases_by_language() -> dict[
+def group_cases_by_language(
+    cases_dir: Path,
+) -> dict[
     literalizer.LanguageCls,
     list[str],
 ]:
@@ -103,17 +106,9 @@ def group_cases_by_language() -> dict[
     overhead on slower CI runners (notably Windows).
     """
     groups: dict[literalizer.LanguageCls, list[str]] = {}
-    for case_name, lang_cls in discover_cases():
+    for case_name, lang_cls in discover_cases(cases_dir=cases_dir):
         groups.setdefault(lang_cls, []).append(case_name)
     return groups
-
-
-@functools.cache
-@beartype
-def golden_file_languages() -> list[literalizer.LanguageCls]:
-    """Return languages that have at least one golden-file case."""
-    groups = group_cases_by_language()
-    return [cls for cls in sorted_languages() if cls in groups]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -131,11 +126,10 @@ class CombinedCase:
 
 @functools.cache
 @beartype
-def discover_combined_cases() -> list[CombinedCase]:
+def discover_combined_cases(cases_dir: Path) -> list[CombinedCase]:
     """Return combined test cases for all redefinition-supporting
     styles.
     """
-    cases_dir = Path(__file__).parent / "cases"
     call_case_dirs = frozenset(cfg.case_dir_name for cfg in CALL_CASE_CONFIGS)
     non_trivial_key_cases = cases_with_non_trivial_dict_keys(
         cases_dir=cases_dir,
@@ -177,7 +171,9 @@ def discover_combined_cases() -> list[CombinedCase]:
 
 @functools.cache
 @beartype
-def group_combined_cases_by_language() -> dict[
+def group_combined_cases_by_language(
+    cases_dir: Path,
+) -> dict[
     literalizer.LanguageCls,
     list[CombinedCase],
 ]:
@@ -189,17 +185,9 @@ def group_combined_cases_by_language() -> dict[
     and per-test overhead on slower CI runners (notably Windows).
     """
     groups: dict[literalizer.LanguageCls, list[CombinedCase]] = {}
-    for case in discover_combined_cases():
+    for case in discover_combined_cases(cases_dir=cases_dir):
         groups.setdefault(case.lang_cls, []).append(case)
     return groups
-
-
-@functools.cache
-@beartype
-def combined_languages() -> list[literalizer.LanguageCls]:
-    """Return languages that have at least one combined-form case."""
-    groups = group_combined_cases_by_language()
-    return [cls for cls in sorted_languages() if cls in groups]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/integration/test_literalize_golden.py
+++ b/tests/integration/test_literalize_golden.py
@@ -27,8 +27,6 @@ from .case_discovery import (
     build_heterogeneous_strategy_combined_cases,
     build_line_ending_combined_cases,
     build_pre_indent_cases,
-    combined_languages,
-    golden_file_languages,
     group_cases_by_language,
     group_combined_cases_by_language,
 )
@@ -37,6 +35,7 @@ from .language_specs import (
     find_redefinition_styles,
     lang_cls_name,
     make_spec,
+    sorted_languages,
 )
 from .variant_cases import (
     group_variant_cases_by_language,
@@ -47,7 +46,7 @@ from .variant_cases import (
 
 @pytest.mark.parametrize(
     argnames="lang_cls",
-    argvalues=golden_file_languages(),
+    argvalues=sorted_languages(),
     ids=lang_cls_name,
 )
 def test_golden_file(
@@ -58,7 +57,8 @@ def test_golden_file(
 ) -> None:
     """Test that literalize_yaml output matches expected golden file."""
     lang_name = lang_cls.__name__
-    for case_name in group_cases_by_language()[lang_cls]:
+    grouped = group_cases_by_language(cases_dir=cases_dir)
+    for case_name in grouped.get(lang_cls, []):
         with subtests.test(case_name=case_name):
             input_path = cases_dir / case_name / "input.yaml"
             yaml_string = input_path.read_text()
@@ -97,7 +97,7 @@ def test_golden_file(
 
 @pytest.mark.parametrize(
     argnames="lang_cls",
-    argvalues=combined_languages(),
+    argvalues=sorted_languages(),
     ids=lang_cls_name,
 )
 def test_golden_file_combined_variable_forms(
@@ -109,7 +109,8 @@ def test_golden_file_combined_variable_forms(
     """Test that literalize with BothVariableForms produces expected
     golden output combining declaration and assignment in one file.
     """
-    for combined_case in group_combined_cases_by_language()[lang_cls]:
+    grouped = group_combined_cases_by_language(cases_dir=cases_dir)
+    for combined_case in grouped.get(lang_cls, []):
         with subtests.test(
             case_name=combined_case.case_name,
             golden_file_name=combined_case.golden_file_name,

--- a/tests/integration/test_orphan_golden_files.py
+++ b/tests/integration/test_orphan_golden_files.py
@@ -25,11 +25,11 @@ def test_no_dead_golden_files(cases_dir: Path) -> None:
     for case_dir in sorted(cases_dir.iterdir()):
         expected.add(case_dir / "input.yaml")
 
-    for case_name, lang_cls in discover_cases():
+    for case_name, lang_cls in discover_cases(cases_dir=cases_dir):
         ext = lang_cls.extension
         expected.add(cases_dir / case_name / (lang_cls.__name__ + ext))
 
-    for combined_case in discover_combined_cases():
+    for combined_case in discover_combined_cases(cases_dir=cases_dir):
         ext = combined_case.lang_cls.extension
         expected.add(
             cases_dir


### PR DESCRIPTION
## Summary
- Drop \`Path(__file__).parent / \"cases\"\` from \`tests/integration/case_discovery.py\`; \`discover_cases\`, \`discover_combined_cases\`, and the grouping helpers now take \`cases_dir: Path\` explicitly.
- Tests resolve \`cases_dir\` through the existing fixture (rooted at \`request.config.rootpath\`) and parametrize \`test_golden_file\` / \`test_golden_file_combined_variable_forms\` over \`sorted_languages()\`, looking up cases in the body — no filesystem access at collection time.
- Removed the now-unused \`golden_file_languages\` and \`combined_languages\` helpers.

## Test plan
- [x] \`uv run pytest tests/integration/test_orphan_golden_files.py tests/integration/test_literalize_golden.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test case discovery/parameterization and mainly affect pytest collection behavior and caching, not production code.
> 
> **Overview**
> Refactors integration golden-case discovery to take `cases_dir: Path` explicitly (instead of deriving it from `__file__`), and updates tests to pass the fixture-provided path throughout.
> 
> `test_literalize_golden` now parametrizes over `sorted_languages()` and looks up per-language cases inside the test body via `.get(...)`, removing the `golden_file_languages`/`combined_languages` helpers and avoiding filesystem enumeration at collection time; `test_orphan_golden_files` is updated to use the new discovery signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1868e1877fdafc00c1dc95fca14f3fe52b8ff87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->