### PR TITLE
Extend type_name axis to match constructor_prefix inputs

### DIFF
--- a/tests/integration/cases/binary/Elm_type_name_JsonVal_binary.elm
+++ b/tests/integration/cases/binary/Elm_type_name_JsonVal_binary.elm
@@ -1,0 +1,12 @@
+module Check exposing (..)
+
+
+type JsonVal
+    = EStr String
+    | EList (List JsonVal)
+
+
+my_data : JsonVal
+my_data = EList [
+    EStr "48656c6c6f"
+    ]

--- a/tests/integration/cases/binary/FSharp_type_name_JsonVal_binary.fs
+++ b/tests/integration/cases/binary/FSharp_type_name_JsonVal_binary.fs
@@ -1,0 +1,8 @@
+module Check
+
+type JsonVal =
+    | FStr of string
+    | FList of JsonVal list
+let my_data: JsonVal = FList [
+    FStr "48656c6c6f"
+]

--- a/tests/integration/cases/binary/Gleam_type_name_JsonVal_binary.gleam
+++ b/tests/integration/cases/binary/Gleam_type_name_JsonVal_binary.gleam
@@ -1,0 +1,11 @@
+pub type JsonVal {
+  GStr(String)
+  GList(List(JsonVal))
+}
+
+pub fn main() {
+  let my_data = GList([
+    GStr("48656c6c6f"),
+  ])
+  let _ = my_data
+}

--- a/tests/integration/cases/binary/Haskell_type_name_JsonVal_binary.hs
+++ b/tests/integration/cases/binary/Haskell_type_name_JsonVal_binary.hs
@@ -1,0 +1,6 @@
+module Check where
+data JsonVal = HStr String | HList [JsonVal]
+my_data :: JsonVal
+my_data = HList [
+    HStr "48656c6c6f"
+    ]

--- a/tests/integration/cases/binary/OCaml_type_name_json_t_binary.ml
+++ b/tests/integration/cases/binary/OCaml_type_name_json_t_binary.ml
@@ -1,0 +1,10 @@
+module Check = struct
+
+type json_t =
+  | OStr of string
+  | OList of json_t list
+let my_data : json_t = OList [
+    OStr "48656c6c6f"
+]
+
+end

--- a/tests/integration/cases/binary/PureScript_type_name_JsonVal_binary.purs
+++ b/tests/integration/cases/binary/PureScript_type_name_JsonVal_binary.purs
@@ -1,0 +1,12 @@
+module Check where
+
+
+data JsonVal
+    = PStr String
+    | PList (Array JsonVal)
+
+
+my_data :: JsonVal
+my_data = PList [
+    PStr "48656c6c6f"
+    ]

--- a/tests/integration/cases/float_list/Elm_type_name_JsonVal_float.elm
+++ b/tests/integration/cases/float_list/Elm_type_name_JsonVal_float.elm
@@ -1,0 +1,14 @@
+module Check exposing (..)
+
+
+type JsonVal
+    = EFloat Float
+    | EList (List JsonVal)
+
+
+my_data : JsonVal
+my_data = EList [
+    EFloat 1.1,
+    EFloat (-2.2),
+    EFloat 3.3
+    ]

--- a/tests/integration/cases/float_list/FSharp_type_name_JsonVal_float.fs
+++ b/tests/integration/cases/float_list/FSharp_type_name_JsonVal_float.fs
@@ -1,0 +1,10 @@
+module Check
+
+type JsonVal =
+    | FFloat of float
+    | FList of JsonVal list
+let my_data: JsonVal = FList [
+    FFloat 1.1;
+    FFloat(-2.2);
+    FFloat 3.3
+]

--- a/tests/integration/cases/float_list/Gleam_type_name_JsonVal_float.gleam
+++ b/tests/integration/cases/float_list/Gleam_type_name_JsonVal_float.gleam
@@ -1,0 +1,13 @@
+pub type JsonVal {
+  GFloat(Float)
+  GList(List(JsonVal))
+}
+
+pub fn main() {
+  let my_data = GList([
+    GFloat(1.1),
+    GFloat(-2.2),
+    GFloat(3.3),
+  ])
+  let _ = my_data
+}

--- a/tests/integration/cases/float_list/Haskell_type_name_JsonVal_float.hs
+++ b/tests/integration/cases/float_list/Haskell_type_name_JsonVal_float.hs
@@ -1,0 +1,19 @@
+module Check where
+data JsonVal = HFloat Double | HList [JsonVal]
+instance Num JsonVal where
+    fromInteger n = HFloat (fromIntegral n)
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional JsonVal where
+    fromRational r = HFloat (realToFrac r)
+    _ / _ = error "not implemented"
+my_data :: JsonVal
+my_data = HList [
+    1.1,
+    -2.2,
+    3.3
+    ]

--- a/tests/integration/cases/float_list/OCaml_type_name_json_t_float.ml
+++ b/tests/integration/cases/float_list/OCaml_type_name_json_t_float.ml
@@ -1,0 +1,12 @@
+module Check = struct
+
+type json_t =
+  | OFloat of float
+  | OList of json_t list
+let my_data : json_t = OList [
+    OFloat 1.1;
+    OFloat (-2.2);
+    OFloat 3.3
+]
+
+end

--- a/tests/integration/cases/float_list/PureScript_type_name_JsonVal_float.purs
+++ b/tests/integration/cases/float_list/PureScript_type_name_JsonVal_float.purs
@@ -1,0 +1,15 @@
+module Check where
+
+
+import Prelude
+data JsonVal
+    = PFloat Number
+    | PList (Array JsonVal)
+
+
+my_data :: JsonVal
+my_data = PList [
+    PFloat 1.1,
+    PFloat (-2.2),
+    PFloat 3.3
+    ]

--- a/tests/integration/cases/float_special_values/Elm_type_name_JsonVal_v.elm
+++ b/tests/integration/cases/float_special_values/Elm_type_name_JsonVal_v.elm
@@ -1,0 +1,14 @@
+module Check exposing (..)
+
+
+type JsonVal
+    = EFloat Float
+    | EList (List JsonVal)
+
+
+my_data : JsonVal
+my_data = EList [
+    EFloat (1 / 0),
+    EFloat (-(1 / 0)),
+    EFloat (0 / 0)
+    ]

--- a/tests/integration/cases/float_special_values/FSharp_type_name_JsonVal_v.fs
+++ b/tests/integration/cases/float_special_values/FSharp_type_name_JsonVal_v.fs
@@ -1,0 +1,10 @@
+module Check
+
+type JsonVal =
+    | FFloat of float
+    | FList of JsonVal list
+let my_data: JsonVal = FList [
+    FFloat infinity;
+    FFloat(-infinity);
+    FFloat nan
+]

--- a/tests/integration/cases/float_special_values/Gleam_type_name_JsonVal_v.gleam
+++ b/tests/integration/cases/float_special_values/Gleam_type_name_JsonVal_v.gleam
@@ -1,0 +1,13 @@
+pub type JsonVal {
+  GFloat(Float)
+  GList(List(JsonVal))
+}
+
+pub fn main() {
+  let my_data = GList([
+    GFloat(todo),
+    GFloat(todo),
+    GFloat(todo),
+  ])
+  let _ = my_data
+}

--- a/tests/integration/cases/float_special_values/Haskell_type_name_JsonVal_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_type_name_JsonVal_v.hs
@@ -1,0 +1,19 @@
+module Check where
+data JsonVal = HFloat Double | HList [JsonVal]
+instance Num JsonVal where
+    fromInteger n = HFloat (fromIntegral n)
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional JsonVal where
+    fromRational r = HFloat (realToFrac r)
+    _ / _ = error "not implemented"
+my_data :: JsonVal
+my_data = HList [
+    (1/0),
+    (-1/0),
+    (0/0)
+    ]

--- a/tests/integration/cases/float_special_values/OCaml_type_name_json_t_v.ml
+++ b/tests/integration/cases/float_special_values/OCaml_type_name_json_t_v.ml
@@ -1,0 +1,12 @@
+module Check = struct
+
+type json_t =
+  | OFloat of float
+  | OList of json_t list
+let my_data : json_t = OList [
+    OFloat infinity;
+    OFloat neg_infinity;
+    OFloat nan
+]
+
+end

--- a/tests/integration/cases/float_special_values/PureScript_type_name_JsonVal_v.purs
+++ b/tests/integration/cases/float_special_values/PureScript_type_name_JsonVal_v.purs
@@ -1,0 +1,15 @@
+module Check where
+
+
+import Prelude
+data JsonVal
+    = PFloat Number
+    | PList (Array JsonVal)
+
+
+my_data :: JsonVal
+my_data = PList [
+    PFloat (1.0 / 0.0),
+    PFloat (-(1.0 / 0.0)),
+    PFloat (0.0 / 0.0)
+    ]

--- a/tests/integration/cases/scalar_date/Elm_type_name_JsonVal_date.elm
+++ b/tests/integration/cases/scalar_date/Elm_type_name_JsonVal_date.elm
@@ -1,0 +1,9 @@
+module Check exposing (..)
+
+
+type JsonVal
+    = EStr String
+
+
+my_data : JsonVal
+my_data = EStr "2024-01-15"

--- a/tests/integration/cases/scalar_date/FSharp_type_name_JsonVal_date.fs
+++ b/tests/integration/cases/scalar_date/FSharp_type_name_JsonVal_date.fs
@@ -1,0 +1,6 @@
+module Check
+
+type JsonVal =
+    | FStr of string
+    | FDate of System.DateTime
+let my_data: JsonVal = FStr (string (System.DateOnly(2024, 1, 15)))

--- a/tests/integration/cases/scalar_date/Gleam_type_name_JsonVal_date.gleam
+++ b/tests/integration/cases/scalar_date/Gleam_type_name_JsonVal_date.gleam
@@ -1,0 +1,8 @@
+pub type JsonVal {
+  GStr(String)
+}
+
+pub fn main() {
+  let my_data = GStr("2024-01-15")
+  let _ = my_data
+}

--- a/tests/integration/cases/scalar_date/Haskell_type_name_JsonVal_date.hs
+++ b/tests/integration/cases/scalar_date/Haskell_type_name_JsonVal_date.hs
@@ -1,0 +1,5 @@
+module Check where
+import Data.Time (Day, fromGregorian)
+data JsonVal = HDate Day
+my_data :: JsonVal
+my_data = HDate (fromGregorian 2024 1 15)

--- a/tests/integration/cases/scalar_date/OCaml_type_name_json_t_date.ml
+++ b/tests/integration/cases/scalar_date/OCaml_type_name_json_t_date.ml
@@ -1,0 +1,7 @@
+module Check = struct
+
+type json_t =
+  | ODate of (int * int * int)
+let my_data : json_t = ODate (2024, 1, 15)
+
+end

--- a/tests/integration/cases/scalar_date/PureScript_type_name_JsonVal_date.purs
+++ b/tests/integration/cases/scalar_date/PureScript_type_name_JsonVal_date.purs
@@ -1,0 +1,9 @@
+module Check where
+
+
+data JsonVal
+    = PStr String
+
+
+my_data :: JsonVal
+my_data = PStr "2024-01-15"

--- a/tests/integration/cases/scalar_datetime/Elm_type_name_JsonVal_datetime.elm
+++ b/tests/integration/cases/scalar_datetime/Elm_type_name_JsonVal_datetime.elm
@@ -1,0 +1,9 @@
+module Check exposing (..)
+
+
+type JsonVal
+    = EStr String
+
+
+my_data : JsonVal
+my_data = EStr "2024-01-15T12:30:00+00:00"

--- a/tests/integration/cases/scalar_datetime/FSharp_type_name_JsonVal_datetime.fs
+++ b/tests/integration/cases/scalar_datetime/FSharp_type_name_JsonVal_datetime.fs
@@ -1,0 +1,6 @@
+module Check
+
+type JsonVal =
+    | FStr of string
+    | FDatetime of System.DateTime
+let my_data: JsonVal = FStr (string (System.DateTime(2024, 1, 15, 12, 30, 0)))

--- a/tests/integration/cases/scalar_datetime/Gleam_type_name_JsonVal_datetime.gleam
+++ b/tests/integration/cases/scalar_datetime/Gleam_type_name_JsonVal_datetime.gleam
@@ -1,0 +1,8 @@
+pub type JsonVal {
+  GStr(String)
+}
+
+pub fn main() {
+  let my_data = GStr("2024-01-15T12:30:00+00:00")
+  let _ = my_data
+}

--- a/tests/integration/cases/scalar_datetime/Haskell_type_name_JsonVal_datetime.hs
+++ b/tests/integration/cases/scalar_datetime/Haskell_type_name_JsonVal_datetime.hs
@@ -1,0 +1,5 @@
+module Check where
+import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
+data JsonVal = HDatetime UTCTime
+my_data :: JsonVal
+my_data = HDatetime (UTCTime (fromGregorian 2024 1 15) (secondsToDiffTime 45000))

--- a/tests/integration/cases/scalar_datetime/OCaml_type_name_json_t_datetime.ml
+++ b/tests/integration/cases/scalar_datetime/OCaml_type_name_json_t_datetime.ml
@@ -1,0 +1,7 @@
+module Check = struct
+
+type json_t =
+  | ODatetime of ((int * int * int) * (int * int * int))
+let my_data : json_t = ODatetime ((2024, 1, 15), (12, 30, 0))
+
+end

--- a/tests/integration/cases/scalar_datetime/PureScript_type_name_JsonVal_datetime.purs
+++ b/tests/integration/cases/scalar_datetime/PureScript_type_name_JsonVal_datetime.purs
@@ -1,0 +1,9 @@
+module Check where
+
+
+data JsonVal
+    = PStr String
+
+
+my_data :: JsonVal
+my_data = PStr "2024-01-15T12:30:00+00:00"

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -1270,7 +1270,14 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     ),
     "line_ending_decl": (_ci(case_dir_name="simple_sequence"),),
     "sequence_decl": (_ci(case_dir_name="int_list"),),
-    "type_name": (_ci(case_dir_name="simple_dict"),),
+    "type_name": (
+        _ci(case_dir_name="simple_dict"),
+        _ci(case_dir_name="float_special_values", suffix="_v"),
+        _ci(case_dir_name="float_list", suffix="_float"),
+        _ci(case_dir_name="binary", suffix="_binary"),
+        _ci(case_dir_name="scalar_date", suffix="_date"),
+        _ci(case_dir_name="scalar_datetime", suffix="_datetime"),
+    ),
     "constructor_prefix": (
         _ci(case_dir_name="simple_dict"),
         _ci(case_dir_name="float_special_values", suffix="_v"),


### PR DESCRIPTION
## Summary
- Extends the `type_name` axis in `tests/integration/variant_cases.py` to run against the same six inputs as `constructor_prefix` (simple_dict, float_special_values, float_list, binary, scalar_date, scalar_datetime), since the named ADT generated by `type_name` is referenced from those same outputs.
- Adds 30 new golden files across Elm, FSharp, Gleam, Haskell, OCaml, and PureScript for the new variant×input combinations.

Closes #1689.

## Test plan
- [x] `uv run pytest tests/integration/test_orphan_golden_files.py tests/integration/test_literalize_golden.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test case selection and new golden outputs, with no production code or runtime behavior modified.
> 
> **Overview**
> Extends the integration test matrix by expanding the `type_name` axis in `tests/integration/variant_cases.py` from a single `simple_dict` input to also cover `float_special_values`, `float_list`, `binary`, `scalar_date`, and `scalar_datetime`.
> 
> Adds new golden files for Elm, FSharp, Gleam, Haskell, OCaml, and PureScript to validate `type_name` output across those additional inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab3b23451341dd4ebb1678adb70dc789827dc90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->