### PR TITLE
Install Odin via direct release download to /opt/odin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -154,10 +154,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # apt installs odin under /usr, which is owned by root and not
+      # writable by the CI user. laytan/setup-odin drops the binary into
+      # a runner-owned directory, so a compromised dependency could
+      # silently replace the odin binary mid-job.
       - name: Install Odin
-        uses: laytan/setup-odin@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq odin
       # Run serially: parallel `odin check` invocations are the
       # suspected cause of the intermittent hangs, so feed fixtures
       # one at a time until the upstream issue is understood.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -154,12 +154,22 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      # apt installs odin under /usr, which is owned by root and not
-      # writable by the CI user. laytan/setup-odin drops the binary into
-      # a runner-owned directory, so a compromised dependency could
-      # silently replace the odin binary mid-job.
+      # Downloading the release zip directly and extracting to /opt/odin
+      # (owned by root, not writable by the CI user) is safer than
+      # laytan/setup-odin, which places the binary in a runner-owned
+      # directory where a compromised dependency could replace it
+      # mid-job. /opt/odin must stay on PATH alongside the binary so
+      # odin can resolve its core library relative to its own location.
       - name: Install Odin
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq odin
+        run: |
+          mkdir -p /tmp/odin-dl
+          gh release download --repo odin-lang/Odin \
+            --pattern 'odin-linux-amd64-*.zip' \
+            -D /tmp/odin-dl
+          sudo unzip /tmp/odin-dl/*.zip -d /opt/odin
+          echo "/opt/odin" >> "$GITHUB_PATH"
+        env:
+          GH_TOKEN: ${{ github.token }}
       # Run serially: parallel `odin check` invocations are the
       # suspected cause of the intermittent hangs, so feed fixtures
       # one at a time until the upstream issue is understood.


### PR DESCRIPTION
## Summary

- Replaces `laytan/setup-odin@v2` with a direct `gh release download` from `odin-lang/Odin`, extracting to `/opt/odin` via `sudo`.
- `/opt/odin` is owned by root and not writable by the CI user, so a compromised dependency cannot silently replace the binary mid-job -- the same property that apt would give if odin were packaged there.
- `/opt/odin` is added to `$GITHUB_PATH` (rather than symlinking just the binary) so odin can resolve its core library relative to its own location.
- Removes the `laytan/setup-odin` action dependency; `GH_TOKEN: ${{ github.token }}` is passed to `gh` to avoid unauthenticated rate limits when fetching the release.

## Test plan

- [ ] Confirm `lint-odin` job passes in CI with the directly-downloaded binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change, but it alters toolchain installation and relies on GitHub release download/unzip behavior; mis-installs or PATH/library resolution issues could break the `lint-odin` job.
> 
> **Overview**
> Updates the `lint-odin` GitHub Actions job to stop using `laytan/setup-odin@v2` and instead download the official Odin Linux release zip via `gh release download`, unzip it to root-owned `/opt/odin`, and add that directory to `PATH`.
> 
> This also drops the action-specific `GITHUB_TOKEN` input in favor of a job-scoped `GH_TOKEN` env, with the stated goal of reducing the risk of the Odin binary being replaced in a runner-writable location mid-job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373cdbab3e0acf90d29ee6bc47fbdd99565e7f87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->