### PR TITLE
Run R fixtures in lint.yml to catch runtime errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -914,6 +914,8 @@ jobs:
       - name: Check R syntax
         run: xargs -0 Rscript -e 'for (f in commandArgs(trailingOnly=TRUE)) parse(file=f)'
           < /tmp/files-to-lint
+      - name: Run R files
+        run: xargs -0 -P "$(nproc)" -n1 Rscript < /tmp/files-to-lint
 
   lint-d:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- ``literalize_call`` now emits R stub declarations
+  (``name <- function(...) NULL``) for the called function and any
+  call-transform wrappers, so generated R call output runs cleanly
+  under ``Rscript`` without ``could not find function`` errors.
+- Removed ``R.TrailingCommas.YES``: R's ``list()`` rejects empty
+  arguments, so ``list(1, 2,)`` parses but raises at runtime.  Only
+  ``R.TrailingCommas.NO`` remains.
 - Fixed Dhall typed-empty literals for doubly-nested lists.  Input like
   ``[[[1, 2]], [], [[3, 4]]]`` previously rendered the empty sibling as
   ``[] : List List Integer``, which is invalid Dhall (parses as

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -68,6 +68,22 @@ from literalizer.exceptions import InvalidDictKeyError
 
 
 @beartype
+def _r_call_stub(
+    name: str,
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return an R stub declaration for a call name.
+
+    R allows ``.`` in identifiers, so a dotted target such as
+    ``app.client.fetch`` is a single name and one ``function(...)``
+    declaration suffices to make the call evaluate at runtime.
+    """
+    return (f"{name} <- function(...) NULL",)
+
+
+@beartype
 def _format_r_dict_entry_positional(
     key: str,
     _raw_value: Value,
@@ -216,7 +232,7 @@ class R(metaclass=LanguageCls):
             close=")",
             supports_heterogeneity=True,
             single_element_trailing_comma=False,
-            supports_trailing_comma=True,
+            supports_trailing_comma=False,
             empty_sequence=None,
             preamble_lines=(),
             format_entry=passthrough_sequence_entry,
@@ -312,9 +328,13 @@ class R(metaclass=LanguageCls):
         DOUBLE = "double"
 
     class TrailingCommas(enum.Enum):
-        """Trailing comma options."""
+        """Trailing comma options.
 
-        YES = TrailingCommaConfig(multiline_trailing_comma=True)
+        R's ``list()`` rejects empty arguments, so a literal trailing
+        comma like ``list(1, 2,)`` parses but raises at runtime; only
+        the comma-free form is supported.
+        """
+
         NO = TrailingCommaConfig(multiline_trailing_comma=False)
 
     date_formats = DateFormats
@@ -490,7 +510,7 @@ class R(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _r_call_stub
 
     @cached_property
     def format_call_preamble_stub(

--- a/tests/integration/cases/call_deep_dotted_method/R_call.R
+++ b/tests/integration/cases/call_deep_dotted_method/R_call.R
@@ -1,3 +1,4 @@
+obj.api.client.post <- function(...) NULL
 obj.api.client.post(data = "hello")
 obj.api.client.post(data = 42)
 obj.api.client.post(data = TRUE)

--- a/tests/integration/cases/call_deep_dotted_transformed/R_call.R
+++ b/tests/integration/cases/call_deep_dotted_transformed/R_call.R
@@ -1,3 +1,5 @@
+app.client.fetch <- function(...) NULL
+emit <- function(...) NULL
 emit(app.client.fetch(payload = "hello"))
 emit(app.client.fetch(payload = 42))
 emit(app.client.fetch(payload = TRUE))

--- a/tests/integration/cases/call_dotted_method/R_call.R
+++ b/tests/integration/cases/call_dotted_method/R_call.R
@@ -1,3 +1,4 @@
+app.client.fetch <- function(...) NULL
 app.client.fetch(payload = "hello")
 app.client.fetch(payload = 42)
 app.client.fetch(payload = TRUE)

--- a/tests/integration/cases/call_keyword_args/R_call.R
+++ b/tests/integration/cases/call_keyword_args/R_call.R
@@ -1,2 +1,4 @@
+throttler.check <- function(...) NULL
+emit <- function(...) NULL
 emit(throttler.check(user_id = "user_1", ts = 1000.0))
 emit(throttler.check(user_id = "user_2", ts = 2000.5))

--- a/tests/integration/cases/call_mixed_type_dicts/R_call.R
+++ b/tests/integration/cases/call_mixed_type_dicts/R_call.R
@@ -1,2 +1,3 @@
+app.mgr.op <- function(...) NULL
 app.mgr.op(operation = list("type" = "create", "pr_id" = "pr_1", "draft" = TRUE))
 app.mgr.op(operation = list("type" = "create", "pr_id" = "pr_2"))

--- a/tests/integration/cases/call_multi_args/R_call.R
+++ b/tests/integration/cases/call_multi_args/R_call.R
@@ -1,2 +1,3 @@
+process <- function(...) NULL
 process(value = 1, count = 42)
 process(value = 2, count = 100)

--- a/tests/integration/cases/call_per_element_false/R_call.R
+++ b/tests/integration/cases/call_per_element_false/R_call.R
@@ -1,1 +1,2 @@
+process <- function(...) NULL
 process(data = 1)

--- a/tests/integration/cases/call_positional/R_call.R
+++ b/tests/integration/cases/call_positional/R_call.R
@@ -1,2 +1,4 @@
+throttler.check <- function(...) NULL
+emit <- function(...) NULL
 emit(throttler.check("user_1", 1000.0))
 emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_ref_args/R_call.R
+++ b/tests/integration/cases/call_ref_args/R_call.R
@@ -1,3 +1,4 @@
+process <- function(...) NULL
 my_var <- list(
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted/R_call.R
+++ b/tests/integration/cases/call_ref_args_converted/R_call.R
@@ -1,3 +1,4 @@
+process <- function(...) NULL
 my_var <- list(
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/R_call.R
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/R_call.R
@@ -1,3 +1,4 @@
+process <- function(...) NULL
 my_var <- list(
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_whole/R_call.R
+++ b/tests/integration/cases/call_ref_args_converted_whole/R_call.R
@@ -1,3 +1,4 @@
+process <- function(...) NULL
 my_var <- list(
     1,
     2,

--- a/tests/integration/cases/call_scalar_args/R_call.R
+++ b/tests/integration/cases/call_scalar_args/R_call.R
@@ -1,3 +1,4 @@
+process <- function(...) NULL
 process(value = "hello")
 process(value = 42)
 process(value = TRUE)

--- a/tests/integration/cases/call_transform_no_wrapper/R_call.R
+++ b/tests/integration/cases/call_transform_no_wrapper/R_call.R
@@ -1,3 +1,4 @@
+process <- function(...) NULL
 process(value = "hello")
 process(value = 42)
 process(value = TRUE)

--- a/tests/integration/cases/call_wrap_in_file/R_call.R
+++ b/tests/integration/cases/call_wrap_in_file/R_call.R
@@ -1,2 +1,3 @@
+process <- function(...) NULL
 process(a = 1, b = 2)
 process(a = 3, b = 4)

--- a/tests/integration/cases/simple_sequence/R_trailing_comma_yes.R
+++ b/tests/integration/cases/simple_sequence/R_trailing_comma_yes.R
@@ -1,6 +1,0 @@
-my_data <- list(
-    1,
-    "hello",
-    TRUE,
-    NULL,
-)


### PR DESCRIPTION
## Summary
- Add a "Run R files" step to ``lint-r`` that executes each fixture via ``Rscript``, mirroring ``lint-perl``/``lint-julia``, so undefined-name and runtime errors no longer slip past the parse-only check.
- Teach ``literalize_call`` to emit R stub declarations (``name <- function(...) NULL``) for the call target and any transform wrappers; regenerated ``R_call.R`` golden files so they run cleanly.
- Drop ``R.TrailingCommas.YES`` and set ``supports_trailing_comma=False`` on the LIST sequence config: R's parser accepts ``list(1, 2,)`` but ``list()`` rejects the empty argument at runtime, so the YES variant could never run; the dead ``simple_sequence/R_trailing_comma_yes.R`` golden is removed.

Closes #1422.

## Test plan
- [x] ``uv run --extra=dev pytest`` (1202 passed)
- [x] ``find tests/integration/cases -name '*.R' -print0 | xargs -0 -P 4 -n1 Rscript`` runs every fixture without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes R code-generation behavior (adds implicit call stubs and removes trailing-comma support) and tightens CI by executing R fixtures, which may surface new failures in downstream usage and in PRs touching fixtures.
> 
> **Overview**
> R fixtures are now **executed in CI**: `lint-r` in `.github/workflows/lint.yml` adds a `Run R files` step to run each `tests/integration/cases/*.R` via `Rscript`, catching runtime errors that a parse-only check missed.
> 
> R `literalize_call` output is adjusted to **run cleanly under `Rscript`** by emitting stub declarations (`name <- function(...) NULL`) for call targets (including dotted names) and call-transform wrappers; the R call golden files are regenerated to include these stubs.
> 
> Trailing-comma support for R `list()` literals is removed (`R.TrailingCommas.YES` dropped and `supports_trailing_comma` disabled), and the obsolete `simple_sequence/R_trailing_comma_yes.R` fixture is deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a63116fa1d613145811555ee54a413118bc2f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->