### PR TITLE
Inline CallStyle typing instead of CallStyleEnum base

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,6 @@ Changelog
 Next
 ----
 
-- Added ``CallStyleEnum`` as the base class for per-language
-  ``CallStyles`` enums.  Its :attr:`config` accessor returns the
-  enum member's value typed as the :data:`CallStyle` union, removing
-  the ``cast("CallStyle", self.call_style.value)`` boilerplate
-  previously duplicated in every multi-style language module.
 - ``literalize`` and ``literalize_call`` now require a ``module_name``
   keyword argument.  The languages whose ``wrap_in_file`` introduces a
   named scope — Java's wrapping class and method, Fortran's

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -254,22 +254,6 @@ CallStyle = (
 """Tagged union describing how a language passes call arguments."""
 
 
-class CallStyleEnum(enum.Enum):
-    """Base class for per-language ``CallStyles`` enums.
-
-    Subclasses define members whose values are :data:`CallStyle`
-    instances.  Reading :attr:`config` narrows ``.value`` from
-    :class:`typing.Any` to :data:`CallStyle`, so subclasses do not
-    need a per-language ``cast``.
-    """
-
-    @property
-    def config(self) -> CallStyle:
-        """The :data:`CallStyle` instance backing this member."""
-        value: CallStyle = self.value
-        return value
-
-
 class CallSupport(enum.Enum):
     """Sentinel describing why a language does not have a
     :class:`CallStyle` configured.

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -45,7 +45,6 @@ from literalizer._formatters.format_strings import format_string_backslash_hash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -395,7 +394,7 @@ class Crystal(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Crystal call style options."""
 
         KEYWORD = KeywordCallStyle(separator=": ")
@@ -681,4 +680,5 @@ class Crystal(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -57,7 +57,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -664,7 +663,7 @@ class CSharp(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """CSharp call style options."""
 
         POSITIONAL = PositionalCallStyle()
@@ -1128,4 +1127,5 @@ class CSharp(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -37,7 +37,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -319,7 +318,7 @@ class Groovy(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Groovy call style options."""
 
         KEYWORD = KeywordCallStyle(separator=": ")
@@ -603,4 +602,5 @@ class Groovy(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -47,7 +47,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -396,7 +395,7 @@ class JavaScript(metaclass=LanguageCls):
     trailing_commas = TrailingCommas
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """JavaScript call style options."""
 
         OBJECT = ObjectCallStyle(separator=": ")
@@ -677,4 +676,5 @@ class JavaScript(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -45,7 +45,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -411,7 +410,7 @@ class Julia(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Julia call style options."""
 
         KEYWORD = KeywordCallStyle(separator="=")
@@ -686,4 +685,5 @@ class Julia(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -58,7 +58,6 @@ from literalizer._formatters.type_inference import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -768,7 +767,7 @@ class Kotlin(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Kotlin call style options."""
 
         KEYWORD = KeywordCallStyle(separator=" = ")
@@ -1137,4 +1136,5 @@ class Kotlin(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -47,7 +47,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -377,7 +376,7 @@ class Php(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Php call style options."""
 
         KEYWORD = KeywordCallStyle(separator=": ")
@@ -661,4 +660,5 @@ class Php(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -49,7 +49,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -871,7 +870,7 @@ class Python(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Call style options for Python."""
 
         KEYWORD = KeywordCallStyle(separator="=")
@@ -1170,4 +1169,5 @@ class Python(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -37,7 +37,6 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -370,7 +369,7 @@ class R(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """R call style options."""
 
         KEYWORD = KeywordCallStyle(separator=" = ")
@@ -647,4 +646,5 @@ class R(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -47,7 +47,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -389,7 +388,7 @@ class Ruby(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Ruby call style options."""
 
         KEYWORD = KeywordCallStyle(separator=": ")
@@ -673,4 +672,5 @@ class Ruby(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -47,7 +47,6 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -489,7 +488,7 @@ class Scala(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """Scala call style options."""
 
         KEYWORD = KeywordCallStyle(separator=" = ")
@@ -828,4 +827,5 @@ class Scala(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -50,7 +50,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -575,7 +574,7 @@ class TypeScript(metaclass=LanguageCls):
     trailing_commas = TrailingCommas
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """TypeScript call style options."""
 
         OBJECT = ObjectCallStyle(separator=": ")
@@ -873,4 +872,5 @@ class TypeScript(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -45,7 +45,6 @@ from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallStyleEnum,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -449,7 +448,7 @@ class VisualBasic(metaclass=LanguageCls):
 
     line_endings = LineEndings
 
-    class CallStyles(CallStyleEnum):
+    class CallStyles(enum.Enum):
         """VisualBasic call style options."""
 
         POSITIONAL = PositionalCallStyle()
@@ -651,7 +650,8 @@ class VisualBasic(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.config
+        config: CallStyle = self.call_style.value
+        return config
 
     @cached_property
     def format_call_preamble_stub(


### PR DESCRIPTION
## Summary
- Remove the ``CallStyleEnum`` base class added in #1679 and revert each language's ``CallStyles`` enum to inherit from ``enum.Enum`` directly.
- Replace ``self.call_style.config`` with a local ``config: CallStyle = self.call_style.value`` at each ``call_style_config`` site across the 13 multi-style language modules.
- Drop the now-stale ``CallStyleEnum`` CHANGELOG entry.

## Test plan
- [x] ``uv run --extra dev mypy src/`` (clean)
- [x] ``uv run --extra dev pytest tests/ --ignore=tests/benchmarks`` (1233 passed)
- [x] ``uv run ruff check`` / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Broad but mechanical refactor across multiple language specs; behavior should be unchanged but any mismatch could affect `literalize_call` call-style selection.
> 
> **Overview**
> Removes the `CallStyleEnum` base class from `_language.py` and reverts each affected language’s `CallStyles` enum to inherit directly from `enum.Enum`.
> 
> Updates `call_style_config` implementations to inline the type narrowing (`config: CallStyle = self.call_style.value`) instead of relying on `self.call_style.config`, and drops the now-stale changelog entry for `CallStyleEnum`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7635954c229fa79bc77a8ad266d6d8cd27888c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->