### PR TITLE
Assert quote structure in bytes hex roundtrip test

### DIFF
--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -144,7 +144,9 @@ def test_roundtrip_bytes_python(data: bytes) -> None:
 def test_roundtrip_bytes_hex(data: bytes) -> None:
     """Format_bytes_hex -> bytes.fromhex round-trips."""
     result = PYTHON.format_bytes(data)
-    assert bytes.fromhex(result.strip('"')) == data
+    assert result.startswith('"')
+    assert result.endswith('"')
+    assert bytes.fromhex(result[1:-1]) == data
 
 
 @given(data=st.binary())


### PR DESCRIPTION
Replaces fragile `result.strip('"')` in `test_roundtrip_bytes_hex` with explicit assertions that the result starts and ends with `"`, then slices the quotes off before `bytes.fromhex`. Prevents silent acceptance of malformed output like `"abc"def"`.

Closes #1197

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that tightens assertions to avoid silently accepting malformed quoted hex output.
> 
> **Overview**
> Tightens `test_roundtrip_bytes_hex` to explicitly assert that `Python.format_bytes` (HEX mode) returns a *fully quoted* string, then slices off the outer quotes (`result[1:-1]`) before calling `bytes.fromhex` instead of using `strip('"')`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43e2d9a5ff05f65255482ac31213d6fc6c6f007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->