### PR TITLE
Use per-fixture module names for Erlang goldens and drop sed-rename in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -509,7 +509,7 @@ jobs:
           while IFS= read -r -d '' f; do
             dir=${f%/*}; dir=${dir##*/}
             stem=$(basename "$f" .erl)
-            name="fixture_${dir}_${stem,,}"
+            name="fixture_${dir,,}_${stem,,}"
             cp "$f" "$ERLANG_FIXTURE_DIR/$name.erl"
           done < /tmp/files-erlang
           (cd "$ERLANG_FIXTURE_DIR" && erlc -Werror fixture_*.erl)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -461,7 +461,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.18'
-          gleam-version: latest
+          gleam-version: v1.16.0
           otp-version: '27'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -1054,6 +1054,8 @@ jobs:
         run: find tests/integration/cases -name '*.cr' -print0 > /tmp/files-to-lint
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: 1.20.0
       # Compile every fixture in a single `crystal run` invocation to
       # pay Crystal's front-end + LLVM codegen + link cost once instead
       # of per fixture. Each fixture is wrapped in a unique

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -497,36 +497,33 @@ jobs:
           elixir .github/scripts/lint-elixir.exs < /tmp/files-elixir
 
       # Compile every fixture in a single erlc invocation to pay the
-      # BEAM VM startup cost once. Erlang requires the module name to
-      # match the filename, so fixtures (all declared `-module(check).`)
-      # are renamed to `fixture_N.erl` with the module declaration
-      # rewritten; the mapping is printed so failures still point back
-      # to the original path.
+      # BEAM VM startup cost once. Each fixture already carries a unique
+      # module name derived from its case directory and stem, so a plain
+      # copy suffices; no sed rewriting needed.
       - name: Lint Erlang
         env:
           ERLANG_FIXTURE_DIR: ${{ runner.temp }}/lint-erlang
         run: |-
           find tests/integration/cases -name '*.erl' -print0 > /tmp/files-erlang
           mkdir -p "$ERLANG_FIXTURE_DIR"
-          i=0
           while IFS= read -r -d '' f; do
-            name="fixture_$i"
-            sed "1s/^-module(check)\./-module($name)./" "$f" > "$ERLANG_FIXTURE_DIR/$name.erl"
-            printf '%s.erl <- %s\n' "$name" "$f"
-            i=$((i+1))
+            dir=${f%/*}; dir=${dir##*/}
+            stem=$(basename "$f" .erl)
+            name="fixture_${dir}_${stem,,}"
+            cp "$f" "$ERLANG_FIXTURE_DIR/$name.erl"
           done < /tmp/files-erlang
           (cd "$ERLANG_FIXTURE_DIR" && erlc -Werror fixture_*.erl)
 
       # `erlc` only compiles; runtime errors (undefined functions, missing
       # imports, failed assertions) slip past unless each fixture is
-      # actually executed. Fixtures all expose `check:x/0`, renamed to
-      # `fixture_N:x/0` during compilation; invoke each in a single BEAM
-      # VM and collect failures so one bad fixture does not mask others.
+      # actually executed. Every module name starts with ``fixture_``;
+      # invoke each in a single BEAM VM and collect failures so one bad
+      # fixture does not mask others.
       - name: Run Erlang files
         env:
           ERLANG_FIXTURE_DIR: ${{ runner.temp }}/lint-erlang
         run: |-
-          modules=$(find "$ERLANG_FIXTURE_DIR" -maxdepth 1 -name 'fixture_*.beam' -printf '%f\n' | sed 's|\.beam$||' | paste -sd, -)
+          modules=$(find "$ERLANG_FIXTURE_DIR" -maxdepth 1 -name '*.beam' -printf '%f\n' | sed 's|\.beam$||' | paste -sd, -)
           erl -noshell -pa "$ERLANG_FIXTURE_DIR" -eval "
             Run = fun(M) ->
                 try M:x(), ok

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -391,7 +391,8 @@ def run_call_golden_case(
     golden_path = input_path.parent / (golden_name + lang_cls.extension)
     if isinstance(spec, Erlang):
         spec = dataclasses.replace(
-            spec, module_name=erlang_module_name(golden_path)
+            spec,
+            module_name=erlang_module_name(golden_path=golden_path),
         )
     effective_ref_case: literalizer.IdentifierCase | None
     if config.ref_case_per_language:

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -22,10 +22,10 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     HeterogeneousCollectionError,
 )
-from literalizer.languages import Sml
+from literalizer.languages import Erlang, Sml
 
 from .check_golden import check_golden
-from .language_specs import sorted_languages
+from .language_specs import erlang_module_name, sorted_languages
 
 if TYPE_CHECKING:
     from literalizer._types import Value
@@ -389,6 +389,10 @@ def run_call_golden_case(
     input_path = cases_dir / config.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
     golden_path = input_path.parent / (golden_name + lang_cls.extension)
+    if isinstance(spec, Erlang):
+        spec = dataclasses.replace(
+            spec, module_name=erlang_module_name(golden_path)
+        )
     effective_ref_case: literalizer.IdentifierCase | None
     if config.ref_case_per_language:
         # First element of ``identifier_cases`` is the language's

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -10,7 +10,7 @@ import dataclasses
 import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from beartype import beartype
@@ -390,9 +390,12 @@ def run_call_golden_case(
     yaml_string = input_path.read_text()
     golden_path = input_path.parent / (golden_name + lang_cls.extension)
     if isinstance(spec, Erlang):
-        spec = dataclasses.replace(
-            spec,
-            module_name=erlang_module_name(golden_path=golden_path),
+        spec = cast(
+            "literalizer.Language",
+            dataclasses.replace(
+                spec,
+                module_name=erlang_module_name(golden_path=golden_path),
+            ),
         )
     effective_ref_case: literalizer.IdentifierCase | None
     if config.ref_case_per_language:

--- a/tests/integration/cases/binary/Erlang.erl
+++ b/tests/integration/cases/binary/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_binary_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/binary/Erlang_bytes_format_base64.erl
+++ b/tests/integration/cases/binary/Erlang_bytes_format_base64.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_binary_erlang_bytes_format_base64).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/bool_list/Erlang.erl
+++ b/tests/integration/cases/bool_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_bool_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/call_deep_dotted_method/Erlang_call.erl
+++ b/tests/integration/cases/call_deep_dotted_method/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_deep_dotted_method_erlang_call).
 -export([x/0]).
 'obj.api.client.post'(_) -> ok.
 x() ->

--- a/tests/integration/cases/call_deep_dotted_transformed/Erlang_call.erl
+++ b/tests/integration/cases/call_deep_dotted_transformed/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_deep_dotted_transformed_erlang_call).
 -export([x/0]).
 'app.client.fetch'(_) -> undefined.
 emit(_) -> ok.

--- a/tests/integration/cases/call_dotted_method/Erlang_call.erl
+++ b/tests/integration/cases/call_dotted_method/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_dotted_method_erlang_call).
 -export([x/0]).
 'app.client.fetch'(_) -> ok.
 x() ->

--- a/tests/integration/cases/call_keyword_args/Erlang_call.erl
+++ b/tests/integration/cases/call_keyword_args/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_keyword_args_erlang_call).
 -export([x/0]).
 'throttler.check'(_, _) -> undefined.
 emit(_) -> ok.

--- a/tests/integration/cases/call_mixed_type_dicts/Erlang_call.erl
+++ b/tests/integration/cases/call_mixed_type_dicts/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_mixed_type_dicts_erlang_call).
 -export([x/0]).
 'app.mgr.op'(_) -> ok.
 x() ->

--- a/tests/integration/cases/call_multi_args/Erlang_call.erl
+++ b/tests/integration/cases/call_multi_args/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_multi_args_erlang_call).
 -export([x/0]).
 process(_, _) -> ok.
 x() ->

--- a/tests/integration/cases/call_per_element_false/Erlang_call.erl
+++ b/tests/integration/cases/call_per_element_false/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_per_element_false_erlang_call).
 -export([x/0]).
 process(_) -> ok.
 x() ->

--- a/tests/integration/cases/call_ref_args/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_ref_args_erlang_call).
 -export([x/0]).
 process(_, _) -> ok.
 x() ->

--- a/tests/integration/cases/call_ref_args_converted/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args_converted/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_ref_args_converted_erlang_call).
 -export([x/0]).
 process(_, _) -> ok.
 x() ->

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_ref_args_converted_nonsnake_erlang_call).
 -export([x/0]).
 process(_, _) -> ok.
 x() ->

--- a/tests/integration/cases/call_ref_args_converted_whole/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args_converted_whole/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_ref_args_converted_whole_erlang_call).
 -export([x/0]).
 process(_) -> ok.
 x() ->

--- a/tests/integration/cases/call_scalar_args/Erlang_call.erl
+++ b/tests/integration/cases/call_scalar_args/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_scalar_args_erlang_call).
 -export([x/0]).
 process(_) -> ok.
 x() ->

--- a/tests/integration/cases/call_snake_dotted_method/Erlang_call.erl
+++ b/tests/integration/cases/call_snake_dotted_method/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_snake_dotted_method_erlang_call).
 -export([x/0]).
 'my_app.http_client.fetch'(_) -> ok.
 x() ->

--- a/tests/integration/cases/call_transform_no_wrapper/Erlang_call.erl
+++ b/tests/integration/cases/call_transform_no_wrapper/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_transform_no_wrapper_erlang_call).
 -export([x/0]).
 process(_) -> undefined.
 x() ->

--- a/tests/integration/cases/call_wrap_in_file/Erlang_call.erl
+++ b/tests/integration/cases/call_wrap_in_file/Erlang_call.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_call_wrap_in_file_erlang_call).
 -export([x/0]).
 process(_, _) -> ok.
 x() ->

--- a/tests/integration/cases/comment_block_scalar_not_comment/Erlang.erl
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comment_block_scalar_not_comment_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/comment_scalar/Erlang.erl
+++ b/tests/integration/cases/comment_scalar/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comment_scalar_erlang).
 -export([x/0]).
 x() ->
     % note

--- a/tests/integration/cases/comment_scalar_document_markers/Erlang.erl
+++ b/tests/integration/cases/comment_scalar_document_markers/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comment_scalar_document_markers_erlang).
 -export([x/0]).
 x() ->
     % note

--- a/tests/integration/cases/comment_scalar_inline/Erlang.erl
+++ b/tests/integration/cases/comment_scalar_inline/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comment_scalar_inline_erlang).
 -export([x/0]).
 x() ->
     % note

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Erlang.erl
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comment_scalar_quoted_with_hash_erlang).
 -export([x/0]).
 x() ->
     % note

--- a/tests/integration/cases/comments/Erlang.erl
+++ b/tests/integration/cases/comments/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/comments_bang_in_double_quote/Erlang.erl
+++ b/tests/integration/cases/comments_bang_in_double_quote/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_bang_in_double_quote_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/comments_double_hash/Erlang.erl
+++ b/tests/integration/cases/comments_double_hash/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_double_hash_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/comments_empty_line/Erlang.erl
+++ b/tests/integration/cases/comments_empty_line/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_empty_line_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/comments_escaped_quote/Erlang.erl
+++ b/tests/integration/cases/comments_escaped_quote/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_escaped_quote_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/comments_escaped_single_quote/Erlang.erl
+++ b/tests/integration/cases/comments_escaped_single_quote/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_escaped_single_quote_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/comments_multi_line/Erlang.erl
+++ b/tests/integration/cases/comments_multi_line/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_multi_line_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/comments_nested_mapping/Erlang.erl
+++ b/tests/integration/cases/comments_nested_mapping/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_nested_mapping_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/comments_sequence_before/Erlang.erl
+++ b/tests/integration/cases/comments_sequence_before/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_sequence_before_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/comments_sequence_inline/Erlang.erl
+++ b/tests/integration/cases/comments_sequence_inline/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_sequence_inline_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/comments_trailing/Erlang.erl
+++ b/tests/integration/cases/comments_trailing/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_trailing_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/comments_vb_before_dim/Erlang.erl
+++ b/tests/integration/cases/comments_vb_before_dim/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_comments_vb_before_dim_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/date_list/Erlang.erl
+++ b/tests/integration/cases/date_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_date_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/date_list/Erlang_date_erlang.erl
+++ b/tests/integration/cases/date_list/Erlang_date_erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_date_list_erlang_date_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/date_set/Erlang.erl
+++ b/tests/integration/cases/date_set/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_date_set_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([

--- a/tests/integration/cases/date_set/Erlang_date_erlang.erl
+++ b/tests/integration/cases/date_set/Erlang_date_erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_date_set_erlang_date_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([

--- a/tests/integration/cases/dates/Erlang.erl
+++ b/tests/integration/cases/dates/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dates_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/datetime_list/Erlang.erl
+++ b/tests/integration/cases/datetime_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_datetime_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/datetime_list/Erlang_datetime_erlang.erl
+++ b/tests/integration/cases/datetime_list/Erlang_datetime_erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_datetime_list_erlang_datetime_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/deep_nesting/Erlang.erl
+++ b/tests/integration/cases/deep_nesting/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_deep_nesting_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_all_null_trailing_comment/Erlang.erl
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_all_null_trailing_comment_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_all_scalar_types/Erlang.erl
+++ b/tests/integration/cases/dict_all_scalar_types/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_all_scalar_types_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_mixed_int_widths/Erlang.erl
+++ b/tests/integration/cases/dict_mixed_int_widths/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_mixed_int_widths_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_mixed_scalars/Erlang.erl
+++ b/tests/integration/cases/dict_mixed_scalars/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_mixed_scalars_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_null_leading_comment/Erlang.erl
+++ b/tests/integration/cases/dict_null_leading_comment/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_null_leading_comment_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_null_middle_inline_comment/Erlang.erl
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_null_middle_inline_comment_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Erlang.erl
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_null_trailing_inline_comment_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_with_control_char_keys/Erlang.erl
+++ b/tests/integration/cases/dict_with_control_char_keys/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_with_control_char_keys_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_with_hyphen_keys/Erlang.erl
+++ b/tests/integration/cases/dict_with_hyphen_keys/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_with_hyphen_keys_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_with_list_value/Erlang.erl
+++ b/tests/integration/cases/dict_with_list_value/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_with_list_value_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/dict_with_nulls/Erlang.erl
+++ b/tests/integration/cases/dict_with_nulls/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_dict_with_nulls_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Erlang.erl
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_doubly_nested_list_with_empty_sibling_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/empty_dict/Erlang.erl
+++ b/tests/integration/cases/empty_dict/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_empty_dict_erlang).
 -export([x/0]).
 x() ->
     My_data = #{},

--- a/tests/integration/cases/empty_dicts_in_sequence/Erlang.erl
+++ b/tests/integration/cases/empty_dicts_in_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_empty_dicts_in_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/empty_list/Erlang.erl
+++ b/tests/integration/cases/empty_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_empty_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [],

--- a/tests/integration/cases/empty_sequence/Erlang.erl
+++ b/tests/integration/cases/empty_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_empty_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/empty_set/Erlang.erl
+++ b/tests/integration/cases/empty_set/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_empty_set_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([]),

--- a/tests/integration/cases/float_list/Erlang.erl
+++ b/tests/integration/cases/float_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_list/Erlang_float_format_fixed.erl
+++ b/tests/integration/cases/float_list/Erlang_float_format_fixed.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_list_erlang_float_format_fixed).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_list/Erlang_float_format_scientific.erl
+++ b/tests/integration/cases/float_list/Erlang_float_format_scientific.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_list_erlang_float_format_scientific).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_list/Erlang_sequence_tuple_float.erl
+++ b/tests/integration/cases/float_list/Erlang_sequence_tuple_float.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_list_erlang_sequence_tuple_float).
 -export([x/0]).
 x() ->
     My_data = {

--- a/tests/integration/cases/float_negative_zero/Erlang.erl
+++ b/tests/integration/cases/float_negative_zero/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_negative_zero_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_scientific_notation/Erlang.erl
+++ b/tests/integration/cases/float_scientific_notation/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_scientific_notation_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_scientific_notation/Erlang_float_format_fixed_s.erl
+++ b/tests/integration/cases/float_scientific_notation/Erlang_float_format_fixed_s.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_scientific_notation_erlang_float_format_fixed_s).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_scientific_notation/Erlang_float_format_scientific_s.erl
+++ b/tests/integration/cases/float_scientific_notation/Erlang_float_format_scientific_s.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_scientific_notation_erlang_float_format_scientific_s).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_special_values/Erlang.erl
+++ b/tests/integration/cases/float_special_values/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_special_values_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_special_values/Erlang_float_format_fixed_v.erl
+++ b/tests/integration/cases/float_special_values/Erlang_float_format_fixed_v.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_special_values_erlang_float_format_fixed_v).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/float_special_values/Erlang_float_format_scientific_v.erl
+++ b/tests/integration/cases/float_special_values/Erlang_float_format_scientific_v.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_float_special_values_erlang_float_format_scientific_v).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_key_dict/Erlang.erl
+++ b/tests/integration/cases/int_key_dict/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_key_dict_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/int_list/Erlang.erl
+++ b/tests/integration/cases/int_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list/Erlang_integer_format_binary.erl
+++ b/tests/integration/cases/int_list/Erlang_integer_format_binary.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_erlang_integer_format_binary).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list/Erlang_integer_format_hex.erl
+++ b/tests/integration/cases/int_list/Erlang_integer_format_hex.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_erlang_integer_format_hex).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list_large/Erlang.erl
+++ b/tests/integration/cases/int_list_large/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_large_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list_large/Erlang_integer_format_binary_large.erl
+++ b/tests/integration/cases/int_list_large/Erlang_integer_format_binary_large.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_large_erlang_integer_format_binary_large).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list_large/Erlang_integer_format_hex_large.erl
+++ b/tests/integration/cases/int_list_large/Erlang_integer_format_hex_large.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_large_erlang_integer_format_hex_large).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list_with_zero/Erlang.erl
+++ b/tests/integration/cases/int_list_with_zero/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_with_zero_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list_with_zero/Erlang_integer_format_binary_zero.erl
+++ b/tests/integration/cases/int_list_with_zero/Erlang_integer_format_binary_zero.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_with_zero_erlang_integer_format_binary_zero).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_list_with_zero/Erlang_integer_format_hex_zero.erl
+++ b/tests/integration/cases/int_list_with_zero/Erlang_integer_format_hex_zero.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_list_with_zero_erlang_integer_format_hex_zero).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/int_set/Erlang.erl
+++ b/tests/integration/cases/int_set/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_int_set_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([

--- a/tests/integration/cases/mixed_number_dict/Erlang.erl
+++ b/tests/integration/cases/mixed_number_dict/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_mixed_number_dict_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/mixed_number_list/Erlang.erl
+++ b/tests/integration/cases/mixed_number_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_mixed_number_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/mixed_set/Erlang.erl
+++ b/tests/integration/cases/mixed_set/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_mixed_set_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Erlang.erl
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_mixed_type_dicts_in_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested/Erlang.erl
+++ b/tests/integration/cases/nested/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/nested_bool_list/Erlang.erl
+++ b/tests/integration/cases/nested_bool_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_bool_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_collection_multi_space_string/Erlang.erl
+++ b/tests/integration/cases/nested_collection_multi_space_string/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_collection_multi_space_string_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_deep_empty/Erlang.erl
+++ b/tests/integration/cases/nested_deep_empty/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_deep_empty_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_deep_mixed/Erlang.erl
+++ b/tests/integration/cases/nested_deep_mixed/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_deep_mixed_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_empty_inner/Erlang.erl
+++ b/tests/integration/cases/nested_empty_inner/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_empty_inner_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_float_list/Erlang.erl
+++ b/tests/integration/cases/nested_float_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_float_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_float_list/Erlang_float_format_fixed_n.erl
+++ b/tests/integration/cases/nested_float_list/Erlang_float_format_fixed_n.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_float_list_erlang_float_format_fixed_n).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_float_list/Erlang_float_format_scientific_n.erl
+++ b/tests/integration/cases/nested_float_list/Erlang_float_format_scientific_n.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_float_list_erlang_float_format_scientific_n).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Erlang.erl
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_list_mixed_sibling_types_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_list_of_dicts/Erlang.erl
+++ b/tests/integration/cases/nested_list_of_dicts/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_list_of_dicts_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_list_with_empty_sibling/Erlang.erl
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_list_with_empty_sibling_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_mixed_dict/Erlang.erl
+++ b/tests/integration/cases/nested_mixed_dict/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_mixed_dict_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/nested_mixed_inner/Erlang.erl
+++ b/tests/integration/cases/nested_mixed_inner/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_mixed_inner_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_mixed_set/Erlang.erl
+++ b/tests/integration/cases/nested_mixed_set/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_mixed_set_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/nested_mixed_types/Erlang.erl
+++ b/tests/integration/cases/nested_mixed_types/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_mixed_types_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_sequence/Erlang.erl
+++ b/tests/integration/cases/nested_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/nested_sequences/Erlang.erl
+++ b/tests/integration/cases/nested_sequences/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_nested_sequences_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/no_comment/Erlang.erl
+++ b/tests/integration/cases/no_comment/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_no_comment_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/ordered_map/Erlang.erl
+++ b/tests/integration/cases/ordered_map/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_ordered_map_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/ordered_map_in_sequence/Erlang.erl
+++ b/tests/integration/cases/ordered_map_in_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_ordered_map_in_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/ordered_map_int_keys/Erlang.erl
+++ b/tests/integration/cases/ordered_map_int_keys/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_ordered_map_int_keys_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/ordered_map_nested_values/Erlang.erl
+++ b/tests/integration/cases/ordered_map_nested_values/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_ordered_map_nested_values_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/pair_sequence/Erlang.erl
+++ b/tests/integration/cases/pair_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_pair_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/pair_sequence/Erlang_sequence_tuple_pair.erl
+++ b/tests/integration/cases/pair_sequence/Erlang_sequence_tuple_pair.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_pair_sequence_erlang_sequence_tuple_pair).
 -export([x/0]).
 x() ->
     My_data = {

--- a/tests/integration/cases/scalar_bool/Erlang.erl
+++ b/tests/integration/cases/scalar_bool/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_bool_erlang).
 -export([x/0]).
 x() ->
     My_data = true,

--- a/tests/integration/cases/scalar_date/Erlang.erl
+++ b/tests/integration/cases/scalar_date/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_date_erlang).
 -export([x/0]).
 x() ->
     My_data = "2024-01-15",

--- a/tests/integration/cases/scalar_date/Erlang_date_erlang.erl
+++ b/tests/integration/cases/scalar_date/Erlang_date_erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_date_erlang_date_erlang).
 -export([x/0]).
 x() ->
     My_data = {2024, 1, 15},

--- a/tests/integration/cases/scalar_datetime/Erlang.erl
+++ b/tests/integration/cases/scalar_datetime/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_erlang).
 -export([x/0]).
 x() ->
     My_data = "2024-01-15T12:30:00+00:00",

--- a/tests/integration/cases/scalar_datetime/Erlang_datetime_erlang.erl
+++ b/tests/integration/cases/scalar_datetime/Erlang_datetime_erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_erlang_datetime_erlang).
 -export([x/0]).
 x() ->
     My_data = {{2024, 1, 15}, {12, 30, 0}},

--- a/tests/integration/cases/scalar_datetime_microsecond/Erlang.erl
+++ b/tests/integration/cases/scalar_datetime_microsecond/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_microsecond_erlang).
 -export([x/0]).
 x() ->
     My_data = "2024-01-15T12:30:00.123456+00:00",

--- a/tests/integration/cases/scalar_datetime_midnight/Erlang.erl
+++ b/tests/integration/cases/scalar_datetime_midnight/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_midnight_erlang).
 -export([x/0]).
 x() ->
     My_data = "2024-01-15T00:00:00",

--- a/tests/integration/cases/scalar_datetime_naive/Erlang.erl
+++ b/tests/integration/cases/scalar_datetime_naive/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_naive_erlang).
 -export([x/0]).
 x() ->
     My_data = "2024-01-15T12:30:00",

--- a/tests/integration/cases/scalar_datetime_naive/Erlang_datetime_erlang_naive.erl
+++ b/tests/integration/cases/scalar_datetime_naive/Erlang_datetime_erlang_naive.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_naive_erlang_datetime_erlang_naive).
 -export([x/0]).
 x() ->
     My_data = {{2024, 1, 15}, {12, 30, 0}},

--- a/tests/integration/cases/scalar_datetime_non_utc/Erlang.erl
+++ b/tests/integration/cases/scalar_datetime_non_utc/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_non_utc_erlang).
 -export([x/0]).
 x() ->
     My_data = "2024-01-15T18:00:00+05:30",

--- a/tests/integration/cases/scalar_datetime_non_utc/Erlang_datetime_erlang_non_utc.erl
+++ b/tests/integration/cases/scalar_datetime_non_utc/Erlang_datetime_erlang_non_utc.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_non_utc_erlang_datetime_erlang_non_utc).
 -export([x/0]).
 x() ->
     My_data = {{2024, 1, 15}, {18, 0, 0}},

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Erlang.erl
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_datetime_seconds_microsecond_erlang).
 -export([x/0]).
 x() ->
     My_data = "2024-01-15T12:30:45.123456",

--- a/tests/integration/cases/scalar_float/Erlang.erl
+++ b/tests/integration/cases/scalar_float/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_float_erlang).
 -export([x/0]).
 x() ->
     My_data = 3.14,

--- a/tests/integration/cases/scalar_float/Erlang_float_format_fixed.erl
+++ b/tests/integration/cases/scalar_float/Erlang_float_format_fixed.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_float_erlang_float_format_fixed).
 -export([x/0]).
 x() ->
     My_data = 3.140000,

--- a/tests/integration/cases/scalar_float/Erlang_float_format_scientific.erl
+++ b/tests/integration/cases/scalar_float/Erlang_float_format_scientific.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_float_erlang_float_format_scientific).
 -export([x/0]).
 x() ->
     My_data = 3.14,

--- a/tests/integration/cases/scalar_int/Erlang.erl
+++ b/tests/integration/cases/scalar_int/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_erlang).
 -export([x/0]).
 x() ->
     My_data = 42,

--- a/tests/integration/cases/scalar_int/Erlang_integer_format_binary.erl
+++ b/tests/integration/cases/scalar_int/Erlang_integer_format_binary.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_erlang_integer_format_binary).
 -export([x/0]).
 x() ->
     My_data = 2#101010,

--- a/tests/integration/cases/scalar_int/Erlang_integer_format_hex.erl
+++ b/tests/integration/cases/scalar_int/Erlang_integer_format_hex.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_erlang_integer_format_hex).
 -export([x/0]).
 x() ->
     My_data = 16#2A,

--- a/tests/integration/cases/scalar_int_large/Erlang.erl
+++ b/tests/integration/cases/scalar_int_large/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_large_erlang).
 -export([x/0]).
 x() ->
     My_data = 2147483648,

--- a/tests/integration/cases/scalar_int_large/Erlang_integer_format_binary.erl
+++ b/tests/integration/cases/scalar_int_large/Erlang_integer_format_binary.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_large_erlang_integer_format_binary).
 -export([x/0]).
 x() ->
     My_data = 2#10000000000000000000000000000000,

--- a/tests/integration/cases/scalar_int_large/Erlang_integer_format_hex.erl
+++ b/tests/integration/cases/scalar_int_large/Erlang_integer_format_hex.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_large_erlang_integer_format_hex).
 -export([x/0]).
 x() ->
     My_data = 16#80000000,

--- a/tests/integration/cases/scalar_int_negative_large/Erlang.erl
+++ b/tests/integration/cases/scalar_int_negative_large/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_negative_large_erlang).
 -export([x/0]).
 x() ->
     My_data = -2147483649,

--- a/tests/integration/cases/scalar_int_very_large/Erlang.erl
+++ b/tests/integration/cases/scalar_int_very_large/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_very_large_erlang).
 -export([x/0]).
 x() ->
     My_data = 9223372036854775808,

--- a/tests/integration/cases/scalar_int_very_negative_large/Erlang.erl
+++ b/tests/integration/cases/scalar_int_very_negative_large/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_int_very_negative_large_erlang).
 -export([x/0]).
 x() ->
     My_data = -9223372036854775809,

--- a/tests/integration/cases/scalar_null/Erlang.erl
+++ b/tests/integration/cases/scalar_null/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_null_erlang).
 -export([x/0]).
 x() ->
     My_data = undefined,

--- a/tests/integration/cases/scalar_null_with_comment/Erlang.erl
+++ b/tests/integration/cases/scalar_null_with_comment/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_null_with_comment_erlang).
 -export([x/0]).
 x() ->
     % note

--- a/tests/integration/cases/scalar_string/Erlang.erl
+++ b/tests/integration/cases/scalar_string/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalar_string_erlang).
 -export([x/0]).
 x() ->
     My_data = "hello",

--- a/tests/integration/cases/scalars/Erlang.erl
+++ b/tests/integration/cases/scalars/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_scalars_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/sequence_of_dicts/Erlang.erl
+++ b/tests/integration/cases/sequence_of_dicts/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_sequence_of_dicts_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/set/Erlang.erl
+++ b/tests/integration/cases/set/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_set_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([

--- a/tests/integration/cases/set_comments/Erlang.erl
+++ b/tests/integration/cases/set_comments/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_set_comments_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([

--- a/tests/integration/cases/set_comments_unsorted_order/Erlang.erl
+++ b/tests/integration/cases/set_comments_unsorted_order/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_set_comments_unsorted_order_erlang).
 -export([x/0]).
 x() ->
     My_data = sets:from_list([

--- a/tests/integration/cases/sibling_list_values_nested/Erlang.erl
+++ b/tests/integration/cases/sibling_list_values_nested/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_sibling_list_values_nested_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Erlang.erl
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_sibling_list_values_uniform_inner_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/simple_dict/Erlang.erl
+++ b/tests/integration/cases/simple_dict/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_simple_dict_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/simple_sequence/Erlang.erl
+++ b/tests/integration/cases/simple_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_simple_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/simple_sequence/Erlang_sequence_tuple.erl
+++ b/tests/integration/cases/simple_sequence/Erlang_sequence_tuple.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_simple_sequence_erlang_sequence_tuple).
 -export([x/0]).
 x() ->
     My_data = {

--- a/tests/integration/cases/simple_sequence/Erlang_sequence_tuple_varname.erl
+++ b/tests/integration/cases/simple_sequence/Erlang_sequence_tuple_varname.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_simple_sequence_erlang_sequence_tuple_varname).
 -export([x/0]).
 x() ->
     My_data = {

--- a/tests/integration/cases/string_control_chars/Erlang.erl
+++ b/tests/integration/cases/string_control_chars/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_control_chars_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Erlang.erl
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_escaped_quotes_and_dashes_erlang).
 -export([x/0]).
 x() ->
     My_data = "hello \"world\" -- not a comment",

--- a/tests/integration/cases/string_list/Erlang.erl
+++ b/tests/integration/cases/string_list/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_list_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/string_with_backslash/Erlang.erl
+++ b/tests/integration/cases/string_with_backslash/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_with_backslash_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/string_with_dollar/Erlang.erl
+++ b/tests/integration/cases/string_with_dollar/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_with_dollar_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/string_with_dollar_brace/Erlang.erl
+++ b/tests/integration/cases/string_with_dollar_brace/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_with_dollar_brace_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/string_with_hash/Erlang.erl
+++ b/tests/integration/cases/string_with_hash/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_with_hash_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/string_with_percent/Erlang.erl
+++ b/tests/integration/cases/string_with_percent/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_string_with_percent_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/triple_sequence/Erlang.erl
+++ b/tests/integration/cases/triple_sequence/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_triple_sequence_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/triple_sequence/Erlang_sequence_tuple_triple.erl
+++ b/tests/integration/cases/triple_sequence/Erlang_sequence_tuple_triple.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_triple_sequence_erlang_sequence_tuple_triple).
 -export([x/0]).
 x() ->
     My_data = {

--- a/tests/integration/cases/type_hints/Erlang.erl
+++ b/tests/integration/cases/type_hints/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_type_hints_erlang).
 -export([x/0]).
 x() ->
     My_data = #{

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Erlang.erl
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_uniform_mixed_num_dicts_in_seq_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Erlang.erl
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Erlang.erl
@@ -1,4 +1,4 @@
--module(check).
+-module(fixture_uniform_string_dicts_in_seq_erlang).
 -export([x/0]).
 x() ->
     My_data = [

--- a/tests/integration/language_specs.py
+++ b/tests/integration/language_specs.py
@@ -13,11 +13,11 @@ from pathlib import Path
 from beartype import beartype
 
 import literalizer
-from literalizer.languages import ALL_LANGUAGES, Erlang
+from literalizer.languages import ALL_LANGUAGES
 
 
 @beartype
-def erlang_module_name(golden_path: Path) -> str:
+def erlang_module_name(*, golden_path: Path) -> str:
     """Return the Erlang module name for *golden_path*.
 
     Produces a deterministic, per-fixture name so every compiled
@@ -39,9 +39,6 @@ def find_redefinition_styles(
         for style in spec.declaration_styles
         if style.value.supports_redefinition
     ]
-
-
-_ERLANG_CLS: type = Erlang
 
 
 @beartype
@@ -74,27 +71,19 @@ def cached_spec(
 def make_spec(
     *,
     lang_cls: literalizer.LanguageCls,
-    golden_path: Path | None = None,
     **kwargs: object,
 ) -> literalizer.Language:
     """Return a cached instance of *lang_cls* for the given kwargs.
 
     Languages whose ``wrap_in_file`` introduces a named scope take a
     ``module_name`` constructor argument; default it to ``"check"`` so
-    fixture output matches the historic golden files.  When
-    *golden_path* is supplied and the language is Erlang, a
-    per-fixture module name is derived from the path instead.
+    fixture output matches the historic golden files.
     """
     has_module_name = "module_name" in getattr(
         lang_cls, "__dataclass_fields__", {}
     )
     if has_module_name and "module_name" not in kwargs:
-        if golden_path is not None and lang_cls is _ERLANG_CLS:
-            kwargs["module_name"] = erlang_module_name(golden_path)
-        else:
-            kwargs["module_name"] = lang_cls.module_name_case.convert(
-                name="check"
-            )
+        kwargs["module_name"] = lang_cls.module_name_case.convert(name="check")
     return cached_spec(
         lang_cls=lang_cls,
         kwargs_items=frozenset(kwargs.items()),

--- a/tests/integration/language_specs.py
+++ b/tests/integration/language_specs.py
@@ -8,11 +8,25 @@ test execution.
 
 import enum
 import functools
+from pathlib import Path
 
 from beartype import beartype
 
 import literalizer
-from literalizer.languages import ALL_LANGUAGES
+from literalizer.languages import ALL_LANGUAGES, Erlang
+
+
+@beartype
+def erlang_module_name(golden_path: Path) -> str:
+    """Return the Erlang module name for *golden_path*.
+
+    Produces a deterministic, per-fixture name so every compiled
+    ``.erl`` file in CI has a unique module declaration without needing
+    ``sed`` rewriting.
+    """
+    dir_name = golden_path.parent.name
+    stem = golden_path.stem
+    return f"fixture_{dir_name}_{stem}".lower()
 
 
 @beartype
@@ -25,6 +39,9 @@ def find_redefinition_styles(
         for style in spec.declaration_styles
         if style.value.supports_redefinition
     ]
+
+
+_ERLANG_CLS: type = Erlang
 
 
 @beartype
@@ -57,19 +74,27 @@ def cached_spec(
 def make_spec(
     *,
     lang_cls: literalizer.LanguageCls,
+    golden_path: Path | None = None,
     **kwargs: object,
 ) -> literalizer.Language:
     """Return a cached instance of *lang_cls* for the given kwargs.
 
     Languages whose ``wrap_in_file`` introduces a named scope take a
     ``module_name`` constructor argument; default it to ``"check"`` so
-    fixture output matches the historic golden files.
+    fixture output matches the historic golden files.  When
+    *golden_path* is supplied and the language is Erlang, a
+    per-fixture module name is derived from the path instead.
     """
     has_module_name = "module_name" in getattr(
         lang_cls, "__dataclass_fields__", {}
     )
     if has_module_name and "module_name" not in kwargs:
-        kwargs["module_name"] = lang_cls.module_name_case.convert(name="check")
+        if golden_path is not None and lang_cls is _ERLANG_CLS:
+            kwargs["module_name"] = erlang_module_name(golden_path)
+        else:
+            kwargs["module_name"] = lang_cls.module_name_case.convert(
+                name="check"
+            )
     return cached_spec(
         lang_cls=lang_cls,
         kwargs_items=frozenset(kwargs.items()),

--- a/tests/integration/test_literalize_golden.py
+++ b/tests/integration/test_literalize_golden.py
@@ -66,13 +66,17 @@ def test_golden_file(
             input_path = cases_dir / case_name / "input.yaml"
             yaml_string = input_path.read_text()
             golden_path = input_path.parent / (lang_name + lang_cls.extension)
+            spec = make_spec(lang_cls=lang_cls)
+            if isinstance(spec, Erlang):
+                spec = dataclasses.replace(
+                    spec,
+                    module_name=erlang_module_name(golden_path=golden_path),
+                )
             try:
                 result = literalizer.literalize(
                     source=yaml_string,
                     input_format=literalizer.InputFormat.YAML,
-                    language=make_spec(
-                        lang_cls=lang_cls, golden_path=golden_path
-                    ),
+                    language=spec,
                     pre_indent_level=0,
                     include_delimiters=True,
                     variable_form=wrap_variable_form(lang_cls=lang_cls),
@@ -127,8 +131,12 @@ def test_golden_file_combined_variable_forms(
             spec = make_spec(
                 lang_cls=lang_cls,
                 declaration_style=combined_case.declaration_style,
-                golden_path=golden_path,
             )
+            if isinstance(spec, Erlang):
+                spec = dataclasses.replace(
+                    spec,
+                    module_name=erlang_module_name(golden_path=golden_path),
+                )
             yaml_string = input_path.read_text()
             try:
                 result = literalizer.literalize(
@@ -191,7 +199,7 @@ def test_format_variant_golden_file(
             spec = (
                 dataclasses.replace(
                     variant.spec,
-                    module_name=erlang_module_name(golden_path),
+                    module_name=erlang_module_name(golden_path=golden_path),
                 )
                 if isinstance(variant.spec, Erlang)
                 else variant.spec
@@ -238,15 +246,13 @@ def test_line_ending_combined_variable_forms(
     """
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    golden_path = input_path.parent / (case.name + case.lang_cls.extension)
-    base_spec = make_spec(lang_cls=case.lang_cls, golden_path=golden_path)
+    base_spec = make_spec(lang_cls=case.lang_cls)
     redef_styles = find_redefinition_styles(spec=base_spec)
     assert redef_styles
     spec = make_spec(
         lang_cls=case.lang_cls,
         line_ending=case.line_ending,
         declaration_style=redef_styles[0],
-        golden_path=golden_path,
     )
     result = literalizer.literalize(
         source=yaml_string,
@@ -262,7 +268,7 @@ def test_line_ending_combined_variable_forms(
         contents=result.code + "\n",
         extension=spec.extension,
         newline=None,
-        golden_path=golden_path,
+        golden_path=input_path.parent / (case.name + spec.extension),
     )
 
 
@@ -281,15 +287,13 @@ def test_heterogeneous_strategy_combined_variable_forms(
     """
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    golden_path = input_path.parent / (case.name + case.lang_cls.extension)
-    base_spec = make_spec(lang_cls=case.lang_cls, golden_path=golden_path)
+    base_spec = make_spec(lang_cls=case.lang_cls)
     redef_styles = find_redefinition_styles(spec=base_spec)
     assert redef_styles
     spec = make_spec(
         lang_cls=case.lang_cls,
         heterogeneous_strategy=case.heterogeneous_strategy,
         declaration_style=redef_styles[0],
-        golden_path=golden_path,
     )
     result = literalizer.literalize(
         source=yaml_string,
@@ -305,7 +309,7 @@ def test_heterogeneous_strategy_combined_variable_forms(
         contents=result.code + "\n",
         extension=spec.extension,
         newline=None,
-        golden_path=golden_path,
+        golden_path=input_path.parent / (case.name + spec.extension),
     )
 
 
@@ -329,8 +333,7 @@ def test_pre_indent_level_with_new_variable_golden_file(
     """
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    golden_path = input_path.parent / (case.name + case.lang_cls.extension)
-    spec = make_spec(lang_cls=case.lang_cls, golden_path=golden_path)
+    spec = make_spec(lang_cls=case.lang_cls)
     result = literalizer.literalize(
         source=yaml_string,
         input_format=literalizer.InputFormat.YAML,
@@ -348,5 +351,5 @@ def test_pre_indent_level_with_new_variable_golden_file(
         contents=result.code + "\n",
         extension=spec.extension,
         newline=None,
-        golden_path=golden_path,
+        golden_path=input_path.parent / (case.name + spec.extension),
     )

--- a/tests/integration/test_literalize_golden.py
+++ b/tests/integration/test_literalize_golden.py
@@ -7,6 +7,7 @@ kwargs, line-ending option, heterogeneous-scalar strategy,
 language and compare against a checked-in golden file.
 """
 
+import dataclasses
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,7 @@ from literalizer.exceptions import (
     NullInCollectionError,
     UnrepresentableIntegerError,
 )
+from literalizer.languages import Erlang
 
 from .case_discovery import (
     HeterogeneousStrategyCombinedCase,
@@ -32,6 +34,7 @@ from .case_discovery import (
 )
 from .check_golden import check_golden
 from .language_specs import (
+    erlang_module_name,
     find_redefinition_styles,
     lang_cls_name,
     make_spec,
@@ -67,7 +70,9 @@ def test_golden_file(
                 result = literalizer.literalize(
                     source=yaml_string,
                     input_format=literalizer.InputFormat.YAML,
-                    language=make_spec(lang_cls=lang_cls),
+                    language=make_spec(
+                        lang_cls=lang_cls, golden_path=golden_path
+                    ),
                     pre_indent_level=0,
                     include_delimiters=True,
                     variable_form=wrap_variable_form(lang_cls=lang_cls),
@@ -116,14 +121,15 @@ def test_golden_file_combined_variable_forms(
             golden_file_name=combined_case.golden_file_name,
         ):
             input_path = cases_dir / combined_case.case_name / "input.yaml"
-            spec = make_spec(
-                lang_cls=lang_cls,
-                declaration_style=combined_case.declaration_style,
-            )
-            yaml_string = input_path.read_text()
             golden_path = input_path.parent / (
                 combined_case.golden_file_name + lang_cls.extension
             )
+            spec = make_spec(
+                lang_cls=lang_cls,
+                declaration_style=combined_case.declaration_style,
+                golden_path=golden_path,
+            )
+            yaml_string = input_path.read_text()
             try:
                 result = literalizer.literalize(
                     source=yaml_string,
@@ -182,11 +188,19 @@ def test_format_variant_golden_file(
             golden_path = case_dir / (
                 variant_case.variant_name + variant.spec.extension
             )
+            spec = (
+                dataclasses.replace(
+                    variant.spec,
+                    module_name=erlang_module_name(golden_path),
+                )
+                if isinstance(variant.spec, Erlang)
+                else variant.spec
+            )
             try:
                 result = literalizer.literalize(
                     source=yaml_string,
                     input_format=literalizer.InputFormat.YAML,
-                    language=variant.spec,
+                    language=spec,
                     pre_indent_level=0,
                     include_delimiters=True,
                     variable_form=variant_case.variable_form,
@@ -224,13 +238,15 @@ def test_line_ending_combined_variable_forms(
     """
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    base_spec = make_spec(lang_cls=case.lang_cls)
+    golden_path = input_path.parent / (case.name + case.lang_cls.extension)
+    base_spec = make_spec(lang_cls=case.lang_cls, golden_path=golden_path)
     redef_styles = find_redefinition_styles(spec=base_spec)
     assert redef_styles
     spec = make_spec(
         lang_cls=case.lang_cls,
         line_ending=case.line_ending,
         declaration_style=redef_styles[0],
+        golden_path=golden_path,
     )
     result = literalizer.literalize(
         source=yaml_string,
@@ -246,7 +262,7 @@ def test_line_ending_combined_variable_forms(
         contents=result.code + "\n",
         extension=spec.extension,
         newline=None,
-        golden_path=input_path.parent / (case.name + spec.extension),
+        golden_path=golden_path,
     )
 
 
@@ -265,13 +281,15 @@ def test_heterogeneous_strategy_combined_variable_forms(
     """
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    base_spec = make_spec(lang_cls=case.lang_cls)
+    golden_path = input_path.parent / (case.name + case.lang_cls.extension)
+    base_spec = make_spec(lang_cls=case.lang_cls, golden_path=golden_path)
     redef_styles = find_redefinition_styles(spec=base_spec)
     assert redef_styles
     spec = make_spec(
         lang_cls=case.lang_cls,
         heterogeneous_strategy=case.heterogeneous_strategy,
         declaration_style=redef_styles[0],
+        golden_path=golden_path,
     )
     result = literalizer.literalize(
         source=yaml_string,
@@ -287,7 +305,7 @@ def test_heterogeneous_strategy_combined_variable_forms(
         contents=result.code + "\n",
         extension=spec.extension,
         newline=None,
-        golden_path=input_path.parent / (case.name + spec.extension),
+        golden_path=golden_path,
     )
 
 
@@ -311,7 +329,8 @@ def test_pre_indent_level_with_new_variable_golden_file(
     """
     input_path = cases_dir / case.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
-    spec = make_spec(lang_cls=case.lang_cls)
+    golden_path = input_path.parent / (case.name + case.lang_cls.extension)
+    spec = make_spec(lang_cls=case.lang_cls, golden_path=golden_path)
     result = literalizer.literalize(
         source=yaml_string,
         input_format=literalizer.InputFormat.YAML,
@@ -329,5 +348,5 @@ def test_pre_indent_level_with_new_variable_golden_file(
         contents=result.code + "\n",
         extension=spec.extension,
         newline=None,
-        golden_path=input_path.parent / (case.name + spec.extension),
+        golden_path=golden_path,
     )

--- a/tests/integration/test_literalize_golden.py
+++ b/tests/integration/test_literalize_golden.py
@@ -132,11 +132,6 @@ def test_golden_file_combined_variable_forms(
                 lang_cls=lang_cls,
                 declaration_style=combined_case.declaration_style,
             )
-            if isinstance(spec, Erlang):
-                spec = dataclasses.replace(
-                    spec,
-                    module_name=erlang_module_name(golden_path=golden_path),
-                )
             yaml_string = input_path.read_text()
             try:
                 result = literalizer.literalize(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `erlang_module_name(golden_path)` helper that maps a golden file path to `fixture_{dir}_{stem}` (lowercased), giving each Erlang golden file a unique `-module(...)` declaration
- Wires the helper into all three `test_literalize_golden.py` test functions and `call_cases.py` via `isinstance(spec, Erlang)` + `dataclasses.replace`
- Regenerates ~163 Erlang golden files to use per-fixture module names instead of the generic `-module(check).`
- Updates `.github/workflows/lint.yml` to replace the `sed`-and-rename loop with a plain `cp` loop that derives the module name from the directory and stem

Closes #1715

## Test plan

- [ ] All existing tests pass (`pytest`)
- [ ] Erlang golden files all have unique `-module(fixture_*).` declarations
- [ ] CI "Lint Erlang" step compiles with `erlc -Werror` without sed rewriting
EOF
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test fixtures and CI lint workflow, with the main risk being CI lint/test failures if module-name derivation misses edge cases or causes filename collisions.
> 
> **Overview**
> Switches Erlang golden generation to use deterministic per-fixture `-module(fixture_{dir}_{stem}).` names via a new `erlang_module_name()` helper, and wires this into golden-file and call-case tests by overriding the Erlang `module_name` per golden path.
> 
> Updates the CI `lint-beam` Erlang steps to drop the `sed`-based module rewriting/renaming and instead copy fixtures using the derived `fixture_*` naming scheme, and pins toolchain versions (`gleam` to `v1.16.0`, `crystal` to `1.20.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d693219cae44daec0e09b55cc96e1eee2fce4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->