### PR TITLE
Use per-fixture module names for Scala goldens and drop CI sed-rename

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -857,23 +857,21 @@ jobs:
         uses: VirtusLab/scala-cli-setup@v1
       # Compile every fixture in a single scala-cli invocation to pay
       # the Scala compile + Bloop daemon startup cost once instead of
-      # per fixture. Fixtures all declare `object Check { ... }`, so
-      # they are renamed to a unique `object FixtureN` to avoid
-      # collisions; a generated `@main` references each one to force
-      # its val initializers to load. The mapping is printed so
-      # failures still point back to the original path.
+      # per fixture. Each fixture already carries a unique object name
+      # derived from its case directory and stem, so a plain copy
+      # suffices; no sed rewriting needed.
       - name: Run Scala files
         run: |-
           workspace=$(mktemp -d)
           main="$workspace/Main.scala"
           printf '@main def __run(): Unit = {\n' > "$main"
-          i=0
           while IFS= read -r -d '' f; do
-            sed "s/^object Check {/object Fixture$i {/" "$f" \
-              > "$workspace/Fixture$i.scala"
-            printf 'Fixture%s.scala <- %s\n' "$i" "$f"
-            printf '  val _%s = Fixture%s\n' "$i" "$i" >> "$main"
-            i=$((i+1))
+            dir=$(basename "$(dirname "$f")")
+            stem=$(basename "$f" .scala)
+            name="Fixture_${dir}_${stem}"
+            cp "$f" "$workspace/${name}.scala"
+            printf '%s.scala <- %s\n' "$name" "$f"
+            printf '  val _%s = %s\n' "$name" "$name" >> "$main"
           done < /tmp/files-to-lint
           printf '}\n' >> "$main"
           scala-cli run "$workspace" --main-class __run

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -10,7 +10,7 @@ import dataclasses
 import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import pytest
 from beartype import beartype
@@ -22,10 +22,10 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     HeterogeneousCollectionError,
 )
-from literalizer.languages import Erlang, Sml
+from literalizer.languages import Sml
 
 from .check_golden import check_golden
-from .language_specs import erlang_module_name, sorted_languages
+from .language_specs import sorted_languages, with_per_fixture_module_name
 
 if TYPE_CHECKING:
     from literalizer._types import Value
@@ -389,14 +389,7 @@ def run_call_golden_case(
     input_path = cases_dir / config.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
     golden_path = input_path.parent / (golden_name + lang_cls.extension)
-    if isinstance(spec, Erlang):
-        spec = cast(
-            "literalizer.Language",
-            dataclasses.replace(
-                spec,
-                module_name=erlang_module_name(golden_path=golden_path),
-            ),
-        )
+    spec = with_per_fixture_module_name(spec=spec, golden_path=golden_path)
     effective_ref_case: literalizer.IdentifierCase | None
     if config.ref_case_per_language:
         # First element of ``identifier_cases`` is the language's

--- a/tests/integration/cases/binary/Scala.scala
+++ b/tests/integration/cases/binary/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_binary_Scala {
 val my_data = List[String](
     "48656c6c6f",
 )

--- a/tests/integration/cases/binary/Scala_bytes_format_base64.scala
+++ b/tests/integration/cases/binary/Scala_bytes_format_base64.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_binary_Scala_bytes_format_base64 {
 val my_data = List[String](
     "SGVsbG8=",
 )

--- a/tests/integration/cases/binary/Scala_combined.scala
+++ b/tests/integration/cases/binary/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_binary_Scala_combined {
 var my_data = List[String](
     "48656c6c6f",
 )

--- a/tests/integration/cases/binary/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/binary/Scala_declaration_style_var.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_binary_Scala_declaration_style_var {
 var my_data = List[String](
     "48656c6c6f",
 )

--- a/tests/integration/cases/bool_list/Scala.scala
+++ b/tests/integration/cases/bool_list/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_bool_list_Scala {
 val my_data = List[Boolean](
     true,
     false,

--- a/tests/integration/cases/bool_list/Scala_combined.scala
+++ b/tests/integration/cases/bool_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_bool_list_Scala_combined {
 var my_data = List[Boolean](
     true,
     false,

--- a/tests/integration/cases/call_deep_dotted_method/Scala_call.scala
+++ b/tests/integration/cases/call_deep_dotted_method/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_deep_dotted_method_Scala_call {
 class _ClientType { def post(data: Any = null): Any = null }
 class _ApiType { val client = new _ClientType }
 class _ObjType { val api = new _ApiType }

--- a/tests/integration/cases/call_deep_dotted_transformed/Scala_call.scala
+++ b/tests/integration/cases/call_deep_dotted_transformed/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_deep_dotted_transformed_Scala_call {
 class _ClientType { def fetch(payload: Any = null): Any = null }
 class _AppType { val client = new _ClientType }
 val app = new _AppType

--- a/tests/integration/cases/call_dotted_method/Scala_call.scala
+++ b/tests/integration/cases/call_dotted_method/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_dotted_method_Scala_call {
 class _ClientType { def fetch(payload: Any = null): Any = null }
 class _AppType { val client = new _ClientType }
 val app = new _AppType

--- a/tests/integration/cases/call_keyword_args/Scala_call.scala
+++ b/tests/integration/cases/call_keyword_args/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_keyword_args_Scala_call {
 class _ThrottlerType { def check(user_id: Any = null, ts: Any = null): Any = null }
 val throttler = new _ThrottlerType
 def emit(_arg: Any = null): Any = null

--- a/tests/integration/cases/call_mixed_type_dicts/Scala_call.scala
+++ b/tests/integration/cases/call_mixed_type_dicts/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_mixed_type_dicts_Scala_call {
 class _MgrType { def op(operation: Any = null): Any = null }
 class _AppType { val mgr = new _MgrType }
 val app = new _AppType

--- a/tests/integration/cases/call_multi_args/Scala_call.scala
+++ b/tests/integration/cases/call_multi_args/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_multi_args_Scala_call {
 def process(value: Any = null, count: Any = null): Any = null
 process(value = 1, count = 42)
 process(value = 2, count = 100)

--- a/tests/integration/cases/call_per_element_false/Scala_call.scala
+++ b/tests/integration/cases/call_per_element_false/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_per_element_false_Scala_call {
 def process(data: Any = null): Any = null
 process(data = 1)
 }

--- a/tests/integration/cases/call_positional/Scala_call.scala
+++ b/tests/integration/cases/call_positional/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_positional_Scala_call {
 class _ThrottlerType { def check(user_id: Any = null, ts: Any = null): Any = null }
 val throttler = new _ThrottlerType
 def emit(_arg: Any = null): Any = null

--- a/tests/integration/cases/call_ref_args/Scala_call.scala
+++ b/tests/integration/cases/call_ref_args/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_ref_args_Scala_call {
 def process(data: Any = null, count: Any = null): Any = null
 val my_var = List[Int](
     1,

--- a/tests/integration/cases/call_ref_args_converted/Scala_call.scala
+++ b/tests/integration/cases/call_ref_args_converted/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_ref_args_converted_Scala_call {
 def process(data: Any = null, count: Any = null): Any = null
 val myVar = List[Int](
     1,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Scala_call.scala
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_ref_args_converted_nonsnake_Scala_call {
 def process(data: Any = null, count: Any = null): Any = null
 val myVar = List[Int](
     1,

--- a/tests/integration/cases/call_ref_args_converted_whole/Scala_call.scala
+++ b/tests/integration/cases/call_ref_args_converted_whole/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_ref_args_converted_whole_Scala_call {
 def process(data: Any = null): Any = null
 val myVar = List[Int](
     1,

--- a/tests/integration/cases/call_scalar_args/Scala_call.scala
+++ b/tests/integration/cases/call_scalar_args/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_scalar_args_Scala_call {
 def process(value: Any = null): Any = null
 process(value = "hello")
 process(value = 42)

--- a/tests/integration/cases/call_snake_dotted_method/Scala_call.scala
+++ b/tests/integration/cases/call_snake_dotted_method/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_snake_dotted_method_Scala_call {
 class _Http_clientType { def fetch(payload: Any = null): Any = null }
 class _My_appType { val http_client = new _Http_clientType }
 val my_app = new _My_appType

--- a/tests/integration/cases/call_transform_no_wrapper/Scala_call.scala
+++ b/tests/integration/cases/call_transform_no_wrapper/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_transform_no_wrapper_Scala_call {
 def process(value: Any = null): Any = null
 process(value = "hello")
 process(value = 42)

--- a/tests/integration/cases/call_wrap_in_file/Scala_call.scala
+++ b/tests/integration/cases/call_wrap_in_file/Scala_call.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_call_wrap_in_file_Scala_call {
 def process(a: Any = null, b: Any = null): Any = null
 process(a = 1, b = 2)
 process(a = 3, b = 4)

--- a/tests/integration/cases/comment_block_scalar_not_comment/Scala.scala
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_block_scalar_not_comment_Scala {
 val my_data = Map[String, String](
     "description" -> "# not a comment\n",
     "name" -> "foo",

--- a/tests/integration/cases/comment_block_scalar_not_comment/Scala_combined.scala
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_block_scalar_not_comment_Scala_combined {
 var my_data = Map[String, String](
     "description" -> "# not a comment\n",
     "name" -> "foo",

--- a/tests/integration/cases/comment_scalar/Scala.scala
+++ b/tests/integration/cases/comment_scalar/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_scalar_Scala {
 val my_data = // note
 42
 }

--- a/tests/integration/cases/comment_scalar/Scala_combined.scala
+++ b/tests/integration/cases/comment_scalar/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_scalar_Scala_combined {
 var my_data = // note
 42
 my_data = // note

--- a/tests/integration/cases/comment_scalar_document_markers/Scala.scala
+++ b/tests/integration/cases/comment_scalar_document_markers/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_scalar_document_markers_Scala {
 val my_data = // note
 42
 }

--- a/tests/integration/cases/comment_scalar_document_markers/Scala_combined.scala
+++ b/tests/integration/cases/comment_scalar_document_markers/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_scalar_document_markers_Scala_combined {
 var my_data = // note
 42
 my_data = // note

--- a/tests/integration/cases/comment_scalar_inline/Scala.scala
+++ b/tests/integration/cases/comment_scalar_inline/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_comment_scalar_inline_Scala {
 val my_data = 42  // note
 }

--- a/tests/integration/cases/comment_scalar_inline/Scala_combined.scala
+++ b/tests/integration/cases/comment_scalar_inline/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_scalar_inline_Scala_combined {
 var my_data = 42  // note
 my_data = 42  // note
 }

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Scala.scala
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_comment_scalar_quoted_with_hash_Scala {
 val my_data = "hello # world"  // note
 }

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Scala_combined.scala
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comment_scalar_quoted_with_hash_Scala_combined {
 var my_data = "hello # world"  // note
 my_data = "hello # world"  // note
 }

--- a/tests/integration/cases/comments/Scala.scala
+++ b/tests/integration/cases/comments/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_Scala {
 val my_data = Map(
     // Server configuration
     "host" -> "localhost",  // default host

--- a/tests/integration/cases/comments/Scala_combined.scala
+++ b/tests/integration/cases/comments/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_Scala_combined {
 var my_data = Map(
     // Server configuration
     "host" -> "localhost",  // default host

--- a/tests/integration/cases/comments/Scala_comment_block.scala
+++ b/tests/integration/cases/comments/Scala_comment_block.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_Scala_comment_block {
 val my_data = Map(
     /* Server configuration */
     "host" -> "localhost",  /* default host */

--- a/tests/integration/cases/comments_bang_in_double_quote/Scala.scala
+++ b/tests/integration/cases/comments_bang_in_double_quote/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_bang_in_double_quote_Scala {
 val my_data = Map[String, String](
     "key" -> "\"bang!\"",  // real
 )

--- a/tests/integration/cases/comments_bang_in_double_quote/Scala_combined.scala
+++ b/tests/integration/cases/comments_bang_in_double_quote/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_bang_in_double_quote_Scala_combined {
 var my_data = Map[String, String](
     "key" -> "\"bang!\"",  // real
 )

--- a/tests/integration/cases/comments_double_hash/Scala.scala
+++ b/tests/integration/cases/comments_double_hash/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_double_hash_Scala {
 val my_data = List[String](
     // # section
     "a",

--- a/tests/integration/cases/comments_double_hash/Scala_combined.scala
+++ b/tests/integration/cases/comments_double_hash/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_double_hash_Scala_combined {
 var my_data = List[String](
     // # section
     "a",

--- a/tests/integration/cases/comments_empty_line/Scala.scala
+++ b/tests/integration/cases/comments_empty_line/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_empty_line_Scala {
 val my_data = List[String](
     "a",
     //

--- a/tests/integration/cases/comments_empty_line/Scala_combined.scala
+++ b/tests/integration/cases/comments_empty_line/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_empty_line_Scala_combined {
 var my_data = List[String](
     "a",
     //

--- a/tests/integration/cases/comments_escaped_quote/Scala.scala
+++ b/tests/integration/cases/comments_escaped_quote/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_escaped_quote_Scala {
 val my_data = Map[String, String](
     "key" -> "value \" # not a comment",  // real
 )

--- a/tests/integration/cases/comments_escaped_quote/Scala_combined.scala
+++ b/tests/integration/cases/comments_escaped_quote/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_escaped_quote_Scala_combined {
 var my_data = Map[String, String](
     "key" -> "value \" # not a comment",  // real
 )

--- a/tests/integration/cases/comments_escaped_single_quote/Scala.scala
+++ b/tests/integration/cases/comments_escaped_single_quote/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_escaped_single_quote_Scala {
 val my_data = Map[String, String](
     "key" -> "it's here",  // a comment
 )

--- a/tests/integration/cases/comments_escaped_single_quote/Scala_combined.scala
+++ b/tests/integration/cases/comments_escaped_single_quote/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_escaped_single_quote_Scala_combined {
 var my_data = Map[String, String](
     "key" -> "it's here",  // a comment
 )

--- a/tests/integration/cases/comments_multi_line/Scala.scala
+++ b/tests/integration/cases/comments_multi_line/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_multi_line_Scala {
 val my_data = List[String](
     // line 1
     // line 2

--- a/tests/integration/cases/comments_multi_line/Scala_combined.scala
+++ b/tests/integration/cases/comments_multi_line/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_multi_line_Scala_combined {
 var my_data = List[String](
     // line 1
     // line 2

--- a/tests/integration/cases/comments_nested_mapping/Scala.scala
+++ b/tests/integration/cases/comments_nested_mapping/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_nested_mapping_Scala {
 val my_data = Map(
     "a" -> Map[String, Int]("x" -> 1),
     "b" -> 2,

--- a/tests/integration/cases/comments_nested_mapping/Scala_combined.scala
+++ b/tests/integration/cases/comments_nested_mapping/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_nested_mapping_Scala_combined {
 var my_data = Map(
     "a" -> Map[String, Int]("x" -> 1),
     "b" -> 2,

--- a/tests/integration/cases/comments_sequence_before/Scala.scala
+++ b/tests/integration/cases/comments_sequence_before/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_sequence_before_Scala {
 val my_data = List[String](
     // first
     "a",

--- a/tests/integration/cases/comments_sequence_before/Scala_combined.scala
+++ b/tests/integration/cases/comments_sequence_before/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_sequence_before_Scala_combined {
 var my_data = List[String](
     // first
     "a",

--- a/tests/integration/cases/comments_sequence_inline/Scala.scala
+++ b/tests/integration/cases/comments_sequence_inline/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_sequence_inline_Scala {
 val my_data = List[String](
     "a",  // note a
     "b",  // note b

--- a/tests/integration/cases/comments_sequence_inline/Scala_combined.scala
+++ b/tests/integration/cases/comments_sequence_inline/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_sequence_inline_Scala_combined {
 var my_data = List[String](
     "a",  // note a
     "b",  // note b

--- a/tests/integration/cases/comments_trailing/Scala.scala
+++ b/tests/integration/cases/comments_trailing/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_trailing_Scala {
 val my_data = List[String](
     "a",
     // trailing

--- a/tests/integration/cases/comments_trailing/Scala_combined.scala
+++ b/tests/integration/cases/comments_trailing/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_trailing_Scala_combined {
 var my_data = List[String](
     "a",
     // trailing

--- a/tests/integration/cases/comments_vb_before_dim/Scala.scala
+++ b/tests/integration/cases/comments_vb_before_dim/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_vb_before_dim_Scala {
 val my_data = Map(
     // Configuration
     "name" -> "app",

--- a/tests/integration/cases/comments_vb_before_dim/Scala_combined.scala
+++ b/tests/integration/cases/comments_vb_before_dim/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_comments_vb_before_dim_Scala_combined {
 var my_data = Map(
     // Configuration
     "name" -> "app",

--- a/tests/integration/cases/date_list/Scala.scala
+++ b/tests/integration/cases/date_list/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.LocalDate
-object Check {
+object Fixture_date_list_Scala {
 val my_data = List[LocalDate](
     LocalDate.of(2024, 1, 15),
     LocalDate.of(2024, 2, 20),

--- a/tests/integration/cases/date_list/Scala_combined.scala
+++ b/tests/integration/cases/date_list/Scala_combined.scala
@@ -1,5 +1,5 @@
 import java.time.LocalDate
-object Check {
+object Fixture_date_list_Scala_combined {
 var my_data = List[LocalDate](
     LocalDate.of(2024, 1, 15),
     LocalDate.of(2024, 2, 20),

--- a/tests/integration/cases/date_list/Scala_date_iso.scala
+++ b/tests/integration/cases/date_list/Scala_date_iso.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_date_list_Scala_date_iso {
 val my_data = List[String](
     "2024-01-15",
     "2024-02-20",

--- a/tests/integration/cases/date_set/Scala.scala
+++ b/tests/integration/cases/date_set/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.LocalDate
-object Check {
+object Fixture_date_set_Scala {
 val my_data = Set[LocalDate](
     LocalDate.of(2024, 1, 15),
     LocalDate.of(2024, 6, 1),

--- a/tests/integration/cases/date_set/Scala_combined.scala
+++ b/tests/integration/cases/date_set/Scala_combined.scala
@@ -1,5 +1,5 @@
 import java.time.LocalDate
-object Check {
+object Fixture_date_set_Scala_combined {
 var my_data = Set[LocalDate](
     LocalDate.of(2024, 1, 15),
     LocalDate.of(2024, 6, 1),

--- a/tests/integration/cases/date_set/Scala_date_iso.scala
+++ b/tests/integration/cases/date_set/Scala_date_iso.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_date_set_Scala_date_iso {
 val my_data = Set[String](
     "2024-01-15",
     "2024-06-01",

--- a/tests/integration/cases/dates/Scala.scala
+++ b/tests/integration/cases/dates/Scala.scala
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_dates_Scala {
 val my_data = Map(
     "date" -> LocalDate.of(2024, 1, 15),
     "datetime" -> ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("+00:00")),

--- a/tests/integration/cases/dates/Scala_combined.scala
+++ b/tests/integration/cases/dates/Scala_combined.scala
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_dates_Scala_combined {
 var my_data = Map(
     "date" -> LocalDate.of(2024, 1, 15),
     "datetime" -> ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("+00:00")),

--- a/tests/integration/cases/datetime_list/Scala.scala
+++ b/tests/integration/cases/datetime_list/Scala.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_datetime_list_Scala {
 val my_data = List[ZonedDateTime](
     ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 123456000, ZoneId.of("+00:00")),
     ZonedDateTime.of(2024, 6, 1, 8, 0, 0, 0, ZoneId.of("+00:00")),

--- a/tests/integration/cases/datetime_list/Scala_combined.scala
+++ b/tests/integration/cases/datetime_list/Scala_combined.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_datetime_list_Scala_combined {
 var my_data = List[ZonedDateTime](
     ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 123456000, ZoneId.of("+00:00")),
     ZonedDateTime.of(2024, 6, 1, 8, 0, 0, 0, ZoneId.of("+00:00")),

--- a/tests/integration/cases/datetime_list/Scala_datetime_iso.scala
+++ b/tests/integration/cases/datetime_list/Scala_datetime_iso.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_datetime_list_Scala_datetime_iso {
 val my_data = List[String](
     "2024-01-15T12:30:00.123456+00:00",
     "2024-06-01T08:00:00+00:00",

--- a/tests/integration/cases/deep_nesting/Scala.scala
+++ b/tests/integration/cases/deep_nesting/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_deep_nesting_Scala {
 val my_data = Map(
     "level1" -> Map("level2" -> Map("level3" -> Map("level4" -> Map("value" -> "deep", "items" -> List[String]("a", "b"))), "sibling" -> 42), "tags" -> List[Map[String, Any]](Map("name" -> "tag1", "meta" -> Map("priority" -> 1, "labels" -> List[String]("x", "y"))))),
 )

--- a/tests/integration/cases/deep_nesting/Scala_combined.scala
+++ b/tests/integration/cases/deep_nesting/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_deep_nesting_Scala_combined {
 var my_data = Map(
     "level1" -> Map("level2" -> Map("level3" -> Map("level4" -> Map("value" -> "deep", "items" -> List[String]("a", "b"))), "sibling" -> 42), "tags" -> List[Map[String, Any]](Map("name" -> "tag1", "meta" -> Map("priority" -> 1, "labels" -> List[String]("x", "y"))))),
 )

--- a/tests/integration/cases/dict_all_null_trailing_comment/Scala.scala
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_all_null_trailing_comment_Scala {
 val my_data = Map(
     "a" -> null,
     "b" -> null,

--- a/tests/integration/cases/dict_all_null_trailing_comment/Scala_combined.scala
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_all_null_trailing_comment_Scala_combined {
 var my_data = Map(
     "a" -> null,
     "b" -> null,

--- a/tests/integration/cases/dict_all_scalar_types/Scala.scala
+++ b/tests/integration/cases/dict_all_scalar_types/Scala.scala
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_dict_all_scalar_types_Scala {
 val my_data = Map(
     "s" -> "string",
     "i" -> 1,

--- a/tests/integration/cases/dict_all_scalar_types/Scala_combined.scala
+++ b/tests/integration/cases/dict_all_scalar_types/Scala_combined.scala
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_dict_all_scalar_types_Scala_combined {
 var my_data = Map(
     "s" -> "string",
     "i" -> 1,

--- a/tests/integration/cases/dict_mixed_int_widths/Scala.scala
+++ b/tests/integration/cases/dict_mixed_int_widths/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_mixed_int_widths_Scala {
 val my_data = Map(
     "a" -> 1,
     "b" -> 3000000000L,

--- a/tests/integration/cases/dict_mixed_int_widths/Scala_combined.scala
+++ b/tests/integration/cases/dict_mixed_int_widths/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_mixed_int_widths_Scala_combined {
 var my_data = Map(
     "a" -> 1,
     "b" -> 3000000000L,

--- a/tests/integration/cases/dict_mixed_scalars/Scala.scala
+++ b/tests/integration/cases/dict_mixed_scalars/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_mixed_scalars_Scala {
 val my_data = Map(
     "a" -> 1,
     "b" -> "x",

--- a/tests/integration/cases/dict_mixed_scalars/Scala_combined.scala
+++ b/tests/integration/cases/dict_mixed_scalars/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_mixed_scalars_Scala_combined {
 var my_data = Map(
     "a" -> 1,
     "b" -> "x",

--- a/tests/integration/cases/dict_null_leading_comment/Scala.scala
+++ b/tests/integration/cases/dict_null_leading_comment/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_null_leading_comment_Scala {
 val my_data = Map(
     // comment
     "name" -> "Alice",

--- a/tests/integration/cases/dict_null_leading_comment/Scala_combined.scala
+++ b/tests/integration/cases/dict_null_leading_comment/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_null_leading_comment_Scala_combined {
 var my_data = Map(
     // comment
     "name" -> "Alice",

--- a/tests/integration/cases/dict_null_middle_inline_comment/Scala.scala
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_null_middle_inline_comment_Scala {
 val my_data = Map(
     "host" -> "localhost",
     "port" -> null,  // not configured yet

--- a/tests/integration/cases/dict_null_middle_inline_comment/Scala_combined.scala
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_null_middle_inline_comment_Scala_combined {
 var my_data = Map(
     "host" -> "localhost",
     "port" -> null,  // not configured yet

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Scala.scala
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_null_trailing_inline_comment_Scala {
 val my_data = Map(
     "host" -> "localhost",
     "port" -> null,  // not configured yet

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Scala_combined.scala
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_null_trailing_inline_comment_Scala_combined {
 var my_data = Map(
     "host" -> "localhost",
     "port" -> null,  // not configured yet

--- a/tests/integration/cases/dict_with_control_char_keys/Scala.scala
+++ b/tests/integration/cases/dict_with_control_char_keys/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_control_char_keys_Scala {
 val my_data = Map[String, String](
     "key\nwith\nnewlines" -> "value1",
     "key\twith\ttabs" -> "value2",

--- a/tests/integration/cases/dict_with_control_char_keys/Scala_combined.scala
+++ b/tests/integration/cases/dict_with_control_char_keys/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_control_char_keys_Scala_combined {
 var my_data = Map[String, String](
     "key\nwith\nnewlines" -> "value1",
     "key\twith\ttabs" -> "value2",

--- a/tests/integration/cases/dict_with_hyphen_keys/Scala.scala
+++ b/tests/integration/cases/dict_with_hyphen_keys/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_hyphen_keys_Scala {
 val my_data = Map[String, String](
     "my-key" -> "value1",
     "another-key" -> "value2",

--- a/tests/integration/cases/dict_with_hyphen_keys/Scala_combined.scala
+++ b/tests/integration/cases/dict_with_hyphen_keys/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_hyphen_keys_Scala_combined {
 var my_data = Map[String, String](
     "my-key" -> "value1",
     "another-key" -> "value2",

--- a/tests/integration/cases/dict_with_list_value/Scala.scala
+++ b/tests/integration/cases/dict_with_list_value/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_list_value_Scala {
 val my_data = Map(
     "name" -> "Alice",
     "scores" -> List[Int](10, 20, 30),

--- a/tests/integration/cases/dict_with_list_value/Scala_combined.scala
+++ b/tests/integration/cases/dict_with_list_value/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_list_value_Scala_combined {
 var my_data = Map(
     "name" -> "Alice",
     "scores" -> List[Int](10, 20, 30),

--- a/tests/integration/cases/dict_with_list_value/Scala_dict_format_list_map_list_val.scala
+++ b/tests/integration/cases/dict_with_list_value/Scala_dict_format_list_map_list_val.scala
@@ -1,5 +1,5 @@
 import scala.collection.immutable.ListMap
-object Check {
+object Fixture_dict_with_list_value_Scala_dict_format_list_map_list_val {
 val my_data = ListMap(
     "name" -> "Alice",
     "scores" -> List[Int](10, 20, 30),

--- a/tests/integration/cases/dict_with_nulls/Scala.scala
+++ b/tests/integration/cases/dict_with_nulls/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_nulls_Scala {
 val my_data = Map(
     "name" -> "Alice",
     "score" -> null,

--- a/tests/integration/cases/dict_with_nulls/Scala_combined.scala
+++ b/tests/integration/cases/dict_with_nulls/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_dict_with_nulls_Scala_combined {
 var my_data = Map(
     "name" -> "Alice",
     "score" -> null,

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Scala.scala
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_doubly_nested_list_with_empty_sibling_Scala {
 val my_data = List[List[List[Int]]](
     List[List[Int]](List[Int](1, 2)),
     List[List[Int]](),

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Scala_combined.scala
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_doubly_nested_list_with_empty_sibling_Scala_combined {
 var my_data = List[List[List[Int]]](
     List[List[Int]](List[Int](1, 2)),
     List[List[Int]](),

--- a/tests/integration/cases/empty_dict/Scala.scala
+++ b/tests/integration/cases/empty_dict/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_empty_dict_Scala {
 val my_data = Map()
 }

--- a/tests/integration/cases/empty_dict/Scala_combined.scala
+++ b/tests/integration/cases/empty_dict/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_empty_dict_Scala_combined {
 var my_data = Map()
 my_data = Map()
 }

--- a/tests/integration/cases/empty_dict/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/empty_dict/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_empty_dict_Scala_declaration_style_var {
 var my_data = Map()
 }

--- a/tests/integration/cases/empty_dicts_in_sequence/Scala.scala
+++ b/tests/integration/cases/empty_dicts_in_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_empty_dicts_in_sequence_Scala {
 val my_data = List[Map[String, Any]](
     Map(),
     Map(),

--- a/tests/integration/cases/empty_dicts_in_sequence/Scala_combined.scala
+++ b/tests/integration/cases/empty_dicts_in_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_empty_dicts_in_sequence_Scala_combined {
 var my_data = List[Map[String, Any]](
     Map(),
     Map(),

--- a/tests/integration/cases/empty_list/Scala.scala
+++ b/tests/integration/cases/empty_list/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_empty_list_Scala {
 val my_data = List()
 }

--- a/tests/integration/cases/empty_list/Scala_combined.scala
+++ b/tests/integration/cases/empty_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_empty_list_Scala_combined {
 var my_data = List()
 my_data = List()
 }

--- a/tests/integration/cases/empty_list/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/empty_list/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_empty_list_Scala_declaration_style_var {
 var my_data = List()
 }

--- a/tests/integration/cases/empty_sequence/Scala.scala
+++ b/tests/integration/cases/empty_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_empty_sequence_Scala {
 val my_data = List(
     List(),
     Map(),

--- a/tests/integration/cases/empty_sequence/Scala_combined.scala
+++ b/tests/integration/cases/empty_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_empty_sequence_Scala_combined {
 var my_data = List(
     List(),
     Map(),

--- a/tests/integration/cases/empty_set/Scala.scala
+++ b/tests/integration/cases/empty_set/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_empty_set_Scala {
 val my_data = Set()
 }

--- a/tests/integration/cases/empty_set/Scala_combined.scala
+++ b/tests/integration/cases/empty_set/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_empty_set_Scala_combined {
 var my_data = Set()
 my_data = Set()
 }

--- a/tests/integration/cases/empty_set/Scala_set_tree_set.scala
+++ b/tests/integration/cases/empty_set/Scala_set_tree_set.scala
@@ -1,4 +1,4 @@
 import scala.collection.immutable.TreeSet
-object Check {
+object Fixture_empty_set_Scala_set_tree_set {
 val my_data = TreeSet.empty[Int]
 }

--- a/tests/integration/cases/float_list/Scala.scala
+++ b/tests/integration/cases/float_list/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_list_Scala {
 val my_data = List[Double](
     1.1,
     -2.2,

--- a/tests/integration/cases/float_list/Scala_combined.scala
+++ b/tests/integration/cases/float_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_list_Scala_combined {
 var my_data = List[Double](
     1.1,
     -2.2,

--- a/tests/integration/cases/float_list/Scala_float_format_fixed.scala
+++ b/tests/integration/cases/float_list/Scala_float_format_fixed.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_list_Scala_float_format_fixed {
 val my_data = List[Double](
     1.100000,
     -2.200000,

--- a/tests/integration/cases/float_list/Scala_float_format_scientific.scala
+++ b/tests/integration/cases/float_list/Scala_float_format_scientific.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_list_Scala_float_format_scientific {
 val my_data = List[Double](
     1.1,
     -2.2,

--- a/tests/integration/cases/float_list/Scala_numeric_separator_underscore_float.scala
+++ b/tests/integration/cases/float_list/Scala_numeric_separator_underscore_float.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_list_Scala_numeric_separator_underscore_float {
 val my_data = List[Double](
     1.1,
     -2.2,

--- a/tests/integration/cases/float_list/Scala_sequence_array_float.scala
+++ b/tests/integration/cases/float_list/Scala_sequence_array_float.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_list_Scala_sequence_array_float {
 val my_data = Array[Double](
     1.1,
     -2.2,

--- a/tests/integration/cases/float_list/Scala_sequence_seq_float.scala
+++ b/tests/integration/cases/float_list/Scala_sequence_seq_float.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_list_Scala_sequence_seq_float {
 val my_data = Seq(
     1.1,
     -2.2,

--- a/tests/integration/cases/float_negative_zero/Scala.scala
+++ b/tests/integration/cases/float_negative_zero/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_negative_zero_Scala {
 val my_data = List[Double](
     -0.0,
     1.5,

--- a/tests/integration/cases/float_negative_zero/Scala_combined.scala
+++ b/tests/integration/cases/float_negative_zero/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_negative_zero_Scala_combined {
 var my_data = List[Double](
     -0.0,
     1.5,

--- a/tests/integration/cases/float_scientific_notation/Scala.scala
+++ b/tests/integration/cases/float_scientific_notation/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_scientific_notation_Scala {
 val my_data = List[Double](
     0.0,
     1.0,

--- a/tests/integration/cases/float_scientific_notation/Scala_combined.scala
+++ b/tests/integration/cases/float_scientific_notation/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_scientific_notation_Scala_combined {
 var my_data = List[Double](
     0.0,
     1.0,

--- a/tests/integration/cases/float_scientific_notation/Scala_float_format_fixed_s.scala
+++ b/tests/integration/cases/float_scientific_notation/Scala_float_format_fixed_s.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_scientific_notation_Scala_float_format_fixed_s {
 val my_data = List[Double](
     0.000000,
     1.000000,

--- a/tests/integration/cases/float_scientific_notation/Scala_float_format_scientific_s.scala
+++ b/tests/integration/cases/float_scientific_notation/Scala_float_format_scientific_s.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_scientific_notation_Scala_float_format_scientific_s {
 val my_data = List[Double](
     0.0,
     1.0,

--- a/tests/integration/cases/float_scientific_notation/Scala_numeric_separator_underscore_float_s.scala
+++ b/tests/integration/cases/float_scientific_notation/Scala_numeric_separator_underscore_float_s.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_scientific_notation_Scala_numeric_separator_underscore_float_s {
 val my_data = List[Double](
     0.0,
     1.0,

--- a/tests/integration/cases/float_special_values/Scala.scala
+++ b/tests/integration/cases/float_special_values/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_special_values_Scala {
 val my_data = List[Double](
     Double.PositiveInfinity,
     Double.NegativeInfinity,

--- a/tests/integration/cases/float_special_values/Scala_combined.scala
+++ b/tests/integration/cases/float_special_values/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_special_values_Scala_combined {
 var my_data = List[Double](
     Double.PositiveInfinity,
     Double.NegativeInfinity,

--- a/tests/integration/cases/float_special_values/Scala_float_format_fixed_v.scala
+++ b/tests/integration/cases/float_special_values/Scala_float_format_fixed_v.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_special_values_Scala_float_format_fixed_v {
 val my_data = List[Double](
     Double.PositiveInfinity,
     Double.NegativeInfinity,

--- a/tests/integration/cases/float_special_values/Scala_float_format_scientific_v.scala
+++ b/tests/integration/cases/float_special_values/Scala_float_format_scientific_v.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_special_values_Scala_float_format_scientific_v {
 val my_data = List[Double](
     Double.PositiveInfinity,
     Double.NegativeInfinity,

--- a/tests/integration/cases/float_special_values/Scala_numeric_separator_underscore_float_v.scala
+++ b/tests/integration/cases/float_special_values/Scala_numeric_separator_underscore_float_v.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_float_special_values_Scala_numeric_separator_underscore_float_v {
 val my_data = List[Double](
     Double.PositiveInfinity,
     Double.NegativeInfinity,

--- a/tests/integration/cases/int_key_dict/Scala.scala
+++ b/tests/integration/cases/int_key_dict/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_key_dict_Scala {
 val my_data = Map[String, String](
     "1" -> "one",
     "2" -> "two",

--- a/tests/integration/cases/int_key_dict/Scala_combined.scala
+++ b/tests/integration/cases/int_key_dict/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_key_dict_Scala_combined {
 var my_data = Map[String, String](
     "1" -> "one",
     "2" -> "two",

--- a/tests/integration/cases/int_key_dict/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/int_key_dict/Scala_declaration_style_var.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_key_dict_Scala_declaration_style_var {
 var my_data = Map[String, String](
     "1" -> "one",
     "2" -> "two",

--- a/tests/integration/cases/int_list/Scala.scala
+++ b/tests/integration/cases/int_list/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_Scala {
 val my_data = List[Int](
     1,
     2,

--- a/tests/integration/cases/int_list/Scala_combined.scala
+++ b/tests/integration/cases/int_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_Scala_combined {
 var my_data = List[Int](
     1,
     2,

--- a/tests/integration/cases/int_list/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/int_list/Scala_declaration_style_var.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_Scala_declaration_style_var {
 var my_data = List[Int](
     1,
     2,

--- a/tests/integration/cases/int_list/Scala_integer_format_hex.scala
+++ b/tests/integration/cases/int_list/Scala_integer_format_hex.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_Scala_integer_format_hex {
 val my_data = List[Int](
     0x1,
     0x2,

--- a/tests/integration/cases/int_list/Scala_numeric_separator_underscore.scala
+++ b/tests/integration/cases/int_list/Scala_numeric_separator_underscore.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_Scala_numeric_separator_underscore {
 val my_data = List[Int](
     1,
     2,

--- a/tests/integration/cases/int_list/Scala_sequence_array_decl_var.scala
+++ b/tests/integration/cases/int_list/Scala_sequence_array_decl_var.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_Scala_sequence_array_decl_var {
 var my_data = Array[Int](
     1,
     2,

--- a/tests/integration/cases/int_list/Scala_sequence_seq_decl_var.scala
+++ b/tests/integration/cases/int_list/Scala_sequence_seq_decl_var.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_Scala_sequence_seq_decl_var {
 var my_data = Seq(
     1,
     2,

--- a/tests/integration/cases/int_list_large/Scala.scala
+++ b/tests/integration/cases/int_list_large/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_large_Scala {
 val my_data = List[Int](
     1000000,
     -1234,

--- a/tests/integration/cases/int_list_large/Scala_combined.scala
+++ b/tests/integration/cases/int_list_large/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_large_Scala_combined {
 var my_data = List[Int](
     1000000,
     -1234,

--- a/tests/integration/cases/int_list_large/Scala_integer_format_hex_large.scala
+++ b/tests/integration/cases/int_list_large/Scala_integer_format_hex_large.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_large_Scala_integer_format_hex_large {
 val my_data = List[Int](
     0xf4240,
     -0x4d2,

--- a/tests/integration/cases/int_list_large/Scala_numeric_separator_underscore_large.scala
+++ b/tests/integration/cases/int_list_large/Scala_numeric_separator_underscore_large.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_large_Scala_numeric_separator_underscore_large {
 val my_data = List[Int](
     1_000_000,
     -1_234,

--- a/tests/integration/cases/int_list_with_zero/Scala.scala
+++ b/tests/integration/cases/int_list_with_zero/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_with_zero_Scala {
 val my_data = List[Int](
     0,
     1,

--- a/tests/integration/cases/int_list_with_zero/Scala_combined.scala
+++ b/tests/integration/cases/int_list_with_zero/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_with_zero_Scala_combined {
 var my_data = List[Int](
     0,
     1,

--- a/tests/integration/cases/int_list_with_zero/Scala_integer_format_hex_zero.scala
+++ b/tests/integration/cases/int_list_with_zero/Scala_integer_format_hex_zero.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_with_zero_Scala_integer_format_hex_zero {
 val my_data = List[Int](
     0x0,
     0x1,

--- a/tests/integration/cases/int_list_with_zero/Scala_numeric_separator_underscore_zero.scala
+++ b/tests/integration/cases/int_list_with_zero/Scala_numeric_separator_underscore_zero.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_list_with_zero_Scala_numeric_separator_underscore_zero {
 val my_data = List[Int](
     0,
     1,

--- a/tests/integration/cases/int_set/Scala.scala
+++ b/tests/integration/cases/int_set/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_set_Scala {
 val my_data = Set[Int](
     1,
     2,

--- a/tests/integration/cases/int_set/Scala_combined.scala
+++ b/tests/integration/cases/int_set/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_int_set_Scala_combined {
 var my_data = Set[Int](
     1,
     2,

--- a/tests/integration/cases/int_set/Scala_set_tree_set.scala
+++ b/tests/integration/cases/int_set/Scala_set_tree_set.scala
@@ -1,5 +1,5 @@
 import scala.collection.immutable.TreeSet
-object Check {
+object Fixture_int_set_Scala_set_tree_set {
 val my_data = TreeSet[Int](
     1,
     2,

--- a/tests/integration/cases/mixed_number_dict/Scala.scala
+++ b/tests/integration/cases/mixed_number_dict/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_number_dict_Scala {
 val my_data = Map[String, Double](
     "a" -> 1,
     "b" -> 2.5,

--- a/tests/integration/cases/mixed_number_dict/Scala_combined.scala
+++ b/tests/integration/cases/mixed_number_dict/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_number_dict_Scala_combined {
 var my_data = Map[String, Double](
     "a" -> 1,
     "b" -> 2.5,

--- a/tests/integration/cases/mixed_number_list/Scala.scala
+++ b/tests/integration/cases/mixed_number_list/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_number_list_Scala {
 val my_data = List[Double](
     1,
     2.5,

--- a/tests/integration/cases/mixed_number_list/Scala_combined.scala
+++ b/tests/integration/cases/mixed_number_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_number_list_Scala_combined {
 var my_data = List[Double](
     1,
     2.5,

--- a/tests/integration/cases/mixed_set/Scala.scala
+++ b/tests/integration/cases/mixed_set/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_set_Scala {
 val my_data = Set(
     true,
     42,

--- a/tests/integration/cases/mixed_set/Scala_combined.scala
+++ b/tests/integration/cases/mixed_set/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_set_Scala_combined {
 var my_data = Set(
     true,
     42,

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Scala.scala
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_type_dicts_in_sequence_Scala {
 val my_data = List[Map[String, Any]](
     Map("type" -> "create", "pr_id" -> "pr_1", "draft" -> true),
     Map("type" -> "create", "pr_id" -> "pr_2"),

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Scala_combined.scala
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_mixed_type_dicts_in_sequence_Scala_combined {
 var my_data = List[Map[String, Any]](
     Map("type" -> "create", "pr_id" -> "pr_1", "draft" -> true),
     Map("type" -> "create", "pr_id" -> "pr_2"),

--- a/tests/integration/cases/nested/Scala.scala
+++ b/tests/integration/cases/nested/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_Scala {
 val my_data = Map(
     "users" -> List[Map[String, Any]](Map("name" -> "Bob", "tags" -> List[String]("admin", "user")), Map("name" -> "Carol", "tags" -> List[String]("guest"))),
 )

--- a/tests/integration/cases/nested/Scala_combined.scala
+++ b/tests/integration/cases/nested/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_Scala_combined {
 var my_data = Map(
     "users" -> List[Map[String, Any]](Map("name" -> "Bob", "tags" -> List[String]("admin", "user")), Map("name" -> "Carol", "tags" -> List[String]("guest"))),
 )

--- a/tests/integration/cases/nested_bool_list/Scala.scala
+++ b/tests/integration/cases/nested_bool_list/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_bool_list_Scala {
 val my_data = List[List[Boolean]](
     List[Boolean](true, false),
     List[Boolean](true, true),

--- a/tests/integration/cases/nested_bool_list/Scala_combined.scala
+++ b/tests/integration/cases/nested_bool_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_bool_list_Scala_combined {
 var my_data = List[List[Boolean]](
     List[Boolean](true, false),
     List[Boolean](true, true),

--- a/tests/integration/cases/nested_collection_multi_space_string/Scala.scala
+++ b/tests/integration/cases/nested_collection_multi_space_string/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_collection_multi_space_string_Scala {
 val my_data = List[Map[String, Any]](
     Map("key" -> "hello   world", "value" -> 1),
 )

--- a/tests/integration/cases/nested_collection_multi_space_string/Scala_combined.scala
+++ b/tests/integration/cases/nested_collection_multi_space_string/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_collection_multi_space_string_Scala_combined {
 var my_data = List[Map[String, Any]](
     Map("key" -> "hello   world", "value" -> 1),
 )

--- a/tests/integration/cases/nested_deep_empty/Scala.scala
+++ b/tests/integration/cases/nested_deep_empty/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_deep_empty_Scala {
 val my_data = List(
     List(List(), List()),
 )

--- a/tests/integration/cases/nested_deep_empty/Scala_combined.scala
+++ b/tests/integration/cases/nested_deep_empty/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_deep_empty_Scala_combined {
 var my_data = List(
     List(List(), List()),
 )

--- a/tests/integration/cases/nested_deep_mixed/Scala.scala
+++ b/tests/integration/cases/nested_deep_mixed/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_deep_mixed_Scala {
 val my_data = List(
     List(List[Int](1, 2), List[String]("a", "b")),
 )

--- a/tests/integration/cases/nested_deep_mixed/Scala_combined.scala
+++ b/tests/integration/cases/nested_deep_mixed/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_deep_mixed_Scala_combined {
 var my_data = List(
     List(List[Int](1, 2), List[String]("a", "b")),
 )

--- a/tests/integration/cases/nested_empty_inner/Scala.scala
+++ b/tests/integration/cases/nested_empty_inner/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_empty_inner_Scala {
 val my_data = List(
     List(),
     List(),

--- a/tests/integration/cases/nested_empty_inner/Scala_combined.scala
+++ b/tests/integration/cases/nested_empty_inner/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_empty_inner_Scala_combined {
 var my_data = List(
     List(),
     List(),

--- a/tests/integration/cases/nested_float_list/Scala.scala
+++ b/tests/integration/cases/nested_float_list/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_float_list_Scala {
 val my_data = List[List[Double]](
     List[Double](1.5, 2.5),
     List[Double](3.5, 4.5),

--- a/tests/integration/cases/nested_float_list/Scala_combined.scala
+++ b/tests/integration/cases/nested_float_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_float_list_Scala_combined {
 var my_data = List[List[Double]](
     List[Double](1.5, 2.5),
     List[Double](3.5, 4.5),

--- a/tests/integration/cases/nested_float_list/Scala_float_format_fixed_n.scala
+++ b/tests/integration/cases/nested_float_list/Scala_float_format_fixed_n.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_float_list_Scala_float_format_fixed_n {
 val my_data = List[List[Double]](
     List[Double](1.500000, 2.500000),
     List[Double](3.500000, 4.500000),

--- a/tests/integration/cases/nested_float_list/Scala_float_format_scientific_n.scala
+++ b/tests/integration/cases/nested_float_list/Scala_float_format_scientific_n.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_float_list_Scala_float_format_scientific_n {
 val my_data = List[List[Double]](
     List[Double](1.5, 2.5),
     List[Double](3.5, 4.5),

--- a/tests/integration/cases/nested_float_list/Scala_numeric_separator_underscore_float_n.scala
+++ b/tests/integration/cases/nested_float_list/Scala_numeric_separator_underscore_float_n.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_float_list_Scala_numeric_separator_underscore_float_n {
 val my_data = List[List[Double]](
     List[Double](1.5, 2.5),
     List[Double](3.5, 4.5),

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Scala.scala
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_list_mixed_sibling_types_Scala {
 val my_data = List(
     List[Int](1, 2),
     List(),

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Scala_combined.scala
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_list_mixed_sibling_types_Scala_combined {
 var my_data = List(
     List[Int](1, 2),
     List(),

--- a/tests/integration/cases/nested_list_of_dicts/Scala.scala
+++ b/tests/integration/cases/nested_list_of_dicts/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_list_of_dicts_Scala {
 val my_data = List[List[Map[String, String]]](
     List[Map[String, String]](Map[String, String]("name" -> "Alice"), Map[String, String]("name" -> "Bob")),
     List[Map[String, String]](Map[String, String]("name" -> "Charlie"), Map[String, String]("name" -> "Dave")),

--- a/tests/integration/cases/nested_list_of_dicts/Scala_combined.scala
+++ b/tests/integration/cases/nested_list_of_dicts/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_list_of_dicts_Scala_combined {
 var my_data = List[List[Map[String, String]]](
     List[Map[String, String]](Map[String, String]("name" -> "Alice"), Map[String, String]("name" -> "Bob")),
     List[Map[String, String]](Map[String, String]("name" -> "Charlie"), Map[String, String]("name" -> "Dave")),

--- a/tests/integration/cases/nested_list_with_empty_sibling/Scala.scala
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_list_with_empty_sibling_Scala {
 val my_data = List[List[Int]](
     List[Int](1, 2),
     List[Int](),

--- a/tests/integration/cases/nested_list_with_empty_sibling/Scala_combined.scala
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_list_with_empty_sibling_Scala_combined {
 var my_data = List[List[Int]](
     List[Int](1, 2),
     List[Int](),

--- a/tests/integration/cases/nested_mixed_dict/Scala.scala
+++ b/tests/integration/cases/nested_mixed_dict/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_dict_Scala {
 val my_data = Map(
     "outer" -> Map("a" -> 1, "b" -> "x", "c" -> null),
 )

--- a/tests/integration/cases/nested_mixed_dict/Scala_combined.scala
+++ b/tests/integration/cases/nested_mixed_dict/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_dict_Scala_combined {
 var my_data = Map(
     "outer" -> Map("a" -> 1, "b" -> "x", "c" -> null),
 )

--- a/tests/integration/cases/nested_mixed_inner/Scala.scala
+++ b/tests/integration/cases/nested_mixed_inner/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_inner_Scala {
 val my_data = List(
     List(1, "a"),
     List(2, "b"),

--- a/tests/integration/cases/nested_mixed_inner/Scala_combined.scala
+++ b/tests/integration/cases/nested_mixed_inner/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_inner_Scala_combined {
 var my_data = List(
     List(1, "a"),
     List(2, "b"),

--- a/tests/integration/cases/nested_mixed_set/Scala.scala
+++ b/tests/integration/cases/nested_mixed_set/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_set_Scala {
 val my_data = Map(
     "name" -> "Alice",
     "tags" -> Set(true, 42, "apple"),

--- a/tests/integration/cases/nested_mixed_set/Scala_combined.scala
+++ b/tests/integration/cases/nested_mixed_set/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_set_Scala_combined {
 var my_data = Map(
     "name" -> "Alice",
     "tags" -> Set(true, 42, "apple"),

--- a/tests/integration/cases/nested_mixed_types/Scala.scala
+++ b/tests/integration/cases/nested_mixed_types/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_types_Scala {
 val my_data = List(
     List[Int](1, 2),
     List[String]("a", "b"),

--- a/tests/integration/cases/nested_mixed_types/Scala_combined.scala
+++ b/tests/integration/cases/nested_mixed_types/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_mixed_types_Scala_combined {
 var my_data = List(
     List[Int](1, 2),
     List[String]("a", "b"),

--- a/tests/integration/cases/nested_sequence/Scala.scala
+++ b/tests/integration/cases/nested_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_sequence_Scala {
 val my_data = List(
     true,
     "hi",

--- a/tests/integration/cases/nested_sequence/Scala_combined.scala
+++ b/tests/integration/cases/nested_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_sequence_Scala_combined {
 var my_data = List(
     true,
     "hi",

--- a/tests/integration/cases/nested_sequences/Scala.scala
+++ b/tests/integration/cases/nested_sequences/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_sequences_Scala {
 val my_data = List[List[List[Int]]](
     List[List[Int]](List[Int](1, 2), List[Int](3, 4)),
     List[List[Int]](List[Int](5)),

--- a/tests/integration/cases/nested_sequences/Scala_combined.scala
+++ b/tests/integration/cases/nested_sequences/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_nested_sequences_Scala_combined {
 var my_data = List[List[List[Int]]](
     List[List[Int]](List[Int](1, 2), List[Int](3, 4)),
     List[List[Int]](List[Int](5)),

--- a/tests/integration/cases/no_comment/Scala.scala
+++ b/tests/integration/cases/no_comment/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_no_comment_Scala {
 val my_data = Map[String, String](
     "message" -> "no comment here",
 )

--- a/tests/integration/cases/no_comment/Scala_combined.scala
+++ b/tests/integration/cases/no_comment/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_no_comment_Scala_combined {
 var my_data = Map[String, String](
     "message" -> "no comment here",
 )

--- a/tests/integration/cases/ordered_map/Scala.scala
+++ b/tests/integration/cases/ordered_map/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_Scala {
 val my_data = scala.collection.immutable.ListMap(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/ordered_map/Scala_combined.scala
+++ b/tests/integration/cases/ordered_map/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_Scala_combined {
 var my_data = scala.collection.immutable.ListMap(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/ordered_map_in_sequence/Scala.scala
+++ b/tests/integration/cases/ordered_map_in_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_in_sequence_Scala {
 val my_data = List(
     scala.collection.immutable.ListMap("a" -> 1),
     "hello",

--- a/tests/integration/cases/ordered_map_in_sequence/Scala_combined.scala
+++ b/tests/integration/cases/ordered_map_in_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_in_sequence_Scala_combined {
 var my_data = List(
     scala.collection.immutable.ListMap("a" -> 1),
     "hello",

--- a/tests/integration/cases/ordered_map_int_keys/Scala.scala
+++ b/tests/integration/cases/ordered_map_int_keys/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_int_keys_Scala {
 val my_data = scala.collection.immutable.ListMap(
     "1" -> "one",
     "2" -> "two",

--- a/tests/integration/cases/ordered_map_int_keys/Scala_combined.scala
+++ b/tests/integration/cases/ordered_map_int_keys/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_int_keys_Scala_combined {
 var my_data = scala.collection.immutable.ListMap(
     "1" -> "one",
     "2" -> "two",

--- a/tests/integration/cases/ordered_map_nested_values/Scala.scala
+++ b/tests/integration/cases/ordered_map_nested_values/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_nested_values_Scala {
 val my_data = scala.collection.immutable.ListMap(
     "name" -> "Alice",
     "scores" -> Map[String, String]("1" -> "first", "2" -> "second"),

--- a/tests/integration/cases/ordered_map_nested_values/Scala_combined.scala
+++ b/tests/integration/cases/ordered_map_nested_values/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_ordered_map_nested_values_Scala_combined {
 var my_data = scala.collection.immutable.ListMap(
     "name" -> "Alice",
     "scores" -> Map[String, String]("1" -> "first", "2" -> "second"),

--- a/tests/integration/cases/pair_sequence/Scala.scala
+++ b/tests/integration/cases/pair_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_pair_sequence_Scala {
 val my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/pair_sequence/Scala_combined.scala
+++ b/tests/integration/cases/pair_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_pair_sequence_Scala_combined {
 var my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/pair_sequence/Scala_sequence_array_pair.scala
+++ b/tests/integration/cases/pair_sequence/Scala_sequence_array_pair.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_pair_sequence_Scala_sequence_array_pair {
 val my_data = Array(
     1,
     "hello",

--- a/tests/integration/cases/pair_sequence/Scala_sequence_seq_pair.scala
+++ b/tests/integration/cases/pair_sequence/Scala_sequence_seq_pair.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_pair_sequence_Scala_sequence_seq_pair {
 val my_data = Seq(
     1,
     "hello",

--- a/tests/integration/cases/scalar_bool/Scala.scala
+++ b/tests/integration/cases/scalar_bool/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_bool_Scala {
 val my_data = true
 }

--- a/tests/integration/cases/scalar_bool/Scala_combined.scala
+++ b/tests/integration/cases/scalar_bool/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_bool_Scala_combined {
 var my_data = true
 my_data = true
 }

--- a/tests/integration/cases/scalar_bool/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_bool/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_bool_Scala_declaration_style_var {
 var my_data = true
 }

--- a/tests/integration/cases/scalar_date/Scala.scala
+++ b/tests/integration/cases/scalar_date/Scala.scala
@@ -1,4 +1,4 @@
 import java.time.LocalDate
-object Check {
+object Fixture_scalar_date_Scala {
 val my_data = LocalDate.of(2024, 1, 15)
 }

--- a/tests/integration/cases/scalar_date/Scala_combined.scala
+++ b/tests/integration/cases/scalar_date/Scala_combined.scala
@@ -1,5 +1,5 @@
 import java.time.LocalDate
-object Check {
+object Fixture_scalar_date_Scala_combined {
 var my_data = LocalDate.of(2024, 1, 15)
 my_data = LocalDate.of(2024, 1, 15)
 }

--- a/tests/integration/cases/scalar_date/Scala_date_iso.scala
+++ b/tests/integration/cases/scalar_date/Scala_date_iso.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_date_Scala_date_iso {
 val my_data = "2024-01-15"
 }

--- a/tests/integration/cases/scalar_date/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_date/Scala_declaration_style_var.scala
@@ -1,4 +1,4 @@
 import java.time.LocalDate
-object Check {
+object Fixture_scalar_date_Scala_declaration_style_var {
 var my_data = LocalDate.of(2024, 1, 15)
 }

--- a/tests/integration/cases/scalar_datetime/Scala.scala
+++ b/tests/integration/cases/scalar_datetime/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_Scala {
 val my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("+00:00"))
 }

--- a/tests/integration/cases/scalar_datetime/Scala_combined.scala
+++ b/tests/integration/cases/scalar_datetime/Scala_combined.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_Scala_combined {
 var my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("+00:00"))
 my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("+00:00"))
 }

--- a/tests/integration/cases/scalar_datetime/Scala_datetime_iso.scala
+++ b/tests/integration/cases/scalar_datetime/Scala_datetime_iso.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_datetime_Scala_datetime_iso {
 val my_data = "2024-01-15T12:30:00+00:00"
 }

--- a/tests/integration/cases/scalar_datetime/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_datetime/Scala_declaration_style_var.scala
@@ -1,5 +1,5 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_Scala_declaration_style_var {
 var my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("+00:00"))
 }

--- a/tests/integration/cases/scalar_datetime_microsecond/Scala.scala
+++ b/tests/integration/cases/scalar_datetime_microsecond/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_microsecond_Scala {
 val my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 123456000, ZoneId.of("+00:00"))
 }

--- a/tests/integration/cases/scalar_datetime_microsecond/Scala_combined.scala
+++ b/tests/integration/cases/scalar_datetime_microsecond/Scala_combined.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_microsecond_Scala_combined {
 var my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 123456000, ZoneId.of("+00:00"))
 my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 123456000, ZoneId.of("+00:00"))
 }

--- a/tests/integration/cases/scalar_datetime_midnight/Scala.scala
+++ b/tests/integration/cases/scalar_datetime_midnight/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_midnight_Scala {
 val my_data = ZonedDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneId.of("UTC"))
 }

--- a/tests/integration/cases/scalar_datetime_midnight/Scala_combined.scala
+++ b/tests/integration/cases/scalar_datetime_midnight/Scala_combined.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_midnight_Scala_combined {
 var my_data = ZonedDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneId.of("UTC"))
 my_data = ZonedDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneId.of("UTC"))
 }

--- a/tests/integration/cases/scalar_datetime_naive/Scala.scala
+++ b/tests/integration/cases/scalar_datetime_naive/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_naive_Scala {
 val my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("UTC"))
 }

--- a/tests/integration/cases/scalar_datetime_naive/Scala_combined.scala
+++ b/tests/integration/cases/scalar_datetime_naive/Scala_combined.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_naive_Scala_combined {
 var my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("UTC"))
 my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 0, 0, ZoneId.of("UTC"))
 }

--- a/tests/integration/cases/scalar_datetime_naive/Scala_datetime_iso_naive.scala
+++ b/tests/integration/cases/scalar_datetime_naive/Scala_datetime_iso_naive.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_datetime_naive_Scala_datetime_iso_naive {
 val my_data = "2024-01-15T12:30:00"
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/Scala.scala
+++ b/tests/integration/cases/scalar_datetime_non_utc/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_non_utc_Scala {
 val my_data = ZonedDateTime.of(2024, 1, 15, 18, 0, 0, 0, ZoneId.of("+05:30"))
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/Scala_combined.scala
+++ b/tests/integration/cases/scalar_datetime_non_utc/Scala_combined.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_non_utc_Scala_combined {
 var my_data = ZonedDateTime.of(2024, 1, 15, 18, 0, 0, 0, ZoneId.of("+05:30"))
 my_data = ZonedDateTime.of(2024, 1, 15, 18, 0, 0, 0, ZoneId.of("+05:30"))
 }

--- a/tests/integration/cases/scalar_datetime_non_utc/Scala_datetime_iso_non_utc.scala
+++ b/tests/integration/cases/scalar_datetime_non_utc/Scala_datetime_iso_non_utc.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_datetime_non_utc_Scala_datetime_iso_non_utc {
 val my_data = "2024-01-15T18:00:00+05:30"
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Scala.scala
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Scala.scala
@@ -1,5 +1,5 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_seconds_microsecond_Scala {
 val my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 45, 123456000, ZoneId.of("UTC"))
 }

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Scala_combined.scala
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Scala_combined.scala
@@ -1,6 +1,6 @@
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_scalar_datetime_seconds_microsecond_Scala_combined {
 var my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 45, 123456000, ZoneId.of("UTC"))
 my_data = ZonedDateTime.of(2024, 1, 15, 12, 30, 45, 123456000, ZoneId.of("UTC"))
 }

--- a/tests/integration/cases/scalar_float/Scala.scala
+++ b/tests/integration/cases/scalar_float/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_float_Scala {
 val my_data = 3.14
 }

--- a/tests/integration/cases/scalar_float/Scala_combined.scala
+++ b/tests/integration/cases/scalar_float/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_float_Scala_combined {
 var my_data = 3.14
 my_data = 3.14
 }

--- a/tests/integration/cases/scalar_float/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_float/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_float_Scala_declaration_style_var {
 var my_data = 3.14
 }

--- a/tests/integration/cases/scalar_float/Scala_float_format_fixed.scala
+++ b/tests/integration/cases/scalar_float/Scala_float_format_fixed.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_float_Scala_float_format_fixed {
 val my_data = 3.140000
 }

--- a/tests/integration/cases/scalar_float/Scala_float_format_scientific.scala
+++ b/tests/integration/cases/scalar_float/Scala_float_format_scientific.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_float_Scala_float_format_scientific {
 val my_data = 3.14
 }

--- a/tests/integration/cases/scalar_float/Scala_numeric_separator_underscore_float_scalar.scala
+++ b/tests/integration/cases/scalar_float/Scala_numeric_separator_underscore_float_scalar.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_float_Scala_numeric_separator_underscore_float_scalar {
 val my_data = 3.14
 }

--- a/tests/integration/cases/scalar_int/Scala.scala
+++ b/tests/integration/cases/scalar_int/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_Scala {
 val my_data = 42
 }

--- a/tests/integration/cases/scalar_int/Scala_combined.scala
+++ b/tests/integration/cases/scalar_int/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_int_Scala_combined {
 var my_data = 42
 my_data = 42
 }

--- a/tests/integration/cases/scalar_int/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_int/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_Scala_declaration_style_var {
 var my_data = 42
 }

--- a/tests/integration/cases/scalar_int/Scala_integer_format_hex.scala
+++ b/tests/integration/cases/scalar_int/Scala_integer_format_hex.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_Scala_integer_format_hex {
 val my_data = 0x2a
 }

--- a/tests/integration/cases/scalar_int/Scala_numeric_separator_underscore.scala
+++ b/tests/integration/cases/scalar_int/Scala_numeric_separator_underscore.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_Scala_numeric_separator_underscore {
 val my_data = 42
 }

--- a/tests/integration/cases/scalar_int_large/Scala.scala
+++ b/tests/integration/cases/scalar_int_large/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_large_Scala {
 val my_data = 2147483648L
 }

--- a/tests/integration/cases/scalar_int_large/Scala_combined.scala
+++ b/tests/integration/cases/scalar_int_large/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_int_large_Scala_combined {
 var my_data = 2147483648L
 my_data = 2147483648L
 }

--- a/tests/integration/cases/scalar_int_large/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_int_large/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_large_Scala_declaration_style_var {
 var my_data = 2147483648L
 }

--- a/tests/integration/cases/scalar_int_large/Scala_integer_format_hex.scala
+++ b/tests/integration/cases/scalar_int_large/Scala_integer_format_hex.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_large_Scala_integer_format_hex {
 val my_data = 0x80000000L
 }

--- a/tests/integration/cases/scalar_int_large/Scala_numeric_separator_underscore.scala
+++ b/tests/integration/cases/scalar_int_large/Scala_numeric_separator_underscore.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_large_Scala_numeric_separator_underscore {
 val my_data = 2_147_483_648L
 }

--- a/tests/integration/cases/scalar_int_negative_large/Scala.scala
+++ b/tests/integration/cases/scalar_int_negative_large/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_negative_large_Scala {
 val my_data = -2147483649L
 }

--- a/tests/integration/cases/scalar_int_negative_large/Scala_combined.scala
+++ b/tests/integration/cases/scalar_int_negative_large/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_int_negative_large_Scala_combined {
 var my_data = -2147483649L
 my_data = -2147483649L
 }

--- a/tests/integration/cases/scalar_int_very_large/Scala.scala
+++ b/tests/integration/cases/scalar_int_very_large/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_very_large_Scala {
 val my_data = BigInt("9223372036854775808")
 }

--- a/tests/integration/cases/scalar_int_very_large/Scala_combined.scala
+++ b/tests/integration/cases/scalar_int_very_large/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_int_very_large_Scala_combined {
 var my_data = BigInt("9223372036854775808")
 my_data = BigInt("9223372036854775808")
 }

--- a/tests/integration/cases/scalar_int_very_negative_large/Scala.scala
+++ b/tests/integration/cases/scalar_int_very_negative_large/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_int_very_negative_large_Scala {
 val my_data = BigInt("-9223372036854775809")
 }

--- a/tests/integration/cases/scalar_int_very_negative_large/Scala_combined.scala
+++ b/tests/integration/cases/scalar_int_very_negative_large/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_int_very_negative_large_Scala_combined {
 var my_data = BigInt("-9223372036854775809")
 my_data = BigInt("-9223372036854775809")
 }

--- a/tests/integration/cases/scalar_null/Scala.scala
+++ b/tests/integration/cases/scalar_null/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_null_Scala {
 val my_data = null
 }

--- a/tests/integration/cases/scalar_null/Scala_combined.scala
+++ b/tests/integration/cases/scalar_null/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_null_Scala_combined {
 var my_data = null
 my_data = null
 }

--- a/tests/integration/cases/scalar_null/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_null/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_null_Scala_declaration_style_var {
 var my_data = null
 }

--- a/tests/integration/cases/scalar_null_with_comment/Scala.scala
+++ b/tests/integration/cases/scalar_null_with_comment/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_null_with_comment_Scala {
 val my_data = null  // note
 }

--- a/tests/integration/cases/scalar_null_with_comment/Scala_combined.scala
+++ b/tests/integration/cases/scalar_null_with_comment/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_null_with_comment_Scala_combined {
 var my_data = null  // note
 my_data = null  // note
 }

--- a/tests/integration/cases/scalar_string/Scala.scala
+++ b/tests/integration/cases/scalar_string/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_string_Scala {
 val my_data = "hello"
 }

--- a/tests/integration/cases/scalar_string/Scala_combined.scala
+++ b/tests/integration/cases/scalar_string/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalar_string_Scala_combined {
 var my_data = "hello"
 my_data = "hello"
 }

--- a/tests/integration/cases/scalar_string/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/scalar_string/Scala_declaration_style_var.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_scalar_string_Scala_declaration_style_var {
 var my_data = "hello"
 }

--- a/tests/integration/cases/scalars/Scala.scala
+++ b/tests/integration/cases/scalars/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalars_Scala {
 val my_data = List(
     42,
     3.14,

--- a/tests/integration/cases/scalars/Scala_combined.scala
+++ b/tests/integration/cases/scalars/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_scalars_Scala_combined {
 var my_data = List(
     42,
     3.14,

--- a/tests/integration/cases/sequence_of_dicts/Scala.scala
+++ b/tests/integration/cases/sequence_of_dicts/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_sequence_of_dicts_Scala {
 val my_data = List[Map[String, Any]](
     Map("name" -> "Alice", "age" -> 30),
     Map("name" -> "Bob", "age" -> 25),

--- a/tests/integration/cases/sequence_of_dicts/Scala_combined.scala
+++ b/tests/integration/cases/sequence_of_dicts/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_sequence_of_dicts_Scala_combined {
 var my_data = List[Map[String, Any]](
     Map("name" -> "Alice", "age" -> 30),
     Map("name" -> "Bob", "age" -> 25),

--- a/tests/integration/cases/set/Scala.scala
+++ b/tests/integration/cases/set/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_set_Scala {
 val my_data = Set[String](
     "apple",
     "banana",

--- a/tests/integration/cases/set/Scala_combined.scala
+++ b/tests/integration/cases/set/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_set_Scala_combined {
 var my_data = Set[String](
     "apple",
     "banana",

--- a/tests/integration/cases/set/Scala_set_tree_set.scala
+++ b/tests/integration/cases/set/Scala_set_tree_set.scala
@@ -1,5 +1,5 @@
 import scala.collection.immutable.TreeSet
-object Check {
+object Fixture_set_Scala_set_tree_set {
 val my_data = TreeSet[String](
     "apple",
     "banana",

--- a/tests/integration/cases/set/Scala_trailing_comma_no_set.scala
+++ b/tests/integration/cases/set/Scala_trailing_comma_no_set.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_set_Scala_trailing_comma_no_set {
 val my_data = Set[String](
     "apple",
     "banana",

--- a/tests/integration/cases/set_comments/Scala.scala
+++ b/tests/integration/cases/set_comments/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_set_comments_Scala {
 val my_data = Set[String](
     "apple",  // inline comment
     // before banana

--- a/tests/integration/cases/set_comments/Scala_combined.scala
+++ b/tests/integration/cases/set_comments/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_set_comments_Scala_combined {
 var my_data = Set[String](
     "apple",  // inline comment
     // before banana

--- a/tests/integration/cases/set_comments_unsorted_order/Scala.scala
+++ b/tests/integration/cases/set_comments_unsorted_order/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_set_comments_unsorted_order_Scala {
 val my_data = Set[String](
     // before apple
     "apple",

--- a/tests/integration/cases/set_comments_unsorted_order/Scala_combined.scala
+++ b/tests/integration/cases/set_comments_unsorted_order/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_set_comments_unsorted_order_Scala_combined {
 var my_data = Set[String](
     // before apple
     "apple",

--- a/tests/integration/cases/sibling_list_values_nested/Scala.scala
+++ b/tests/integration/cases/sibling_list_values_nested/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_sibling_list_values_nested_Scala {
 val my_data = Map(
     "lint" -> List(2, List()),
     "test" -> List(5, List("compile")),

--- a/tests/integration/cases/sibling_list_values_nested/Scala_combined.scala
+++ b/tests/integration/cases/sibling_list_values_nested/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_sibling_list_values_nested_Scala_combined {
 var my_data = Map(
     "lint" -> List(2, List()),
     "test" -> List(5, List("compile")),

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Scala.scala
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_sibling_list_values_uniform_inner_Scala {
 val my_data = Map(
     "lint" -> List(2, List[Int](1)),
     "test" -> List(5, List[Int](7)),

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Scala_combined.scala
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_sibling_list_values_uniform_inner_Scala_combined {
 var my_data = Map(
     "lint" -> List(2, List[Int](1)),
     "test" -> List(5, List[Int](7)),

--- a/tests/integration/cases/simple_dict/Scala.scala
+++ b/tests/integration/cases/simple_dict/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_dict_Scala {
 val my_data = Map(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/simple_dict/Scala_combined.scala
+++ b/tests/integration/cases/simple_dict/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_dict_Scala_combined {
 var my_data = Map(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/simple_dict/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/simple_dict/Scala_declaration_style_var.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_dict_Scala_declaration_style_var {
 var my_data = Map(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/simple_dict/Scala_dict_format_list_map.scala
+++ b/tests/integration/cases/simple_dict/Scala_dict_format_list_map.scala
@@ -1,5 +1,5 @@
 import scala.collection.immutable.ListMap
-object Check {
+object Fixture_simple_dict_Scala_dict_format_list_map {
 val my_data = ListMap(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/simple_dict/Scala_trailing_comma_no_dict.scala
+++ b/tests/integration/cases/simple_dict/Scala_trailing_comma_no_dict.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_dict_Scala_trailing_comma_no_dict {
 val my_data = Map(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/simple_sequence/Scala.scala
+++ b/tests/integration/cases/simple_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala {
 val my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/Scala_combined.scala
+++ b/tests/integration/cases/simple_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala_combined {
 var my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/Scala_declaration_style_var.scala
+++ b/tests/integration/cases/simple_sequence/Scala_declaration_style_var.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala_declaration_style_var {
 var my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/Scala_sequence_array.scala
+++ b/tests/integration/cases/simple_sequence/Scala_sequence_array.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala_sequence_array {
 val my_data = Array(
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/Scala_sequence_array_varname.scala
+++ b/tests/integration/cases/simple_sequence/Scala_sequence_array_varname.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala_sequence_array_varname {
 val my_data = Array(
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/Scala_sequence_seq.scala
+++ b/tests/integration/cases/simple_sequence/Scala_sequence_seq.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala_sequence_seq {
 val my_data = Seq(
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/Scala_sequence_seq_varname.scala
+++ b/tests/integration/cases/simple_sequence/Scala_sequence_seq_varname.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala_sequence_seq_varname {
 val my_data = Seq(
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/Scala_trailing_comma_no.scala
+++ b/tests/integration/cases/simple_sequence/Scala_trailing_comma_no.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_simple_sequence_Scala_trailing_comma_no {
 val my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/string_control_chars/Scala.scala
+++ b/tests/integration/cases/string_control_chars/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_control_chars_Scala {
 val my_data = List[String](
     "line1\r\nline2",
     "line1\rline2",

--- a/tests/integration/cases/string_control_chars/Scala_combined.scala
+++ b/tests/integration/cases/string_control_chars/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_control_chars_Scala_combined {
 var my_data = List[String](
     "line1\r\nline2",
     "line1\rline2",

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Scala.scala
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Scala.scala
@@ -1,3 +1,3 @@
-object Check {
+object Fixture_string_escaped_quotes_and_dashes_Scala {
 val my_data = "hello \"world\" -- not a comment"
 }

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Scala_combined.scala
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_escaped_quotes_and_dashes_Scala_combined {
 var my_data = "hello \"world\" -- not a comment"
 my_data = "hello \"world\" -- not a comment"
 }

--- a/tests/integration/cases/string_list/Scala.scala
+++ b/tests/integration/cases/string_list/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_list_Scala {
 val my_data = List[String](
     "foo",
     "bar",

--- a/tests/integration/cases/string_list/Scala_combined.scala
+++ b/tests/integration/cases/string_list/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_list_Scala_combined {
 var my_data = List[String](
     "foo",
     "bar",

--- a/tests/integration/cases/string_with_backslash/Scala.scala
+++ b/tests/integration/cases/string_with_backslash/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_backslash_Scala {
 val my_data = List[String](
     "C:\\path\\to\\file",
     "back\\\\slash",

--- a/tests/integration/cases/string_with_backslash/Scala_combined.scala
+++ b/tests/integration/cases/string_with_backslash/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_backslash_Scala_combined {
 var my_data = List[String](
     "C:\\path\\to\\file",
     "back\\\\slash",

--- a/tests/integration/cases/string_with_dollar/Scala.scala
+++ b/tests/integration/cases/string_with_dollar/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_dollar_Scala {
 val my_data = List[String](
     "price $10",
     "$HOME",

--- a/tests/integration/cases/string_with_dollar/Scala_combined.scala
+++ b/tests/integration/cases/string_with_dollar/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_dollar_Scala_combined {
 var my_data = List[String](
     "price $10",
     "$HOME",

--- a/tests/integration/cases/string_with_dollar_brace/Scala.scala
+++ b/tests/integration/cases/string_with_dollar_brace/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_dollar_brace_Scala {
 val my_data = List[String](
     "prefix ${HOME} suffix",
     "${interpolated}",

--- a/tests/integration/cases/string_with_dollar_brace/Scala_combined.scala
+++ b/tests/integration/cases/string_with_dollar_brace/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_dollar_brace_Scala_combined {
 var my_data = List[String](
     "prefix ${HOME} suffix",
     "${interpolated}",

--- a/tests/integration/cases/string_with_hash/Scala.scala
+++ b/tests/integration/cases/string_with_hash/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_hash_Scala {
 val my_data = List[String](
     "issue #{42}",
     "color #red",

--- a/tests/integration/cases/string_with_hash/Scala_combined.scala
+++ b/tests/integration/cases/string_with_hash/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_hash_Scala_combined {
 var my_data = List[String](
     "issue #{42}",
     "color #red",

--- a/tests/integration/cases/string_with_percent/Scala.scala
+++ b/tests/integration/cases/string_with_percent/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_percent_Scala {
 val my_data = List[String](
     "100% done",
     "%(name) is here",

--- a/tests/integration/cases/string_with_percent/Scala_combined.scala
+++ b/tests/integration/cases/string_with_percent/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_string_with_percent_Scala_combined {
 var my_data = List[String](
     "100% done",
     "%(name) is here",

--- a/tests/integration/cases/triple_sequence/Scala.scala
+++ b/tests/integration/cases/triple_sequence/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_triple_sequence_Scala {
 val my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/triple_sequence/Scala_combined.scala
+++ b/tests/integration/cases/triple_sequence/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_triple_sequence_Scala_combined {
 var my_data = List(
     1,
     "hello",

--- a/tests/integration/cases/triple_sequence/Scala_sequence_array_triple.scala
+++ b/tests/integration/cases/triple_sequence/Scala_sequence_array_triple.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_triple_sequence_Scala_sequence_array_triple {
 val my_data = Array(
     1,
     "hello",

--- a/tests/integration/cases/triple_sequence/Scala_sequence_seq_triple.scala
+++ b/tests/integration/cases/triple_sequence/Scala_sequence_seq_triple.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_triple_sequence_Scala_sequence_seq_triple {
 val my_data = Seq(
     1,
     "hello",

--- a/tests/integration/cases/type_hints/Scala.scala
+++ b/tests/integration/cases/type_hints/Scala.scala
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_type_hints_Scala {
 val my_data = Map(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/type_hints/Scala_combined.scala
+++ b/tests/integration/cases/type_hints/Scala_combined.scala
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
-object Check {
+object Fixture_type_hints_Scala_combined {
 var my_data = Map(
     "name" -> "Alice",
     "age" -> 30,

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Scala.scala
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_uniform_mixed_num_dicts_in_seq_Scala {
 val my_data = List[Map[String, Double]](
     Map[String, Double]("x" -> 1, "y" -> 2.5),
     Map[String, Double]("x" -> 3, "y" -> 4.0),

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Scala_combined.scala
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_uniform_mixed_num_dicts_in_seq_Scala_combined {
 var my_data = List[Map[String, Double]](
     Map[String, Double]("x" -> 1, "y" -> 2.5),
     Map[String, Double]("x" -> 3, "y" -> 4.0),

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Scala.scala
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Scala.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_uniform_string_dicts_in_seq_Scala {
 val my_data = List[Map[String, String]](
     Map[String, String]("first" -> "Alice", "last" -> "Smith"),
     Map[String, String]("first" -> "Bob", "last" -> "Jones"),

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Scala_combined.scala
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Scala_combined.scala
@@ -1,4 +1,4 @@
-object Check {
+object Fixture_uniform_string_dicts_in_seq_Scala_combined {
 var my_data = List[Map[String, String]](
     Map[String, String]("first" -> "Alice", "last" -> "Smith"),
     Map[String, String]("first" -> "Bob", "last" -> "Jones"),

--- a/tests/integration/language_specs.py
+++ b/tests/integration/language_specs.py
@@ -6,6 +6,7 @@ combination cuts thousands of redundant builds across collection and
 test execution.
 """
 
+import dataclasses
 import enum
 import functools
 from pathlib import Path
@@ -13,7 +14,7 @@ from pathlib import Path
 from beartype import beartype
 
 import literalizer
-from literalizer.languages import ALL_LANGUAGES
+from literalizer.languages import ALL_LANGUAGES, Erlang, Scala
 
 
 @beartype
@@ -27,6 +28,44 @@ def erlang_module_name(*, golden_path: Path) -> str:
     dir_name = golden_path.parent.name
     stem = golden_path.stem
     return f"fixture_{dir_name}_{stem}".lower()
+
+
+@beartype
+def scala_module_name(*, golden_path: Path) -> str:
+    """Return the Scala object name for *golden_path*.
+
+    Produces a deterministic, per-fixture name so every compiled
+    ``.scala`` file in CI has a unique object declaration without needing
+    ``sed`` rewriting.
+    """
+    dir_name = golden_path.parent.name
+    stem = golden_path.stem
+    return f"Fixture_{dir_name}_{stem}"
+
+
+@beartype
+def with_per_fixture_module_name(
+    *,
+    spec: literalizer.Language,
+    golden_path: Path,
+) -> literalizer.Language:
+    """Return *spec* with a per-fixture ``module_name`` if applicable.
+
+    Languages whose CI lint requires unique module names (Erlang, Scala)
+    get a deterministic name derived from *golden_path*; all other
+    languages are returned unchanged.
+    """
+    if isinstance(spec, Erlang):
+        return dataclasses.replace(
+            spec,
+            module_name=erlang_module_name(golden_path=golden_path),
+        )
+    if isinstance(spec, Scala):
+        return dataclasses.replace(
+            spec,
+            module_name=scala_module_name(golden_path=golden_path),
+        )
+    return spec
 
 
 @beartype

--- a/tests/integration/test_literalize_golden.py
+++ b/tests/integration/test_literalize_golden.py
@@ -7,7 +7,6 @@ kwargs, line-ending option, heterogeneous-scalar strategy,
 language and compare against a checked-in golden file.
 """
 
-import dataclasses
 from pathlib import Path
 
 import pytest
@@ -20,7 +19,6 @@ from literalizer.exceptions import (
     NullInCollectionError,
     UnrepresentableIntegerError,
 )
-from literalizer.languages import Erlang
 
 from .case_discovery import (
     HeterogeneousStrategyCombinedCase,
@@ -34,11 +32,11 @@ from .case_discovery import (
 )
 from .check_golden import check_golden
 from .language_specs import (
-    erlang_module_name,
     find_redefinition_styles,
     lang_cls_name,
     make_spec,
     sorted_languages,
+    with_per_fixture_module_name,
 )
 from .variant_cases import (
     group_variant_cases_by_language,
@@ -66,12 +64,10 @@ def test_golden_file(
             input_path = cases_dir / case_name / "input.yaml"
             yaml_string = input_path.read_text()
             golden_path = input_path.parent / (lang_name + lang_cls.extension)
-            spec = make_spec(lang_cls=lang_cls)
-            if isinstance(spec, Erlang):
-                spec = dataclasses.replace(
-                    spec,
-                    module_name=erlang_module_name(golden_path=golden_path),
-                )
+            spec = with_per_fixture_module_name(
+                spec=make_spec(lang_cls=lang_cls),
+                golden_path=golden_path,
+            )
             try:
                 result = literalizer.literalize(
                     source=yaml_string,
@@ -128,9 +124,12 @@ def test_golden_file_combined_variable_forms(
             golden_path = input_path.parent / (
                 combined_case.golden_file_name + lang_cls.extension
             )
-            spec = make_spec(
-                lang_cls=lang_cls,
-                declaration_style=combined_case.declaration_style,
+            spec = with_per_fixture_module_name(
+                spec=make_spec(
+                    lang_cls=lang_cls,
+                    declaration_style=combined_case.declaration_style,
+                ),
+                golden_path=golden_path,
             )
             yaml_string = input_path.read_text()
             try:
@@ -191,13 +190,9 @@ def test_format_variant_golden_file(
             golden_path = case_dir / (
                 variant_case.variant_name + variant.spec.extension
             )
-            spec = (
-                dataclasses.replace(
-                    variant.spec,
-                    module_name=erlang_module_name(golden_path=golden_path),
-                )
-                if isinstance(variant.spec, Erlang)
-                else variant.spec
+            spec = with_per_fixture_module_name(
+                spec=variant.spec,
+                golden_path=golden_path,
             )
             try:
                 result = literalizer.literalize(


### PR DESCRIPTION
Each Scala golden now carries a deterministic `object Fixture_<dir>_<stem>` name derived from its path, matching the pattern established for Erlang in #1734. The `lint-scala` CI job is simplified to a plain `cp` loop with no `sed` rewriting. A shared `with_per_fixture_module_name` helper in `language_specs.py` replaces all per-language `isinstance` blocks across the three golden-file test functions and the `literalize_call` runner, leaving a single extension point ready for Crystal and Haskell. Closes #1735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the Scala CI compilation harness and renames all Scala golden fixture top-level objects, which could break lint/test expectations if any name derivation or module_name wiring is inconsistent.
> 
> **Overview**
> **Scala fixtures now use deterministic, per-fixture object names** (`Fixture_<caseDir>_<stem>`) instead of a shared `object Check`, and the `lint-scala` GitHub Actions job is simplified to just `cp` fixtures into a temp workspace (no `sed` renaming).
> 
> Test harnesses are refactored to apply per-fixture module/object naming via a shared `with_per_fixture_module_name()` helper (covering both Erlang and Scala) across `test_literalize_golden.py` and the `literalize_call` golden runner, removing scattered per-language `isinstance` blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2bbc62253807eba9f6e1a8d7ac5a4b60991b50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->