### PR TITLE
Remove cast from FloatSpecialsMixin.__call__

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import math
 from collections.abc import Callable, Sequence
-from typing import Protocol, assert_never, cast, runtime_checkable
+from typing import Protocol, assert_never, runtime_checkable
 
 import humps
 from beartype import beartype
@@ -283,6 +283,7 @@ class FloatSpecialsMixin:
     _positive_infinity: str
     _negative_infinity: str
     _nan: str
+    _formatter: Callable[[float], str]
 
     def __init_subclass__(
         cls,
@@ -297,6 +298,10 @@ class FloatSpecialsMixin:
         cls._negative_infinity = negative_infinity
         cls._nan = nan
 
+    def __init__(self, formatter: Callable[[float], str], /) -> None:
+        """Capture the per-member formatter from the enum value."""
+        self._formatter = formatter
+
     def __call__(self, value: float, /) -> str:
         """Format a float, handling inf and nan."""
         if math.isinf(value):
@@ -305,8 +310,7 @@ class FloatSpecialsMixin:
             return self._positive_infinity
         if math.isnan(value):
             return self._nan
-        formatter: Callable[[float], str] = cast("enum.Enum", self).value
-        return formatter(value)
+        return self._formatter(value)
 
 
 class StubReturn(enum.Enum):


### PR DESCRIPTION
Closes #1692.

Adds `__init__` to `FloatSpecialsMixin` that captures the enum member's value (the formatter callable) into a typed `_formatter` attribute. `__call__` then uses `self._formatter` directly, removing the need for `cast("enum.Enum", self).value` and the `cast` import entirely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to special-float formatting dispatch; behavior should be unchanged aside from relying on enum member initialization semantics.
> 
> **Overview**
> Refactors `FloatSpecialsMixin` to cache each enum member’s float formatter in a typed `_formatter` attribute via a new `__init__`, and updates `__call__` to invoke that directly for finite values.
> 
> This removes the runtime `cast("enum.Enum", self).value` pattern and drops the now-unneeded `cast` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1046f2733ed849b4384931f8c5de766ede88e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->