### PR TITLE
Run Zig fixtures in CI to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1149,6 +1149,8 @@ jobs:
           version: 0.14.0
       - name: Check Zig
         run: xargs -0 -P "$(nproc)" -n1 zig build-obj -fno-emit-bin < /tmp/files-to-lint
+      - name: Run Zig files
+        run: xargs -0 -P "$(nproc)" -n1 zig run < /tmp/files-to-lint
 
   lint-systemverilog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `zig run` step to `lint-zig` so each fixture is actually executed, mirroring the pattern used by `lint-bash`, `lint-perl`, etc.
- The existing `zig build-obj -fno-emit-bin` step skipped binary emission and never executed the fixtures, so runtime errors (undefined calls, missing imports, failed assertions) slipped past CI.

Closes #1434

## Test plan
- [x] Ran every `tests/integration/cases/**/*.zig` fixture locally with `zig run`; all 269 fixtures succeed.
- [ ] CI `lint-zig` job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that may increase runtime and surface new fixture failures by actually executing Zig code in `lint-zig`.
> 
> **Overview**
> Updates the `lint-zig` GitHub Actions job to *run* each Zig integration fixture (`zig run`) in addition to the existing compile-only check, so runtime errors in `tests/integration/cases/**/*.zig` are caught by CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb678377b2b69efde823c41d6e355b05a1b8b857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->