### PR TITLE
Add literalize_call support to Odin

### DIFF
--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -43,7 +43,6 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -54,6 +53,7 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -120,6 +120,39 @@ def _nil_safe_declaration(
         )
 
     return _format
+
+
+@beartype
+def _odin_call_preamble_stub(
+    name: str,
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return file-scope Odin stub declarations for a call name."""
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"{parts[0]} :: proc(args: ..any) -> any {{ return nil }}",)
+    root = parts[0]
+    method = parts[-1]
+    chain = parts[:-1]
+    holder = chain[-1]
+    holder_type = f"{holder.title()}Type_"
+    lines: list[str] = [
+        f"{holder_type} :: struct {{ {method}: proc(..any) -> any }}",
+    ]
+    prev_type = holder_type
+    for i in range(len(chain) - 2, 0, -1):
+        curr = chain[i]
+        child = chain[i + 1]
+        curr_type = f"{curr.title()}Type_"
+        lines.append(f"{curr_type} :: struct {{ {child}: {prev_type} }}")
+        prev_type = curr_type
+    root_type = f"{root.title()}Type_"
+    if len(chain) > 1:
+        lines.append(f"{root_type} :: struct {{ {chain[1]}: {prev_type} }}")
+    lines.append(f"{root}: {root_type}")
+    return tuple(lines)
 
 
 @beartype
@@ -356,6 +389,8 @@ class Odin(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Odin call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -391,7 +426,8 @@ class Odin(metaclass=LanguageCls):
             content=content,
             body_preamble=body_preamble,
         )
-        return f"\nmain :: proc() {{\n{content}\n_ = {variable_name}\n}}"
+        use_line = f"\n_ = {variable_name}" if variable_name else ""
+        return f"\nmain :: proc() {{\n{content}{use_line}\n}}"
 
     @staticmethod
     def wrap_combined_in_file(
@@ -448,9 +484,12 @@ class Odin(metaclass=LanguageCls):
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ('import "core:math"',)
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+    call_style: CallStyles = CallStyles.POSITIONAL
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -501,7 +540,7 @@ class Odin(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return no_call_stub
+        return _odin_call_preamble_stub
 
     @cached_property
     def format_call_target(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -138,7 +138,9 @@ def _odin_call_preamble_stub(
     chain = parts[:-1]
     holder = chain[-1]
     holder_type = f"{holder.title()}Type_"
+    helper_name = f"_{holder}_{method}_"
     lines: list[str] = [
+        f"{helper_name} :: proc(args: ..any) -> any {{ return nil }}",
         f"{holder_type} :: struct {{ {method}: proc(..any) -> any }}",
     ]
     prev_type = holder_type
@@ -151,7 +153,12 @@ def _odin_call_preamble_stub(
     root_type = f"{root.title()}Type_"
     if len(chain) > 1:
         lines.append(f"{root_type} :: struct {{ {chain[1]}: {prev_type} }}")
-    lines.append(f"{root}: {root_type}")
+    init_expr = f"{holder_type}{{ {method} = {helper_name} }}"
+    for i in range(len(chain) - 2, -1, -1):
+        outer_type = f"{chain[i].title()}Type_"
+        inner_field = chain[i + 1]
+        init_expr = f"{outer_type}{{ {inner_field} = {init_expr} }}"
+    lines.append(f"{root}: {root_type} = {init_expr}")
     return tuple(lines)
 
 

--- a/tests/integration/cases/call_deep_dotted_method/Odin_call.odin
+++ b/tests/integration/cases/call_deep_dotted_method/Odin_call.odin
@@ -1,9 +1,10 @@
 #+feature dynamic-literals
 package main
+_client_post_ :: proc(args: ..any) -> any { return nil }
 ClientType_ :: struct { post: proc(..any) -> any }
 ApiType_ :: struct { client: ClientType_ }
 ObjType_ :: struct { api: ApiType_ }
-obj: ObjType_
+obj: ObjType_ = ObjType_{ api = ApiType_{ client = ClientType_{ post = _client_post_ } } }
 
 main :: proc() {
 obj.api.client.post("hello");

--- a/tests/integration/cases/call_deep_dotted_method/Odin_call.odin
+++ b/tests/integration/cases/call_deep_dotted_method/Odin_call.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+ClientType_ :: struct { post: proc(..any) -> any }
+ApiType_ :: struct { client: ClientType_ }
+ObjType_ :: struct { api: ApiType_ }
+obj: ObjType_
+
+main :: proc() {
+obj.api.client.post("hello");
+obj.api.client.post(42);
+obj.api.client.post(true);
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Odin_call.odin
+++ b/tests/integration/cases/call_deep_dotted_transformed/Odin_call.odin
@@ -1,8 +1,9 @@
 #+feature dynamic-literals
 package main
+_client_fetch_ :: proc(args: ..any) -> any { return nil }
 ClientType_ :: struct { fetch: proc(..any) -> any }
 AppType_ :: struct { client: ClientType_ }
-app: AppType_
+app: AppType_ = AppType_{ client = ClientType_{ fetch = _client_fetch_ } }
 emit :: proc(args: ..any) -> any { return nil }
 
 main :: proc() {

--- a/tests/integration/cases/call_deep_dotted_transformed/Odin_call.odin
+++ b/tests/integration/cases/call_deep_dotted_transformed/Odin_call.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+ClientType_ :: struct { fetch: proc(..any) -> any }
+AppType_ :: struct { client: ClientType_ }
+app: AppType_
+emit :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+emit(app.client.fetch("hello"));
+emit(app.client.fetch(42));
+emit(app.client.fetch(true));
+}

--- a/tests/integration/cases/call_dotted_method/Odin_call.odin
+++ b/tests/integration/cases/call_dotted_method/Odin_call.odin
@@ -1,0 +1,11 @@
+#+feature dynamic-literals
+package main
+ClientType_ :: struct { fetch: proc(..any) -> any }
+AppType_ :: struct { client: ClientType_ }
+app: AppType_
+
+main :: proc() {
+app.client.fetch("hello");
+app.client.fetch(42);
+app.client.fetch(true);
+}

--- a/tests/integration/cases/call_dotted_method/Odin_call.odin
+++ b/tests/integration/cases/call_dotted_method/Odin_call.odin
@@ -1,8 +1,9 @@
 #+feature dynamic-literals
 package main
+_client_fetch_ :: proc(args: ..any) -> any { return nil }
 ClientType_ :: struct { fetch: proc(..any) -> any }
 AppType_ :: struct { client: ClientType_ }
-app: AppType_
+app: AppType_ = AppType_{ client = ClientType_{ fetch = _client_fetch_ } }
 
 main :: proc() {
 app.client.fetch("hello");

--- a/tests/integration/cases/call_keyword_args/Odin_call.odin
+++ b/tests/integration/cases/call_keyword_args/Odin_call.odin
@@ -1,7 +1,8 @@
 #+feature dynamic-literals
 package main
+_throttler_check_ :: proc(args: ..any) -> any { return nil }
 ThrottlerType_ :: struct { check: proc(..any) -> any }
-throttler: ThrottlerType_
+throttler: ThrottlerType_ = ThrottlerType_{ check = _throttler_check_ }
 emit :: proc(args: ..any) -> any { return nil }
 
 main :: proc() {

--- a/tests/integration/cases/call_keyword_args/Odin_call.odin
+++ b/tests/integration/cases/call_keyword_args/Odin_call.odin
@@ -1,0 +1,10 @@
+#+feature dynamic-literals
+package main
+ThrottlerType_ :: struct { check: proc(..any) -> any }
+throttler: ThrottlerType_
+emit :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+emit(throttler.check("user_1", 1000.0));
+emit(throttler.check("user_2", 2000.5));
+}

--- a/tests/integration/cases/call_mixed_type_dicts/Odin_call.odin
+++ b/tests/integration/cases/call_mixed_type_dicts/Odin_call.odin
@@ -1,8 +1,9 @@
 #+feature dynamic-literals
 package main
+_mgr_op_ :: proc(args: ..any) -> any { return nil }
 MgrType_ :: struct { op: proc(..any) -> any }
 AppType_ :: struct { mgr: MgrType_ }
-app: AppType_
+app: AppType_ = AppType_{ mgr = MgrType_{ op = _mgr_op_ } }
 
 main :: proc() {
 app.mgr.op(map[string]any{"type" = "create", "pr_id" = "pr_1", "draft" = true});

--- a/tests/integration/cases/call_mixed_type_dicts/Odin_call.odin
+++ b/tests/integration/cases/call_mixed_type_dicts/Odin_call.odin
@@ -1,0 +1,10 @@
+#+feature dynamic-literals
+package main
+MgrType_ :: struct { op: proc(..any) -> any }
+AppType_ :: struct { mgr: MgrType_ }
+app: AppType_
+
+main :: proc() {
+app.mgr.op(map[string]any{"type" = "create", "pr_id" = "pr_1", "draft" = true});
+app.mgr.op(map[string]any{"type" = "create", "pr_id" = "pr_2"});
+}

--- a/tests/integration/cases/call_multi_args/Odin_call.odin
+++ b/tests/integration/cases/call_multi_args/Odin_call.odin
@@ -1,0 +1,8 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process(1, 42);
+process(2, 100);
+}

--- a/tests/integration/cases/call_per_element_false/Odin_call.odin
+++ b/tests/integration/cases/call_per_element_false/Odin_call.odin
@@ -1,0 +1,7 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process(1);
+}

--- a/tests/integration/cases/call_ref_args/Odin_call.odin
+++ b/tests/integration/cases/call_ref_args/Odin_call.odin
@@ -1,0 +1,18 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+my_var := [dynamic]any{
+	1,
+	2,
+	3,
+}
+my_other := [dynamic]any{
+	4,
+	5,
+	6,
+}
+process(my_var, 42);
+process(my_other, 7);
+}

--- a/tests/integration/cases/call_ref_args_converted/Odin_call.odin
+++ b/tests/integration/cases/call_ref_args_converted/Odin_call.odin
@@ -1,0 +1,18 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+my_var := [dynamic]any{
+	1,
+	2,
+	3,
+}
+my_other := [dynamic]any{
+	4,
+	5,
+	6,
+}
+process(my_var, 42);
+process(my_other, 7);
+}

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Odin_call.odin
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Odin_call.odin
@@ -1,0 +1,18 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+my_var := [dynamic]any{
+	1,
+	2,
+	3,
+}
+my_other := [dynamic]any{
+	4,
+	5,
+	6,
+}
+process(my_var, 42);
+process(my_other, 7);
+}

--- a/tests/integration/cases/call_ref_args_converted_whole/Odin_call.odin
+++ b/tests/integration/cases/call_ref_args_converted_whole/Odin_call.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+my_var := [dynamic]any{
+	1,
+	2,
+	3,
+}
+process(my_var);
+}

--- a/tests/integration/cases/call_scalar_args/Odin_call.odin
+++ b/tests/integration/cases/call_scalar_args/Odin_call.odin
@@ -1,0 +1,9 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process("hello");
+process(42);
+process(true);
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Odin_call.odin
+++ b/tests/integration/cases/call_transform_no_wrapper/Odin_call.odin
@@ -1,0 +1,9 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process("hello");
+process(42);
+process(true);
+}

--- a/tests/integration/cases/call_wrap_in_file/Odin_call.odin
+++ b/tests/integration/cases/call_wrap_in_file/Odin_call.odin
@@ -1,0 +1,8 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process(1, 2);
+process(3, 4);
+}


### PR DESCRIPTION
## Summary

- Implements `literalize_call` for the Odin language module with positional call style
- Adds `_odin_call_preamble_stub` which emits file-scope procedure declarations for simple targets and nested struct types with proc fields for dotted targets (e.g. `app.client.fetch(...)`)
- Fixes `wrap_in_file` to omit the `_ = ` assignment when no variable name is present (the call-rendering path)
- Adds 14 golden test files covering all call case configurations

Closes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new call-literalization/codegen behavior for Odin, including generated file-scope stubs for dotted targets; regressions would surface as invalid emitted Odin code or broken integration expectations.
> 
> **Overview**
> Adds Odin support for `literalize_call` using a **positional** call style and introduces `_odin_call_preamble_stub` to emit file-scope proc/struct stubs (including nested structs) so dotted call targets like `app.client.fetch(...)` are representable.
> 
> Adjusts `wrap_in_file` to omit the `_ = {variable_name}` usage line when no variable name is provided (call-only output path). Adds new Odin golden integration outputs covering simple calls, multi-arg/ref args, keyword args, and deep dotted method/transformed-call scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e956d3ba69a221578e21527591abe74d7b559b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->