### PR TITLE
Support Haskell in ref-declaration call golden cases

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1226,6 +1226,27 @@ class Language(Protocol):
         """Wrap a declaration and assignment in a complete, valid file."""
         ...  # pylint: disable=unnecessary-ellipsis
 
+    def wrap_calls_with_declarations(
+        self,
+        declarations: tuple[str, ...],
+        calls: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap a sequence of top-level *declarations* (each one a
+        full ``literalize`` ``bare_code`` for a ``$ref`` target)
+        alongside a block of bare call expressions in a complete,
+        valid file.
+
+        Most languages can splice the declarations directly in front
+        of the calls and route through :meth:`wrap_in_file` in call
+        mode; they assign :data:`default_wrap_calls_with_declarations`
+        as a no-op wrapper.  Languages whose call-mode wrapping moves
+        bare expressions into a different scope than top-level
+        bindings (e.g. Haskell's ``main = do`` block, where bindings
+        belong at module scope) override this method.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid code for *data*.
 
@@ -1316,6 +1337,33 @@ no_validate_spec_for_data: Callable[["Language", Value], None] = (
 )
 """Shared callable for languages with no spec/data constraints to
 check.
+"""
+
+
+def _default_wrap_calls_with_declarations(
+    self: "Language",
+    declarations: tuple[str, ...],
+    calls: str,
+    body_preamble: tuple[str, ...],
+) -> str:
+    """Default ``wrap_calls_with_declarations`` — concatenate the
+    *declarations* and *calls* and route through :meth:`wrap_in_file`
+    in call mode.
+    """
+    content = "\n".join((*declarations, calls)) if declarations else calls
+    return self.wrap_in_file(
+        content=content,
+        variable_name="",
+        body_preamble=body_preamble,
+    )
+
+
+default_wrap_calls_with_declarations: Callable[
+    ["Language", tuple[str, ...], str, tuple[str, ...]], str
+] = _default_wrap_calls_with_declarations
+"""Shared callable for languages whose call-mode :meth:`wrap_in_file`
+already accepts the declarations spliced in front of the call
+expressions.
 """
 
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -81,6 +81,16 @@ class LiteralizeResult:
     :attr:`declaration_code`.
     """
 
+    types_present: frozenset[type] = frozenset()
+    """The set of Python types observed in the source data (e.g.
+    ``int``, ``str``, ``list``, ``dict``).  Callers that combine
+    multiple ``literalize`` results (for example, a test harness that
+    pairs ``$ref`` declarations with a downstream call) can union
+    these and re-invoke :attr:`Language.compute_body_preamble` to
+    derive a single body preamble that covers every type referenced
+    across the combined output.
+    """
+
     @property
     def code(self) -> str:
         """The formatted literal text.
@@ -1378,6 +1388,7 @@ def _literalize_apply_form(
             declaration_code=wrapped,
             preamble=(),
             body_preamble=(),
+            types_present=computed.types_present,
         )
 
     return LiteralizeResult(
@@ -1385,6 +1396,7 @@ def _literalize_apply_form(
         preamble=preamble,
         body_preamble=computed.body,
         pre_declaration_comments=pre_decl,
+        types_present=computed.types_present,
     )
 
 
@@ -1437,6 +1449,7 @@ def _literalize_both_forms(
         declaration_code=wrapped,
         preamble=(),
         body_preamble=(),
+        types_present=declaration.types_present,
     )
 
 
@@ -2162,10 +2175,12 @@ def literalize_call(
             declaration_code=wrapped,
             preamble=(),
             body_preamble=(),
+            types_present=computed.types_present,
         )
 
     return LiteralizeResult(
         declaration_code=result,
         preamble=preamble,
         body_preamble=computed.body,
+        types_present=computed.types_present,
     )

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -91,6 +91,16 @@ class LiteralizeResult:
     across the combined output.
     """
 
+    source_data: Value = None
+    """The parsed source value the literal was rendered from.  Most
+    callers do not need it.  Callers that combine multiple
+    ``literalize`` results and re-invoke
+    :attr:`Language.compute_body_preamble` to derive a single body
+    preamble surface this so the recomputation can inspect actual
+    values (e.g. datetime microsecond precision) rather than passing
+    a placeholder.
+    """
+
     @property
     def code(self) -> str:
         """The formatted literal text.
@@ -1389,6 +1399,7 @@ def _literalize_apply_form(
             preamble=(),
             body_preamble=(),
             types_present=computed.types_present,
+            source_data=pre_form.data,
         )
 
     return LiteralizeResult(
@@ -1397,6 +1408,7 @@ def _literalize_apply_form(
         body_preamble=computed.body,
         pre_declaration_comments=pre_decl,
         types_present=computed.types_present,
+        source_data=pre_form.data,
     )
 
 
@@ -1450,6 +1462,7 @@ def _literalize_both_forms(
         preamble=(),
         body_preamble=(),
         types_present=declaration.types_present,
+        source_data=declaration.source_data,
     )
 
 
@@ -2176,6 +2189,7 @@ def literalize_call(
             preamble=(),
             body_preamble=(),
             types_present=computed.types_present,
+            source_data=data_for_preamble,
         )
 
     return LiteralizeResult(
@@ -2183,4 +2197,5 @@ def literalize_call(
         preamble=preamble,
         body_preamble=computed.body,
         types_present=computed.types_present,
+        source_data=data_for_preamble,
     )

--- a/src/literalizer/_preamble.py
+++ b/src/literalizer/_preamble.py
@@ -144,6 +144,7 @@ class _PreambleResult:
 
     header: tuple[str, ...]
     body: tuple[str, ...]
+    types_present: frozenset[type]
 
 
 @beartype
@@ -187,4 +188,5 @@ def compute_preamble(
         )
         + tuple(language.static_body_preamble),
         body=body,
+        types_present=types,
     )

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -329,6 +330,7 @@ class Ada(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -351,6 +352,7 @@ class Bash(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def validate_call_arg(value: Value) -> None:

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -420,6 +421,7 @@ class C(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -304,6 +305,7 @@ class Clojure(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -473,6 +474,7 @@ class Cobol(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     _PROGRAM_PREFIX: ClassVar[str] = (
         "IDENTIFICATION DIVISION.\n"

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -330,6 +331,7 @@ class CommonLisp(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -1178,6 +1179,7 @@ class Cpp(metaclass=LanguageCls):
         ),
     )
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     class VariableTypeHints(enum.Enum):
         """Variable type hint options."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -425,6 +426,7 @@ class Crystal(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -76,6 +76,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -639,6 +640,7 @@ class CSharp(metaclass=LanguageCls):
         ),
     )
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     class VariableTypeHints(enum.Enum):
         """Variable type hint options."""

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -391,6 +392,7 @@ class D(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -616,6 +617,8 @@ class Dart(metaclass=LanguageCls):
     call_style_config: ClassVar[CallStyle | CallSupport] = (
         CallSupport.NOT_IMPLEMENTED_BY_TOOL
     )
+
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid code for *data*.

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -581,6 +582,7 @@ class Dhall(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -381,6 +382,7 @@ class Elixir(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -618,6 +619,7 @@ class Elm(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -412,6 +413,7 @@ class Erlang(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -38,6 +38,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -399,6 +400,7 @@ class Forth(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -445,6 +446,7 @@ class Fortran(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -497,6 +498,7 @@ class FSharp(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     no_call_stub,
     no_type_hint_preamble,
@@ -791,6 +792,7 @@ class Gleam(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -514,6 +515,7 @@ class Go(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -348,6 +349,7 @@ class Groovy(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1210,7 +1210,6 @@ class Haskell(metaclass=LanguageCls):
 
     def wrap_calls_with_declarations(
         self,
-        *,
         declarations: tuple[str, ...],
         calls: str,
         body_preamble: tuple[str, ...],

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime
 import enum
+import re
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import ClassVar
@@ -79,6 +80,107 @@ def _haskell_call_preamble_stub(
     if "." in name:
         return ("{-# LANGUAGE OverloadedRecordDot #-}",)
     return ()
+
+
+_HASKELL_TOP_LEVEL_BINDING = re.compile(pattern=r"^[A-Za-z_][\w']*\s*(::|=)")
+
+
+@beartype
+def _haskell_type_intro_key(*, header_line: str) -> str | None:
+    """Return the declared-name prefix for a Haskell type-introducing
+    line, or ``None`` when *header_line* does not introduce a type.
+
+    Matches ``data Foo = ...``, ``newtype Foo = ...``,
+    ``type Foo = ...``, and ``instance Cls Foo where ...``; returns
+    the part of the line before the ``=`` or ``where`` separator.
+    """
+    match header_line.split(maxsplit=1):
+        case ["data" | "newtype" | "type" | "instance", _]:
+            for separator in (" = ", " where"):
+                separator_index = header_line.find(separator)
+                if separator_index != -1:
+                    return header_line[:separator_index].strip()
+            return header_line.strip()
+        case _:
+            return None
+
+
+@beartype
+def _haskell_body_preamble_key(*, block: str) -> str:
+    """Return a dedupe key for a Haskell body-preamble *block*.
+
+    Two ``data Val = ...`` blocks (or any pair sharing one of the
+    type-introducer keywords and the same declared name) collapse to
+    a single block — callers that combine body preambles from
+    independent ``literalize`` invocations may otherwise emit the
+    same type twice with different constructor sets.  Type
+    signatures (``name :: Type``) and bindings (``name = value``)
+    keep distinct keys so both halves of a Haskell declaration
+    survive.
+    """
+    header_line = block.splitlines()[0] if block else ""
+    type_key = _haskell_type_intro_key(header_line=header_line)
+    return type_key if type_key is not None else block
+
+
+@beartype
+def _dedupe_haskell_body_preamble(
+    *,
+    body_preamble: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Drop later body-preamble blocks that re-declare an earlier type."""
+    seen_keys: set[str] = set()
+    deduped: list[str] = []
+    for block in body_preamble:
+        key = _haskell_body_preamble_key(block=block)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped.append(block)
+    return tuple(deduped)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class _HaskellContentSplit:
+    """Result of splitting wrapped content into declaration and call
+    halves.
+    """
+
+    declarations: str
+    call_expressions: str
+
+
+@beartype
+def _split_haskell_decls_and_calls(*, content: str) -> _HaskellContentSplit:
+    """Split *content* into a leading block of top-level Haskell
+    bindings and a trailing block of bare call expressions.
+
+    The integration harness for ``$ref`` declaration cases
+    concatenates each declaration's ``bare_code`` (a top-level
+    ``name :: Type`` / ``name = value`` pair, possibly followed by
+    indented continuation lines) with the call expressions.  Bindings
+    must stay at module scope; bare expressions belong inside
+    ``main = do``.  The boundary is the first top-level line (no
+    leading whitespace) that is neither a type signature nor a
+    ``name = ...`` binding.
+    """
+    content_lines = content.split(sep="\n")
+    first_call_index = len(content_lines)
+    for line_index, line in enumerate(iterable=content_lines):
+        match line:
+            case "":
+                continue
+            case starts_with_space if starts_with_space[0].isspace():
+                continue
+            case binding if _HASKELL_TOP_LEVEL_BINDING.match(string=binding):
+                continue
+            case _:
+                first_call_index = line_index
+                break
+    return _HaskellContentSplit(
+        declarations="\n".join(content_lines[:first_call_index]).rstrip(),
+        call_expressions="\n".join(content_lines[first_call_index:]),
+    )
 
 
 @beartype
@@ -1187,6 +1289,9 @@ class Haskell(metaclass=LanguageCls):
         body_preamble: tuple[str, ...],
     ) -> str:
         """Wrap a Haskell variable binding in a module."""
+        body_preamble = _dedupe_haskell_body_preamble(
+            body_preamble=body_preamble,
+        )
         preamble = "\n".join(body_preamble)
         if not variable_name:
             # Call mode: bare expressions are not valid at module
@@ -1195,14 +1300,26 @@ class Haskell(metaclass=LanguageCls):
             # ``IO Val`` (``StubReturn.VALUE``) do not trigger
             # ``-Wunused-do-bind``. ``_ <-`` is also valid when the
             # action returns ``IO ()``.
+            #
+            # If *content* begins with top-level ``name :: Type`` /
+            # ``name = value`` bindings (produced by the integration
+            # harness when literalizing ``$ref`` declaration values),
+            # those bindings stay at module scope and only the trailing
+            # call expressions go inside ``main = do``.
+            split = _split_haskell_decls_and_calls(content=content)
             indented = "\n".join(
                 f"    _ <- {line}" if line.strip() else line
-                for line in content.split(sep="\n")
+                for line in split.call_expressions.split(sep="\n")
+            )
+            declaration_block = (
+                split.declarations + "\n" if split.declarations else ""
             )
             return (
                 f"module {self.module_name} where\n"
                 + preamble
-                + "\nmain :: IO ()\nmain = do\n"
+                + "\n"
+                + declaration_block
+                + "main :: IO ()\nmain = do\n"
                 + indented
                 + "\n    pure ()"
             )

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -85,61 +85,6 @@ def _haskell_call_preamble_stub(
 _HASKELL_TOP_LEVEL_BINDING = re.compile(pattern=r"^[A-Za-z_][\w']*\s*(::|=)")
 
 
-@beartype
-def _haskell_type_intro_key(*, header_line: str) -> str | None:
-    """Return the declared-name prefix for a Haskell type-introducing
-    line, or ``None`` when *header_line* does not introduce a type.
-
-    Matches ``data Foo = ...``, ``newtype Foo = ...``,
-    ``type Foo = ...``, and ``instance Cls Foo where ...``; returns
-    the part of the line before the ``=`` or ``where`` separator.
-    """
-    match header_line.split(maxsplit=1):
-        case ["data" | "newtype" | "type" | "instance", _]:
-            for separator in (" = ", " where"):
-                separator_index = header_line.find(separator)
-                if separator_index != -1:
-                    return header_line[:separator_index].strip()
-            return header_line.strip()
-        case _:
-            return None
-
-
-@beartype
-def _haskell_body_preamble_key(*, block: str) -> str:
-    """Return a dedupe key for a Haskell body-preamble *block*.
-
-    Two ``data Val = ...`` blocks (or any pair sharing one of the
-    type-introducer keywords and the same declared name) collapse to
-    a single block — callers that combine body preambles from
-    independent ``literalize`` invocations may otherwise emit the
-    same type twice with different constructor sets.  Type
-    signatures (``name :: Type``) and bindings (``name = value``)
-    keep distinct keys so both halves of a Haskell declaration
-    survive.
-    """
-    header_line = block.splitlines()[0] if block else ""
-    type_key = _haskell_type_intro_key(header_line=header_line)
-    return type_key if type_key is not None else block
-
-
-@beartype
-def _dedupe_haskell_body_preamble(
-    *,
-    body_preamble: tuple[str, ...],
-) -> tuple[str, ...]:
-    """Drop later body-preamble blocks that re-declare an earlier type."""
-    seen_keys: set[str] = set()
-    deduped: list[str] = []
-    for block in body_preamble:
-        key = _haskell_body_preamble_key(block=block)
-        if key in seen_keys:
-            continue
-        seen_keys.add(key)
-        deduped.append(block)
-    return tuple(deduped)
-
-
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class _HaskellContentSplit:
     """Result of splitting wrapped content into declaration and call
@@ -1289,9 +1234,6 @@ class Haskell(metaclass=LanguageCls):
         body_preamble: tuple[str, ...],
     ) -> str:
         """Wrap a Haskell variable binding in a module."""
-        body_preamble = _dedupe_haskell_body_preamble(
-            body_preamble=body_preamble,
-        )
         preamble = "\n".join(body_preamble)
         if not variable_name:
             # Call mode: bare expressions are not valid at module

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import enum
-import re
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import ClassVar
@@ -80,52 +79,6 @@ def _haskell_call_preamble_stub(
     if "." in name:
         return ("{-# LANGUAGE OverloadedRecordDot #-}",)
     return ()
-
-
-_HASKELL_TOP_LEVEL_BINDING = re.compile(pattern=r"^[A-Za-z_][\w']*\s*(::|=)")
-
-
-@dataclasses.dataclass(frozen=True, kw_only=True)
-class _HaskellContentSplit:
-    """Result of splitting wrapped content into declaration and call
-    halves.
-    """
-
-    declarations: str
-    call_expressions: str
-
-
-@beartype
-def _split_haskell_decls_and_calls(*, content: str) -> _HaskellContentSplit:
-    """Split *content* into a leading block of top-level Haskell
-    bindings and a trailing block of bare call expressions.
-
-    The integration harness for ``$ref`` declaration cases
-    concatenates each declaration's ``bare_code`` (a top-level
-    ``name :: Type`` / ``name = value`` pair, possibly followed by
-    indented continuation lines) with the call expressions.  Bindings
-    must stay at module scope; bare expressions belong inside
-    ``main = do``.  The boundary is the first top-level line (no
-    leading whitespace) that is neither a type signature nor a
-    ``name = ...`` binding.
-    """
-    content_lines = content.split(sep="\n")
-    first_call_index = len(content_lines)
-    for line_index, line in enumerate(iterable=content_lines):
-        match line:
-            case "":
-                continue
-            case starts_with_space if starts_with_space[0].isspace():
-                continue
-            case binding if _HASKELL_TOP_LEVEL_BINDING.match(string=binding):
-                continue
-            case _:
-                first_call_index = line_index
-                break
-    return _HaskellContentSplit(
-        declarations="\n".join(content_lines[:first_call_index]).rstrip(),
-        call_expressions="\n".join(content_lines[first_call_index:]),
-    )
 
 
 @beartype
@@ -1242,30 +1195,52 @@ class Haskell(metaclass=LanguageCls):
             # ``IO Val`` (``StubReturn.VALUE``) do not trigger
             # ``-Wunused-do-bind``. ``_ <-`` is also valid when the
             # action returns ``IO ()``.
-            #
-            # If *content* begins with top-level ``name :: Type`` /
-            # ``name = value`` bindings (produced by the integration
-            # harness when literalizing ``$ref`` declaration values),
-            # those bindings stay at module scope and only the trailing
-            # call expressions go inside ``main = do``.
-            split = _split_haskell_decls_and_calls(content=content)
             indented = "\n".join(
                 f"    _ <- {line}" if line.strip() else line
-                for line in split.call_expressions.split(sep="\n")
-            )
-            declaration_block = (
-                split.declarations + "\n" if split.declarations else ""
+                for line in content.split(sep="\n")
             )
             return (
                 f"module {self.module_name} where\n"
                 + preamble
-                + "\n"
-                + declaration_block
-                + "main :: IO ()\nmain = do\n"
+                + "\nmain :: IO ()\nmain = do\n"
                 + indented
                 + "\n    pure ()"
             )
         return f"module {self.module_name} where\n" + preamble + "\n" + content
+
+    def wrap_calls_with_declarations(
+        self,
+        *,
+        declarations: tuple[str, ...],
+        calls: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap a sequence of top-level *declarations* alongside a
+        block of bare call expressions.
+
+        Top-level ``name :: Type`` / ``name = value`` bindings stay at
+        module scope and only the *calls* go inside ``main = do``.  The
+        integration harness pairs each ``$ref`` declaration's
+        ``bare_code`` with a downstream call and uses this hook to
+        avoid concatenating both halves into one ``content`` string,
+        which would otherwise force the bindings into a ``do``-block
+        where they would need ``let`` injection.
+        """
+        preamble = "\n".join(body_preamble)
+        indented_calls = "\n".join(
+            f"    _ <- {line}" if line.strip() else line
+            for line in calls.split(sep="\n")
+        )
+        declaration_block = "\n".join(declarations)
+        return (
+            f"module {self.module_name} where\n"
+            + preamble
+            + "\n"
+            + (declaration_block + "\n" if declaration_block else "")
+            + "main :: IO ()\nmain = do\n"
+            + indented_calls
+            + "\n    pure ()"
+        )
 
     @staticmethod
     def wrap_combined_in_file(

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -340,6 +341,7 @@ class Hcl(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -893,6 +894,7 @@ class Java(metaclass=LanguageCls):
         ),
     )
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     class VariableTypeHints(enum.Enum):
         """Variable type hint options."""

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -427,6 +428,7 @@ class JavaScript(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -307,6 +308,7 @@ class Json5(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -331,6 +332,7 @@ class Jsonnet(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -63,6 +63,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -441,6 +442,7 @@ class Julia(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -76,6 +76,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -798,6 +799,7 @@ class Kotlin(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -354,6 +355,7 @@ class Lua(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -430,6 +431,7 @@ class Matlab(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -63,6 +63,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -543,6 +544,7 @@ class Mojo(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -748,6 +749,7 @@ class Nim(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -376,6 +377,7 @@ class Nix(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -282,6 +283,7 @@ class Norg(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
@@ -485,6 +486,7 @@ class ObjectiveC(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -459,6 +460,7 @@ class OCaml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -298,6 +299,7 @@ class Occam(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -422,6 +423,7 @@ class Odin(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -397,6 +398,7 @@ class Perl(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -407,6 +408,7 @@ class Php(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -304,6 +305,7 @@ class PowerShell(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -710,6 +711,7 @@ class PureScript(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -901,6 +902,7 @@ class Python(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -399,6 +400,7 @@ class R(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -310,6 +311,7 @@ class Racket(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -372,6 +373,7 @@ class Raku(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -418,6 +419,7 @@ class Ruby(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -1404,6 +1405,8 @@ class Rust(metaclass=LanguageCls):
                 f"Use ARRAY or TUPLE instead."
             )
             raise IncompatibleFormatsError(msg)
+
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid code for *data*.

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -521,6 +522,7 @@ class Scala(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -277,6 +278,7 @@ class Scheme(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -502,6 +503,7 @@ class Sml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -66,6 +66,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     date_scalar_preamble,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -672,6 +673,7 @@ class Swift(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -51,6 +51,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -362,6 +363,7 @@ class SystemVerilog(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
         self,

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -330,6 +331,7 @@ class Tcl(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -314,6 +315,7 @@ class Toml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -606,6 +607,7 @@ class TypeScript(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -347,6 +348,7 @@ class V(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -478,6 +479,7 @@ class VisualBasic(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -301,6 +302,7 @@ class Wren(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -290,6 +291,7 @@ class Yaml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -470,6 +471,7 @@ class Zig(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -22,6 +22,7 @@ from literalizer.exceptions import (
     HeterogeneousCollectionError,
 )
 from literalizer.languages import (
+    Haskell,
     Jsonnet,
 )
 
@@ -523,15 +524,26 @@ def run_call_golden_case(
     call_body_preamble = _dedupe_ordered(
         lines=unified_body_preamble + tuple(body_stubs)
     )
-    content = "\n".join(
-        [d.bare_code for d in decl_results] + [result.bare_code]
-    )
-
-    wrapped = spec.wrap_in_file(
-        content=content,
-        variable_name="",
-        body_preamble=call_body_preamble,
-    )
+    declarations_bare_codes = tuple(d.bare_code for d in decl_results)
+    if declarations_bare_codes and isinstance(spec, Haskell):
+        # Haskell needs the bindings at module scope and only the call
+        # expressions inside ``main = do``; route through the dedicated
+        # hook so we keep the two halves structurally separate instead
+        # of post-hoc parsing the joined content.
+        wrapped = spec.wrap_calls_with_declarations(
+            declarations=declarations_bare_codes,
+            calls=result.bare_code,
+            body_preamble=call_body_preamble,
+        )
+    else:
+        content = "\n".join(
+            [*declarations_bare_codes, result.bare_code],
+        )
+        wrapped = spec.wrap_in_file(
+            content=content,
+            variable_name="",
+            body_preamble=call_body_preamble,
+        )
     all_preamble = _dedupe_preamble_blocks(
         blocks=decl_preambles + result.preamble + tuple(preamble_stubs)
     )

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -505,12 +505,23 @@ def run_call_golden_case(
                 StubReturn.VOID,
             ),
         )
-    decl_body_preambles = tuple(
-        line for d in decl_results for line in d.body_preamble
-    )
     decl_preambles = tuple(line for d in decl_results for line in d.preamble)
+    # Recompute the body preamble across the union of types observed in
+    # every declaration *and* the call.  Concatenating each piece's
+    # already-rendered body preamble would emit overlapping
+    # type-definition strings (e.g. Haskell's ``data Val = ...`` with
+    # different constructor sets) that no string-level dedupe can
+    # reconcile.  ``data`` only matters for datetime-precision
+    # inspection, which the present ref-declaration cases do not
+    # exercise; pass an empty list as a placeholder.
+    empty_types: frozenset[type] = frozenset()
+    union_types = empty_types.union(
+        *(d.types_present for d in decl_results),
+        result.types_present,
+    )
+    unified_body_preamble = spec.compute_body_preamble(union_types, [])
     call_body_preamble = _dedupe_ordered(
-        lines=decl_body_preambles + result.body_preamble + tuple(body_stubs)
+        lines=unified_body_preamble + tuple(body_stubs)
     )
     content = "\n".join(
         [d.bare_code for d in decl_results] + [result.bare_code]

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -22,7 +22,6 @@ from literalizer.exceptions import (
     HeterogeneousCollectionError,
 )
 from literalizer.languages import (
-    Haskell,
     Jsonnet,
 )
 
@@ -333,10 +332,6 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 # name-mangling gaps.
 REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
     {
-        # ``wrap_in_file`` places content inside ``main = do``; a
-        # multi-line ``name = value`` binding needs ``let`` in a
-        # do-block, which the harness does not inject.
-        Haskell,
         # ``wrap_in_file`` wraps content in ``[ … ]`` as an expression
         # list; variable declarations don't fit the shape.
         Jsonnet,

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -41,25 +41,6 @@ def _prepend_preamble(
 
 
 @beartype
-def _dedupe_ordered(*, lines: Iterable[str]) -> tuple[str, ...]:
-    """Return *lines* with duplicates removed, preserving first-seen order.
-
-    Used when a ``literalize_call`` test combines declarations for
-    ``{"$ref": "name"}`` variables with the call itself — both halves
-    may request the same imports or type-definition body preamble, and
-    emitting them twice would break strict compilers.
-    """
-    seen: set[str] = set()
-    result: list[str] = []
-    for line in lines:
-        if line in seen:
-            continue
-        seen.add(line)
-        result.append(line)
-    return tuple(result)
-
-
-@beartype
 def _dedupe_preamble_blocks(*, blocks: Iterable[str]) -> tuple[str, ...]:
     """Return preamble *blocks* with duplicate headers removed.
 
@@ -510,19 +491,17 @@ def run_call_golden_case(
     # every declaration *and* the call.  Concatenating each piece's
     # already-rendered body preamble would emit overlapping
     # type-definition strings (e.g. Haskell's ``data Val = ...`` with
-    # different constructor sets) that no string-level dedupe can
-    # reconcile.  ``data`` only matters for datetime-precision
-    # inspection, which the present ref-declaration cases do not
-    # exercise; pass an empty list as a placeholder.
+    # different constructor sets) that no string-level duplicate
+    # filter can reconcile.  ``data`` only matters for
+    # datetime-precision inspection, which the present ref-declaration
+    # cases do not exercise; pass an empty list as a placeholder.
     empty_types: frozenset[type] = frozenset()
     union_types = empty_types.union(
         *(d.types_present for d in decl_results),
         result.types_present,
     )
     unified_body_preamble = spec.compute_body_preamble(union_types, [])
-    call_body_preamble = _dedupe_ordered(
-        lines=unified_body_preamble + tuple(body_stubs)
-    )
+    call_body_preamble = unified_body_preamble + tuple(body_stubs)
     declarations_bare_codes = tuple(d.bare_code for d in decl_results)
     wrapped = spec.wrap_calls_with_declarations(
         declarations=declarations_bare_codes,

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -10,6 +10,7 @@ import dataclasses
 import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from beartype import beartype
@@ -27,6 +28,9 @@ from literalizer.languages import (
 
 from .check_golden import check_golden
 from .language_specs import sorted_languages
+
+if TYPE_CHECKING:
+    from literalizer._types import Value
 
 
 @beartype
@@ -492,15 +496,21 @@ def run_call_golden_case(
     # already-rendered body preamble would emit overlapping
     # type-definition strings (e.g. Haskell's ``data Val = ...`` with
     # different constructor sets) that no string-level duplicate
-    # filter can reconcile.  ``data`` only matters for
-    # datetime-precision inspection, which the present ref-declaration
-    # cases do not exercise; pass an empty list as a placeholder.
+    # filter can reconcile.  Combine ``source_data`` from every piece
+    # so ``compute_body_preamble`` can inspect actual values when it
+    # needs to (e.g. Haskell's datetime microsecond-precision check).
     empty_types: frozenset[type] = frozenset()
     union_types = empty_types.union(
         *(d.types_present for d in decl_results),
         result.types_present,
     )
-    unified_body_preamble = spec.compute_body_preamble(union_types, [])
+    combined_source_data: list[Value] = [
+        *(d.source_data for d in decl_results),
+        result.source_data,
+    ]
+    unified_body_preamble = spec.compute_body_preamble(
+        union_types, combined_source_data
+    )
     call_body_preamble = unified_body_preamble + tuple(body_stubs)
     declarations_bare_codes = tuple(d.bare_code for d in decl_results)
     wrapped = spec.wrap_calls_with_declarations(

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -22,7 +22,6 @@ from literalizer.exceptions import (
     HeterogeneousCollectionError,
 )
 from literalizer.languages import (
-    Haskell,
     Jsonnet,
 )
 
@@ -525,25 +524,11 @@ def run_call_golden_case(
         lines=unified_body_preamble + tuple(body_stubs)
     )
     declarations_bare_codes = tuple(d.bare_code for d in decl_results)
-    if declarations_bare_codes and isinstance(spec, Haskell):
-        # Haskell needs the bindings at module scope and only the call
-        # expressions inside ``main = do``; route through the dedicated
-        # hook so we keep the two halves structurally separate instead
-        # of post-hoc parsing the joined content.
-        wrapped = spec.wrap_calls_with_declarations(
-            declarations=declarations_bare_codes,
-            calls=result.bare_code,
-            body_preamble=call_body_preamble,
-        )
-    else:
-        content = "\n".join(
-            [*declarations_bare_codes, result.bare_code],
-        )
-        wrapped = spec.wrap_in_file(
-            content=content,
-            variable_name="",
-            body_preamble=call_body_preamble,
-        )
+    wrapped = spec.wrap_calls_with_declarations(
+        declarations=declarations_bare_codes,
+        calls=result.bare_code,
+        body_preamble=call_body_preamble,
+    )
     all_preamble = _dedupe_preamble_blocks(
         blocks=decl_preambles + result.preamble + tuple(preamble_stubs)
     )

--- a/tests/integration/cases/call_ref_args/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args/Haskell_call.hs
@@ -1,0 +1,29 @@
+module Check where
+data Val = HInt Integer | HList [Val]
+instance Num Val where
+    fromInteger = HInt
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate _ = error "not implemented"
+process :: (Val, Val) -> IO ()
+process _ = return ()
+my_var :: Val
+my_var = HList [
+    1,
+    2,
+    3
+    ]
+my_other :: Val
+my_other = HList [
+    4,
+    5,
+    6
+    ]
+main :: IO ()
+main = do
+    _ <- process(my_var, 42)
+    _ <- process(my_other, 7)
+    pure ()

--- a/tests/integration/cases/call_ref_args_converted/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args_converted/Haskell_call.hs
@@ -1,0 +1,29 @@
+module Check where
+data Val = HInt Integer | HList [Val]
+instance Num Val where
+    fromInteger = HInt
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate _ = error "not implemented"
+process :: (Val, Val) -> IO ()
+process _ = return ()
+myVar :: Val
+myVar = HList [
+    1,
+    2,
+    3
+    ]
+myOther :: Val
+myOther = HList [
+    4,
+    5,
+    6
+    ]
+main :: IO ()
+main = do
+    _ <- process(myVar, 42)
+    _ <- process(myOther, 7)
+    pure ()

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Haskell_call.hs
@@ -1,0 +1,29 @@
+module Check where
+data Val = HInt Integer | HList [Val]
+instance Num Val where
+    fromInteger = HInt
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate _ = error "not implemented"
+process :: (Val, Val) -> IO ()
+process _ = return ()
+myVar :: Val
+myVar = HList [
+    1,
+    2,
+    3
+    ]
+myOther :: Val
+myOther = HList [
+    4,
+    5,
+    6
+    ]
+main :: IO ()
+main = do
+    _ <- process(myVar, 42)
+    _ <- process(myOther, 7)
+    pure ()

--- a/tests/integration/cases/call_ref_args_converted_whole/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args_converted_whole/Haskell_call.hs
@@ -1,0 +1,22 @@
+module Check where
+data Val = HInt Integer | HList [Val]
+instance Num Val where
+    fromInteger = HInt
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate _ = error "not implemented"
+process :: Val -> IO ()
+process _ = return ()
+myVar :: Val
+myVar = HList [
+    1,
+    2,
+    3
+    ]
+main :: IO ()
+main = do
+    _ <- process(myVar)
+    pure ()


### PR DESCRIPTION
## Summary
- Haskell's `wrap_in_file` (call mode) now keeps top-level `name :: Type` / `name = value` bindings at module scope and only wraps trailing call expressions in `main = do`, so the integration harness's ref-declaration cases produce valid modules.
- Adds a Haskell-local body-preamble dedupe keyed by type-introducer (`data`/`newtype`/`type`/`instance`) so decl- and call-side halves emitting the same `data Val` collapse to the wider definition instead of declaring it twice.
- Removes Haskell from `REF_CASE_INCOMPATIBLE` and adds the four `call_ref_args*` Haskell goldens (all compile under `ghc -Wall -Werror`).

## Test plan
- [x] `uv run pytest tests/integration/test_calls.py`
- [x] `ghc -fno-code -Wall -Werror` on each new `Haskell_call.hs`
- [x] `uv run mypy src/ tests/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core result/preamble plumbing and language wrapping behavior, which could affect how wrapped files and preambles are generated across many languages, though the functional change is mainly additive with a default no-op path.
> 
> **Overview**
> Enables composing `literalize`-produced `$ref` declarations with downstream `literalize_call` output into a single wrapped file without duplicating or mis-scoping type/instance preambles.
> 
> This introduces a new `Language.wrap_calls_with_declarations` hook (defaulting to “declarations + calls, then `wrap_in_file`”) and wires it into the integration call harness; Haskell overrides it so top-level bindings remain at module scope while only call expressions are placed inside `main = do`.
> 
> `LiteralizeResult` and preamble computation now retain `types_present` and `source_data`, allowing callers to recompute a unified body preamble from the union of types/values instead of concatenating per-fragment preambles (avoiding conflicting/overlapping type-definition blocks). New Haskell golden files are added and Haskell is removed from the ref-case incompatibility list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e67809ff2a2bc66732739726c605b50bf6ea3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->