### PR TITLE
Run odin run serially to avoid intermittent segfaults

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -158,9 +158,9 @@ jobs:
         uses: laytan/setup-odin@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      # Run serially: parallel `odin check` invocations are the
-      # suspected cause of the intermittent hangs, so feed fixtures
-      # one at a time until the upstream issue is understood.
+      # Run serially: parallel `odin check` and `odin run` invocations
+      # are the suspected cause of intermittent crashes/hangs, so feed
+      # fixtures one at a time until the upstream issue is understood.
       - name: Lint Odin
         run: |-
           find tests/integration/cases -name '*.odin' -print0 > /tmp/files-odin
@@ -175,7 +175,7 @@ jobs:
           odin run "$1" -file -out:"$tmpdir/prog"
           SCRIPT
           chmod +x /tmp/run-odin-file.sh
-          xargs -0 -P "$(nproc)" -I{} /tmp/run-odin-file.sh {} < /tmp/files-odin
+          xargs -0 -I{} /tmp/run-odin-file.sh {} < /tmp/files-odin
 
   # Fixture languages whose interpreter is a quick `apt-get install`.
   # Grouped so the apt-get cost is paid once for the whole group.


### PR DESCRIPTION
## Summary

- The `lint-odin` CI job was running `odin run` in parallel with `xargs -P "$(nproc)"`, causing intermittent segfaults (exit code 123).
- The `odin check` step already had a serial workaround for the same root cause (a known upstream parallelism issue with the Odin toolchain).
- This PR extends that workaround to the `odin run` step by removing `-P "$(nproc)"`, making it run one file at a time.

## Test plan

- [ ] The `lint-odin` CI job passes reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that trades some parallelism for improved stability in the `lint-odin` job; main impact is potentially longer workflow runtime.
> 
> **Overview**
> Updates the GitHub Actions `lint-odin` job to run Odin fixtures **serially** during the `odin run` step by removing `xargs` parallelism.
> 
> Also expands the inline comment to note that both `odin check` and `odin run` can intermittently crash/hang when invoked in parallel, documenting the rationale for the serial workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3055d6d5c53b5606a610268e67635d8d89b4b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->