### PR TITLE
Run Clojure lint files to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -505,10 +505,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Install clj-kondo
+      - name: Install clj-kondo and Babashka
         uses: DeLaGuardo/setup-clojure@13
         with:
           clj-kondo: latest
+          bb: latest
       - name: Install Groovy
         uses: wtfjoke/setup-groovy@v3
         with:
@@ -518,6 +519,8 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.clj' -print0 > /tmp/files-clj
           xargs -0 clj-kondo --lint < /tmp/files-clj
+      - name: Run Clojure files
+        run: xargs -0 -P "$(nproc)" -n1 bb < /tmp/files-clj
 
       # Parse and run every fixture inside a single Groovy JVM via
       # GroovyShell, so the compiler stays warm across iterations


### PR DESCRIPTION
Closes #1417.

`clj-kondo --lint` only inspects fixtures statically, so calls to undefined functions, missing requires, and similar runtime errors slip past CI. This adds Babashka to the `setup-clojure` install and a second step that executes every Clojure fixture, matching the pattern used by lint-bash, lint-ruby, lint-perl, and others. Verified locally that all 251 fixtures run cleanly under `bb`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes by adding a new runtime execution step for all `*.clj` fixtures, which may increase job time and cause new failures if fixtures have runtime-only issues or Babashka incompatibilities.
> 
> **Overview**
> **Clojure linting in CI is strengthened to catch runtime errors.** The `lint-jvm-mini` job now installs Babashka alongside `clj-kondo` and adds a new step to execute every Clojure fixture (`bb` via `xargs`), in addition to the existing static `clj-kondo --lint` pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8d1d0d1b5800c2c2c604326d7f1184176f6a02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->