### PR TITLE
Remove default for SetFormatConfig/DictFormatConfig.supports_trailing_comma

### DIFF
--- a/src/literalizer/_formatters/format_factories.py
+++ b/src/literalizer/_formatters/format_factories.py
@@ -139,6 +139,7 @@ def _build_set_format_config(
     preamble_lines: tuple[str, ...],
     set_opener_template: str,
     supports_heterogeneity: bool,
+    supports_trailing_comma: bool,
 ) -> SetFormatConfig:
     """Build a ``SetFormatConfig`` with the given default type."""
     open_str = open_template.format(type=default_type)
@@ -153,6 +154,7 @@ def _build_set_format_config(
         preamble_lines=preamble_lines,
         set_opener_template=set_opener_template,
         supports_heterogeneity=supports_heterogeneity,
+        supports_trailing_comma=supports_trailing_comma,
     )
 
 
@@ -165,6 +167,7 @@ def set_format_factory(
     preamble_lines: tuple[str, ...],
     set_opener_template: str,
     supports_heterogeneity: bool,
+    supports_trailing_comma: bool,
 ) -> Callable[[str], SetFormatConfig]:
     """Return a callable that builds a ``SetFormatConfig`` for a given
     type.
@@ -179,6 +182,7 @@ def set_format_factory(
             empty_template="Set<{type}>()",
             preamble_lines=(),
             set_opener_template="",
+            supports_trailing_comma=True,
         )
         config = factory("Any")
     """
@@ -193,6 +197,7 @@ def set_format_factory(
             preamble_lines=preamble_lines,
             set_opener_template=set_opener_template,
             supports_heterogeneity=supports_heterogeneity,
+            supports_trailing_comma=supports_trailing_comma,
         )
 
     return _build
@@ -209,6 +214,7 @@ def _build_dict_format_config(
     empty_template: str | None,
     preamble_lines: tuple[str, ...],
     narrowed_open: str | None,
+    supports_trailing_comma: bool,
 ) -> DictFormatConfig:
     """Build a ``DictFormatConfig`` with the given default type."""
     fmt_kwargs = {"type": default_type, "key_type": default_key_type}
@@ -225,6 +231,7 @@ def _build_dict_format_config(
         ),
         preamble_lines=preamble_lines,
         narrowed_open=narrowed_open,
+        supports_trailing_comma=supports_trailing_comma,
     )
 
 
@@ -237,6 +244,7 @@ def dict_format_factory(
     empty_template: str | None,
     preamble_lines: tuple[str, ...],
     narrowed_open: str | None,
+    supports_trailing_comma: bool,
 ) -> _DictFormatBuilder:
     """Return a callable that builds a ``DictFormatConfig`` for a given
     type.
@@ -261,6 +269,7 @@ def dict_format_factory(
             empty_template=empty_template,
             preamble_lines=preamble_lines,
             narrowed_open=narrowed_open,
+            supports_trailing_comma=supports_trailing_comma,
         )
 
     return _build

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -96,7 +96,7 @@ class SetFormatConfig:
     preamble_lines: tuple[str, ...]
     set_opener_template: str
     supports_heterogeneity: bool
-    supports_trailing_comma: bool = True
+    supports_trailing_comma: bool
 
     def with_typed_opener(
         self,
@@ -136,7 +136,7 @@ class DictFormatConfig:
     empty_dict: str | None
     preamble_lines: tuple[str, ...]
     narrowed_open: str | None
-    supports_trailing_comma: bool = True
+    supports_trailing_comma: bool
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -195,6 +195,7 @@ class Ada(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -517,6 +518,7 @@ class Ada(metaclass=LanguageCls):
             empty_dict="AMap'(1 .. 0 => ANull)",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -210,6 +210,7 @@ class Bash(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -531,6 +532,7 @@ class Bash(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -268,6 +268,7 @@ class C(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -631,6 +632,7 @@ class C(metaclass=LanguageCls):
             preamble_lines=self.set_format.value.preamble_lines,
             set_opener_template=self.set_format.value.set_opener_template,
             supports_heterogeneity=self.set_format.value.supports_heterogeneity,
+            supports_trailing_comma=True,
         )
 
     @cached_property
@@ -650,6 +652,7 @@ class C(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -164,6 +164,7 @@ class Clojure(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -470,6 +471,7 @@ class Clojure(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -340,6 +340,7 @@ class Cobol(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -664,6 +665,7 @@ class Cobol(metaclass=LanguageCls):
             empty_dict=_COBOL_EMPTY_LITERAL,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -182,6 +182,7 @@ class CommonLisp(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -498,6 +499,7 @@ class CommonLisp(metaclass=LanguageCls):
             empty_dict="nil",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -952,6 +952,7 @@ class Cpp(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
         def get_config(
@@ -1003,6 +1004,7 @@ class Cpp(metaclass=LanguageCls):
                 empty_dict=None,
                 preamble_lines=("#include <map>",),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             ),
             opener_template="std::map<std::string, {type_name}>{{",
         )
@@ -1016,6 +1018,7 @@ class Cpp(metaclass=LanguageCls):
                 empty_dict=None,
                 preamble_lines=("#include <unordered_map>",),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             ),
             opener_template=("std::unordered_map<std::string, {type_name}>{{"),
         )

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -241,6 +241,7 @@ class Crystal(metaclass=LanguageCls):
                 preamble_lines=('require "set"',),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -285,6 +286,7 @@ class Crystal(metaclass=LanguageCls):
                 empty_template="{{}} of {key_type} => {type}",
                 preamble_lines=(),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             )
         )
 

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -463,6 +463,7 @@ class CSharp(metaclass=LanguageCls):
                 preamble_lines=("using System.Collections.Generic;",),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
         SORTED_SET = enum.member(
@@ -473,6 +474,7 @@ class CSharp(metaclass=LanguageCls):
                 preamble_lines=("using System.Collections.Generic;",),
                 set_opener_template="new SortedSet<{type_name}> {{",
                 supports_heterogeneity=False,
+                supports_trailing_comma=True,
             )
         )
 
@@ -989,6 +991,7 @@ class CSharp(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=("using System.Collections.Generic;",),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -220,6 +220,7 @@ class D(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -562,6 +563,7 @@ class D(metaclass=LanguageCls):
             empty_dict='parseJSON("{}")',
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -333,6 +333,7 @@ class Dart(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -795,6 +796,7 @@ class Dart(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -416,6 +416,7 @@ class Dhall(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -763,6 +764,7 @@ class Dhall(metaclass=LanguageCls):
             empty_dict="{=}",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -209,6 +209,7 @@ class Elixir(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -541,6 +542,7 @@ class Elixir(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -472,6 +472,7 @@ class Elm(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -800,6 +801,7 @@ class Elm(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -269,6 +269,7 @@ class Erlang(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -603,6 +604,7 @@ class Erlang(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -257,6 +257,7 @@ class Forth(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -559,6 +560,7 @@ class Forth(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -304,6 +304,7 @@ class Fortran(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -664,6 +665,7 @@ class Fortran(metaclass=LanguageCls):
             preamble_lines=self.set_format.value.preamble_lines,
             set_opener_template=self.set_format.value.set_opener_template,
             supports_heterogeneity=self.set_format.value.supports_heterogeneity,
+            supports_trailing_comma=True,
         )
 
     @cached_property
@@ -686,6 +688,7 @@ class Fortran(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -340,6 +340,7 @@ class FSharp(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -690,6 +691,7 @@ class FSharp(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -582,6 +582,7 @@ class Gleam(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -982,6 +983,7 @@ class Gleam(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -326,6 +326,7 @@ class Go(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -726,6 +727,7 @@ class Go(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open="{",
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -198,6 +198,7 @@ class Groovy(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -512,6 +513,7 @@ class Groovy(metaclass=LanguageCls):
             empty_dict="[:]",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1015,6 +1015,7 @@ class Haskell(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -1358,6 +1359,7 @@ class Haskell(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -199,6 +199,7 @@ class Hcl(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -523,6 +524,7 @@ class Hcl(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -193,6 +193,7 @@ class JavaScript(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -268,6 +269,7 @@ class JavaScript(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
         MAP = DictFormatConfig(
             dict_open=fixed_open(open_str="new Map(["),
@@ -279,6 +281,7 @@ class JavaScript(metaclass=LanguageCls):
             empty_dict="new Map()",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     class EmptyDictKey(enum.Enum):

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -173,6 +173,7 @@ class Json5(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -460,6 +461,7 @@ class Json5(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -191,6 +191,7 @@ class Jsonnet(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -491,6 +492,7 @@ class Jsonnet(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -240,6 +240,7 @@ class Julia(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -282,6 +283,7 @@ class Julia(metaclass=LanguageCls):
             empty_dict="Dict()",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
         ORDERED = DictFormatConfig(
             dict_open=fixed_open(open_str="OrderedDict("),
@@ -293,6 +295,7 @@ class Julia(metaclass=LanguageCls):
             empty_dict="OrderedDict()",
             preamble_lines=("using DataStructures",),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     class EmptyDictKey(enum.Enum):

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -550,6 +550,7 @@ class Kotlin(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
         SORTED_SET = enum.member(
@@ -560,6 +561,7 @@ class Kotlin(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template="sortedSetOf<{type_name}>(",
                 supports_heterogeneity=False,
+                supports_trailing_comma=True,
             )
         )
 
@@ -1005,6 +1007,7 @@ class Kotlin(metaclass=LanguageCls):
                 ),
             ),
             narrowed_open=None,
+            supports_trailing_comma=True,
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" to ",

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -200,6 +200,7 @@ class Lua(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -510,6 +511,7 @@ class Lua(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -270,6 +270,7 @@ class Matlab(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -309,10 +310,12 @@ class Matlab(metaclass=LanguageCls):
             empty_dict="struct()",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
         CONTAINERS_MAP = DictFormatConfig(
             dict_open=_containers_map_open,
             narrowed_open=None,
+            supports_trailing_comma=True,
             close="})",
             format_entry=_format_containers_map_entry,
             empty_dict="containers.Map()",

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -348,6 +348,7 @@ class Mojo(metaclass=LanguageCls):
                 preamble_lines=("from std.collections import Set",),
                 set_opener_template="Set[{type_name}](",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -392,6 +393,7 @@ class Mojo(metaclass=LanguageCls):
                 empty_template="Dict[{key_type}, {type}]()",
                 preamble_lines=(),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             )
         )
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -526,6 +526,7 @@ class Nim(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -1022,6 +1023,7 @@ class Nim(metaclass=LanguageCls):
                 empty_dict=None,
                 preamble_lines=("import tables",),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             )
         return DictFormatConfig(
             dict_open=fixed_open(open_str="{"),
@@ -1033,6 +1035,7 @@ class Nim(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -241,6 +241,7 @@ class Nix(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -542,6 +543,7 @@ class Nix(metaclass=LanguageCls):
             empty_dict="{ }",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -147,6 +147,7 @@ class Norg(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -455,6 +456,7 @@ class Norg(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -336,6 +336,7 @@ class ObjectiveC(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -670,6 +671,7 @@ class ObjectiveC(metaclass=LanguageCls):
             empty_dict="@{}",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -289,6 +289,7 @@ class OCaml(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -642,6 +643,7 @@ class OCaml(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -161,6 +161,7 @@ class Occam(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -492,6 +493,7 @@ class Occam(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -199,6 +199,7 @@ class Odin(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template="",
                 supports_heterogeneity=False,
+                supports_trailing_comma=True,
             )
         )
 
@@ -569,6 +570,7 @@ class Odin(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -219,6 +219,7 @@ class Perl(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -548,6 +549,7 @@ class Perl(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -216,6 +216,7 @@ class Php(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -568,6 +569,7 @@ class Php(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -164,6 +164,7 @@ class PowerShell(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -477,6 +478,7 @@ class PowerShell(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -564,6 +564,7 @@ class PureScript(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -902,6 +903,7 @@ class PureScript(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -630,6 +630,7 @@ class Python(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
         FROZENSET = SetFormatConfig(
             set_open=fixed_open(open_str="frozenset({"),
@@ -638,6 +639,7 @@ class Python(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
         @property
@@ -1055,6 +1057,7 @@ class Python(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -253,6 +253,7 @@ class R(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -558,6 +559,7 @@ class R(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -165,6 +165,7 @@ class Racket(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -481,6 +482,7 @@ class Racket(metaclass=LanguageCls):
             empty_dict="(hash)",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -196,6 +196,7 @@ class Raku(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -532,6 +533,7 @@ class Raku(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -224,6 +224,7 @@ class Ruby(metaclass=LanguageCls):
             preamble_lines=("require 'set'",),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -567,6 +568,7 @@ class Ruby(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -808,6 +808,7 @@ class Rust(metaclass=LanguageCls):
                 preamble_lines=("use std::collections::HashSet;",),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
         BTREE_SET = enum.member(
@@ -818,6 +819,7 @@ class Rust(metaclass=LanguageCls):
                 preamble_lines=("use std::collections::BTreeSet;",),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -994,6 +996,7 @@ class Rust(metaclass=LanguageCls):
                 empty_template="HashMap::<{key_type}, {type}>::from([])",
                 preamble_lines=("use std::collections::HashMap;",),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             )
         )
         BTREE_MAP = enum.member(
@@ -1006,6 +1009,7 @@ class Rust(metaclass=LanguageCls):
                 empty_template="BTreeMap::<{key_type}, {type}>::from([])",
                 preamble_lines=("use std::collections::BTreeMap;",),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             )
         )
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -328,6 +328,7 @@ class Scala(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
         TREE_SET = SetFormatConfig(
             set_open=fixed_open(open_str="TreeSet("),
@@ -336,6 +337,7 @@ class Scala(metaclass=LanguageCls):
             preamble_lines=("import scala.collection.immutable.TreeSet",),
             set_opener_template="TreeSet[{type_name}](",
             supports_heterogeneity=False,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -723,6 +725,7 @@ class Scala(metaclass=LanguageCls):
                 fallback=dict_spec.fallback,
             ),
             narrowed_open=None,
+            supports_trailing_comma=True,
             close=")",
             format_entry=dict_entry_with_separator(
                 separator=" -> ",

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -138,6 +138,7 @@ class Scheme(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -445,6 +446,7 @@ class Scheme(metaclass=LanguageCls):
             empty_dict="(list)",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -342,6 +342,7 @@ class Sml(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -691,6 +692,7 @@ class Sml(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -409,6 +409,7 @@ class Swift(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template="",
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -463,6 +464,7 @@ class Swift(metaclass=LanguageCls):
                 empty_template="[{key_type}: {type}]()",
                 preamble_lines=(),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             )
         )
 

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -217,6 +217,7 @@ class SystemVerilog(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -555,6 +556,7 @@ class SystemVerilog(metaclass=LanguageCls):
             empty_dict="'{}",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -192,6 +192,7 @@ class Tcl(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -490,6 +491,7 @@ class Tcl(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -179,6 +179,7 @@ class Toml(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -477,6 +478,7 @@ class Toml(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -326,6 +326,7 @@ class TypeScript(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -407,6 +408,7 @@ class TypeScript(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
         MAP = DictFormatConfig(
             dict_open=fixed_open(open_str="new Map<string, unknown>(["),
@@ -418,6 +420,7 @@ class TypeScript(metaclass=LanguageCls):
             empty_dict="new Map()",
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     class EmptyDictKey(enum.Enum):

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -165,6 +165,7 @@ class V(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -510,6 +511,7 @@ class V(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -310,6 +310,7 @@ class VisualBasic(metaclass=LanguageCls):
                 preamble_lines=(),
                 set_opener_template=("New HashSet(Of {type_name}) From {{"),
                 supports_heterogeneity=True,
+                supports_trailing_comma=True,
             )
         )
 
@@ -353,6 +354,7 @@ class VisualBasic(metaclass=LanguageCls):
                 empty_template=None,
                 preamble_lines=("Imports System.Collections.Generic",),
                 narrowed_open=None,
+                supports_trailing_comma=True,
             )
         )
 

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -149,6 +149,7 @@ class Wren(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -464,6 +465,7 @@ class Wren(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -155,6 +155,7 @@ class Yaml(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -451,6 +452,7 @@ class Yaml(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -294,6 +294,7 @@ class Zig(metaclass=LanguageCls):
             preamble_lines=(),
             set_opener_template="",
             supports_heterogeneity=True,
+            supports_trailing_comma=True,
         )
 
     class CommentFormats(enum.Enum):
@@ -665,6 +666,7 @@ class Zig(metaclass=LanguageCls):
             empty_dict=None,
             preamble_lines=(),
             narrowed_open=None,
+            supports_trailing_comma=True,
         )
 
     @cached_property


### PR DESCRIPTION
## Summary

- Removes the `= True` default from `supports_trailing_comma` on `SetFormatConfig` and `DictFormatConfig`, making it a required field so all callers must declare their trailing-comma support explicitly
- Adds `supports_trailing_comma` to `set_format_factory` and `dict_format_factory` in `format_factories.py` and threads it through to the config constructors
- Updates all 62 language files to pass `supports_trailing_comma=True`, preserving existing behaviour

## Test plan

- All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public config/factory call signatures and touches many language spec files; behavior should be unchanged but any missed call site would now fail at runtime/type-check time.
> 
> **Overview**
> **Makes trailing-comma support explicit for set/dict formats.** `SetFormatConfig.supports_trailing_comma` and `DictFormatConfig.supports_trailing_comma` are now required fields (no default), forcing callers to declare support explicitly.
> 
> Threads a new `supports_trailing_comma` parameter through `set_format_factory` and `dict_format_factory`, and updates all affected language specs to pass `supports_trailing_comma=True` to preserve existing output behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10aa1ce5f102ce3bc46a7163179a443dd9bfb55b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->