### PR TITLE
Run COBOL fixtures in CI to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -626,6 +626,15 @@ jobs:
         run: find tests/integration/cases -name '*.cob' -print0 > /tmp/files-to-lint
       - name: Check COBOL syntax
         run: xargs -0 -P "$(nproc)" -n1 cobc -free -fsyntax-only < /tmp/files-to-lint
+      - name: Run COBOL files
+        run: |-
+          cat > /tmp/run-cobol.sh <<'SCRIPT'
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cobc -x -free "$1" -o "$tmpdir/run" || exit 1
+          "$tmpdir/run" || exit 1
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-cobol.sh < /tmp/files-to-lint
 
   lint-cpp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1408

## Summary
- Adds a `Run COBOL files` step to the `lint-cobol` job that compiles each fixture with `cobc -x -free` and executes the resulting binary, mirroring the run-step pattern used by other compiled-language jobs (e.g. Fortran, C++).
- Verified locally that all 233 `.cob` fixtures compile and run cleanly.

## Test plan
- [ ] CI `lint-cobol` job passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds a runtime execution step for COBOL fixtures; main impact is potential CI time increase or new failures from runtime issues in existing fixtures.
> 
> **Overview**
> **COBOL fixtures are now executed in CI.** The `lint-cobol` workflow step now compiles each `*.cob` fixture into a temporary binary (`cobc -x -free`) and runs it in parallel, so runtime errors in COBOL fixtures fail CI instead of only syntax issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819cf87d14cd004beeb5282a913876f578c7d228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->