### PR TITLE
Split lint-clang-tidy into separate C and C++ jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -613,8 +613,10 @@ jobs:
 
   # Ubuntu's packaged clang-tidy is several releases behind and is the
   # dominant cost of this job on runners. Pull a recent build from PyPI
-  # via uv instead. Shared across C and C++ since it's the same tool.
-  lint-clang-tidy:
+  # via uv instead.
+  # Pass compile flags after `--` so clang-tidy treats them as the full
+  # compile command and skips searching for a compile_commands.json.
+  lint-c-tidy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -627,12 +629,24 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
         run: uv tool install clang-tidy
-      # Pass compile flags after `--` so clang-tidy treats them as the full
-      # compile command and skips searching for a compile_commands.json.
       - name: Run clang-tidy on C files
         run: |-
           find tests/integration/cases -name '*.c' -print0 > /tmp/files-c-tidy
           xargs -0 -P "$(nproc)" -n1 -I{} clang-tidy {} -- -std=c11 < /tmp/files-c-tidy
+
+  lint-cpp-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Install clang-tidy
+        run: uv tool install clang-tidy
       - name: Run clang-tidy on C++ files
         run: |-
           find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-cpp-tidy
@@ -1394,7 +1408,8 @@ jobs:
       - lint-beam
       - lint-jvm-mini
       - lint-haskell-family
-      - lint-clang-tidy
+      - lint-c-tidy
+      - lint-cpp-tidy
       - lint-c
       - lint-cobol
       - lint-cpp


### PR DESCRIPTION
Splits the single `lint-clang-tidy` job into two independent jobs: `lint-c-tidy` (runs clang-tidy on `.c` files with `-std=c11`) and `lint-cpp-tidy` (runs clang-tidy on `.cpp` files with `-std=c++20`). The `completion-lint` job's `needs` list is updated to reference both new jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it can affect PR gating if either new job is misconfigured or times out independently.
> 
> **Overview**
> Splits the previous combined `clang-tidy` linting into two independent GitHub Actions jobs: `lint-c-tidy` for `.c` fixtures (using `-std=c11`) and `lint-cpp-tidy` for `.cpp` fixtures (using `-std=c++20`).
> 
> Updates the `completion-lint` aggregator to depend on both new jobs so overall lint status reflects both C and C++ tidy runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a123c9323c6c988cbb13f32054b9502e5cfd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->