### PR TITLE
Add set to line_ending axis inputs

### DIFF
--- a/tests/integration/cases/set/JavaScript_line_ending_none_set.js
+++ b/tests/integration/cases/set/JavaScript_line_ending_none_set.js
@@ -1,0 +1,5 @@
+const my_data = new Set([
+  "apple",
+  "banana",
+  "cherry",
+])

--- a/tests/integration/cases/set/TypeScript_line_ending_none_set.ts
+++ b/tests/integration/cases/set/TypeScript_line_ending_none_set.ts
@@ -1,0 +1,6 @@
+const my_data = new Set([
+  "apple",
+  "banana",
+  "cherry",
+])
+export {};

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -1267,6 +1267,7 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     "line_ending": (
         _ci(case_dir_name="simple_sequence"),
         _ci(case_dir_name="simple_dict", suffix="_dict"),
+        _ci(case_dir_name="set", suffix="_set"),
     ),
     "line_ending_decl": (_ci(case_dir_name="simple_sequence"),),
     "sequence_decl": (_ci(case_dir_name="int_list"),),


### PR DESCRIPTION
## Summary
- Add `set` case to the `line_ending` entry in `AXIS_INPUTS` so the line_ending axis exercises set literal output alongside sequences and dicts.
- Generated new golden files for JavaScript and TypeScript line_ending_none variants.

Closes #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that expand golden-file coverage for `line_ending` formatting without modifying runtime/library code.
> 
> **Overview**
> Extends the `line_ending` format-variant test axis to also run against the `set` case (in addition to sequences and dicts).
> 
> Adds new JavaScript and TypeScript golden files for the `line_ending_none` variant when rendering sets (`JavaScript_line_ending_none_set.js`, `TypeScript_line_ending_none_set.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52cf92eba1583c6c7f12619531240f0689927eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->