### PR TITLE
Run Swift lint with -warnings-as-errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -737,11 +737,11 @@ jobs:
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
           cp "$1" "$tmpdir/check.swift"
-          swiftc -typecheck "$tmpdir/check.swift" || exit 1
+          swiftc -typecheck -warnings-as-errors "$tmpdir/check.swift" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/check-swift.sh < /tmp/files-to-lint
       - name: Run Swift files
-        run: xargs -0 -P "$(nproc)" -n1 swift < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 swift -warnings-as-errors < /tmp/files-to-lint
 
   lint-ocaml:
     runs-on: ubuntu-latest

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -129,21 +129,24 @@ def _swift_call_stub(
     param_list = ", ".join(_swift_param(p) for p in params)
     parts = name.split(sep=".")
     if len(parts) == 1:
-        return (f"func {parts[0]}({param_list}) -> Any {{ 0 }}",)
+        return (
+            f"@discardableResult func {parts[0]}({param_list}) -> Any {{ 0 }}",
+        )
     root = parts[0]
     method = parts[-1]
     fields = parts[1:-1]
+    method_decl = (
+        f"@discardableResult func {method}({param_list}) -> Any {{ 0 }}"
+    )
     if not fields:
         cls = f"_{root}Type"
         return (
-            f"class {cls} {{ func {method}({param_list}) -> Any {{ 0 }} }}",
+            f"class {cls} {{ {method_decl} }}",
             f"let {root} = {cls}()",
         )
     lines: list[str] = []
     inner_cls = f"_{fields[-1]}Type"
-    lines.append(
-        f"class {inner_cls} {{ func {method}({param_list}) -> Any {{ 0 }} }}"
-    )
+    lines.append(f"class {inner_cls} {{ {method_decl} }}")
     prev_cls = inner_cls
     for i in range(len(fields) - 2, -1, -1):
         cls = f"_{fields[i]}Type"

--- a/tests/integration/cases/call_deep_dotted_method/Swift_call.swift
+++ b/tests/integration/cases/call_deep_dotted_method/Swift_call.swift
@@ -1,4 +1,4 @@
-class _clientType { func post(data: Any = 0) -> Any { 0 } }
+class _clientType { @discardableResult func post(data: Any = 0) -> Any { 0 } }
 class _apiType { var client = _clientType() }
 class _objType { var api = _apiType() }
 let obj = _objType()

--- a/tests/integration/cases/call_deep_dotted_transformed/Swift_call.swift
+++ b/tests/integration/cases/call_deep_dotted_transformed/Swift_call.swift
@@ -1,7 +1,7 @@
-class _clientType { func fetch(payload: Any = 0) -> Any { 0 } }
+class _clientType { @discardableResult func fetch(payload: Any = 0) -> Any { 0 } }
 class _appType { var client = _clientType() }
 let app = _appType()
-func emit(_ _arg: Any = 0) -> Any { 0 }
+@discardableResult func emit(_ _arg: Any = 0) -> Any { 0 }
 emit(app.client.fetch(payload: "hello"));
 emit(app.client.fetch(payload: 42));
 emit(app.client.fetch(payload: true));

--- a/tests/integration/cases/call_dotted_method/Swift_call.swift
+++ b/tests/integration/cases/call_dotted_method/Swift_call.swift
@@ -1,4 +1,4 @@
-class _clientType { func fetch(payload: Any = 0) -> Any { 0 } }
+class _clientType { @discardableResult func fetch(payload: Any = 0) -> Any { 0 } }
 class _appType { var client = _clientType() }
 let app = _appType()
 app.client.fetch(payload: "hello");

--- a/tests/integration/cases/call_keyword_args/Swift_call.swift
+++ b/tests/integration/cases/call_keyword_args/Swift_call.swift
@@ -1,5 +1,5 @@
-class _throttlerType { func check(user_id: Any = 0, ts: Any = 0) -> Any { 0 } }
+class _throttlerType { @discardableResult func check(user_id: Any = 0, ts: Any = 0) -> Any { 0 } }
 let throttler = _throttlerType()
-func emit(_ _arg: Any = 0) -> Any { 0 }
+@discardableResult func emit(_ _arg: Any = 0) -> Any { 0 }
 emit(throttler.check(user_id: "user_1", ts: 1000.0));
 emit(throttler.check(user_id: "user_2", ts: 2000.5));

--- a/tests/integration/cases/call_mixed_type_dicts/Swift_call.swift
+++ b/tests/integration/cases/call_mixed_type_dicts/Swift_call.swift
@@ -1,4 +1,4 @@
-class _mgrType { func op(operation: Any = 0) -> Any { 0 } }
+class _mgrType { @discardableResult func op(operation: Any = 0) -> Any { 0 } }
 class _appType { var mgr = _mgrType() }
 let app = _appType()
 app.mgr.op(operation: ["type": "create", "pr_id": "pr_1", "draft": true]);

--- a/tests/integration/cases/call_multi_args/Swift_call.swift
+++ b/tests/integration/cases/call_multi_args/Swift_call.swift
@@ -1,3 +1,3 @@
-func process(value: Any = 0, count: Any = 0) -> Any { 0 }
+@discardableResult func process(value: Any = 0, count: Any = 0) -> Any { 0 }
 process(value: 1, count: 42);
 process(value: 2, count: 100);

--- a/tests/integration/cases/call_per_element_false/Swift_call.swift
+++ b/tests/integration/cases/call_per_element_false/Swift_call.swift
@@ -1,2 +1,2 @@
-func process(data: Any = 0) -> Any { 0 }
+@discardableResult func process(data: Any = 0) -> Any { 0 }
 process(data: 1);

--- a/tests/integration/cases/call_ref_args/Swift_call.swift
+++ b/tests/integration/cases/call_ref_args/Swift_call.swift
@@ -1,4 +1,4 @@
-func process(data: Any = 0, count: Any = 0) -> Any { 0 }
+@discardableResult func process(data: Any = 0, count: Any = 0) -> Any { 0 }
 let my_var: Any = [
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted/Swift_call.swift
+++ b/tests/integration/cases/call_ref_args_converted/Swift_call.swift
@@ -1,4 +1,4 @@
-func process(data: Any = 0, count: Any = 0) -> Any { 0 }
+@discardableResult func process(data: Any = 0, count: Any = 0) -> Any { 0 }
 let myVar: Any = [
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Swift_call.swift
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Swift_call.swift
@@ -1,4 +1,4 @@
-func process(data: Any = 0, count: Any = 0) -> Any { 0 }
+@discardableResult func process(data: Any = 0, count: Any = 0) -> Any { 0 }
 let myVar: Any = [
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_whole/Swift_call.swift
+++ b/tests/integration/cases/call_ref_args_converted_whole/Swift_call.swift
@@ -1,4 +1,4 @@
-func process(data: Any = 0) -> Any { 0 }
+@discardableResult func process(data: Any = 0) -> Any { 0 }
 let myVar: Any = [
     1,
     2,

--- a/tests/integration/cases/call_scalar_args/Swift_call.swift
+++ b/tests/integration/cases/call_scalar_args/Swift_call.swift
@@ -1,4 +1,4 @@
-func process(value: Any = 0) -> Any { 0 }
+@discardableResult func process(value: Any = 0) -> Any { 0 }
 process(value: "hello");
 process(value: 42);
 process(value: true);

--- a/tests/integration/cases/call_transform_no_wrapper/Swift_call.swift
+++ b/tests/integration/cases/call_transform_no_wrapper/Swift_call.swift
@@ -1,4 +1,4 @@
-func process(value: Any = 0) -> Any { 0 }
+@discardableResult func process(value: Any = 0) -> Any { 0 }
 process(value: "hello");
 process(value: 42);
 process(value: true);

--- a/tests/integration/cases/call_wrap_in_file/Swift_call.swift
+++ b/tests/integration/cases/call_wrap_in_file/Swift_call.swift
@@ -1,3 +1,3 @@
-func process(a: Any = 0, b: Any = 0) -> Any { 0 }
+@discardableResult func process(a: Any = 0, b: Any = 0) -> Any { 0 }
 process(a: 1, b: 2);
 process(a: 3, b: 4);


### PR DESCRIPTION
## Summary
- Pass `-warnings-as-errors` to both `swiftc -typecheck` and `swift` in the `lint-swift` job so Swift warnings fail CI.
- Emit `@discardableResult` on Swift call stubs so the existing `Swift_call.swift` fixtures don't trip the `#no-usage` warning, and regenerate the 14 affected goldens.

## Test plan
- [x] `swiftc -typecheck -warnings-as-errors` and `swift -warnings-as-errors` pass locally across all 347 Swift fixtures
- [x] `pytest tests/integration/test_calls.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens Swift CI to `-warnings-as-errors`, which can introduce new PR failures from previously-ignored warnings. Stub/fixture regeneration is mechanical but touches many golden files.
> 
> **Overview**
> Swift linting in GitHub Actions is now stricter by running both `swiftc -typecheck` and `swift` with `-warnings-as-errors`, causing any Swift warnings to fail CI.
> 
> Swift call stub generation now emits `@discardableResult` on stubbed functions/methods, and the affected `Swift_call.swift` golden fixtures are regenerated accordingly to keep the stricter lint green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c0d7a9729cdaba584753a59693cff252b11a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->