### PR TITLE
Run C fixtures in lint workflow to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -689,12 +689,9 @@ jobs:
       # Fixtures define `void check_(void)` with no main, so compile each
       # alongside `.github/scripts/c_main.c` which invokes it. Compile
       # `c_main.c` once up front so each fixture link reuses the object
-      # instead of re-parsing the same TU. Fixtures forward-declare a
-      # handful of host helpers (`emit`, `process`) without defining
-      # them; rewrite each forward declaration to a static empty stub
-      # so the link succeeds and the fixture body still executes. The
-      # build-and-run step also surfaces any syntax errors, so a separate
-      # `-fsyntax-only` pass would be redundant.
+      # instead of re-parsing the same TU. The build-and-run step also
+      # surfaces any syntax errors, so a separate `-fsyntax-only` pass
+      # would be redundant.
       - name: Build c_main object
         run: clang -std=c11 -c .github/scripts/c_main.c -o /tmp/c_main.o
       - name: Run C files
@@ -702,12 +699,7 @@ jobs:
           cat > /tmp/run-c.sh <<'SCRIPT'
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
-          sed -e 's/^void emit(CVal);$/static void emit(CVal _x) { (void)_x; }/' \
-              -e 's/^void process(CVal);$/static void process(CVal _x) { (void)_x; }/' \
-              -e 's/^void process(CVal, CVal);$/static void process(CVal _x, CVal _y) { (void)_x; (void)_y; }/' \
-              -e 's/^CVal process(CVal);$/static CVal process(CVal _x) { (void)_x; return (CVal){0}; }/' \
-              "$1" > "$tmpdir/check.c"
-          clang -std=c11 "$tmpdir/check.c" /tmp/c_main.o -o "$tmpdir/run" || exit 1
+          clang -std=c11 "$1" /tmp/c_main.o -o "$tmpdir/run" || exit 1
           "$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-c.sh < /tmp/files-to-lint

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- C single-name call stubs (e.g. ``emit``, ``process``) are now emitted
+  as ``static`` definitions with a stub body instead of bare forward
+  declarations, so generated fixtures can be linked and run.  The lint
+  workflow now compiles each C fixture against a small ``c_main.c``
+  driver and executes the resulting binary, surfacing runtime errors
+  that the previous ``-fsyntax-only`` check missed.
 - ``Crystal.wrap_in_file`` now wraps content in a
   ``module Check ... end`` block with ``extend self``, matching what
   Erlang, Scala, and Haskell already do.  ``Crystal`` gains a

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -137,32 +137,44 @@ def _c_call_stub(
     avoids the K&R unspecified-parameter syntax (and the
     ``-Wdeprecated-non-prototype`` clang warning it triggers) while
     still letting the same stub accept any mix of argument types.
+
+    Single-name calls emit a ``static`` definition so the fixture links
+    under the lint workflow's run step — a bare prototype without a body
+    would otherwise fail at link time.
     """
     is_value = stub_return is StubReturn.VALUE
     return_keyword = "CVal" if is_value else "void"
     proto = ", ".join(["CVal"] * len(params)) if params else "void"
-    parts = name.split(sep=".")
-    if len(parts) == 1:
-        return (f"{return_keyword} {parts[0]}({proto});",)
-    root = parts[0]
-    method = parts[-1]
-    fields = parts[1:-1]
-    stub_fn = "_".join((*parts, "stub_"))
     stub_params = ", ".join(f"CVal _a{i}" for i in range(len(params)))
     stub_signature = stub_params or "void"
     discards = "".join(f" (void)_a{i};" for i in range(len(params)))
     return_stmt = " return (CVal){0};" if is_value else ""
     has_body = discards or is_value
     stub_body = f"{{{discards}{return_stmt} }}" if has_body else "{}"
-    if not fields:
-        type_name = f"{root}Type_"
-        return (
-            f"static {return_keyword} {stub_fn}({stub_signature}) {stub_body}",
-            f"struct {type_name} "
-            f"{{ {return_keyword} (*{method})({proto}); }};",
-            f"static const struct {type_name} {root} = "
-            f"{{ .{method} = {stub_fn} }};",
-        )
+    parts = name.split(sep=".")
+    match parts:
+        case [single]:
+            return (
+                f"static {return_keyword} {single}({stub_signature}) "
+                f"{stub_body}",
+            )
+        case [root, method]:
+            stub_fn = f"{root}_{method}_stub_"
+            type_name = f"{root}Type_"
+            return (
+                f"static {return_keyword} {stub_fn}({stub_signature}) "
+                f"{stub_body}",
+                f"struct {type_name} "
+                f"{{ {return_keyword} (*{method})({proto}); }};",
+                f"static const struct {type_name} {root} = "
+                f"{{ .{method} = {stub_fn} }};",
+            )
+        case _:
+            pass
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    stub_fn = "_".join((*parts, "stub_"))
     lines: list[str] = [
         f"static {return_keyword} {stub_fn}({stub_signature}) {stub_body}",
     ]

--- a/tests/integration/cases/call_deep_dotted_transformed/C_call.c
+++ b/tests/integration/cases/call_deep_dotted_transformed/C_call.c
@@ -18,7 +18,7 @@ static CVal app_client_fetch_stub_(CVal _a0) { (void)_a0; return (CVal){0}; }
 struct clientType_ { CVal (*fetch)(CVal); };
 struct appType_ { struct clientType_ client; };
 static const struct appType_ app = { .client = { .fetch = app_client_fetch_stub_ } };
-void emit(CVal);
+static void emit(CVal _a0) { (void)_a0; }
 void check_(void) {
 emit(app.client.fetch(((CVal){.s = "hello"})));
 emit(app.client.fetch(((CVal){.i = 42})));

--- a/tests/integration/cases/call_keyword_args/C_call.c
+++ b/tests/integration/cases/call_keyword_args/C_call.c
@@ -17,7 +17,7 @@ struct CKV { const char *k; CVal v; };
 static CVal throttler_check_stub_(CVal _a0, CVal _a1) { (void)_a0; (void)_a1; return (CVal){0}; }
 struct throttlerType_ { CVal (*check)(CVal, CVal); };
 static const struct throttlerType_ throttler = { .check = throttler_check_stub_ };
-void emit(CVal);
+static void emit(CVal _a0) { (void)_a0; }
 void check_(void) {
 emit(throttler.check(((CVal){.s = "user_1"}), ((CVal){.f = 1000.0})));
 emit(throttler.check(((CVal){.s = "user_2"}), ((CVal){.f = 2000.5})));

--- a/tests/integration/cases/call_multi_args/C_call.c
+++ b/tests/integration/cases/call_multi_args/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal, CVal);
+static void process(CVal _a0, CVal _a1) { (void)_a0; (void)_a1; }
 void check_(void) {
 process(((CVal){.i = 1}), ((CVal){.i = 42}));
 process(((CVal){.i = 2}), ((CVal){.i = 100}));

--- a/tests/integration/cases/call_per_element_false/C_call.c
+++ b/tests/integration/cases/call_per_element_false/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal);
+static void process(CVal _a0) { (void)_a0; }
 void check_(void) {
 process(((CVal){.i = 1}));
 }

--- a/tests/integration/cases/call_ref_args/C_call.c
+++ b/tests/integration/cases/call_ref_args/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal, CVal);
+static void process(CVal _a0, CVal _a1) { (void)_a0; (void)_a1; }
 void check_(void) {
 CVal my_var = ((CVal){.a = (CVal[]){
     ((CVal){.i = 1}),

--- a/tests/integration/cases/call_ref_args_converted/C_call.c
+++ b/tests/integration/cases/call_ref_args_converted/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal, CVal);
+static void process(CVal _a0, CVal _a1) { (void)_a0; (void)_a1; }
 void check_(void) {
 CVal my_var = ((CVal){.a = (CVal[]){
     ((CVal){.i = 1}),

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/C_call.c
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal, CVal);
+static void process(CVal _a0, CVal _a1) { (void)_a0; (void)_a1; }
 void check_(void) {
 CVal my_var = ((CVal){.a = (CVal[]){
     ((CVal){.i = 1}),

--- a/tests/integration/cases/call_ref_args_converted_whole/C_call.c
+++ b/tests/integration/cases/call_ref_args_converted_whole/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal);
+static void process(CVal _a0) { (void)_a0; }
 void check_(void) {
 CVal my_var = ((CVal){.a = (CVal[]){
     ((CVal){.i = 1}),

--- a/tests/integration/cases/call_scalar_args/C_call.c
+++ b/tests/integration/cases/call_scalar_args/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal);
+static void process(CVal _a0) { (void)_a0; }
 void check_(void) {
 process(((CVal){.s = "hello"}));
 process(((CVal){.i = 42}));

--- a/tests/integration/cases/call_transform_no_wrapper/C_call.c
+++ b/tests/integration/cases/call_transform_no_wrapper/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-CVal process(CVal);
+static CVal process(CVal _a0) { (void)_a0; return (CVal){0}; }
 void check_(void) {
 process(((CVal){.s = "hello"}));
 process(((CVal){.i = 42}));

--- a/tests/integration/cases/call_wrap_in_file/C_call.c
+++ b/tests/integration/cases/call_wrap_in_file/C_call.c
@@ -14,7 +14,7 @@ struct CVal {
     };
 };
 struct CKV { const char *k; CVal v; };
-void process(CVal, CVal);
+static void process(CVal _a0, CVal _a1) { (void)_a0; (void)_a1; }
 void check_(void) {
 process(((CVal){.i = 1}), ((CVal){.i = 2}));
 process(((CVal){.i = 3}), ((CVal){.i = 4}));


### PR DESCRIPTION
Closes #1407.

The C lint job previously only ran ``clang -fsyntax-only``, so runtime errors (calls to undefined functions, etc.) slipped past CI. This PR replaces the syntax-only step with a build-and-run step that links each fixture against a small ``c_main.c`` driver and executes the resulting binary, mirroring the C++ / Objective-C pattern. To make the fixtures linkable, ``_c_call_stub`` now emits ``static`` definitions with stub bodies for single-name calls (``emit``, ``process``) instead of bare forward declarations; affected ``C_call.c`` golden files were regenerated.

## Test plan
- [ ] CI passes, including the new C run step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI behavior to build and execute all C fixtures and adjusts C call-stub generation, which could introduce new CI failures or alter generated fixture output if the stub logic has edge cases.
> 
> **Overview**
> Updates the C lint job to **compile each C fixture against `.github/scripts/c_main.c` and execute the resulting binary**, replacing the prior syntax-only approach and removing the workflow’s ad-hoc `sed` rewrites of missing `emit`/`process` helpers.
> 
> Adjusts C `literalize_call` stub emission (`_c_call_stub`) so **single-name call targets** now generate `static` stub *definitions* with no-op bodies (and `CVal` zero return when needed) to make fixtures linkable under the new run step; associated C integration golden files are regenerated, and the change is documented in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee6463de2cd4f19ffbe89e0a9d1f25eae56f58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->