### PR TITLE
Drop HCL from REF_CASE_INCOMPATIBLE in call golden harness

### DIFF
--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime
 import enum
+import re
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import ClassVar
@@ -60,6 +61,65 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+
+_HCL_DECLARATION_PATTERN = re.compile(pattern=r"^\s*[A-Za-z_]\w*\s*=")
+
+
+@dataclasses.dataclass
+class _HclScanState:
+    """Mutable HCL bracket/string scan state across lines."""
+
+    depth: int = 0
+    in_string: bool = False
+    escaped: bool = False
+
+
+@beartype
+def _advance_scan_state(*, line: str, state: _HclScanState) -> None:
+    """Update *state* by scanning brackets and strings in *line*."""
+    for char in line:
+        if state.escaped:
+            state.escaped = False
+            continue
+        if state.in_string:
+            if char == "\\":
+                state.escaped = True
+            elif char == '"':
+                state.in_string = False
+            continue
+        if char == '"':
+            state.in_string = True
+        elif char in "[{(":
+            state.depth += 1
+        elif char in "]})":
+            state.depth -= 1
+
+
+@beartype
+def _split_top_level_statements(*, content: str) -> list[str]:
+    r"""Split *content* into top-level HCL statements.
+
+    A statement boundary is a line that returns the bracket and string
+    nesting to depth zero.  Multi-line list or object literals stay
+    grouped with their opening line so a declaration like ``name = [\n
+    ...\n]`` is preserved as a single statement.
+    """
+    if not content:
+        return []
+    statements: list[str] = []
+    current: list[str] = []
+    state = _HclScanState()
+    for line in content.split(sep="\n"):
+        if not line and state.depth == 0 and not current:
+            continue
+        current.append(line)
+        _advance_scan_state(line=line, state=state)
+        if state.depth == 0 and not state.in_string:
+            statements.append("\n".join(current))
+            current = []
+    if current:
+        statements.append("\n".join(current))
+    return statements
 
 
 @beartype
@@ -287,9 +347,12 @@ class Hcl(metaclass=LanguageCls):
     ) -> str:
         """Wrap code in a valid HCL file.
 
-        When *variable_name* is empty (call rendering), each content line
-        is a bare function call which is not valid HCL.  Assign each to a
-        unique local so the file parses.
+        When *variable_name* is empty (call rendering), bare function
+        calls are not valid HCL, so each is assigned to a unique local
+        ``_N``.  Top-level ``name = value`` statements (including
+        multi-line list/object literals) are already valid HCL and pass
+        through unchanged so a mixed file of variable declarations and
+        calls parses correctly.
         """
         if variable_name:
             return wrap_in_file_noop(
@@ -297,11 +360,17 @@ class Hcl(metaclass=LanguageCls):
                 variable_name=variable_name,
                 body_preamble=body_preamble,
             )
-        lines = content.split(sep="\n") if content else []
-        assigned = [
-            f"_{i} = {line}" for i, line in enumerate(iterable=lines) if line
-        ]
-        result = "\n".join(assigned)
+        statements = _split_top_level_statements(content=content)
+        rendered: list[str] = []
+        call_counter = 0
+        for statement in statements:
+            first_line = statement.split(sep="\n", maxsplit=1)[0]
+            if _HCL_DECLARATION_PATTERN.match(string=first_line):
+                rendered.append(statement)
+            else:
+                rendered.append(f"_{call_counter} = {statement}")
+                call_counter += 1
+        result = "\n".join(rendered)
         return prepend_body_preamble(
             content=result,
             body_preamble=body_preamble,

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -71,20 +71,14 @@ class _HclScanState:
 
     depth: int = 0
     in_string: bool = False
-    escaped: bool = False
 
 
 @beartype
 def _advance_scan_state(*, line: str, state: _HclScanState) -> None:
     """Update *state* by scanning brackets and strings in *line*."""
     for char in line:
-        if state.escaped:
-            state.escaped = False
-            continue
         if state.in_string:
-            if char == "\\":
-                state.escaped = True
-            elif char == '"':
+            if char == '"':
                 state.in_string = False
             continue
         if char == '"':
@@ -104,21 +98,15 @@ def _split_top_level_statements(*, content: str) -> list[str]:
     grouped with their opening line so a declaration like ``name = [\n
     ...\n]`` is preserved as a single statement.
     """
-    if not content:
-        return []
     statements: list[str] = []
     current: list[str] = []
     state = _HclScanState()
     for line in content.split(sep="\n"):
-        if not line and state.depth == 0 and not current:
-            continue
         current.append(line)
         _advance_scan_state(line=line, state=state)
         if state.depth == 0 and not state.in_string:
             statements.append("\n".join(current))
             current = []
-    if current:
-        statements.append("\n".join(current))
     return statements
 
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -71,14 +71,27 @@ class _HclScanState:
 
     depth: int = 0
     in_string: bool = False
+    escaped: bool = False
 
 
 @beartype
 def _advance_scan_state(*, line: str, state: _HclScanState) -> None:
-    """Update *state* by scanning brackets and strings in *line*."""
+    r"""Update *state* by scanning brackets and strings in *line*.
+
+    Honours ``\`` escapes inside strings so a backslash-escaped quote
+    (``"a\"b"``) does not flip ``in_string`` at the wrong character.
+    Without this, an odd number of escaped quotes would leave the
+    scanner stuck inside a phantom string and merge later statements
+    into it.
+    """
     for char in line:
+        if state.escaped:
+            state.escaped = False
+            continue
         if state.in_string:
-            if char == '"':
+            if char == "\\":
+                state.escaped = True
+            elif char == '"':
                 state.in_string = False
             continue
         if char == '"':

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -78,7 +78,7 @@ class _HclScanState:
 def _advance_scan_state(*, line: str, state: _HclScanState) -> None:
     r"""Update *state* by scanning brackets and strings in *line*.
 
-    Honours ``\`` escapes inside strings so a backslash-escaped quote
+    Tracks ``\`` escapes inside strings so a backslash-escaped quote
     (``"a\"b"``) does not flip ``in_string`` at the wrong character.
     Without this, an odd number of escaped quotes would leave the
     scanner stuck inside a phantom string and merge later statements

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -23,7 +23,6 @@ from literalizer.exceptions import (
 )
 from literalizer.languages import (
     Haskell,
-    Hcl,
     Jsonnet,
 )
 
@@ -338,9 +337,6 @@ REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
         # multi-line ``name = value`` binding needs ``let`` in a
         # do-block, which the harness does not inject.
         Haskell,
-        # ``wrap_in_file`` renames each content line as ``_N = …``,
-        # which breaks multi-line variable declarations.
-        Hcl,
         # ``wrap_in_file`` wraps content in ``[ … ]`` as an expression
         # list; variable declarations don't fit the shape.
         Jsonnet,

--- a/tests/integration/cases/call_ref_args/Hcl_call.hcl
+++ b/tests/integration/cases/call_ref_args/Hcl_call.hcl
@@ -1,0 +1,12 @@
+my_var = [
+    1,
+    2,
+    3,
+]
+my_other = [
+    4,
+    5,
+    6,
+]
+_0 = process(my_var, 42)
+_1 = process(my_other, 7)

--- a/tests/integration/cases/call_ref_args_converted/Hcl_call.hcl
+++ b/tests/integration/cases/call_ref_args_converted/Hcl_call.hcl
@@ -1,0 +1,12 @@
+my_var = [
+    1,
+    2,
+    3,
+]
+my_other = [
+    4,
+    5,
+    6,
+]
+_0 = process(my_var, 42)
+_1 = process(my_other, 7)

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Hcl_call.hcl
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Hcl_call.hcl
@@ -1,0 +1,12 @@
+my_var = [
+    1,
+    2,
+    3,
+]
+my_other = [
+    4,
+    5,
+    6,
+]
+_0 = process(my_var, 42)
+_1 = process(my_other, 7)

--- a/tests/integration/cases/call_ref_args_converted_whole/Hcl_call.hcl
+++ b/tests/integration/cases/call_ref_args_converted_whole/Hcl_call.hcl
@@ -1,0 +1,6 @@
+my_var = [
+    1,
+    2,
+    3,
+]
+_0 = process(my_var)

--- a/tests/integration/test_hcl_wrap_in_file.py
+++ b/tests/integration/test_hcl_wrap_in_file.py
@@ -1,0 +1,59 @@
+"""Targeted ``Hcl.wrap_in_file`` regression tests.
+
+Covers content that the broad ``test_call_golden_file`` parametrization
+does not exercise but that ``literalize_call`` can still produce — most
+notably HCL strings with backslash-escaped double quotes — to guard
+the statement-splitting scanner used by :func:`Hcl.wrap_in_file`.
+"""
+
+import literalizer
+from literalizer.languages import Hcl
+
+
+def test_call_string_with_escaped_quote_preserved() -> None:
+    r"""A call line with ``\"`` in a string argument is not dropped."""
+    spec = Hcl()
+    result = literalizer.literalize_call(
+        source='---\n- - "a\\"b"\n',
+        input_format=literalizer.InputFormat.YAML,
+        language=spec,
+        target_function="process",
+        parameter_names=["v"],
+    )
+    wrapped = spec.wrap_in_file(
+        content=result.bare_code,
+        variable_name="",
+        body_preamble=(),
+    )
+    assert wrapped == '_0 = process("a\\"b")'
+
+
+def test_call_after_decl_with_escaped_quote_preserved() -> None:
+    """A ref-decl whose value contains ``"`` keeps the trailing call.
+
+    Reproduces a scanner bug where an odd number of escaped quotes left
+    ``in_string`` flipped at end-of-line, causing the splitter to merge
+    the next line into the ongoing string and silently drop everything
+    that followed.
+    """
+    spec = Hcl()
+    decl = literalizer.literalize(
+        source='"a\\"b"',
+        input_format=literalizer.InputFormat.JSON,
+        language=spec,
+        variable_form=literalizer.NewVariable(name="my_str"),
+    )
+    call = literalizer.literalize_call(
+        source="---\n- - {$ref: my_str}\n",
+        input_format=literalizer.InputFormat.YAML,
+        language=spec,
+        target_function="process",
+        parameter_names=["v"],
+    )
+    content = decl.bare_code + "\n" + call.bare_code
+    wrapped = spec.wrap_in_file(
+        content=content,
+        variable_name="",
+        body_preamble=(),
+    )
+    assert wrapped == 'my_str = "a\\"b"\n_0 = process(my_str)'


### PR DESCRIPTION
## Summary
- Teach `Hcl.wrap_in_file` to track bracket/string depth and pass top-level `name = ...` declarations through unchanged, while still wrapping bare call expressions as `_N = ...`.
- Drop `Hcl` from `REF_CASE_INCOMPATIBLE` in the call golden harness and add the four new `call_ref_args*/Hcl_call.hcl` goldens; all parse cleanly under `hcl2json`.

## Test plan
- [x] `pytest tests/integration/test_calls.py -k Hcl`
- [x] Full `pytest tests/` suite
- [x] `hcl2json` parses every `Hcl_call.hcl` golden

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HCL file-wrapping logic by adding a custom statement splitter that tracks bracket/string nesting (including escaped quotes), which could affect how multi-line content is grouped and emitted.
> 
> **Overview**
> Improves `Hcl.wrap_in_file` so call-rendered output becomes a valid mixed HCL file: **top-level `name = value` declarations (including multi-line list/object literals) are left unchanged**, while non-declaration statements are wrapped as `_N = ...` assignments.
> 
> Adds a bracket/string-depth scanner (handling backslash-escaped quotes) to split content into top-level statements, enabling HCL to be included in the call golden harness’ `$ref` declaration cases and adding new HCL golden fixtures plus targeted regression tests for escaped-quote handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148317c598c3c6ac88754e3b4e3211ed3da51fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->