### PR TITLE
Add literalize_call support for Zig

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Next
   :class:`PositionalCallStyle`, and ``format_call_preamble_stub``
   emits file-scope Zig stub declarations because Zig disallows
   nested function definitions inside ``main``.  Dotted targets like
-  ``app.client.fetch`` are realized as a chain of structs rooted at
+  ``app.client.fetch`` are realized as a nested ``struct`` chain rooted at
   a module-level constant, and call arguments are wrapped in the
   ``ZVal`` union so anonymous union literals coerce to a concrete
   type at the call site.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Changelog
 Next
 ----
 
+- Added ``literalize_call`` support for ``Zig``.  ``Zig.CallStyles``
+  now exposes a ``POSITIONAL`` member backed by
+  :class:`PositionalCallStyle`, and ``format_call_preamble_stub``
+  emits file-scope Zig stub declarations because Zig disallows
+  nested function definitions inside ``main``.  Dotted targets like
+  ``app.client.fetch`` are realized as a chain of structs rooted at
+  a module-level constant, and call arguments are wrapped in the
+  ``ZVal`` union so anonymous union literals coerce to a concrete
+  type at the call site.
 - ``literalize_call`` now emits R stub declarations
   (``name <- function(...) NULL``) for the called function and any
   call-transform wrappers, so generated R call output runs cleanly

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -169,9 +169,9 @@ def _zig_call_preamble_stub(
     ``.{ .int = 1 }`` coerce to a concrete type at the call site;
     transform wrappers (``["_arg"]``) take ``anytype`` so they accept
     both ``ZVal`` and ``void`` arguments.  Dotted targets are
-    realized as a chain of structs rooted at a module-level constant
-    so an expression like ``app.client.fetch(...)`` resolves to a
-    real method call on a real value.
+    realized as a nested ``struct`` chain rooted at a module-level
+    constant, so an expression like ``app.client.fetch(...)`` resolves
+    to a real method call on a real value.
     """
     param_type = "anytype" if list(params) == ["_arg"] else "ZVal"
     param_discards = "".join(f" _ = {p};" for p in params)

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -43,7 +43,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -54,6 +53,7 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -150,6 +150,70 @@ def _format_variable_assignment(name: str, value: str, data: Value) -> str:
     """Format a Zig assignment to an existing ``ZVal`` variable."""
     wrapped = _format_zig_entry(original=data, formatted=value)
     return f"{name} = {wrapped};"
+
+
+@beartype
+def _zig_call_preamble_stub(
+    name: str,
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return file-scope Zig stub declarations for a call name.
+
+    Zig disallows nested function declarations inside ``main``, so
+    call stubs are emitted at module scope.  Stubs always return
+    ``void`` so a bare ``stub(...);`` statement compiles whether or
+    not a ``call_transform`` consumed the value.  Target stubs take
+    ``ZVal`` parameters so anonymous union literals like
+    ``.{ .int = 1 }`` coerce to a concrete type at the call site;
+    transform wrappers (``["_arg"]``) take ``anytype`` so they accept
+    both ``ZVal`` and ``void`` arguments.  Dotted targets are
+    realized as a chain of structs rooted at a module-level constant
+    so an expression like ``app.client.fetch(...)`` resolves to a
+    real method call on a real value.
+    """
+    param_type = "anytype" if list(params) == ["_arg"] else "ZVal"
+    param_discards = "".join(f" _ = {p};" for p in params)
+    parts = name.split(sep=".")
+    method = parts[-1]
+    if len(parts) == 1:
+        param_list = ", ".join(f"{p}: {param_type}" for p in params)
+        return (f"fn {method}({param_list}) void {{{param_discards} }}",)
+    chain = parts[:-1]
+    holder = chain[-1]
+    holder_type = f"{holder.title()}Type_"
+    method_param_list = ", ".join(
+        [
+            f"self: {holder_type}",
+            *(f"{p}: {param_type}" for p in params),
+        ],
+    )
+    lines: list[str] = [
+        f"const {holder_type} = struct {{ "
+        f"fn {method}({method_param_list}) void "
+        f"{{ _ = self;{param_discards} }} }};",
+    ]
+    prev_type = holder_type
+    for i in range(len(chain) - 2, 0, -1):
+        curr_type = f"{chain[i].title()}Type_"
+        lines.append(
+            f"const {curr_type} = struct {{ "
+            f"{chain[i + 1]}: {prev_type} = .{{}} }};",
+        )
+        prev_type = curr_type
+    root = chain[0]
+    intermediates = chain[1:]
+    if intermediates:
+        root_type = f"{root.title()}Type_"
+        lines.append(
+            f"const {root_type} = struct {{ "
+            f"{intermediates[0]}: {prev_type} = .{{}} }};",
+        )
+    else:
+        root_type = prev_type
+    lines.append(f"const {root}: {root_type} = .{{}};")
+    return tuple(lines)
 
 
 @beartype
@@ -380,6 +444,8 @@ class Zig(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Zig call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -416,6 +482,8 @@ class Zig(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
         indented = textwrap.indent(text=content, prefix="    ")
+        if not variable_name:
+            return f"pub fn main() void {{\n{indented}\n}}"
         if "var " in content:
             use = f"    {variable_name} = .nil;"
         else:
@@ -489,9 +557,12 @@ class Zig(metaclass=LanguageCls):
     special_float_preamble: ClassVar[tuple[str, ...]] = (
         'const std = @import("std");',
     )
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+    call_style: CallStyles = CallStyles.POSITIONAL
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:
@@ -529,7 +600,12 @@ class Zig(metaclass=LanguageCls):
     def format_call_stub(
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
-        """Return stub declarations for a call expression."""
+        """Return stub declarations for a call expression.
+
+        Zig disallows nested function declarations inside ``main``, so
+        every stub is emitted at file scope via
+        :attr:`format_call_preamble_stub` instead.
+        """
         return no_call_stub
 
     @cached_property
@@ -537,7 +613,15 @@ class Zig(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return no_call_stub
+        return _zig_call_preamble_stub
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Wrap each call argument in the ``ZVal`` union so call sites
+        match the parameter shape emitted by
+        :func:`_zig_call_preamble_stub`.
+        """
+        return _format_zig_entry
 
     @cached_property
     def format_call_target(self) -> Callable[[str], str]:

--- a/tests/integration/cases/call_deep_dotted_method/Zig_call.zig
+++ b/tests/integration/cases/call_deep_dotted_method/Zig_call.zig
@@ -1,0 +1,21 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+const ClientType_ = struct { fn post(self: ClientType_, data: ZVal) void { _ = self; _ = data; } };
+const ApiType_ = struct { client: ClientType_ = .{} };
+const ObjType_ = struct { api: ApiType_ = .{} };
+const obj: ObjType_ = .{};
+pub fn main() void {
+    obj.api.client.post(.{ .str = "hello" });
+    obj.api.client.post(.{ .int = 42 });
+    obj.api.client.post(.{ .bool = true });
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Zig_call.zig
+++ b/tests/integration/cases/call_deep_dotted_transformed/Zig_call.zig
@@ -1,0 +1,21 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+const ClientType_ = struct { fn fetch(self: ClientType_, payload: ZVal) void { _ = self; _ = payload; } };
+const AppType_ = struct { client: ClientType_ = .{} };
+const app: AppType_ = .{};
+fn emit(_arg: anytype) void { _ = _arg; }
+pub fn main() void {
+    emit(app.client.fetch(.{ .str = "hello" }));
+    emit(app.client.fetch(.{ .int = 42 }));
+    emit(app.client.fetch(.{ .bool = true }));
+}

--- a/tests/integration/cases/call_dotted_method/Zig_call.zig
+++ b/tests/integration/cases/call_dotted_method/Zig_call.zig
@@ -1,0 +1,20 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+const ClientType_ = struct { fn fetch(self: ClientType_, payload: ZVal) void { _ = self; _ = payload; } };
+const AppType_ = struct { client: ClientType_ = .{} };
+const app: AppType_ = .{};
+pub fn main() void {
+    app.client.fetch(.{ .str = "hello" });
+    app.client.fetch(.{ .int = 42 });
+    app.client.fetch(.{ .bool = true });
+}

--- a/tests/integration/cases/call_keyword_args/Zig_call.zig
+++ b/tests/integration/cases/call_keyword_args/Zig_call.zig
@@ -1,0 +1,19 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+const ThrottlerType_ = struct { fn check(self: ThrottlerType_, user_id: ZVal, ts: ZVal) void { _ = self; _ = user_id; _ = ts; } };
+const throttler: ThrottlerType_ = .{};
+fn emit(_arg: anytype) void { _ = _arg; }
+pub fn main() void {
+    emit(throttler.check(.{ .str = "user_1" }, .{ .float = 1000.0 }));
+    emit(throttler.check(.{ .str = "user_2" }, .{ .float = 2000.5 }));
+}

--- a/tests/integration/cases/call_mixed_type_dicts/Zig_call.zig
+++ b/tests/integration/cases/call_mixed_type_dicts/Zig_call.zig
@@ -1,0 +1,19 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+const MgrType_ = struct { fn op(self: MgrType_, operation: ZVal) void { _ = self; _ = operation; } };
+const AppType_ = struct { mgr: MgrType_ = .{} };
+const app: AppType_ = .{};
+pub fn main() void {
+    app.mgr.op(.{ .map = &.{.{ .key = "type", .val = .{ .str = "create" } }, .{ .key = "pr_id", .val = .{ .str = "pr_1" } }, .{ .key = "draft", .val = .{ .bool = true } }}});
+    app.mgr.op(.{ .map = &.{.{ .key = "type", .val = .{ .str = "create" } }, .{ .key = "pr_id", .val = .{ .str = "pr_2" } }}});
+}

--- a/tests/integration/cases/call_multi_args/Zig_call.zig
+++ b/tests/integration/cases/call_multi_args/Zig_call.zig
@@ -1,0 +1,17 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(value: ZVal, count: ZVal) void { _ = value; _ = count; }
+pub fn main() void {
+    process(.{ .int = 1 }, .{ .int = 42 });
+    process(.{ .int = 2 }, .{ .int = 100 });
+}

--- a/tests/integration/cases/call_per_element_false/Zig_call.zig
+++ b/tests/integration/cases/call_per_element_false/Zig_call.zig
@@ -1,0 +1,16 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(data: ZVal) void { _ = data; }
+pub fn main() void {
+    process(.{ .int = 1 });
+}

--- a/tests/integration/cases/call_ref_args/Zig_call.zig
+++ b/tests/integration/cases/call_ref_args/Zig_call.zig
@@ -1,0 +1,27 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(data: ZVal, count: ZVal) void { _ = data; _ = count; }
+pub fn main() void {
+    const my_var: ZVal = .{ .arr = &.{
+        .{ .int = 1 },
+        .{ .int = 2 },
+        .{ .int = 3 },
+    }};
+    const my_other: ZVal = .{ .arr = &.{
+        .{ .int = 4 },
+        .{ .int = 5 },
+        .{ .int = 6 },
+    }};
+    process(my_var, .{ .int = 42 });
+    process(my_other, .{ .int = 7 });
+}

--- a/tests/integration/cases/call_ref_args_converted/Zig_call.zig
+++ b/tests/integration/cases/call_ref_args_converted/Zig_call.zig
@@ -1,0 +1,27 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(data: ZVal, count: ZVal) void { _ = data; _ = count; }
+pub fn main() void {
+    const my_var: ZVal = .{ .arr = &.{
+        .{ .int = 1 },
+        .{ .int = 2 },
+        .{ .int = 3 },
+    }};
+    const my_other: ZVal = .{ .arr = &.{
+        .{ .int = 4 },
+        .{ .int = 5 },
+        .{ .int = 6 },
+    }};
+    process(my_var, .{ .int = 42 });
+    process(my_other, .{ .int = 7 });
+}

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Zig_call.zig
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Zig_call.zig
@@ -1,0 +1,27 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(data: ZVal, count: ZVal) void { _ = data; _ = count; }
+pub fn main() void {
+    const my_var: ZVal = .{ .arr = &.{
+        .{ .int = 1 },
+        .{ .int = 2 },
+        .{ .int = 3 },
+    }};
+    const my_other: ZVal = .{ .arr = &.{
+        .{ .int = 4 },
+        .{ .int = 5 },
+        .{ .int = 6 },
+    }};
+    process(my_var, .{ .int = 42 });
+    process(my_other, .{ .int = 7 });
+}

--- a/tests/integration/cases/call_ref_args_converted_whole/Zig_call.zig
+++ b/tests/integration/cases/call_ref_args_converted_whole/Zig_call.zig
@@ -1,0 +1,21 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(data: ZVal) void { _ = data; }
+pub fn main() void {
+    const my_var: ZVal = .{ .arr = &.{
+        .{ .int = 1 },
+        .{ .int = 2 },
+        .{ .int = 3 },
+    }};
+    process(my_var);
+}

--- a/tests/integration/cases/call_scalar_args/Zig_call.zig
+++ b/tests/integration/cases/call_scalar_args/Zig_call.zig
@@ -1,0 +1,18 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(value: ZVal) void { _ = value; }
+pub fn main() void {
+    process(.{ .str = "hello" });
+    process(.{ .int = 42 });
+    process(.{ .bool = true });
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Zig_call.zig
+++ b/tests/integration/cases/call_transform_no_wrapper/Zig_call.zig
@@ -1,0 +1,18 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(value: ZVal) void { _ = value; }
+pub fn main() void {
+    process(.{ .str = "hello" });
+    process(.{ .int = 42 });
+    process(.{ .bool = true });
+}

--- a/tests/integration/cases/call_wrap_in_file/Zig_call.zig
+++ b/tests/integration/cases/call_wrap_in_file/Zig_call.zig
@@ -1,0 +1,17 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(a: ZVal, b: ZVal) void { _ = a; _ = b; }
+pub fn main() void {
+    process(.{ .int = 1 }, .{ .int = 2 });
+    process(.{ .int = 3 }, .{ .int = 4 });
+}


### PR DESCRIPTION
Closes #1150.

Wires up Zig's call style to `PositionalCallStyle` and emits file-scope stub declarations via `format_call_preamble_stub` (Zig disallows nested function definitions inside `main`). Stubs always return `void` so bare call statements compile regardless of `call_transform`; target stubs take `ZVal` parameters so anonymous union literals coerce at the call site, while transform wrappers (`["_arg"]`) take `anytype` so they accept both `ZVal` and `void`. Dotted targets like `app.client.fetch` materialize a chain of structs rooted at a module-level constant. Adds golden fixtures for all 14 applicable call cases; each compiles and runs cleanly under `zig run`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new call-rendering and stub-generation logic for Zig, including dotted-target materialization and argument wrapping, which could affect correctness of generated Zig call fixtures across multiple call scenarios.
> 
> **Overview**
> Adds `literalize_call` support for Zig by wiring `Zig.CallStyles` to `PositionalCallStyle` and implementing `format_call_preamble_stub` to emit **module-scope** Zig stub declarations (since Zig forbids nested `fn` inside `main`).
> 
> Updates Zig call rendering to wrap each call argument in the `ZVal` union and generates struct/constant chains for dotted targets (e.g. `app.client.fetch`) so generated calls resolve and compile, including `call_transform` wrapper stubs using `anytype`. Adds new Zig golden integration fixtures covering dotted calls, transforms, multi-arg calls, keyword-arg input handling, ref args, and mixed dict args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599950dac06ee8629e6121e025073e180fc8938c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->