### PR TITLE
Add function call rendering to PowerShell

### DIFF
--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -33,7 +33,6 @@ from literalizer._formatters.format_floats import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -44,14 +43,13 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
-    identity_call_ref_identifier,
-    identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -87,6 +85,67 @@ def _format_string(value: str) -> str:
         .replace("\t", "`t")
     )
     return f'"{escaped}"'
+
+
+@beartype
+def _powershell_call_stub(
+    name: str,
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return PowerShell stub declarations for a call name."""
+    parts = name.split(sep=".")
+    if len(parts) == 1:
+        return (f"function {name} {{}}",)
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    param_list = ", ".join(f"[object] ${p}" for p in params)
+    if not fields:
+        type_name = f"{root.title()}Type_"
+        return (
+            f"class {type_name}"
+            f" {{ [object] {method}({param_list}) {{ return $null }} }}",
+            f"${root} = [{type_name}]::new()",
+        )
+    lines: list[str] = []
+    inner_type = f"{fields[-1].title()}Type_"
+    lines.append(
+        f"class {inner_type}"
+        f" {{ [object] {method}({param_list}) {{ return $null }} }}"
+    )
+    prev_type = inner_type
+    for i in range(len(fields) - 2, -1, -1):
+        curr_type = f"{fields[i].title()}Type_"
+        lines.append(
+            f"class {curr_type}"
+            f" {{ [{prev_type}] ${fields[i + 1]} = [{prev_type}]::new() }}"
+        )
+        prev_type = curr_type
+    root_type = f"{root.title()}Type_"
+    lines.append(
+        f"class {root_type}"
+        f" {{ [{prev_type}] ${fields[0]} = [{prev_type}]::new() }}"
+    )
+    lines.append(f"${root} = [{root_type}]::new()")
+    return tuple(lines)
+
+
+@beartype
+def _powershell_call_target(name: str, /) -> str:
+    """Prepend ``$`` for dotted targets so they resolve as variable access."""
+    if "." in name:
+        return f"${name}"
+    return name
+
+
+@beartype
+def _powershell_call_ref_identifier(name: str, /) -> str:
+    """Prepend ``$`` so ``$ref`` identifiers resolve as PowerShell
+    variables.
+    """
+    return f"${name}"
 
 
 @beartype
@@ -283,6 +342,8 @@ class PowerShell(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """PowerShell call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -355,6 +416,7 @@ class PowerShell(metaclass=LanguageCls):
     string_format: StringFormats = StringFormats.DOUBLE
     trailing_comma: TrailingCommas = TrailingCommas.NO
     line_ending: LineEndings = LineEndings.SEMICOLON
+    call_style: CallStyles = CallStyles.POSITIONAL
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
@@ -373,9 +435,6 @@ class PowerShell(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -424,7 +483,7 @@ class PowerShell(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _powershell_call_stub
 
     @cached_property
     def format_call_preamble_stub(
@@ -434,18 +493,23 @@ class PowerShell(metaclass=LanguageCls):
         return no_call_stub
 
     @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
+
+    @cached_property
     def format_call_target(self) -> Callable[[str], str]:
         """Rewrite a dotted call target into the language's call
         syntax.
         """
-        return identity_call_target
+        return _powershell_call_target
 
     @cached_property
     def format_call_ref_identifier(self) -> Callable[[str], str]:
         """Rewrite a ``{"$ref": "name"}`` identifier into the
         language's call expression syntax.
         """
-        return identity_call_ref_identifier
+        return _powershell_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/tests/integration/cases/call_deep_dotted_method/PowerShell_call.ps1
+++ b/tests/integration/cases/call_deep_dotted_method/PowerShell_call.ps1
@@ -1,0 +1,7 @@
+class ClientType_ { [object] post([object] $data) { return $null } }
+class ApiType_ { [ClientType_] $client = [ClientType_]::new() }
+class ObjType_ { [ApiType_] $api = [ApiType_]::new() }
+$obj = [ObjType_]::new()
+$obj.api.client.post("hello")
+$obj.api.client.post(42)
+$obj.api.client.post($true)

--- a/tests/integration/cases/call_deep_dotted_transformed/PowerShell_call.ps1
+++ b/tests/integration/cases/call_deep_dotted_transformed/PowerShell_call.ps1
@@ -1,0 +1,7 @@
+class ClientType_ { [object] fetch([object] $payload) { return $null } }
+class AppType_ { [ClientType_] $client = [ClientType_]::new() }
+$app = [AppType_]::new()
+function emit {}
+emit($app.client.fetch("hello"))
+emit($app.client.fetch(42))
+emit($app.client.fetch($true))

--- a/tests/integration/cases/call_dotted_method/PowerShell_call.ps1
+++ b/tests/integration/cases/call_dotted_method/PowerShell_call.ps1
@@ -1,0 +1,6 @@
+class ClientType_ { [object] fetch([object] $payload) { return $null } }
+class AppType_ { [ClientType_] $client = [ClientType_]::new() }
+$app = [AppType_]::new()
+$app.client.fetch("hello")
+$app.client.fetch(42)
+$app.client.fetch($true)

--- a/tests/integration/cases/call_keyword_args/PowerShell_call.ps1
+++ b/tests/integration/cases/call_keyword_args/PowerShell_call.ps1
@@ -1,0 +1,5 @@
+class ThrottlerType_ { [object] check([object] $user_id, [object] $ts) { return $null } }
+$throttler = [ThrottlerType_]::new()
+function emit {}
+emit($throttler.check("user_1", 1000.0))
+emit($throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_mixed_type_dicts/PowerShell_call.ps1
+++ b/tests/integration/cases/call_mixed_type_dicts/PowerShell_call.ps1
@@ -1,0 +1,5 @@
+class MgrType_ { [object] op([object] $operation) { return $null } }
+class AppType_ { [MgrType_] $mgr = [MgrType_]::new() }
+$app = [AppType_]::new()
+$app.mgr.op(@{"type" = "create"; "pr_id" = "pr_1"; "draft" = $true})
+$app.mgr.op(@{"type" = "create"; "pr_id" = "pr_2"})

--- a/tests/integration/cases/call_multi_args/PowerShell_call.ps1
+++ b/tests/integration/cases/call_multi_args/PowerShell_call.ps1
@@ -1,0 +1,3 @@
+function process {}
+process(1, 42)
+process(2, 100)

--- a/tests/integration/cases/call_per_element_false/PowerShell_call.ps1
+++ b/tests/integration/cases/call_per_element_false/PowerShell_call.ps1
@@ -1,0 +1,2 @@
+function process {}
+process(1)

--- a/tests/integration/cases/call_ref_args/PowerShell_call.ps1
+++ b/tests/integration/cases/call_ref_args/PowerShell_call.ps1
@@ -1,0 +1,13 @@
+function process {}
+$my_var = @(
+    1;
+    2;
+    3
+)
+$my_other = @(
+    4;
+    5;
+    6
+)
+process($my_var, 42)
+process($my_other, 7)

--- a/tests/integration/cases/call_ref_args_converted/PowerShell_call.ps1
+++ b/tests/integration/cases/call_ref_args_converted/PowerShell_call.ps1
@@ -1,0 +1,13 @@
+function process {}
+$MyVar = @(
+    1;
+    2;
+    3
+)
+$MyOther = @(
+    4;
+    5;
+    6
+)
+process($MyVar, 42)
+process($MyOther, 7)

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/PowerShell_call.ps1
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/PowerShell_call.ps1
@@ -1,0 +1,13 @@
+function process {}
+$MyVar = @(
+    1;
+    2;
+    3
+)
+$MyOther = @(
+    4;
+    5;
+    6
+)
+process($MyVar, 42)
+process($MyOther, 7)

--- a/tests/integration/cases/call_ref_args_converted_whole/PowerShell_call.ps1
+++ b/tests/integration/cases/call_ref_args_converted_whole/PowerShell_call.ps1
@@ -1,0 +1,7 @@
+function process {}
+$MyVar = @(
+    1;
+    2;
+    3
+)
+process($MyVar)

--- a/tests/integration/cases/call_scalar_args/PowerShell_call.ps1
+++ b/tests/integration/cases/call_scalar_args/PowerShell_call.ps1
@@ -1,0 +1,4 @@
+function process {}
+process("hello")
+process(42)
+process($true)

--- a/tests/integration/cases/call_transform_no_wrapper/PowerShell_call.ps1
+++ b/tests/integration/cases/call_transform_no_wrapper/PowerShell_call.ps1
@@ -1,0 +1,4 @@
+function process {}
+process("hello")
+process(42)
+process($true)

--- a/tests/integration/cases/call_wrap_in_file/PowerShell_call.ps1
+++ b/tests/integration/cases/call_wrap_in_file/PowerShell_call.ps1
@@ -1,0 +1,3 @@
+function process {}
+process(1, 2)
+process(3, 4)


### PR DESCRIPTION
## Summary

- Implements `literalize_call` support for the PowerShell language module (closes #1138)
- Uses `PositionalCallStyle` with PowerShell class-hierarchy stubs for dotted call targets (`$app.client.fetch("hello")`) and simple `function name {}` stubs for plain names
- Adds `_powershell_call_target` to prepend `$` on dotted targets and `_powershell_call_ref_identifier` to prepend `$` on `$ref` variable references, matching PowerShell variable syntax
- Adds 14 golden test files covering all applicable call scenarios

## Test plan

- [ ] All 14 new `test_call_golden_file[*/PowerShell]` tests pass
- [ ] Full test suite passes (1265 passed, 390 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new call-literalization behavior for PowerShell, changing generated output for any call specs and introducing new stub-generation logic for dotted targets. Risk is moderate because call syntax/stubs must be correct PowerShell and could affect downstream golden expectations.
> 
> **Overview**
> PowerShell now supports `literalize_call` by defaulting to a positional call style and emitting PowerShell-style call targets/`$ref` identifiers (prefixing variable accesses with `$`, including dotted targets like `$app.client.fetch(...)`).
> 
> It also replaces the previous “not implemented” call support with real stub generation: plain names get `function name {}` stubs, while dotted targets generate a lightweight class/property hierarchy that ends in a method stub returning `$null`.
> 
> Adds golden integration outputs for a range of call scenarios (scalar/multi-arg calls, `$ref` args and casing conversions, dotted/deep-dotted method calls, transforms/wrapping, and dict payloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 048b33a0d89ef1ae427a628a45a5d3f41c01be2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->