### PR TITLE
Support ref_declarations for Jsonnet via local bindings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Changelog
 Next
 ----
 
+- ``Jsonnet`` now emits ``$ref`` declarations as top-level ``local``
+  bindings before the call expressions, so call-mode output with
+  ``ref_declarations`` is supported.  Previously the integration
+  harness skipped ``Jsonnet`` for ref-declaration cases because the
+  array-wrapped output had no place for variable bindings.  The
+  ``DeclarationStyles.ASSIGN`` template changed from ``{value}`` to
+  ``local {name} = {value};``, and ``Jsonnet`` now overrides
+  ``wrap_calls_with_declarations`` to emit those bindings before
+  ``wrap_in_file`` wraps the calls in ``[ … ]``.
 - ``Crystal.wrap_in_file`` now wraps content in a
   ``module Check ... end`` block with ``extend self``, matching what
   Erlang, Scala, and Haskell already do.  ``Crystal`` gains a

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -52,7 +52,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -211,7 +210,9 @@ class Jsonnet(metaclass=LanguageCls):
         """Declaration style options."""
 
         ASSIGN = DeclarationStyleConfig(
-            formatter=variable_declaration_formatter(template="{value}"),
+            formatter=variable_declaration_formatter(
+                template="local {name} = {value};",
+            ),
             supports_redefinition=False,
         )
 
@@ -332,7 +333,30 @@ class Jsonnet(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
-    wrap_calls_with_declarations = default_wrap_calls_with_declarations
+
+    def wrap_calls_with_declarations(
+        self,
+        declarations: tuple[str, ...],
+        calls: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Emit ref declarations as top-level ``local`` bindings before
+        the call expressions, which :meth:`wrap_in_file` wraps in a
+        Jsonnet array.
+
+        The default ``wrap_calls_with_declarations`` would splice
+        declarations *into* the array, where ``local`` bindings are
+        invalid; placing them before keeps the file a single chained
+        let-binding ending in an array expression.
+        """
+        wrapped_calls = self.wrap_in_file(
+            content=calls,
+            variable_name="",
+            body_preamble=body_preamble,
+        )
+        if not declarations:
+            return wrapped_calls
+        return "\n".join(declarations) + "\n" + wrapped_calls
 
     @staticmethod
     def wrap_in_file(

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -22,9 +22,6 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     HeterogeneousCollectionError,
 )
-from literalizer.languages import (
-    Jsonnet,
-)
 
 from .check_golden import check_golden
 from .language_specs import sorted_languages
@@ -306,24 +303,6 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 ]
 
 
-# Languages where the current integration harness cannot produce a
-# golden that passes its language-specific lint step for a
-# ``ref_declarations``-using case.  The feature itself renders the ref
-# marker as an identifier correctly; the limitations below are about
-# how the resulting declarations+calls compose into a complete file
-# or how names line up with the declaration site — see
-# https://github.com/adamtheturtle/literalizer/issues/1473 for the
-# per-language identifier rename hook that will close the
-# name-mangling gaps.
-REF_CASE_INCOMPATIBLE: frozenset[literalizer.LanguageCls] = frozenset(
-    {
-        # ``wrap_in_file`` wraps content in ``[ … ]`` as an expression
-        # list; variable declarations don't fit the shape.
-        Jsonnet,
-    }
-)
-
-
 @dataclasses.dataclass(frozen=True)
 class CallCase:
     """A parameterized call-style golden-file test case."""
@@ -343,8 +322,6 @@ def discover_call_cases() -> list[CallCase]:
                 continue
             has_dotted_target = "." in config.target_function
             if has_dotted_target and not lang_cls.supports_dotted_calls:
-                continue
-            if config.ref_declarations and lang_cls in REF_CASE_INCOMPATIBLE:
                 continue
             if config.call_style_type is not None:
                 # Only include languages that have this as a

--- a/tests/integration/cases/call_ref_args/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_ref_args/Jsonnet_call.jsonnet
@@ -1,0 +1,15 @@
+local my_var = [
+    1,
+    2,
+    3,
+];
+local my_other = [
+    4,
+    5,
+    6,
+];
+local process(data, count) = null;
+[
+    process(data=my_var, count=42),
+    process(data=my_other, count=7),
+]

--- a/tests/integration/cases/call_ref_args_converted/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_ref_args_converted/Jsonnet_call.jsonnet
@@ -1,0 +1,15 @@
+local my_var = [
+    1,
+    2,
+    3,
+];
+local my_other = [
+    4,
+    5,
+    6,
+];
+local process(data, count) = null;
+[
+    process(data=my_var, count=42),
+    process(data=my_other, count=7),
+]

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Jsonnet_call.jsonnet
@@ -1,0 +1,15 @@
+local my_var = [
+    1,
+    2,
+    3,
+];
+local my_other = [
+    4,
+    5,
+    6,
+];
+local process(data, count) = null;
+[
+    process(data=my_var, count=42),
+    process(data=my_other, count=7),
+]

--- a/tests/integration/cases/call_ref_args_converted_whole/Jsonnet_call.jsonnet
+++ b/tests/integration/cases/call_ref_args_converted_whole/Jsonnet_call.jsonnet
@@ -1,0 +1,9 @@
+local my_var = [
+    1,
+    2,
+    3,
+];
+local process(data) = null;
+[
+    process(data=my_var),
+]


### PR DESCRIPTION
## Summary
- Jsonnet's ``DeclarationStyles.ASSIGN`` template now emits ``local {name} = {value};``, and Jsonnet overrides ``wrap_calls_with_declarations`` to place those bindings before ``wrap_in_file`` wraps the calls in ``[ … ]`` (where ``local`` would be invalid).
- This lets the integration harness produce Jsonnet goldens for ref-declaration cases, so the ``REF_CASE_INCOMPATIBLE`` filter and constant in ``tests/integration/call_cases.py`` are gone.
- Adds Jsonnet goldens for the four ``call_ref_args*`` cases; all parse cleanly via the ``jsonnet`` CLI.

## Test plan
- [x] ``uv run pytest tests/integration/`` (725 passed)
- [x] ``uv run pytest tests/`` (unit suite passes)
- [x] ``jsonnet`` CLI evaluates each new golden without errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Jsonnet code generation and integration fixtures; main risk is minor output-format churn for existing Jsonnet declaration/call users.
> 
> **Overview**
> Adds proper `ref_declarations` support for Jsonnet call-mode output by emitting `$ref` declarations as top-level `local` bindings *before* the array-wrapped call expressions.
> 
> This updates Jsonnet’s `DeclarationStyles.ASSIGN` to render `local {name} = {value};`, overrides `Jsonnet.wrap_calls_with_declarations` to prepend those bindings ahead of `wrap_in_file`, removes the integration-test skip that previously excluded Jsonnet from ref-declaration call cases, and adds new Jsonnet golden fixtures for the `call_ref_args*` scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27c679a9b840f1feb9cd768207dc9231d579e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->