### PR TITLE
Add literalize_call support to Raku

### DIFF
--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -683,4 +683,5 @@ class Raku(metaclass=LanguageCls):
     @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
-        return self.call_style.value
+        config: CallStyle = self.call_style.value
+        return config

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -90,7 +90,7 @@ def _raku_call_stub(
     """
     parts = name.split(sep=".")
     if len(parts) == 1:
-        return (f"sub {parts[0]} {{}}",)
+        return (f"sub {parts[0]}(*@a, *%kw) {{}}",)
     root = parts[0]
     method = parts[-1]
     fields = parts[1:-1]
@@ -119,13 +119,13 @@ def _raku_call_stub(
 
 @beartype
 def _raku_format_call_ref_identifier(name: str, /) -> str:
-    """Prepend Raku's scalar ``$`` sigil to a ``$ref`` identifier."""
+    """Prepend the Raku scalar ``$`` sigil to a ``$ref`` identifier."""
     return f"${name}"
 
 
 @beartype
 def _raku_format_call_target(name: str, /) -> str:
-    """Rewrite a dotted call target into Raku's ``$obj.method`` form."""
+    """Rewrite a dotted call target into the Raku ``$obj.method`` form."""
     parts = name.split(sep=".")
     if len(parts) == 1:
         return name

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     FloatSpecialsMixin,
     HeterogeneousBehavior,
     IdentifierCase,
+    KeywordCallStyle,
     LanguageCls,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -408,6 +409,7 @@ class Raku(metaclass=LanguageCls):
         """Raku call style options."""
 
         POSITIONAL = PositionalCallStyle()
+        KEYWORD = KeywordCallStyle(separator=" => ")
 
     call_styles = CallStyles
 

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -45,7 +45,6 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -56,6 +55,7 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -63,8 +63,6 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
-    identity_call_ref_identifier,
-    identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -73,6 +71,64 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+
+
+@beartype
+def _raku_call_stub(
+    name: str,
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return Raku stub declarations for a call name.
+
+    Raku uses ``.`` for method dispatch, so a dotted target such as
+    ``app.client.fetch("hello")`` requires class stubs with ``method``
+    definitions.  A bare (non-dotted) target only needs a ``sub``
+    declaration.
+    """
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"sub {parts[0]} {{}}",)
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    if not fields:
+        cls = root.capitalize() + "Type"
+        return (
+            f"class {cls} {{ method {method}(*@a, *%kw) {{}} }}",
+            f"my ${root} = {cls}.new;",
+        )
+    lines: list[str] = []
+    inner_cls = fields[-1].capitalize() + "Type"
+    lines.append(f"class {inner_cls} {{ method {method}(*@a, *%kw) {{}} }}")
+    prev_cls = inner_cls
+    for i in range(len(fields) - 2, -1, -1):
+        cls = fields[i].capitalize() + "Type"
+        field = fields[i + 1]
+        lines.append(f"class {cls} {{ method {field} {{ {prev_cls}.new }} }}")
+        prev_cls = cls
+    root_cls = root.capitalize() + "Type"
+    lines.append(
+        f"class {root_cls} {{ method {fields[0]} {{ {prev_cls}.new }} }}"
+    )
+    lines.append(f"my ${root} = {root_cls}.new;")
+    return tuple(lines)
+
+
+@beartype
+def _raku_format_call_ref_identifier(name: str, /) -> str:
+    """Prepend Raku's scalar ``$`` sigil to a ``$ref`` identifier."""
+    return f"${name}"
+
+
+@beartype
+def _raku_format_call_target(name: str, /) -> str:
+    """Rewrite a dotted call target into Raku's ``$obj.method`` form."""
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return name
+    return "$" + parts[0] + "".join(f".{p}" for p in parts[1:])
 
 
 @beartype
@@ -351,6 +407,8 @@ class Raku(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Raku call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -423,6 +481,7 @@ class Raku(metaclass=LanguageCls):
     string_format: StringFormats = StringFormats.SINGLE
     trailing_comma: TrailingCommas = TrailingCommas.YES
     line_ending: LineEndings = LineEndings.SEMICOLON
+    call_style: CallStyles = CallStyles.POSITIONAL
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
@@ -437,13 +496,10 @@ class Raku(metaclass=LanguageCls):
     supports_collection_comments: ClassVar[bool] = True
     supports_scalar_before_comments: ClassVar[bool] = True
     supports_scalar_inline_comments: ClassVar[bool] = False
-    statement_terminator: ClassVar[str] = ""
+    statement_terminator: ClassVar[str] = ";"
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
 
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:
@@ -482,7 +538,7 @@ class Raku(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _raku_call_stub
 
     @cached_property
     def format_call_preamble_stub(
@@ -496,14 +552,14 @@ class Raku(metaclass=LanguageCls):
         """Rewrite a dotted call target into the language's call
         syntax.
         """
-        return identity_call_target
+        return _raku_format_call_target
 
     @cached_property
     def format_call_ref_identifier(self) -> Callable[[str], str]:
         """Rewrite a ``{"$ref": "name"}`` identifier into the
         language's call expression syntax.
         """
-        return identity_call_ref_identifier
+        return _raku_format_call_ref_identifier
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
@@ -621,3 +677,8 @@ class Raku(metaclass=LanguageCls):
             scalar_body_preamble=self.scalar_body_preamble,
             format_lines=tuple,
         )
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value

--- a/tests/integration/cases/call_deep_dotted_method/Raku_call.raku
+++ b/tests/integration/cases/call_deep_dotted_method/Raku_call.raku
@@ -1,0 +1,7 @@
+class ClientType { method post(*@a, *%kw) {} }
+class ApiType { method client { ClientType.new } }
+class ObjType { method api { ApiType.new } }
+my $obj = ObjType.new;
+$obj.api.client.post('hello');
+$obj.api.client.post(42);
+$obj.api.client.post(True);

--- a/tests/integration/cases/call_deep_dotted_transformed/Raku_call.raku
+++ b/tests/integration/cases/call_deep_dotted_transformed/Raku_call.raku
@@ -1,0 +1,7 @@
+class ClientType { method fetch(*@a, *%kw) {} }
+class AppType { method client { ClientType.new } }
+my $app = AppType.new;
+sub emit {}
+emit($app.client.fetch('hello'));
+emit($app.client.fetch(42));
+emit($app.client.fetch(True));

--- a/tests/integration/cases/call_deep_dotted_transformed/Raku_call.raku
+++ b/tests/integration/cases/call_deep_dotted_transformed/Raku_call.raku
@@ -1,7 +1,7 @@
 class ClientType { method fetch(*@a, *%kw) {} }
 class AppType { method client { ClientType.new } }
 my $app = AppType.new;
-sub emit {}
+sub emit(*@a, *%kw) {}
 emit($app.client.fetch('hello'));
 emit($app.client.fetch(42));
 emit($app.client.fetch(True));

--- a/tests/integration/cases/call_dotted_method/Raku_call.raku
+++ b/tests/integration/cases/call_dotted_method/Raku_call.raku
@@ -1,0 +1,6 @@
+class ClientType { method fetch(*@a, *%kw) {} }
+class AppType { method client { ClientType.new } }
+my $app = AppType.new;
+$app.client.fetch('hello');
+$app.client.fetch(42);
+$app.client.fetch(True);

--- a/tests/integration/cases/call_keyword/Raku_call.raku
+++ b/tests/integration/cases/call_keyword/Raku_call.raku
@@ -1,5 +1,5 @@
 class ThrottlerType { method check(*@a, *%kw) {} }
 my $throttler = ThrottlerType.new;
-sub emit {}
+sub emit(*@a, *%kw) {}
 emit($throttler.check(user_id => 'user_1', ts => 1000.0));
 emit($throttler.check(user_id => 'user_2', ts => 2000.5));

--- a/tests/integration/cases/call_keyword/Raku_call.raku
+++ b/tests/integration/cases/call_keyword/Raku_call.raku
@@ -1,0 +1,5 @@
+class ThrottlerType { method check(*@a, *%kw) {} }
+my $throttler = ThrottlerType.new;
+sub emit {}
+emit($throttler.check(user_id => 'user_1', ts => 1000.0));
+emit($throttler.check(user_id => 'user_2', ts => 2000.5));

--- a/tests/integration/cases/call_keyword_args/Raku_call.raku
+++ b/tests/integration/cases/call_keyword_args/Raku_call.raku
@@ -1,0 +1,5 @@
+class ThrottlerType { method check(*@a, *%kw) {} }
+my $throttler = ThrottlerType.new;
+sub emit {}
+emit($throttler.check('user_1', 1000.0));
+emit($throttler.check('user_2', 2000.5));

--- a/tests/integration/cases/call_keyword_args/Raku_call.raku
+++ b/tests/integration/cases/call_keyword_args/Raku_call.raku
@@ -1,5 +1,5 @@
 class ThrottlerType { method check(*@a, *%kw) {} }
 my $throttler = ThrottlerType.new;
-sub emit {}
+sub emit(*@a, *%kw) {}
 emit($throttler.check('user_1', 1000.0));
 emit($throttler.check('user_2', 2000.5));

--- a/tests/integration/cases/call_mixed_type_dicts/Raku_call.raku
+++ b/tests/integration/cases/call_mixed_type_dicts/Raku_call.raku
@@ -1,0 +1,5 @@
+class MgrType { method op(*@a, *%kw) {} }
+class AppType { method mgr { MgrType.new } }
+my $app = AppType.new;
+$app.mgr.op({'type' => 'create', 'pr_id' => 'pr_1', 'draft' => True});
+$app.mgr.op({'type' => 'create', 'pr_id' => 'pr_2'});

--- a/tests/integration/cases/call_multi_args/Raku_call.raku
+++ b/tests/integration/cases/call_multi_args/Raku_call.raku
@@ -1,3 +1,3 @@
-sub process {}
+sub process(*@a, *%kw) {}
 process(1, 42);
 process(2, 100);

--- a/tests/integration/cases/call_multi_args/Raku_call.raku
+++ b/tests/integration/cases/call_multi_args/Raku_call.raku
@@ -1,0 +1,3 @@
+sub process {}
+process(1, 42);
+process(2, 100);

--- a/tests/integration/cases/call_per_element_false/Raku_call.raku
+++ b/tests/integration/cases/call_per_element_false/Raku_call.raku
@@ -1,0 +1,2 @@
+sub process {}
+process(1);

--- a/tests/integration/cases/call_per_element_false/Raku_call.raku
+++ b/tests/integration/cases/call_per_element_false/Raku_call.raku
@@ -1,2 +1,2 @@
-sub process {}
+sub process(*@a, *%kw) {}
 process(1);

--- a/tests/integration/cases/call_ref_args/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args/Raku_call.raku
@@ -1,4 +1,4 @@
-sub process {}
+sub process(*@a, *%kw) {}
 my $my_var = [
     1,
     2,

--- a/tests/integration/cases/call_ref_args/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args/Raku_call.raku
@@ -1,0 +1,13 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+my $my_other = [
+    4,
+    5,
+    6,
+];
+process($my_var, 42);
+process($my_other, 7);

--- a/tests/integration/cases/call_ref_args_converted/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args_converted/Raku_call.raku
@@ -1,4 +1,4 @@
-sub process {}
+sub process(*@a, *%kw) {}
 my $my_var = [
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args_converted/Raku_call.raku
@@ -1,0 +1,13 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+my $my_other = [
+    4,
+    5,
+    6,
+];
+process($my_var, 42);
+process($my_other, 7);

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Raku_call.raku
@@ -1,4 +1,4 @@
-sub process {}
+sub process(*@a, *%kw) {}
 my $my_var = [
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Raku_call.raku
@@ -1,0 +1,13 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+my $my_other = [
+    4,
+    5,
+    6,
+];
+process($my_var, 42);
+process($my_other, 7);

--- a/tests/integration/cases/call_ref_args_converted_whole/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args_converted_whole/Raku_call.raku
@@ -1,4 +1,4 @@
-sub process {}
+sub process(*@a, *%kw) {}
 my $my_var = [
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_whole/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args_converted_whole/Raku_call.raku
@@ -1,0 +1,7 @@
+sub process {}
+my $my_var = [
+    1,
+    2,
+    3,
+];
+process($my_var);

--- a/tests/integration/cases/call_scalar_args/Raku_call.raku
+++ b/tests/integration/cases/call_scalar_args/Raku_call.raku
@@ -1,0 +1,4 @@
+sub process {}
+process('hello');
+process(42);
+process(True);

--- a/tests/integration/cases/call_scalar_args/Raku_call.raku
+++ b/tests/integration/cases/call_scalar_args/Raku_call.raku
@@ -1,4 +1,4 @@
-sub process {}
+sub process(*@a, *%kw) {}
 process('hello');
 process(42);
 process(True);

--- a/tests/integration/cases/call_transform_no_wrapper/Raku_call.raku
+++ b/tests/integration/cases/call_transform_no_wrapper/Raku_call.raku
@@ -1,0 +1,4 @@
+sub process {}
+process('hello');
+process(42);
+process(True);

--- a/tests/integration/cases/call_transform_no_wrapper/Raku_call.raku
+++ b/tests/integration/cases/call_transform_no_wrapper/Raku_call.raku
@@ -1,4 +1,4 @@
-sub process {}
+sub process(*@a, *%kw) {}
 process('hello');
 process(42);
 process(True);

--- a/tests/integration/cases/call_wrap_in_file/Raku_call.raku
+++ b/tests/integration/cases/call_wrap_in_file/Raku_call.raku
@@ -1,3 +1,3 @@
-sub process {}
+sub process(*@a, *%kw) {}
 process(1, 2);
 process(3, 4);

--- a/tests/integration/cases/call_wrap_in_file/Raku_call.raku
+++ b/tests/integration/cases/call_wrap_in_file/Raku_call.raku
@@ -1,0 +1,3 @@
+sub process {}
+process(1, 2);
+process(3, 4);


### PR DESCRIPTION
Closes #1142

## Summary

- Adds `PositionalCallStyle` to Raku's `CallStyles` enum and wires up `call_style`/`call_style_config`
- Implements `_raku_call_stub`: uses `sub name {}` for plain calls; generates nested class stubs (like Ruby/Crystal) for dotted method calls, since Raku's `.` is method dispatch
- Implements `_raku_format_call_target`: prefixes the root object with `$` for dotted calls (e.g. `app.client.fetch` → `$app.client.fetch`)
- Implements `_raku_format_call_ref_identifier`: prepends `$` sigil to `$ref` variable names
- Fixes `statement_terminator` from `""` to `";"` so generated call statements are valid Raku
- Adds 14 golden test fixtures covering scalar args, multi-args, dotted method calls, deep dotted calls, ref args, mixed-type dicts, and wrap-in-file

## Test plan

- [ ] All 14 new `test_call_golden_file[*/Raku]` tests pass
- [ ] Full integration suite passes (735 passed, 14940 subtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new call-rendering behavior for Raku including stub generation and dotted-call rewriting, which can affect correctness of generated output across many call-related cases. Risk is mitigated by extensive new golden integration fixtures but still touches core codegen paths.
> 
> **Overview**
> Adds Raku support for `literalize_call`, including configurable positional vs keyword argument rendering (using `=>`) and wiring `call_style`/`call_style_config` into the Raku language spec.
> 
> Implements Raku-specific call handling: generates appropriate stubs for plain functions vs dotted method chains (nested `class`/`method` scaffolding plus `my $root = ...`) and rewrites dotted targets/`$ref` identifiers to use the Raku `$` sigil. Also fixes Raku call statements to terminate with `;`.
> 
> Adds new Raku golden integration fixtures covering scalar/multi-arg calls, keyword calls, dotted/deep-dotted calls (including transformed calls), `$ref` arguments, mixed dict arguments, and wrap-in-file behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316976f478a64bbcde8b77108e3449cced0b7e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->