### PR TITLE
Add literalize_call support to Visual Basic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- ``literalize_call`` now supports Visual Basic.  The default style is
+  positional (``foo(1, 2)``); ``VisualBasic.CallStyles.NAMED`` enables
+  VB's named-argument syntax (``foo(x:=1, y:=2)``).  Generated stubs
+  are emitted as module-level ``Class`` and ``Function`` blocks and
+  the call body is placed inside ``Sub _calls()`` because VB does not
+  allow bare expression statements at module scope.
 - ``literalize_call`` now emits R stub declarations
   (``name <- function(...) NULL``) for the called function and any
   call-transform wrappers, so generated R call output runs cleanly

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -146,6 +146,18 @@ def _format_string_vb(value: str) -> str:
     return " & ".join(parts)
 
 
+def _vb_unique_class_name(*, segment: str, position: int) -> str:
+    """Build a stub class name unique to a segment's path position.
+
+    VB.NET is case-insensitive, so two segments that differ only in
+    case (or repeat exactly) — e.g. ``app.app.method`` — would
+    otherwise produce duplicate ``Class`` declarations.  Suffixing
+    with the segment's position in the dotted target keeps every
+    generated name distinct.
+    """
+    return f"{segment.title()}Type_{position}_"
+
+
 def _vb_call_stub(
     name: str,
     params: Sequence[str],
@@ -185,35 +197,28 @@ def _vb_call_stub(
         text=method_block.format(method=method),
         prefix="    ",
     )
-
-    # Include each segment's path position in its generated type
-    # name so dotted targets that repeat a segment (case-insensitively)
-    # — e.g. ``app.app.method`` — do not collide.  VB.NET is
-    # case-insensitive, so ``AppType_`` for both segments would be
-    # rejected as a duplicate type declaration.
-    def _type_name(*, segment: str, position: int) -> str:
-        """Build a stub class name unique to a segment's path position."""
-        return f"{segment.title()}Type_{position}_"
-
     if not fields:
-        type_name = _type_name(segment=root, position=0)
+        type_name = _vb_unique_class_name(segment=root, position=0)
         return (
             f"Class {type_name}\n{method_body}\nEnd Class",
             f"Dim {root} As New {type_name}()",
         )
     blocks: list[str] = []
-    inner_type = _type_name(segment=fields[-1], position=len(fields))
+    inner_type = _vb_unique_class_name(
+        segment=fields[-1],
+        position=len(fields),
+    )
     blocks.append(f"Class {inner_type}\n{method_body}\nEnd Class")
     prev_type = inner_type
     for i in range(len(fields) - 2, -1, -1):
-        curr_type = _type_name(segment=fields[i], position=i + 1)
+        curr_type = _vb_unique_class_name(segment=fields[i], position=i + 1)
         blocks.append(
             f"Class {curr_type}\n"
             f"    Public {fields[i + 1]} As New {prev_type}()\n"
             "End Class"
         )
         prev_type = curr_type
-    root_type = _type_name(segment=root, position=0)
+    root_type = _vb_unique_class_name(segment=root, position=0)
     blocks.append(
         f"Class {root_type}\n"
         f"    Public {fields[0]} As New {prev_type}()\n"

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -6,7 +6,7 @@ import enum
 import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from beartype import beartype
 
@@ -45,7 +45,6 @@ from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -54,8 +53,10 @@ from literalizer._language import (
     FloatSpecialsMixin,
     HeterogeneousBehavior,
     IdentifierCase,
+    KeywordCallStyle,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -143,6 +144,73 @@ def _format_string_vb(value: str) -> str:
     if len(parts) == 1:
         return parts[0]
     return " & ".join(parts)
+
+
+def _vb_call_stub(
+    name: str,
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Visual Basic stub declarations for a call name.
+
+    For a single-name target the stub is a module-level ``Function``
+    whose parameter list matches the given names; for a dotted target
+    a chain of nested stub classes is emitted so ``a.b.c.d(...)``
+    dispatches to a real method whose body returns ``Nothing``.
+
+    Each declaration block is returned as one tuple entry containing
+    embedded newlines so that the call-test harness's whole-line
+    deduplication does not strip repeated structural keywords like
+    ``End Class`` or ``End Function`` that legitimately appear in
+    every block.
+    """
+    param_list = ", ".join(f"{p} As Object" for p in params)
+    parts = name.split(sep=".")
+    method_block = (
+        f"Public Function {{method}}({param_list}) As Object\n"
+        "    Return Nothing\n"
+        "End Function"
+    )
+    if len(parts) == 1:
+        return (
+            f"Function {parts[0]}({param_list}) As Object\n"
+            "    Return Nothing\n"
+            "End Function",
+        )
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    method_body = textwrap.indent(
+        text=method_block.format(method=method),
+        prefix="    ",
+    )
+    if not fields:
+        type_name = f"{root.title()}Type_"
+        return (
+            f"Class {type_name}\n{method_body}\nEnd Class",
+            f"Dim {root} As New {type_name}()",
+        )
+    blocks: list[str] = []
+    inner_type = f"{fields[-1].title()}Type_"
+    blocks.append(f"Class {inner_type}\n{method_body}\nEnd Class")
+    prev_type = inner_type
+    for i in range(len(fields) - 2, -1, -1):
+        curr_type = f"{fields[i].title()}Type_"
+        blocks.append(
+            f"Class {curr_type}\n"
+            f"    Public {fields[i + 1]} As New {prev_type}()\n"
+            "End Class"
+        )
+        prev_type = curr_type
+    root_type = f"{root.title()}Type_"
+    blocks.append(
+        f"Class {root_type}\n"
+        f"    Public {fields[0]} As New {prev_type}()\n"
+        "End Class"
+    )
+    blocks.append(f"Dim {root} As New {root_type}()")
+    return tuple(blocks)
 
 
 @beartype
@@ -368,6 +436,9 @@ class VisualBasic(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """VisualBasic call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+        NAMED = KeywordCallStyle(separator=":=")
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -397,8 +468,34 @@ class VisualBasic(metaclass=LanguageCls):
         variable_name: str,
         body_preamble: tuple[str, ...],
     ) -> str:
-        """Wrap a VB.NET Dim declaration inside a Module."""
+        """Wrap a VB.NET Dim declaration inside a Module.
+
+        When *body_preamble* carries call-stub declarations (``Class``
+        and ``Function`` blocks plus their ``Dim ... As New ...``
+        instances) the stubs sit at module scope and *content* is
+        placed inside ``Sub _calls()``: VB rejects bare expression
+        statements at module level, but parameterless shared subs are
+        invoked by the fixture linter so the calls still execute.
+        """
         del variable_name
+        has_stubs = any(
+            line.startswith(("Function ", "Class ")) for line in body_preamble
+        )
+        if has_stubs:
+            preamble_block = "\n".join(body_preamble)
+            preamble_indented = textwrap.indent(
+                text=preamble_block,
+                prefix="    ",
+            )
+            content_indented = textwrap.indent(text=content, prefix="        ")
+            return (
+                "Module Check\n"
+                f"{preamble_indented}\n"
+                "    Sub _calls()\n"
+                f"{content_indented}\n"
+                "    End Sub\n"
+                "End Module"
+            )
         content = prepend_body_preamble(
             content=content,
             body_preamble=body_preamble,
@@ -456,6 +553,7 @@ class VisualBasic(metaclass=LanguageCls):
     string_format: StringFormats = StringFormats.DOUBLE
     trailing_comma: TrailingCommas = TrailingCommas.NO
     line_ending: LineEndings = LineEndings.SEMICOLON
+    call_style: CallStyles = CallStyles.POSITIONAL
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
@@ -474,9 +572,6 @@ class VisualBasic(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -531,7 +626,12 @@ class VisualBasic(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _vb_call_stub
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return cast("CallStyle", self.call_style.value)
 
     @cached_property
     def format_call_preamble_stub(

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -185,25 +185,35 @@ def _vb_call_stub(
         text=method_block.format(method=method),
         prefix="    ",
     )
+
+    # Include each segment's path position in its generated type
+    # name so dotted targets that repeat a segment (case-insensitively)
+    # — e.g. ``app.app.method`` — do not collide.  VB.NET is
+    # case-insensitive, so ``AppType_`` for both segments would be
+    # rejected as a duplicate type declaration.
+    def _type_name(*, segment: str, position: int) -> str:
+        """Build a stub class name unique to a segment's path position."""
+        return f"{segment.title()}Type_{position}_"
+
     if not fields:
-        type_name = f"{root.title()}Type_"
+        type_name = _type_name(segment=root, position=0)
         return (
             f"Class {type_name}\n{method_body}\nEnd Class",
             f"Dim {root} As New {type_name}()",
         )
     blocks: list[str] = []
-    inner_type = f"{fields[-1].title()}Type_"
+    inner_type = _type_name(segment=fields[-1], position=len(fields))
     blocks.append(f"Class {inner_type}\n{method_body}\nEnd Class")
     prev_type = inner_type
     for i in range(len(fields) - 2, -1, -1):
-        curr_type = f"{fields[i].title()}Type_"
+        curr_type = _type_name(segment=fields[i], position=i + 1)
         blocks.append(
             f"Class {curr_type}\n"
             f"    Public {fields[i + 1]} As New {prev_type}()\n"
             "End Class"
         )
         prev_type = curr_type
-    root_type = f"{root.title()}Type_"
+    root_type = _type_name(segment=root, position=0)
     blocks.append(
         f"Class {root_type}\n"
         f"    Public {fields[0]} As New {prev_type}()\n"

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -161,7 +161,7 @@ def _vb_call_stub(
 
     Each declaration block is returned as one tuple entry containing
     embedded newlines so that the call-test harness's whole-line
-    deduplication does not strip repeated structural keywords like
+    duplicate filter does not strip repeated structural keywords like
     ``End Class`` or ``End Function`` that legitimately appear in
     every block.
     """
@@ -474,8 +474,9 @@ class VisualBasic(metaclass=LanguageCls):
         and ``Function`` blocks plus their ``Dim ... As New ...``
         instances) the stubs sit at module scope and *content* is
         placed inside ``Sub _calls()``: VB rejects bare expression
-        statements at module level, but parameterless shared subs are
-        invoked by the fixture linter so the calls still execute.
+        statements at module level, but shared subs taking no
+        arguments are invoked by the fixture linter so the calls
+        still execute.
         """
         del variable_name
         has_stubs = any(

--- a/tests/integration/cases/call_deep_dotted_method/VisualBasic_call.vb
+++ b/tests/integration/cases/call_deep_dotted_method/VisualBasic_call.vb
@@ -1,0 +1,20 @@
+Imports System.Collections.Generic
+Module Check
+    Class ClientType_
+        Public Function post(data As Object) As Object
+            Return Nothing
+        End Function
+    End Class
+    Class ApiType_
+        Public client As New ClientType_()
+    End Class
+    Class ObjType_
+        Public api As New ApiType_()
+    End Class
+    Dim obj As New ObjType_()
+    Sub _calls()
+        obj.api.client.post("hello")
+        obj.api.client.post(42)
+        obj.api.client.post(True)
+    End Sub
+End Module

--- a/tests/integration/cases/call_deep_dotted_method/VisualBasic_call.vb
+++ b/tests/integration/cases/call_deep_dotted_method/VisualBasic_call.vb
@@ -1,17 +1,17 @@
 Imports System.Collections.Generic
 Module Check
-    Class ClientType_
+    Class ClientType_2_
         Public Function post(data As Object) As Object
             Return Nothing
         End Function
     End Class
-    Class ApiType_
-        Public client As New ClientType_()
+    Class ApiType_1_
+        Public client As New ClientType_2_()
     End Class
-    Class ObjType_
-        Public api As New ApiType_()
+    Class ObjType_0_
+        Public api As New ApiType_1_()
     End Class
-    Dim obj As New ObjType_()
+    Dim obj As New ObjType_0_()
     Sub _calls()
         obj.api.client.post("hello")
         obj.api.client.post(42)

--- a/tests/integration/cases/call_deep_dotted_transformed/VisualBasic_call.vb
+++ b/tests/integration/cases/call_deep_dotted_transformed/VisualBasic_call.vb
@@ -1,14 +1,14 @@
 Imports System.Collections.Generic
 Module Check
-    Class ClientType_
+    Class ClientType_1_
         Public Function fetch(payload As Object) As Object
             Return Nothing
         End Function
     End Class
-    Class AppType_
-        Public client As New ClientType_()
+    Class AppType_0_
+        Public client As New ClientType_1_()
     End Class
-    Dim app As New AppType_()
+    Dim app As New AppType_0_()
     Function emit(_arg As Object) As Object
         Return Nothing
     End Function

--- a/tests/integration/cases/call_deep_dotted_transformed/VisualBasic_call.vb
+++ b/tests/integration/cases/call_deep_dotted_transformed/VisualBasic_call.vb
@@ -1,0 +1,20 @@
+Imports System.Collections.Generic
+Module Check
+    Class ClientType_
+        Public Function fetch(payload As Object) As Object
+            Return Nothing
+        End Function
+    End Class
+    Class AppType_
+        Public client As New ClientType_()
+    End Class
+    Dim app As New AppType_()
+    Function emit(_arg As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        emit(app.client.fetch("hello"))
+        emit(app.client.fetch(42))
+        emit(app.client.fetch(True))
+    End Sub
+End Module

--- a/tests/integration/cases/call_dotted_method/VisualBasic_call.vb
+++ b/tests/integration/cases/call_dotted_method/VisualBasic_call.vb
@@ -1,14 +1,14 @@
 Imports System.Collections.Generic
 Module Check
-    Class ClientType_
+    Class ClientType_1_
         Public Function fetch(payload As Object) As Object
             Return Nothing
         End Function
     End Class
-    Class AppType_
-        Public client As New ClientType_()
+    Class AppType_0_
+        Public client As New ClientType_1_()
     End Class
-    Dim app As New AppType_()
+    Dim app As New AppType_0_()
     Sub _calls()
         app.client.fetch("hello")
         app.client.fetch(42)

--- a/tests/integration/cases/call_dotted_method/VisualBasic_call.vb
+++ b/tests/integration/cases/call_dotted_method/VisualBasic_call.vb
@@ -1,0 +1,17 @@
+Imports System.Collections.Generic
+Module Check
+    Class ClientType_
+        Public Function fetch(payload As Object) As Object
+            Return Nothing
+        End Function
+    End Class
+    Class AppType_
+        Public client As New ClientType_()
+    End Class
+    Dim app As New AppType_()
+    Sub _calls()
+        app.client.fetch("hello")
+        app.client.fetch(42)
+        app.client.fetch(True)
+    End Sub
+End Module

--- a/tests/integration/cases/call_keyword/VisualBasic_call.vb
+++ b/tests/integration/cases/call_keyword/VisualBasic_call.vb
@@ -1,11 +1,11 @@
 Imports System.Collections.Generic
 Module Check
-    Class ThrottlerType_
+    Class ThrottlerType_0_
         Public Function check(user_id As Object, ts As Object) As Object
             Return Nothing
         End Function
     End Class
-    Dim throttler As New ThrottlerType_()
+    Dim throttler As New ThrottlerType_0_()
     Function emit(_arg As Object) As Object
         Return Nothing
     End Function

--- a/tests/integration/cases/call_keyword/VisualBasic_call.vb
+++ b/tests/integration/cases/call_keyword/VisualBasic_call.vb
@@ -1,0 +1,16 @@
+Imports System.Collections.Generic
+Module Check
+    Class ThrottlerType_
+        Public Function check(user_id As Object, ts As Object) As Object
+            Return Nothing
+        End Function
+    End Class
+    Dim throttler As New ThrottlerType_()
+    Function emit(_arg As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        emit(throttler.check(user_id:="user_1", ts:=1000.0))
+        emit(throttler.check(user_id:="user_2", ts:=2000.5))
+    End Sub
+End Module

--- a/tests/integration/cases/call_keyword_args/VisualBasic_call.vb
+++ b/tests/integration/cases/call_keyword_args/VisualBasic_call.vb
@@ -1,0 +1,16 @@
+Imports System.Collections.Generic
+Module Check
+    Class ThrottlerType_
+        Public Function check(user_id As Object, ts As Object) As Object
+            Return Nothing
+        End Function
+    End Class
+    Dim throttler As New ThrottlerType_()
+    Function emit(_arg As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        emit(throttler.check("user_1", 1000.0))
+        emit(throttler.check("user_2", 2000.5))
+    End Sub
+End Module

--- a/tests/integration/cases/call_keyword_args/VisualBasic_call.vb
+++ b/tests/integration/cases/call_keyword_args/VisualBasic_call.vb
@@ -1,11 +1,11 @@
 Imports System.Collections.Generic
 Module Check
-    Class ThrottlerType_
+    Class ThrottlerType_0_
         Public Function check(user_id As Object, ts As Object) As Object
             Return Nothing
         End Function
     End Class
-    Dim throttler As New ThrottlerType_()
+    Dim throttler As New ThrottlerType_0_()
     Function emit(_arg As Object) As Object
         Return Nothing
     End Function

--- a/tests/integration/cases/call_mixed_type_dicts/VisualBasic_call.vb
+++ b/tests/integration/cases/call_mixed_type_dicts/VisualBasic_call.vb
@@ -1,14 +1,14 @@
 Imports System.Collections.Generic
 Module Check
-    Class MgrType_
+    Class MgrType_1_
         Public Function op(operation As Object) As Object
             Return Nothing
         End Function
     End Class
-    Class AppType_
-        Public mgr As New MgrType_()
+    Class AppType_0_
+        Public mgr As New MgrType_1_()
     End Class
-    Dim app As New AppType_()
+    Dim app As New AppType_0_()
     Sub _calls()
         app.mgr.op(New Dictionary(Of String, Object) From {{"type", "create"}, {"pr_id", "pr_1"}, {"draft", True}})
         app.mgr.op(New Dictionary(Of String, Object) From {{"type", "create"}, {"pr_id", "pr_2"}})

--- a/tests/integration/cases/call_mixed_type_dicts/VisualBasic_call.vb
+++ b/tests/integration/cases/call_mixed_type_dicts/VisualBasic_call.vb
@@ -1,0 +1,16 @@
+Imports System.Collections.Generic
+Module Check
+    Class MgrType_
+        Public Function op(operation As Object) As Object
+            Return Nothing
+        End Function
+    End Class
+    Class AppType_
+        Public mgr As New MgrType_()
+    End Class
+    Dim app As New AppType_()
+    Sub _calls()
+        app.mgr.op(New Dictionary(Of String, Object) From {{"type", "create"}, {"pr_id", "pr_1"}, {"draft", True}})
+        app.mgr.op(New Dictionary(Of String, Object) From {{"type", "create"}, {"pr_id", "pr_2"}})
+    End Sub
+End Module

--- a/tests/integration/cases/call_multi_args/VisualBasic_call.vb
+++ b/tests/integration/cases/call_multi_args/VisualBasic_call.vb
@@ -1,0 +1,10 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(value As Object, count As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        process(1, 42)
+        process(2, 100)
+    End Sub
+End Module

--- a/tests/integration/cases/call_per_element_false/VisualBasic_call.vb
+++ b/tests/integration/cases/call_per_element_false/VisualBasic_call.vb
@@ -1,0 +1,8 @@
+Module Check
+    Function process(data As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        process(1)
+    End Sub
+End Module

--- a/tests/integration/cases/call_ref_args/VisualBasic_call.vb
+++ b/tests/integration/cases/call_ref_args/VisualBasic_call.vb
@@ -1,0 +1,20 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(data As Object, count As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        Dim my_var = New Integer() {
+            1,
+            2,
+            3
+        }
+        Dim my_other = New Integer() {
+            4,
+            5,
+            6
+        }
+        process(my_var, 42)
+        process(my_other, 7)
+    End Sub
+End Module

--- a/tests/integration/cases/call_ref_args_converted/VisualBasic_call.vb
+++ b/tests/integration/cases/call_ref_args_converted/VisualBasic_call.vb
@@ -1,0 +1,20 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(data As Object, count As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        Dim MyVar = New Integer() {
+            1,
+            2,
+            3
+        }
+        Dim MyOther = New Integer() {
+            4,
+            5,
+            6
+        }
+        process(MyVar, 42)
+        process(MyOther, 7)
+    End Sub
+End Module

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/VisualBasic_call.vb
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/VisualBasic_call.vb
@@ -1,0 +1,20 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(data As Object, count As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        Dim MyVar = New Integer() {
+            1,
+            2,
+            3
+        }
+        Dim MyOther = New Integer() {
+            4,
+            5,
+            6
+        }
+        process(MyVar, 42)
+        process(MyOther, 7)
+    End Sub
+End Module

--- a/tests/integration/cases/call_ref_args_converted_whole/VisualBasic_call.vb
+++ b/tests/integration/cases/call_ref_args_converted_whole/VisualBasic_call.vb
@@ -1,0 +1,14 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(data As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        Dim MyVar = New Integer() {
+            1,
+            2,
+            3
+        }
+        process(MyVar)
+    End Sub
+End Module

--- a/tests/integration/cases/call_scalar_args/VisualBasic_call.vb
+++ b/tests/integration/cases/call_scalar_args/VisualBasic_call.vb
@@ -1,0 +1,11 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(value As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        process("hello")
+        process(42)
+        process(True)
+    End Sub
+End Module

--- a/tests/integration/cases/call_transform_no_wrapper/VisualBasic_call.vb
+++ b/tests/integration/cases/call_transform_no_wrapper/VisualBasic_call.vb
@@ -1,0 +1,11 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(value As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        process("hello")
+        process(42)
+        process(True)
+    End Sub
+End Module

--- a/tests/integration/cases/call_wrap_in_file/VisualBasic_call.vb
+++ b/tests/integration/cases/call_wrap_in_file/VisualBasic_call.vb
@@ -1,0 +1,10 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(a As Object, b As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        process(1, 2)
+        process(3, 4)
+    End Sub
+End Module


### PR DESCRIPTION
Closes #1148.

Adds `literalize_call` support to the `VisualBasic` language module with `POSITIONAL` (default) and `NAMED` (`x:=value`) call styles. Stub declarations are emitted as module-level `Class` and `Function` blocks, and the call body is placed inside `Sub _calls()` because VB rejects bare expression statements at module scope (the fixture linter invokes parameterless shared subs, so the calls still execute). Includes 15 new VB call golden fixtures (all pass `dotnet`-VB lint) and a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new call-stub generation and changes `VisualBasic.wrap_in_file` output structure when call stubs are present, which could affect VB call fixture generation and any downstream consumers of VB output.
> 
> **Overview**
> Adds `literalize_call` support for `VisualBasic`, including positional calls by default and an opt-in named-argument style using `:=`.
> 
> Implements VB call stub emission (module-scope `Function` plus dotted-target `Class` chains with unique, case-insensitive-safe type names) and updates `wrap_in_file` to place call bodies inside `Sub _calls()` when stubs are included.
> 
> Adds a new set of Visual Basic integration golden fixtures covering scalar/keyword/multi-arg calls, ref args, call transforms, and deep dotted targets, and documents the new capability in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0fd0015474357f29decb7d65895ea325776132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->