### PR TITLE
Refactor variant_cases into a declarative axis × inputs table

### DIFF
--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -884,7 +884,7 @@ class _SimpleAxis:
     :func:`build_non_default_variants`.
 
     ``kwarg`` is the language-class constructor parameter name; the
-    accessor callables read the default value and the formats enum from
+    accessor functions read the default value and the formats enum from
     a built spec (which sometimes diverge from ``kwarg``, e.g.
     ``bytes_format`` reads from ``format_bytes``).
     """

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -870,60 +870,167 @@ def build_modifier_variant_cases() -> list[VariantCase]:
     return cases
 
 
-@functools.cache
-@beartype
-def build_variant_cases() -> list[VariantCase]:
-    """Collect all format-variant golden-file test cases."""
-    nv = build_non_default_variants
-    date = nv(
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CaseInput:
+    """An input case directory plus a variant-name suffix."""
+
+    case_dir_name: str
+    suffix: str = ""
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class _SimpleAxis:
+    """A format axis whose variants come from
+    :func:`build_non_default_variants`.
+
+    ``kwarg`` is the language-class constructor parameter name; the
+    accessor callables read the default value and the formats enum from
+    a built spec (which sometimes diverge from ``kwarg``, e.g.
+    ``bytes_format`` reads from ``format_bytes``).
+    """
+
+    category: str
+    kwarg: str
+    get_default: Callable[[literalizer.Language], object]
+    get_formats: Callable[[literalizer.Language], type[enum.Enum]]
+
+
+_SIMPLE_AXES: dict[str, _SimpleAxis] = {
+    "date": _SimpleAxis(
         category="date",
+        kwarg="date_format",
         get_default=lambda s: s.format_date,
         get_formats=lambda s: s.date_formats,
-        make_variant_spec=lambda cls, fmt: cls(date_format=fmt),
-    )
-    datetime_ = nv(
+    ),
+    "datetime": _SimpleAxis(
         category="datetime",
+        kwarg="datetime_format",
         get_default=lambda s: s.format_datetime,
         get_formats=lambda s: s.datetime_formats,
-        make_variant_spec=lambda cls, fmt: cls(datetime_format=fmt),
-    )
-    sequence = nv(
+    ),
+    "sequence": _SimpleAxis(
         category="sequence",
+        kwarg="sequence_format",
         get_default=lambda s: s.sequence_format,
         get_formats=lambda s: s.sequence_formats,
-        make_variant_spec=lambda cls, fmt: cls(sequence_format=fmt),
-    )
-    set_ = nv(
+    ),
+    "set": _SimpleAxis(
         category="set",
+        kwarg="set_format",
         get_default=lambda s: s.set_format,
         get_formats=lambda s: s.set_formats,
-        make_variant_spec=lambda cls, fmt: cls(set_format=fmt),
-    )
-    comment = nv(
+    ),
+    "comment": _SimpleAxis(
         category="comment",
+        kwarg="comment_format",
         get_default=lambda s: s.comment_format,
         get_formats=lambda s: s.comment_formats,
-        make_variant_spec=lambda cls, fmt: cls(comment_format=fmt),
-    )
-    type_hints = nv(
+    ),
+    "type_hints": _SimpleAxis(
         category="type_hints",
+        kwarg="variable_type_hints",
         get_default=lambda s: s.variable_type_hints,
         get_formats=lambda s: s.variable_type_hints_formats,
-        make_variant_spec=lambda cls, fmt: cls(variable_type_hints=fmt),
+    ),
+    "dict_format": _SimpleAxis(
+        category="dict_format",
+        kwarg="dict_format",
+        get_default=lambda s: s.dict_format,
+        get_formats=lambda s: s.dict_formats,
+    ),
+    "dict_entry_style": _SimpleAxis(
+        category="dict_entry_style",
+        kwarg="dict_entry_style",
+        get_default=lambda s: s.dict_entry_style,
+        get_formats=lambda s: s.dict_entry_styles,
+    ),
+    "integer_format": _SimpleAxis(
+        category="integer_format",
+        kwarg="integer_format",
+        get_default=lambda s: s.integer_format,
+        get_formats=lambda s: s.integer_formats,
+    ),
+    "numeric_literal_suffix": _SimpleAxis(
+        category="numeric_literal_suffix",
+        kwarg="numeric_literal_suffix",
+        get_default=lambda s: s.numeric_literal_suffix,
+        get_formats=lambda s: s.numeric_literal_suffixes,
+    ),
+    "numeric_separator": _SimpleAxis(
+        category="numeric_separator",
+        kwarg="numeric_separator",
+        get_default=lambda s: s.numeric_separator,
+        get_formats=lambda s: s.numeric_separators,
+    ),
+    "float_format": _SimpleAxis(
+        category="float_format",
+        kwarg="float_format",
+        get_default=lambda s: s.float_format,
+        get_formats=lambda s: s.float_formats,
+    ),
+    "numeric_style": _SimpleAxis(
+        category="numeric_style",
+        kwarg="numeric_style",
+        get_default=lambda s: s.numeric_style,
+        get_formats=lambda s: s.numeric_styles,
+    ),
+    "string_format": _SimpleAxis(
+        category="string_format",
+        kwarg="string_format",
+        get_default=lambda s: s.string_format,
+        get_formats=lambda s: s.string_formats,
+    ),
+    "bytes_format": _SimpleAxis(
+        category="bytes_format",
+        kwarg="bytes_format",
+        get_default=lambda s: s.format_bytes,
+        get_formats=lambda s: s.bytes_formats,
+    ),
+    "trailing_comma": _SimpleAxis(
+        category="trailing_comma",
+        kwarg="trailing_comma",
+        get_default=lambda s: s.trailing_comma,
+        get_formats=lambda s: s.trailing_commas,
+    ),
+    "line_ending": _SimpleAxis(
+        category="line_ending",
+        kwarg="line_ending",
+        get_default=lambda s: s.line_ending,
+        get_formats=lambda s: s.line_endings,
+    ),
+    "heterogeneous_strategy": _SimpleAxis(
+        category="heterogeneous_strategy",
+        kwarg="heterogeneous_strategy",
+        get_default=lambda s: s.heterogeneous_strategy,
+        get_formats=lambda s: s.heterogeneous_strategies,
+    ),
+}
+
+
+@beartype
+def _build_simple_axis(*, axis: _SimpleAxis) -> list[Variant]:
+    """Build variants for a simple format axis."""
+    return build_non_default_variants(
+        category=axis.category,
+        get_default=axis.get_default,
+        get_formats=axis.get_formats,
+        make_variant_spec=lambda cls, fmt: cls(**{axis.kwarg: fmt}),
     )
 
-    def declaration_style_make_spec(
+
+@beartype
+def _build_declaration_style_variants() -> list[Variant]:
+    """Build declaration-style variants, applying per-language sequence-
+    format overrides where the default sequence format is incompatible
+    (e.g. Rust ``CONST`` / ``STATIC`` with ``VEC``).
+    """
+
+    def make_spec_for(
         cls: literalizer.LanguageCls,
         fmt: enum.Enum,
     ) -> literalizer.Language:
-        """Build a spec for *fmt*, applying any per-language sequence-
-        format
-        override listed in
-        :data:`DECLARATION_STYLE_SEQUENCE_FORMAT_OVERRIDES`.
-
-        Some declaration styles are incompatible with the default sequence
-        format (e.g. Rust CONST/STATIC raise ``IncompatibleFormatsError``
-        when combined with ``VEC``).
+        """Build a spec for *fmt*, applying any sequence-format
+        override.
         """
         overrides = DECLARATION_STYLE_SEQUENCE_FORMAT_OVERRIDES.get(cls, {})
         seq_format_name = overrides.get(fmt.name)
@@ -935,264 +1042,286 @@ def build_variant_cases() -> list[VariantCase]:
         )
         return cls(declaration_style=fmt, sequence_format=seq_fmt)
 
-    declaration_style = nv(
+    return build_non_default_variants(
         category="declaration_style",
         get_default=lambda s: s.declaration_style,
         get_formats=lambda s: s.declaration_styles,
-        make_variant_spec=declaration_style_make_spec,
-    )
-    dict_format = nv(
-        category="dict_format",
-        get_default=lambda s: s.dict_format,
-        get_formats=lambda s: s.dict_formats,
-        make_variant_spec=lambda cls, fmt: cls(dict_format=fmt),
-    )
-    dict_entry_style = nv(
-        category="dict_entry_style",
-        get_default=lambda s: s.dict_entry_style,
-        get_formats=lambda s: s.dict_entry_styles,
-        make_variant_spec=lambda cls, fmt: cls(dict_entry_style=fmt),
-    )
-    integer_format = nv(
-        category="integer_format",
-        get_default=lambda s: s.integer_format,
-        get_formats=lambda s: s.integer_formats,
-        make_variant_spec=lambda cls, fmt: cls(integer_format=fmt),
-    )
-    numeric_literal_suffix = nv(
-        category="numeric_literal_suffix",
-        get_default=lambda s: s.numeric_literal_suffix,
-        get_formats=lambda s: s.numeric_literal_suffixes,
-        make_variant_spec=lambda cls, fmt: cls(numeric_literal_suffix=fmt),
-    )
-    numeric_separator = nv(
-        category="numeric_separator",
-        get_default=lambda s: s.numeric_separator,
-        get_formats=lambda s: s.numeric_separators,
-        make_variant_spec=lambda cls, fmt: cls(numeric_separator=fmt),
-    )
-    float_format = nv(
-        category="float_format",
-        get_default=lambda s: s.float_format,
-        get_formats=lambda s: s.float_formats,
-        make_variant_spec=lambda cls, fmt: cls(float_format=fmt),
-    )
-    numeric_style = nv(
-        category="numeric_style",
-        get_default=lambda s: s.numeric_style,
-        get_formats=lambda s: s.numeric_styles,
-        make_variant_spec=lambda cls, fmt: cls(numeric_style=fmt),
-    )
-    string_format = nv(
-        category="string_format",
-        get_default=lambda s: s.string_format,
-        get_formats=lambda s: s.string_formats,
-        make_variant_spec=lambda cls, fmt: cls(string_format=fmt),
-    )
-    bytes_format = nv(
-        category="bytes_format",
-        get_default=lambda s: s.format_bytes,
-        get_formats=lambda s: s.bytes_formats,
-        make_variant_spec=lambda cls, fmt: cls(bytes_format=fmt),
-    )
-    trailing_comma = nv(
-        category="trailing_comma",
-        get_default=lambda s: s.trailing_comma,
-        get_formats=lambda s: s.trailing_commas,
-        make_variant_spec=lambda cls, fmt: cls(trailing_comma=fmt),
-    )
-    line_ending = nv(
-        category="line_ending",
-        get_default=lambda s: s.line_ending,
-        get_formats=lambda s: s.line_endings,
-        make_variant_spec=lambda cls, fmt: cls(line_ending=fmt),
-    )
-    heterogeneous_strategy = nv(
-        category="heterogeneous_strategy",
-        get_default=lambda s: s.heterogeneous_strategy,
-        get_formats=lambda s: s.heterogeneous_strategies,
-        make_variant_spec=lambda cls, fmt: cls(heterogeneous_strategy=fmt),
+        make_variant_spec=make_spec_for,
     )
 
-    type_hints_cross = build_type_hints_cross_variants()
-    string_format_date_cross = build_string_format_cross_variants(
+
+_COMPLEX_BUILDERS: dict[str, Callable[[], Iterable[Variant]]] = {
+    "declaration_style": _build_declaration_style_variants,
+    "default_set_element_type": build_default_set_element_type_variants,
+    "default_sequence_element_type": (
+        build_default_sequence_element_type_variants
+    ),
+    "default_dict_value_type": build_default_dict_value_type_variants,
+    "default_dict_key_type": build_default_dict_key_type_variants,
+    "default_ordered_map_value_type": (
+        build_default_ordered_map_value_type_variants
+    ),
+    "line_ending_decl": build_line_ending_decl_variants,
+    "sequence_decl": build_sequence_decl_variants,
+    "type_hints_cross": build_type_hints_cross_variants,
+    "string_format_date_cross": lambda: build_string_format_cross_variants(
         other_kwarg="date_format",
         other_tag="date",
         get_other_default=lambda s: s.date_format,
         get_other_formats=lambda s: s.date_formats,
-    )
-    string_format_datetime_cross = build_string_format_cross_variants(
+    ),
+    "string_format_datetime_cross": lambda: build_string_format_cross_variants(
         other_kwarg="datetime_format",
         other_tag="dt",
         get_other_default=lambda s: s.datetime_format,
         get_other_formats=lambda s: s.datetime_formats,
-    )
+    ),
+    "type_name": build_type_name_variants,
+    "constructor_prefix": build_constructor_prefix_variants,
+    "constructor_name": build_constructor_name_variants,
+    "c_field_name": build_c_field_name_variants,
+    "heterogeneous_value_enum_name": build_heterogeneous_value_name_variants,
+    "heterogeneous_value_union_name": (
+        build_heterogeneous_value_union_name_variants
+    ),
+    "heterogeneous_value_variant_name": (
+        build_heterogeneous_value_variant_name_variants
+    ),
+}
 
-    cases: list[VariantCase] = []
-    variant_sources: list[tuple[Iterable[Variant], str, str]] = [
-        (date, "scalar_date", ""),
-        (date, "date_list", ""),
-        (date, "date_set", ""),
-        (datetime_, "scalar_datetime", ""),
-        (datetime_, "scalar_datetime_naive", "_naive"),
-        (datetime_, "scalar_datetime_non_utc", "_non_utc"),
-        (sequence, "simple_sequence", ""),
-        (sequence, "pair_sequence", "_pair"),
-        (sequence, "triple_sequence", "_triple"),
-        (sequence, "simple_sequence", "_varname"),
-        (set_, "set", ""),
-        (build_default_set_element_type_variants(), "empty_set", ""),
-        (build_default_set_element_type_variants(), "set", ""),
-        (
-            build_default_sequence_element_type_variants(),
-            "empty_sequence",
-            "",
-        ),
-        (
-            build_default_sequence_element_type_variants(),
-            "simple_sequence",
-            "",
-        ),
-        (build_default_dict_value_type_variants(), "empty_dict", ""),
-        (build_default_dict_value_type_variants(), "simple_dict", ""),
-        (build_default_dict_key_type_variants(), "empty_dict", ""),
-        (build_default_dict_key_type_variants(), "simple_dict", ""),
-        (
-            build_default_ordered_map_value_type_variants(),
-            "ordered_map",
-            "",
-        ),
-        (comment, "comments", ""),
-        (type_hints, "type_hints", ""),
-        (type_hints, "scalar_date", ""),
-        (type_hints, "scalar_datetime", ""),
-        (type_hints, "binary", ""),
-        (type_hints, "mixed_type_dicts_in_sequence", ""),
-        (type_hints, "empty_dicts_in_sequence", ""),
-        (type_hints, "float_list", ""),
-        (type_hints, "int_list", ""),
-        (type_hints, "empty_list", ""),
-        (type_hints, "int_set", ""),
-        (type_hints, "mixed_set", ""),
-        (type_hints, "empty_set", ""),
-        (type_hints, "mixed_number_list", ""),
-        (type_hints, "nested_sequence", ""),
-        (type_hints, "dict_with_list_value", ""),
-        (type_hints, "ordered_map_in_sequence", ""),
-        (type_hints_cross, "int_list", ""),
-        (type_hints_cross, "int_list_large", ""),
-        (type_hints_cross, "pair_sequence", ""),
-        (type_hints_cross, "empty_list", ""),
-        (type_hints_cross, "scalar_date", ""),
-        (type_hints_cross, "scalar_datetime", ""),
-        (type_hints_cross, "simple_dict", ""),
-        (type_hints_cross, "int_set", ""),
-        (declaration_style, "simple_sequence", ""),
-        (declaration_style, "simple_dict", ""),
-        (declaration_style, "empty_list", ""),
-        (declaration_style, "empty_dict", ""),
-        (declaration_style, "int_list", ""),
-        (declaration_style, "int_key_dict", ""),
-        (declaration_style, "scalar_int", ""),
-        (declaration_style, "scalar_int_large", ""),
-        (declaration_style, "scalar_float", ""),
-        (declaration_style, "scalar_bool", ""),
-        (declaration_style, "scalar_string", ""),
-        (declaration_style, "scalar_null", ""),
-        (declaration_style, "scalar_date", ""),
-        (declaration_style, "scalar_datetime", ""),
-        (declaration_style, "binary", ""),
-        (dict_format, "simple_dict", ""),
-        (dict_format, "dict_with_list_value", "_list_val"),
-        (dict_entry_style, "simple_dict", ""),
-        (
-            dict_entry_style,
+
+@beartype
+def _ci(*, case_dir_name: str, suffix: str = "") -> CaseInput:
+    """Shorthand for :class:`CaseInput` to keep the table compact."""
+    return CaseInput(case_dir_name=case_dir_name, suffix=suffix)
+
+
+# Per-axis input table.  Each axis names the input case directories it
+# should run against; coverage is added or removed by editing this table
+# alone.  The cross product of every axis's variants with its inputs
+# yields the full set of golden-file test cases.
+AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
+    "date": (
+        _ci(case_dir_name="scalar_date"),
+        _ci(case_dir_name="date_list"),
+        _ci(case_dir_name="date_set"),
+    ),
+    "datetime": (
+        _ci(case_dir_name="scalar_datetime"),
+        _ci(case_dir_name="scalar_datetime_naive", suffix="_naive"),
+        _ci(case_dir_name="scalar_datetime_non_utc", suffix="_non_utc"),
+    ),
+    "sequence": (
+        _ci(case_dir_name="simple_sequence"),
+        _ci(case_dir_name="pair_sequence", suffix="_pair"),
+        _ci(case_dir_name="triple_sequence", suffix="_triple"),
+        _ci(case_dir_name="simple_sequence", suffix="_varname"),
+        _ci(case_dir_name="float_list", suffix="_float"),
+    ),
+    "set": (_ci(case_dir_name="set"),),
+    "default_set_element_type": (
+        _ci(case_dir_name="empty_set"),
+        _ci(case_dir_name="set"),
+    ),
+    "default_sequence_element_type": (
+        _ci(case_dir_name="empty_sequence"),
+        _ci(case_dir_name="simple_sequence"),
+    ),
+    "default_dict_value_type": (
+        _ci(case_dir_name="empty_dict"),
+        _ci(case_dir_name="simple_dict"),
+    ),
+    "default_dict_key_type": (
+        _ci(case_dir_name="empty_dict"),
+        _ci(case_dir_name="simple_dict"),
+    ),
+    "default_ordered_map_value_type": (_ci(case_dir_name="ordered_map"),),
+    "comment": (_ci(case_dir_name="comments"),),
+    "type_hints": tuple(
+        _ci(case_dir_name=d)
+        for d in (
+            "type_hints",
+            "scalar_date",
+            "scalar_datetime",
+            "binary",
+            "mixed_type_dicts_in_sequence",
+            "empty_dicts_in_sequence",
+            "float_list",
+            "int_list",
+            "empty_list",
+            "int_set",
+            "mixed_set",
+            "empty_set",
+            "mixed_number_list",
+            "nested_sequence",
             "dict_with_list_value",
-            "_list_val",
-        ),
-        (sequence, "float_list", "_float"),
-        (float_format, "float_list", ""),
-        (float_format, "float_scientific_notation", "_s"),
-        (float_format, "float_special_values", "_v"),
-        (float_format, "nested_float_list", "_n"),
-        (integer_format, "int_list", ""),
-        (integer_format, "int_list_large", "_large"),
-        (integer_format, "int_list_with_zero", "_zero"),
-        (numeric_literal_suffix, "int_list", ""),
-        (numeric_literal_suffix, "int_list_large", "_large"),
-        (
-            numeric_literal_suffix,
-            "int_list_with_zero",
-            "_zero",
-        ),
-        (numeric_separator, "int_list", ""),
-        (numeric_separator, "int_list_large", "_large"),
-        (numeric_separator, "int_list_with_zero", "_zero"),
-        (string_format, "string_list", ""),
-        (string_format, "string_with_backslash", ""),
-        (string_format, "simple_dict", "_dict"),
-        (string_format, "binary", "_binary"),
-        (string_format_date_cross, "scalar_date", ""),
-        (string_format_datetime_cross, "scalar_datetime", "_dt"),
-        (bytes_format, "binary", ""),
-        (trailing_comma, "simple_sequence", ""),
-        (line_ending, "simple_sequence", ""),
-        (line_ending, "simple_dict", "_dict"),
-        (build_line_ending_decl_variants(), "simple_sequence", ""),
-        (build_sequence_decl_variants(), "int_list", ""),
-        (build_type_name_variants(), "simple_dict", ""),
-        (build_constructor_prefix_variants(), "simple_dict", ""),
-        (build_constructor_prefix_variants(), "float_special_values", "_v"),
-        (build_constructor_prefix_variants(), "float_list", "_float"),
-        (build_constructor_prefix_variants(), "binary", "_binary"),
-        (build_constructor_prefix_variants(), "scalar_date", "_date"),
-        (build_constructor_prefix_variants(), "scalar_datetime", "_datetime"),
-        (numeric_style, "int_list", ""),
-        (numeric_style, "int_list_with_zero", "_zero"),
-        (numeric_style, "float_list", ""),
-        (numeric_style, "float_special_values", ""),
-        (numeric_style, "mixed_number_list", ""),
-        (numeric_style, "scalars", ""),
-        (build_c_field_name_variants(), "simple_dict", ""),
-        (build_c_field_name_variants(), "simple_sequence", ""),
-        (build_constructor_name_variants(), "simple_dict", ""),
-        (type_hints_cross, "bool_list", ""),
-        (type_hints_cross, "float_list", ""),
-        (heterogeneous_strategy, "dict_mixed_scalars", ""),
-        (heterogeneous_strategy, "mixed_type_dicts_in_sequence", ""),
-        (
-            build_heterogeneous_value_name_variants(),
-            "dict_mixed_scalars",
-            "",
-        ),
-        (
-            build_heterogeneous_value_union_name_variants(),
-            "dict_mixed_scalars",
-            "",
-        ),
-        (
-            build_heterogeneous_value_variant_name_variants(),
-            "dict_mixed_scalars",
-            "",
-        ),
-        (heterogeneous_strategy, "nested_mixed_types", "_sibling"),
-        (heterogeneous_strategy, "nested_mixed_inner", "_inner"),
-        (heterogeneous_strategy, "nested_mixed_dict", ""),
-        (heterogeneous_strategy, "dict_all_scalar_types", ""),
-        (heterogeneous_strategy, "nested_sequences", ""),
-        (heterogeneous_strategy, "dict_mixed_int_widths", ""),
-        (heterogeneous_strategy, "ordered_map", ""),
-    ]
-    for variants, case_dir_name, suffix in variant_sources:
-        cases.extend(
-            VariantCase(
-                variant_name=f"{variant.name}{suffix}",
-                variant=variant,
-                case_dir_name=case_dir_name,
-                variable_form=wrap_variable_form(lang_cls=variant.lang_cls),
-            )
-            for variant in variants
+            "ordered_map_in_sequence",
         )
+    ),
+    "type_hints_cross": tuple(
+        _ci(case_dir_name=d)
+        for d in (
+            "int_list",
+            "int_list_large",
+            "pair_sequence",
+            "empty_list",
+            "scalar_date",
+            "scalar_datetime",
+            "simple_dict",
+            "int_set",
+            "bool_list",
+            "float_list",
+        )
+    ),
+    "declaration_style": tuple(
+        _ci(case_dir_name=d)
+        for d in (
+            "simple_sequence",
+            "simple_dict",
+            "empty_list",
+            "empty_dict",
+            "int_list",
+            "int_key_dict",
+            "scalar_int",
+            "scalar_int_large",
+            "scalar_float",
+            "scalar_bool",
+            "scalar_string",
+            "scalar_null",
+            "scalar_date",
+            "scalar_datetime",
+            "binary",
+        )
+    ),
+    "dict_format": (
+        _ci(case_dir_name="simple_dict"),
+        _ci(case_dir_name="dict_with_list_value", suffix="_list_val"),
+    ),
+    "dict_entry_style": (
+        _ci(case_dir_name="simple_dict"),
+        _ci(case_dir_name="dict_with_list_value", suffix="_list_val"),
+    ),
+    "float_format": (
+        _ci(case_dir_name="float_list"),
+        _ci(case_dir_name="float_scientific_notation", suffix="_s"),
+        _ci(case_dir_name="float_special_values", suffix="_v"),
+        _ci(case_dir_name="nested_float_list", suffix="_n"),
+    ),
+    "integer_format": (
+        _ci(case_dir_name="int_list"),
+        _ci(case_dir_name="int_list_large", suffix="_large"),
+        _ci(case_dir_name="int_list_with_zero", suffix="_zero"),
+    ),
+    "numeric_literal_suffix": (
+        _ci(case_dir_name="int_list"),
+        _ci(case_dir_name="int_list_large", suffix="_large"),
+        _ci(case_dir_name="int_list_with_zero", suffix="_zero"),
+    ),
+    "numeric_separator": (
+        _ci(case_dir_name="int_list"),
+        _ci(case_dir_name="int_list_large", suffix="_large"),
+        _ci(case_dir_name="int_list_with_zero", suffix="_zero"),
+    ),
+    "string_format": (
+        _ci(case_dir_name="string_list"),
+        _ci(case_dir_name="string_with_backslash"),
+        _ci(case_dir_name="simple_dict", suffix="_dict"),
+        _ci(case_dir_name="binary", suffix="_binary"),
+    ),
+    "string_format_date_cross": (_ci(case_dir_name="scalar_date"),),
+    "string_format_datetime_cross": (
+        _ci(case_dir_name="scalar_datetime", suffix="_dt"),
+    ),
+    "bytes_format": (_ci(case_dir_name="binary"),),
+    "trailing_comma": (_ci(case_dir_name="simple_sequence"),),
+    "line_ending": (
+        _ci(case_dir_name="simple_sequence"),
+        _ci(case_dir_name="simple_dict", suffix="_dict"),
+    ),
+    "line_ending_decl": (_ci(case_dir_name="simple_sequence"),),
+    "sequence_decl": (_ci(case_dir_name="int_list"),),
+    "type_name": (_ci(case_dir_name="simple_dict"),),
+    "constructor_prefix": (
+        _ci(case_dir_name="simple_dict"),
+        _ci(case_dir_name="float_special_values", suffix="_v"),
+        _ci(case_dir_name="float_list", suffix="_float"),
+        _ci(case_dir_name="binary", suffix="_binary"),
+        _ci(case_dir_name="scalar_date", suffix="_date"),
+        _ci(case_dir_name="scalar_datetime", suffix="_datetime"),
+    ),
+    "numeric_style": (
+        _ci(case_dir_name="int_list"),
+        _ci(case_dir_name="int_list_with_zero", suffix="_zero"),
+        _ci(case_dir_name="float_list"),
+        _ci(case_dir_name="float_special_values"),
+        _ci(case_dir_name="mixed_number_list"),
+        _ci(case_dir_name="scalars"),
+    ),
+    "c_field_name": (
+        _ci(case_dir_name="simple_dict"),
+        _ci(case_dir_name="simple_sequence"),
+    ),
+    "constructor_name": (_ci(case_dir_name="simple_dict"),),
+    "heterogeneous_strategy": tuple(
+        _ci(case_dir_name=d, suffix=s)
+        for d, s in (
+            ("dict_mixed_scalars", ""),
+            ("mixed_type_dicts_in_sequence", ""),
+            ("nested_mixed_types", "_sibling"),
+            ("nested_mixed_inner", "_inner"),
+            ("nested_mixed_dict", ""),
+            ("dict_all_scalar_types", ""),
+            ("nested_sequences", ""),
+            ("dict_mixed_int_widths", ""),
+            ("ordered_map", ""),
+        )
+    ),
+    "heterogeneous_value_enum_name": (
+        _ci(case_dir_name="dict_mixed_scalars"),
+    ),
+    "heterogeneous_value_union_name": (
+        _ci(case_dir_name="dict_mixed_scalars"),
+    ),
+    "heterogeneous_value_variant_name": (
+        _ci(case_dir_name="dict_mixed_scalars"),
+    ),
+}
+
+
+@beartype
+def _variants_for_axis(axis_key: str) -> list[Variant]:
+    """Return the variants for an axis key, dispatching to the simple
+    or complex builder.
+    """
+    if axis_key in _SIMPLE_AXES:
+        return _build_simple_axis(axis=_SIMPLE_AXES[axis_key])
+    return list(_COMPLEX_BUILDERS[axis_key]())
+
+
+@functools.cache
+@beartype
+def build_variant_cases() -> list[VariantCase]:
+    """Collect all format-variant golden-file test cases.
+
+    The full set is the cross product of every axis's variants with its
+    declared inputs in :data:`AXIS_INPUTS`, plus the bespoke modifier
+    cases from :func:`build_modifier_variant_cases`.
+    """
+    cases: list[VariantCase] = []
+    for axis_key, inputs in AXIS_INPUTS.items():
+        variants = _variants_for_axis(axis_key=axis_key)
+        for variant in variants:
+            cases.extend(
+                VariantCase(
+                    variant_name=f"{variant.name}{ci.suffix}",
+                    variant=variant,
+                    case_dir_name=ci.case_dir_name,
+                    variable_form=wrap_variable_form(
+                        lang_cls=variant.lang_cls
+                    ),
+                )
+                for ci in inputs
+            )
     cases.extend(build_modifier_variant_cases())
     return cases
 


### PR DESCRIPTION
## Summary
- Replace the long hand-curated `variant_sources` list and 18 repeated `build_non_default_variants` calls with a `_SIMPLE_AXES` table, a small `_COMPLEX_BUILDERS` registry, and a single `AXIS_INPUTS` dict mapping each axis to its input case directories.
- The resulting `VariantCase` set is unchanged (2323 cases, identical `(variant_name, case_dir_name, variable_form)` tuples), so all existing golden files apply byte-for-byte.
- Adding coverage is now a one-line edit and per-axis input gaps are visible at a glance — follow-up issues will be filed for the gaps surfaced by the consolidation.

## Test plan
- [ ] CI golden-file test suite passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that restructures how variant golden-file cases are generated; main risk is accidental change in the set/naming of generated cases causing golden mismatches.
> 
> **Overview**
> Refactors `build_variant_cases()` in `tests/integration/variant_cases.py` to generate golden-file `VariantCase`s from a declarative **axis × inputs** table instead of a long hand-maintained `variant_sources` list.
> 
> Introduces `_SIMPLE_AXES` and `_COMPLEX_BUILDERS` dispatch (including a dedicated declaration-style builder with Rust sequence-format overrides) plus `AXIS_INPUTS`/`CaseInput` to define which case directories each axis runs against, then builds the cross product and appends the existing modifier-specific cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac494360594ddd4b6004a610ba9732ef100c29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->