### PR TITLE
Use per-fixture module names for Haskell goldens and drop CI sed-rename

### DIFF
--- a/.github/scripts/haskell_main.hs
+++ b/.github/scripts/haskell_main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Check
+import MODULE_PLACEHOLDER
 
 main :: IO ()
-main = seq Check.my_data (return ())
+main = seq MODULE_PLACEHOLDER.my_data (return ())

--- a/.github/scripts/haskell_run_fixture.sh
+++ b/.github/scripts/haskell_run_fixture.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f="$1"
+mod=$(basename "$f" .hs)
+builddir=$(mktemp -d)
+trap 'rm -rf "$builddir"' EXIT
+if grep -qE "^main " "$f"; then
+    ghc -Wall -Werror -main-is "$mod" -outputdir "$builddir" \
+        -o "$builddir/run" "$f"
+else
+    sed "s/MODULE_PLACEHOLDER/$mod/g" .github/scripts/haskell_main.hs \
+        > "$builddir/Main.hs"
+    ghc -Wall -Werror -outputdir "$builddir" \
+        -o "$builddir/run" "$builddir/Main.hs" "$f"
+fi
+"$builddir/run"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -587,31 +587,27 @@ jobs:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
-      # Most fixtures declare only `module Check` with a `my_data` val;
-      # GHC never evaluates its body unless a top-level expression
-      # references it, so compile alongside a small Main wrapper that
-      # forces `Check.my_data`. Fixtures that already define their own
-      # `main` compile with `-main-is Check` instead.
+      # Most fixtures declare only `module Fixture_<dir>_<stem>` with a
+      # `my_data` val; GHC never evaluates its body unless a top-level
+      # expression references it, so compile alongside a small Main wrapper
+      # that forces `<module>.my_data`. Fixtures that already define their
+      # own `main` compile with `-main-is <module>` instead. Each fixture
+      # uses its own build dir so parallel ghc invocations do not clobber
+      # each other's intermediates.
       - name: Lint Haskell
         run: |-
           find tests/integration/cases -name '*.hs' -print0 > /tmp/files-haskell
+          workspace=$(mktemp -d)
           tmpdir=$(mktemp -d)
           xargs -0 -n1 ghc -fno-code -Wall -Werror -outputdir "$tmpdir" < /tmp/files-haskell
-          # shellcheck disable=SC2016  # $0/$tmpdir expand in the inner shell
-          xargs -0 -P "$(nproc)" -n1 bash -c '
-            tmpdir=$(mktemp -d)
-            trap "rm -rf \"$tmpdir\"" EXIT
-            cp "$0" "$tmpdir/Check.hs"
-            if grep -qE "^main " "$0"; then
-              ghc -Wall -Werror -main-is Check -outputdir "$tmpdir" \
-                -o "$tmpdir/run" "$tmpdir/Check.hs" || exit 1
-            else
-              cp .github/scripts/haskell_main.hs "$tmpdir/Main.hs"
-              ghc -Wall -Werror -outputdir "$tmpdir" \
-                -o "$tmpdir/run" "$tmpdir/Main.hs" "$tmpdir/Check.hs" || exit 1
-            fi
-            "$tmpdir/run" || exit 1
-          ' < /tmp/files-haskell
+          while IFS= read -r -d '' f; do
+            dir=$(basename "$(dirname "$f")")
+            stem=$(basename "$f" .hs)
+            mod="Fixture_${dir}_${stem}"
+            cp "$f" "$workspace/$mod.hs"
+          done < /tmp/files-haskell
+          find "$workspace" -name '*.hs' -print0 | \
+          xargs -0 -P "$(nproc)" -n1 bash .github/scripts/haskell_run_fixture.sh
 
       - name: Lint PureScript
         run: |-

--- a/tests/integration/cases/binary/Haskell.hs
+++ b/tests/integration/cases/binary/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_binary_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/binary/Haskell_bytes_format_base64.hs
+++ b/tests/integration/cases/binary/Haskell_bytes_format_base64.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_binary_Haskell_bytes_format_base64 where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/binary/Haskell_bytes_format_hex.hs
+++ b/tests/integration/cases/binary/Haskell_bytes_format_hex.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_binary_Haskell_bytes_format_hex where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/binary/Haskell_prefix_J_binary.hs
+++ b/tests/integration/cases/binary/Haskell_prefix_J_binary.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_binary_Haskell_prefix_J_binary where
 data Val = JStr String | JList [Val]
 my_data :: Val
 my_data = JList [

--- a/tests/integration/cases/binary/Haskell_string_format_double_binary.hs
+++ b/tests/integration/cases/binary/Haskell_string_format_double_binary.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Check where
+module Fixture_binary_Haskell_string_format_double_binary where
 import Data.String (IsString(fromString))
 data Val = HStr String | HList [Val]
 instance IsString Val where

--- a/tests/integration/cases/binary/Haskell_type_name_JsonVal_binary.hs
+++ b/tests/integration/cases/binary/Haskell_type_name_JsonVal_binary.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_binary_Haskell_type_name_JsonVal_binary where
 data JsonVal = HStr String | HList [JsonVal]
 my_data :: JsonVal
 my_data = HList [

--- a/tests/integration/cases/bool_list/Haskell.hs
+++ b/tests/integration/cases/bool_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_bool_list_Haskell where
 data Val = HBool Bool | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/call_deep_dotted_method/Haskell_call.hs
+++ b/tests/integration/cases/call_deep_dotted_method/Haskell_call.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedRecordDot #-}
-module Check where
+module Fixture_call_deep_dotted_method_Haskell_call where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_deep_dotted_transformed/Haskell_call.hs
+++ b/tests/integration/cases/call_deep_dotted_transformed/Haskell_call.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedRecordDot #-}
-module Check where
+module Fixture_call_deep_dotted_transformed_Haskell_call where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_dotted_method/Haskell_call.hs
+++ b/tests/integration/cases/call_dotted_method/Haskell_call.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedRecordDot #-}
-module Check where
+module Fixture_call_dotted_method_Haskell_call where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_keyword_args/Haskell_call.hs
+++ b/tests/integration/cases/call_keyword_args/Haskell_call.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedRecordDot #-}
-module Check where
+module Fixture_call_keyword_args_Haskell_call where
 data Val = HFloat Double | HStr String | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/call_mixed_type_dicts/Haskell_call.hs
+++ b/tests/integration/cases/call_mixed_type_dicts/Haskell_call.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedRecordDot #-}
-module Check where
+module Fixture_call_mixed_type_dicts_Haskell_call where
 data Val = HBool Bool | HStr String | HList [Val] | HMap [(String, Val)]
 data MgrType_ = MgrType_ { op :: Val -> IO () }
 data AppType_ = AppType_ { mgr :: MgrType_ }

--- a/tests/integration/cases/call_multi_args/Haskell_call.hs
+++ b/tests/integration/cases/call_multi_args/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_multi_args_Haskell_call where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_per_element_false/Haskell_call.hs
+++ b/tests/integration/cases/call_per_element_false/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_per_element_false_Haskell_call where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_ref_args/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_ref_args_Haskell_call where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_ref_args_converted/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args_converted/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_ref_args_converted_Haskell_call where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_ref_args_converted_nonsnake_Haskell_call where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_ref_args_converted_whole/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args_converted_whole/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_ref_args_converted_whole_Haskell_call where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_scalar_args/Haskell_call.hs
+++ b/tests/integration/cases/call_scalar_args/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_scalar_args_Haskell_call where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_snake_dotted_method/Haskell_call.hs
+++ b/tests/integration/cases/call_snake_dotted_method/Haskell_call.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedRecordDot #-}
-module Check where
+module Fixture_call_snake_dotted_method_Haskell_call where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_transform_no_wrapper/Haskell_call.hs
+++ b/tests/integration/cases/call_transform_no_wrapper/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_transform_no_wrapper_Haskell_call where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/call_wrap_in_file/Haskell_call.hs
+++ b/tests/integration/cases/call_wrap_in_file/Haskell_call.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_call_wrap_in_file_Haskell_call where
 process :: (Val, Val) -> IO ()
 process _ = return ()
 data Val = HInt Integer | HList [Val]

--- a/tests/integration/cases/comment_block_scalar_not_comment/Haskell.hs
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comment_block_scalar_not_comment_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/comment_scalar/Haskell.hs
+++ b/tests/integration/cases/comment_scalar/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comment_scalar_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/comment_scalar_document_markers/Haskell.hs
+++ b/tests/integration/cases/comment_scalar_document_markers/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comment_scalar_document_markers_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/comment_scalar_inline/Haskell.hs
+++ b/tests/integration/cases/comment_scalar_inline/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comment_scalar_inline_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Haskell.hs
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comment_scalar_quoted_with_hash_Haskell where
 data Val = HStr String
 my_data :: Val
 my_data = HStr "hello # world"  -- note

--- a/tests/integration/cases/comments/Haskell.hs
+++ b/tests/integration/cases/comments/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_Haskell where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/comments/Haskell_comment_block.hs
+++ b/tests/integration/cases/comments/Haskell_comment_block.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_Haskell_comment_block where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/comments_bang_in_double_quote/Haskell.hs
+++ b/tests/integration/cases/comments_bang_in_double_quote/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_bang_in_double_quote_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/comments_double_hash/Haskell.hs
+++ b/tests/integration/cases/comments_double_hash/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_double_hash_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/comments_empty_line/Haskell.hs
+++ b/tests/integration/cases/comments_empty_line/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_empty_line_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/comments_escaped_quote/Haskell.hs
+++ b/tests/integration/cases/comments_escaped_quote/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_escaped_quote_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/comments_escaped_single_quote/Haskell.hs
+++ b/tests/integration/cases/comments_escaped_single_quote/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_escaped_single_quote_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/comments_multi_line/Haskell.hs
+++ b/tests/integration/cases/comments_multi_line/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_multi_line_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/comments_nested_mapping/Haskell.hs
+++ b/tests/integration/cases/comments_nested_mapping/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_nested_mapping_Haskell where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/comments_sequence_before/Haskell.hs
+++ b/tests/integration/cases/comments_sequence_before/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_sequence_before_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/comments_sequence_inline/Haskell.hs
+++ b/tests/integration/cases/comments_sequence_inline/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_sequence_inline_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/comments_trailing/Haskell.hs
+++ b/tests/integration/cases/comments_trailing/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_trailing_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/comments_vb_before_dim/Haskell.hs
+++ b/tests/integration/cases/comments_vb_before_dim/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_comments_vb_before_dim_Haskell where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/date_list/Haskell.hs
+++ b/tests/integration/cases/date_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_date_list_Haskell where
 import Data.Time (Day, fromGregorian)
 data Val = HList [Val] | HDate Day
 my_data :: Val

--- a/tests/integration/cases/date_list/Haskell_date_haskell.hs
+++ b/tests/integration/cases/date_list/Haskell_date_haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_date_list_Haskell_date_haskell where
 import Data.Time (Day, fromGregorian)
 data Val = HList [Val] | HDate Day
 my_data :: Val

--- a/tests/integration/cases/date_list/Haskell_date_iso.hs
+++ b/tests/integration/cases/date_list/Haskell_date_iso.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_date_list_Haskell_date_iso where
 data Val = HList [Val] | HStr String
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/date_set/Haskell.hs
+++ b/tests/integration/cases/date_set/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_date_set_Haskell where
 import Data.Time (Day, fromGregorian)
 data Val = HSet [Val] | HDate Day
 my_data :: Val

--- a/tests/integration/cases/date_set/Haskell_date_haskell.hs
+++ b/tests/integration/cases/date_set/Haskell_date_haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_date_set_Haskell_date_haskell where
 import Data.Time (Day, fromGregorian)
 data Val = HSet [Val] | HDate Day
 my_data :: Val

--- a/tests/integration/cases/date_set/Haskell_date_iso.hs
+++ b/tests/integration/cases/date_set/Haskell_date_iso.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_date_set_Haskell_date_iso where
 data Val = HSet [Val] | HStr String
 my_data :: Val
 my_data = HSet [

--- a/tests/integration/cases/dates/Haskell.hs
+++ b/tests/integration/cases/dates/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dates_Haskell where
 import Data.Time (Day, fromGregorian, UTCTime(..), secondsToDiffTime)
 data Val = HStr String | HMap [(String, Val)] | HDate Day | HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/datetime_list/Haskell.hs
+++ b/tests/integration/cases/datetime_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_datetime_list_Haskell where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime, picosecondsToDiffTime)
 data Val = HList [Val] | HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/datetime_list/Haskell_datetime_haskell.hs
+++ b/tests/integration/cases/datetime_list/Haskell_datetime_haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_datetime_list_Haskell_datetime_haskell where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime, picosecondsToDiffTime)
 data Val = HList [Val] | HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/datetime_list/Haskell_datetime_iso.hs
+++ b/tests/integration/cases/datetime_list/Haskell_datetime_iso.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_datetime_list_Haskell_datetime_iso where
 data Val = HList [Val] | HStr String
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/deep_nesting/Haskell.hs
+++ b/tests/integration/cases/deep_nesting/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_deep_nesting_Haskell where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/dict_all_null_trailing_comment/Haskell.hs
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_all_null_trailing_comment_Haskell where
 data Val = HNull | HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/dict_all_scalar_types/Haskell.hs
+++ b/tests/integration/cases/dict_all_scalar_types/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_all_scalar_types_Haskell where
 import Data.Time (Day, fromGregorian, UTCTime(..), secondsToDiffTime)
 data Val = HNull | HBool Bool | HInt Integer | HFloat Double | HStr String | HMap [(String, Val)] | HDate Day | HDatetime UTCTime
 instance Num Val where

--- a/tests/integration/cases/dict_mixed_int_widths/Haskell.hs
+++ b/tests/integration/cases/dict_mixed_int_widths/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_mixed_int_widths_Haskell where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/dict_mixed_scalars/Haskell.hs
+++ b/tests/integration/cases/dict_mixed_scalars/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_mixed_scalars_Haskell where
 data Val = HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/dict_null_leading_comment/Haskell.hs
+++ b/tests/integration/cases/dict_null_leading_comment/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_null_leading_comment_Haskell where
 data Val = HNull | HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/dict_null_middle_inline_comment/Haskell.hs
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_null_middle_inline_comment_Haskell where
 data Val = HNull | HBool Bool | HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Haskell.hs
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_null_trailing_inline_comment_Haskell where
 data Val = HNull | HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/dict_with_control_char_keys/Haskell.hs
+++ b/tests/integration/cases/dict_with_control_char_keys/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_with_control_char_keys_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/dict_with_hyphen_keys/Haskell.hs
+++ b/tests/integration/cases/dict_with_hyphen_keys/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_with_hyphen_keys_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/dict_with_list_value/Haskell.hs
+++ b/tests/integration/cases/dict_with_list_value/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_with_list_value_Haskell where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/dict_with_nulls/Haskell.hs
+++ b/tests/integration/cases/dict_with_nulls/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_dict_with_nulls_Haskell where
 data Val = HNull | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Haskell.hs
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_doubly_nested_list_with_empty_sibling_Haskell where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/empty_dict/Haskell.hs
+++ b/tests/integration/cases/empty_dict/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_empty_dict_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap []

--- a/tests/integration/cases/empty_dicts_in_sequence/Haskell.hs
+++ b/tests/integration/cases/empty_dicts_in_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_empty_dicts_in_sequence_Haskell where
 data Val = HStr String | HList [Val] | HMap [(String, Val)]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/empty_list/Haskell.hs
+++ b/tests/integration/cases/empty_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_empty_list_Haskell where
 data Val = HList [Val]
 my_data :: Val
 my_data = HList []

--- a/tests/integration/cases/empty_sequence/Haskell.hs
+++ b/tests/integration/cases/empty_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_empty_sequence_Haskell where
 data Val = HStr String | HList [Val] | HMap [(String, Val)]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/empty_set/Haskell.hs
+++ b/tests/integration/cases/empty_set/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_empty_set_Haskell where
 data Val = HSet [Val]
 my_data :: Val
 my_data = HSet []

--- a/tests/integration/cases/float_list/Haskell.hs
+++ b/tests/integration/cases/float_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_list_Haskell where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_list/Haskell_float_format_fixed.hs
+++ b/tests/integration/cases/float_list/Haskell_float_format_fixed.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_list_Haskell_float_format_fixed where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_list/Haskell_float_format_scientific.hs
+++ b/tests/integration/cases/float_list/Haskell_float_format_scientific.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_list_Haskell_float_format_scientific where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_list/Haskell_numeric_style_explicit.hs
+++ b/tests/integration/cases/float_list/Haskell_numeric_style_explicit.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_list_Haskell_numeric_style_explicit where
 data Val = HFloat Double | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/float_list/Haskell_prefix_J_float.hs
+++ b/tests/integration/cases/float_list/Haskell_prefix_J_float.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_list_Haskell_prefix_J_float where
 data Val = JFloat Double | JList [Val]
 instance Num Val where
     fromInteger n = JFloat (fromIntegral n)

--- a/tests/integration/cases/float_list/Haskell_sequence_tuple_float.hs
+++ b/tests/integration/cases/float_list/Haskell_sequence_tuple_float.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_list_Haskell_sequence_tuple_float where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_list/Haskell_type_name_JsonVal_float.hs
+++ b/tests/integration/cases/float_list/Haskell_type_name_JsonVal_float.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_list_Haskell_type_name_JsonVal_float where
 data JsonVal = HFloat Double | HList [JsonVal]
 instance Num JsonVal where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_negative_zero/Haskell.hs
+++ b/tests/integration/cases/float_negative_zero/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_negative_zero_Haskell where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_scientific_notation/Haskell.hs
+++ b/tests/integration/cases/float_scientific_notation/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_scientific_notation_Haskell where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_scientific_notation/Haskell_float_format_fixed_s.hs
+++ b/tests/integration/cases/float_scientific_notation/Haskell_float_format_fixed_s.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_scientific_notation_Haskell_float_format_fixed_s where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_scientific_notation/Haskell_float_format_scientific_s.hs
+++ b/tests/integration/cases/float_scientific_notation/Haskell_float_format_scientific_s.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_scientific_notation_Haskell_float_format_scientific_s where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_special_values/Haskell.hs
+++ b/tests/integration/cases/float_special_values/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_special_values_Haskell where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_special_values/Haskell_float_format_fixed_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_float_format_fixed_v.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_special_values_Haskell_float_format_fixed_v where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_special_values/Haskell_float_format_scientific_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_float_format_scientific_v.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_special_values_Haskell_float_format_scientific_v where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/float_special_values/Haskell_numeric_style_explicit.hs
+++ b/tests/integration/cases/float_special_values/Haskell_numeric_style_explicit.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_special_values_Haskell_numeric_style_explicit where
 data Val = HFloat Double | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/float_special_values/Haskell_prefix_J_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_prefix_J_v.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_special_values_Haskell_prefix_J_v where
 data Val = JFloat Double | JList [Val]
 instance Num Val where
     fromInteger n = JFloat (fromIntegral n)

--- a/tests/integration/cases/float_special_values/Haskell_type_name_JsonVal_v.hs
+++ b/tests/integration/cases/float_special_values/Haskell_type_name_JsonVal_v.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_float_special_values_Haskell_type_name_JsonVal_v where
 data JsonVal = HFloat Double | HList [JsonVal]
 instance Num JsonVal where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/int_key_dict/Haskell.hs
+++ b/tests/integration/cases/int_key_dict/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_key_dict_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/int_list/Haskell.hs
+++ b/tests/integration/cases/int_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_Haskell where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list/Haskell_integer_format_binary.hs
+++ b/tests/integration/cases/int_list/Haskell_integer_format_binary.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_Haskell_integer_format_binary where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list/Haskell_integer_format_hex.hs
+++ b/tests/integration/cases/int_list/Haskell_integer_format_hex.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_Haskell_integer_format_hex where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list/Haskell_integer_format_octal.hs
+++ b/tests/integration/cases/int_list/Haskell_integer_format_octal.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_Haskell_integer_format_octal where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list/Haskell_numeric_style_explicit.hs
+++ b/tests/integration/cases/int_list/Haskell_numeric_style_explicit.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_Haskell_numeric_style_explicit where
 data Val = HInt Integer | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/int_list_large/Haskell.hs
+++ b/tests/integration/cases/int_list_large/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_large_Haskell where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_large/Haskell_integer_format_binary_large.hs
+++ b/tests/integration/cases/int_list_large/Haskell_integer_format_binary_large.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_large_Haskell_integer_format_binary_large where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_large/Haskell_integer_format_hex_large.hs
+++ b/tests/integration/cases/int_list_large/Haskell_integer_format_hex_large.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_large_Haskell_integer_format_hex_large where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_large/Haskell_integer_format_octal_large.hs
+++ b/tests/integration/cases/int_list_large/Haskell_integer_format_octal_large.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_large_Haskell_integer_format_octal_large where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_large/Haskell_numeric_style_explicit_large.hs
+++ b/tests/integration/cases/int_list_large/Haskell_numeric_style_explicit_large.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_large_Haskell_numeric_style_explicit_large where
 data Val = HInt Integer | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/int_list_with_zero/Haskell.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_with_zero_Haskell where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_with_zero/Haskell_integer_format_binary_zero.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell_integer_format_binary_zero.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_with_zero_Haskell_integer_format_binary_zero where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_with_zero/Haskell_integer_format_hex_zero.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell_integer_format_hex_zero.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_with_zero_Haskell_integer_format_hex_zero where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_with_zero/Haskell_integer_format_octal_zero.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell_integer_format_octal_zero.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_with_zero_Haskell_integer_format_octal_zero where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/int_list_with_zero/Haskell_numeric_style_explicit_zero.hs
+++ b/tests/integration/cases/int_list_with_zero/Haskell_numeric_style_explicit_zero.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_list_with_zero_Haskell_numeric_style_explicit_zero where
 data Val = HInt Integer | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/int_set/Haskell.hs
+++ b/tests/integration/cases/int_set/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_int_set_Haskell where
 data Val = HInt Integer | HSet [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/mixed_number_dict/Haskell.hs
+++ b/tests/integration/cases/mixed_number_dict/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_mixed_number_dict_Haskell where
 data Val = HInt Integer | HFloat Double | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/mixed_number_list/Haskell.hs
+++ b/tests/integration/cases/mixed_number_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_mixed_number_list_Haskell where
 data Val = HInt Integer | HFloat Double | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/mixed_number_list/Haskell_numeric_style_explicit.hs
+++ b/tests/integration/cases/mixed_number_list/Haskell_numeric_style_explicit.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_mixed_number_list_Haskell_numeric_style_explicit where
 data Val = HInt Integer | HFloat Double | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/mixed_set/Haskell.hs
+++ b/tests/integration/cases/mixed_set/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_mixed_set_Haskell where
 data Val = HBool Bool | HInt Integer | HStr String | HSet [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Haskell.hs
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_mixed_type_dicts_in_sequence_Haskell where
 data Val = HBool Bool | HStr String | HList [Val] | HMap [(String, Val)]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/nested/Haskell.hs
+++ b/tests/integration/cases/nested/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_Haskell where
 data Val = HStr String | HList [Val] | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/nested_bool_list/Haskell.hs
+++ b/tests/integration/cases/nested_bool_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_bool_list_Haskell where
 data Val = HBool Bool | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/nested_collection_multi_space_string/Haskell.hs
+++ b/tests/integration/cases/nested_collection_multi_space_string/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_collection_multi_space_string_Haskell where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_deep_empty/Haskell.hs
+++ b/tests/integration/cases/nested_deep_empty/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_deep_empty_Haskell where
 data Val = HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/nested_deep_mixed/Haskell.hs
+++ b/tests/integration/cases/nested_deep_mixed/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_deep_mixed_Haskell where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_empty_inner/Haskell.hs
+++ b/tests/integration/cases/nested_empty_inner/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_empty_inner_Haskell where
 data Val = HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/nested_float_list/Haskell.hs
+++ b/tests/integration/cases/nested_float_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_float_list_Haskell where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/nested_float_list/Haskell_float_format_fixed_n.hs
+++ b/tests/integration/cases/nested_float_list/Haskell_float_format_fixed_n.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_float_list_Haskell_float_format_fixed_n where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/nested_float_list/Haskell_float_format_scientific_n.hs
+++ b/tests/integration/cases/nested_float_list/Haskell_float_format_scientific_n.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_float_list_Haskell_float_format_scientific_n where
 data Val = HFloat Double | HList [Val]
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Haskell.hs
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_list_mixed_sibling_types_Haskell where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_list_of_dicts/Haskell.hs
+++ b/tests/integration/cases/nested_list_of_dicts/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_list_of_dicts_Haskell where
 data Val = HStr String | HList [Val] | HMap [(String, Val)]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/nested_list_with_empty_sibling/Haskell.hs
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_list_with_empty_sibling_Haskell where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_mixed_dict/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_dict/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_mixed_dict_Haskell where
 data Val = HNull | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_mixed_inner/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_inner/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_mixed_inner_Haskell where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_mixed_set/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_set/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_mixed_set_Haskell where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)] | HSet [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_mixed_types/Haskell.hs
+++ b/tests/integration/cases/nested_mixed_types/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_mixed_types_Haskell where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_sequence/Haskell.hs
+++ b/tests/integration/cases/nested_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_sequence_Haskell where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/nested_sequences/Haskell.hs
+++ b/tests/integration/cases/nested_sequences/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_nested_sequences_Haskell where
 data Val = HInt Integer | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/no_comment/Haskell.hs
+++ b/tests/integration/cases/no_comment/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_no_comment_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/ordered_map/Haskell.hs
+++ b/tests/integration/cases/ordered_map/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_ordered_map_Haskell where
 data Val = HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/ordered_map_in_sequence/Haskell.hs
+++ b/tests/integration/cases/ordered_map_in_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_ordered_map_in_sequence_Haskell where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/ordered_map_int_keys/Haskell.hs
+++ b/tests/integration/cases/ordered_map_int_keys/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_ordered_map_int_keys_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/ordered_map_nested_values/Haskell.hs
+++ b/tests/integration/cases/ordered_map_nested_values/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_ordered_map_nested_values_Haskell where
 data Val = HStr String | HMap [(String, Val)]
 my_data :: Val
 my_data = HMap [

--- a/tests/integration/cases/pair_sequence/Haskell.hs
+++ b/tests/integration/cases/pair_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_pair_sequence_Haskell where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/pair_sequence/Haskell_sequence_tuple_pair.hs
+++ b/tests/integration/cases/pair_sequence/Haskell_sequence_tuple_pair.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_pair_sequence_Haskell_sequence_tuple_pair where
 data Val = HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_bool/Haskell.hs
+++ b/tests/integration/cases/scalar_bool/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_bool_Haskell where
 data Val = HBool Bool
 my_data :: Val
 my_data = HBool True

--- a/tests/integration/cases/scalar_date/Haskell.hs
+++ b/tests/integration/cases/scalar_date/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_date_Haskell where
 import Data.Time (Day, fromGregorian)
 data Val = HDate Day
 my_data :: Val

--- a/tests/integration/cases/scalar_date/Haskell_date_haskell.hs
+++ b/tests/integration/cases/scalar_date/Haskell_date_haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_date_Haskell_date_haskell where
 import Data.Time (Day, fromGregorian)
 data Val = HDate Day
 my_data :: Val

--- a/tests/integration/cases/scalar_date/Haskell_date_iso.hs
+++ b/tests/integration/cases/scalar_date/Haskell_date_iso.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_date_Haskell_date_iso where
 data Val = HStr String
 my_data :: Val
 my_data = HStr "2024-01-15"

--- a/tests/integration/cases/scalar_date/Haskell_prefix_J_date.hs
+++ b/tests/integration/cases/scalar_date/Haskell_prefix_J_date.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_date_Haskell_prefix_J_date where
 import Data.Time (Day, fromGregorian)
 data Val = JDate Day
 my_data :: Val

--- a/tests/integration/cases/scalar_date/Haskell_string_double_date_iso.hs
+++ b/tests/integration/cases/scalar_date/Haskell_string_double_date_iso.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Check where
+module Fixture_scalar_date_Haskell_string_double_date_iso where
 import Data.String (IsString(fromString))
 data Val = HStr String
 instance IsString Val where

--- a/tests/integration/cases/scalar_date/Haskell_type_name_JsonVal_date.hs
+++ b/tests/integration/cases/scalar_date/Haskell_type_name_JsonVal_date.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_date_Haskell_type_name_JsonVal_date where
 import Data.Time (Day, fromGregorian)
 data JsonVal = HDate Day
 my_data :: JsonVal

--- a/tests/integration/cases/scalar_datetime/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_Haskell where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime/Haskell_datetime_haskell.hs
+++ b/tests/integration/cases/scalar_datetime/Haskell_datetime_haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_Haskell_datetime_haskell where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime/Haskell_datetime_iso.hs
+++ b/tests/integration/cases/scalar_datetime/Haskell_datetime_iso.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_Haskell_datetime_iso where
 data Val = HStr String
 my_data :: Val
 my_data = HStr "2024-01-15T12:30:00+00:00"

--- a/tests/integration/cases/scalar_datetime/Haskell_prefix_J_datetime.hs
+++ b/tests/integration/cases/scalar_datetime/Haskell_prefix_J_datetime.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_Haskell_prefix_J_datetime where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = JDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime/Haskell_string_double_dt_iso_dt.hs
+++ b/tests/integration/cases/scalar_datetime/Haskell_string_double_dt_iso_dt.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Check where
+module Fixture_scalar_datetime_Haskell_string_double_dt_iso_dt where
 import Data.String (IsString(fromString))
 data Val = HStr String
 instance IsString Val where

--- a/tests/integration/cases/scalar_datetime/Haskell_type_name_JsonVal_datetime.hs
+++ b/tests/integration/cases/scalar_datetime/Haskell_type_name_JsonVal_datetime.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_Haskell_type_name_JsonVal_datetime where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data JsonVal = HDatetime UTCTime
 my_data :: JsonVal

--- a/tests/integration/cases/scalar_datetime_microsecond/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime_microsecond/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_microsecond_Haskell where
 import Data.Time (UTCTime(..), fromGregorian, picosecondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime_midnight/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime_midnight/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_midnight_Haskell where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime_naive/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime_naive/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_naive_Haskell where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime_naive/Haskell_datetime_haskell_naive.hs
+++ b/tests/integration/cases/scalar_datetime_naive/Haskell_datetime_haskell_naive.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_naive_Haskell_datetime_haskell_naive where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime_naive/Haskell_datetime_iso_naive.hs
+++ b/tests/integration/cases/scalar_datetime_naive/Haskell_datetime_iso_naive.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_naive_Haskell_datetime_iso_naive where
 data Val = HStr String
 my_data :: Val
 my_data = HStr "2024-01-15T12:30:00"

--- a/tests/integration/cases/scalar_datetime_non_utc/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime_non_utc/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_non_utc_Haskell where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime_non_utc/Haskell_datetime_haskell_non_utc.hs
+++ b/tests/integration/cases/scalar_datetime_non_utc/Haskell_datetime_haskell_non_utc.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_non_utc_Haskell_datetime_haskell_non_utc where
 import Data.Time (UTCTime(..), fromGregorian, secondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_datetime_non_utc/Haskell_datetime_iso_non_utc.hs
+++ b/tests/integration/cases/scalar_datetime_non_utc/Haskell_datetime_iso_non_utc.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_non_utc_Haskell_datetime_iso_non_utc where
 data Val = HStr String
 my_data :: Val
 my_data = HStr "2024-01-15T18:00:00+05:30"

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Haskell.hs
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_datetime_seconds_microsecond_Haskell where
 import Data.Time (UTCTime(..), fromGregorian, picosecondsToDiffTime)
 data Val = HDatetime UTCTime
 my_data :: Val

--- a/tests/integration/cases/scalar_float/Haskell.hs
+++ b/tests/integration/cases/scalar_float/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_float_Haskell where
 data Val = HFloat Double
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/scalar_float/Haskell_float_format_fixed.hs
+++ b/tests/integration/cases/scalar_float/Haskell_float_format_fixed.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_float_Haskell_float_format_fixed where
 data Val = HFloat Double
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/scalar_float/Haskell_float_format_scientific.hs
+++ b/tests/integration/cases/scalar_float/Haskell_float_format_scientific.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_float_Haskell_float_format_scientific where
 data Val = HFloat Double
 instance Num Val where
     fromInteger n = HFloat (fromIntegral n)

--- a/tests/integration/cases/scalar_int/Haskell.hs
+++ b/tests/integration/cases/scalar_int/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int/Haskell_integer_format_binary.hs
+++ b/tests/integration/cases/scalar_int/Haskell_integer_format_binary.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_Haskell_integer_format_binary where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int/Haskell_integer_format_hex.hs
+++ b/tests/integration/cases/scalar_int/Haskell_integer_format_hex.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_Haskell_integer_format_hex where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int/Haskell_integer_format_octal.hs
+++ b/tests/integration/cases/scalar_int/Haskell_integer_format_octal.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_Haskell_integer_format_octal where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_large/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_large_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int_large/Haskell_integer_format_binary.hs
+++ b/tests/integration/cases/scalar_int_large/Haskell_integer_format_binary.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_large_Haskell_integer_format_binary where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int_large/Haskell_integer_format_hex.hs
+++ b/tests/integration/cases/scalar_int_large/Haskell_integer_format_hex.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_large_Haskell_integer_format_hex where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int_large/Haskell_integer_format_octal.hs
+++ b/tests/integration/cases/scalar_int_large/Haskell_integer_format_octal.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_large_Haskell_integer_format_octal where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int_negative_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_negative_large/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_negative_large_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int_very_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_very_large/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_very_large_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_int_very_negative_large/Haskell.hs
+++ b/tests/integration/cases/scalar_int_very_negative_large/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_int_very_negative_large_Haskell where
 data Val = HInt Integer
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalar_null/Haskell.hs
+++ b/tests/integration/cases/scalar_null/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_null_Haskell where
 data Val = HNull
 my_data :: Val
 my_data = HNull

--- a/tests/integration/cases/scalar_null_with_comment/Haskell.hs
+++ b/tests/integration/cases/scalar_null_with_comment/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_null_with_comment_Haskell where
 data Val = HNull
 my_data :: Val
 my_data = HNull  -- note

--- a/tests/integration/cases/scalar_string/Haskell.hs
+++ b/tests/integration/cases/scalar_string/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalar_string_Haskell where
 data Val = HStr String
 my_data :: Val
 my_data = HStr "hello"

--- a/tests/integration/cases/scalar_string/Haskell_string_format_double.hs
+++ b/tests/integration/cases/scalar_string/Haskell_string_format_double.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Check where
+module Fixture_scalar_string_Haskell_string_format_double where
 import Data.String (IsString(fromString))
 data Val = HStr String
 instance IsString Val where

--- a/tests/integration/cases/scalars/Haskell.hs
+++ b/tests/integration/cases/scalars/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalars_Haskell where
 data Val = HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/scalars/Haskell_numeric_style_explicit.hs
+++ b/tests/integration/cases/scalars/Haskell_numeric_style_explicit.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_scalars_Haskell_numeric_style_explicit where
 data Val = HBool Bool | HInt Integer | HFloat Double | HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/sequence_of_dicts/Haskell.hs
+++ b/tests/integration/cases/sequence_of_dicts/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_sequence_of_dicts_Haskell where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/set/Haskell.hs
+++ b/tests/integration/cases/set/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_set_Haskell where
 data Val = HStr String | HSet [Val]
 my_data :: Val
 my_data = HSet [

--- a/tests/integration/cases/set_comments/Haskell.hs
+++ b/tests/integration/cases/set_comments/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_set_comments_Haskell where
 data Val = HStr String | HSet [Val]
 my_data :: Val
 my_data = HSet [

--- a/tests/integration/cases/set_comments_unsorted_order/Haskell.hs
+++ b/tests/integration/cases/set_comments_unsorted_order/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_set_comments_unsorted_order_Haskell where
 data Val = HStr String | HSet [Val]
 my_data :: Val
 my_data = HSet [

--- a/tests/integration/cases/sibling_list_values_nested/Haskell.hs
+++ b/tests/integration/cases/sibling_list_values_nested/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_sibling_list_values_nested_Haskell where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Haskell.hs
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_sibling_list_values_uniform_inner_Haskell where
 data Val = HInt Integer | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/simple_dict/Haskell.hs
+++ b/tests/integration/cases/simple_dict/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_simple_dict_Haskell where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/simple_dict/Haskell_prefix_J.hs
+++ b/tests/integration/cases/simple_dict/Haskell_prefix_J.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_simple_dict_Haskell_prefix_J where
 data Val = JNull | JBool Bool | JInt Integer | JStr String | JMap [(String, Val)]
 instance Num Val where
     fromInteger = JInt

--- a/tests/integration/cases/simple_dict/Haskell_string_format_double_dict.hs
+++ b/tests/integration/cases/simple_dict/Haskell_string_format_double_dict.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Check where
+module Fixture_simple_dict_Haskell_string_format_double_dict where
 import Data.String (IsString(fromString))
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, Val)]
 instance IsString Val where

--- a/tests/integration/cases/simple_dict/Haskell_type_name_JsonVal.hs
+++ b/tests/integration/cases/simple_dict/Haskell_type_name_JsonVal.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_simple_dict_Haskell_type_name_JsonVal where
 data JsonVal = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, JsonVal)]
 instance Num JsonVal where
     fromInteger = HInt

--- a/tests/integration/cases/simple_sequence/Haskell.hs
+++ b/tests/integration/cases/simple_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_simple_sequence_Haskell where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/simple_sequence/Haskell_sequence_tuple.hs
+++ b/tests/integration/cases/simple_sequence/Haskell_sequence_tuple.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_simple_sequence_Haskell_sequence_tuple where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/simple_sequence/Haskell_sequence_tuple_varname.hs
+++ b/tests/integration/cases/simple_sequence/Haskell_sequence_tuple_varname.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_simple_sequence_Haskell_sequence_tuple_varname where
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/string_control_chars/Haskell.hs
+++ b/tests/integration/cases/string_control_chars/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_control_chars_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Haskell.hs
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_escaped_quotes_and_dashes_Haskell where
 data Val = HStr String
 my_data :: Val
 my_data = HStr "hello \"world\" -- not a comment"

--- a/tests/integration/cases/string_list/Haskell.hs
+++ b/tests/integration/cases/string_list/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_list_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/string_list/Haskell_string_format_double.hs
+++ b/tests/integration/cases/string_list/Haskell_string_format_double.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Check where
+module Fixture_string_list_Haskell_string_format_double where
 import Data.String (IsString(fromString))
 data Val = HStr String | HList [Val]
 instance IsString Val where

--- a/tests/integration/cases/string_with_backslash/Haskell.hs
+++ b/tests/integration/cases/string_with_backslash/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_with_backslash_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/string_with_backslash/Haskell_string_format_double.hs
+++ b/tests/integration/cases/string_with_backslash/Haskell_string_format_double.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Check where
+module Fixture_string_with_backslash_Haskell_string_format_double where
 import Data.String (IsString(fromString))
 data Val = HStr String | HList [Val]
 instance IsString Val where

--- a/tests/integration/cases/string_with_dollar/Haskell.hs
+++ b/tests/integration/cases/string_with_dollar/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_with_dollar_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/string_with_dollar_brace/Haskell.hs
+++ b/tests/integration/cases/string_with_dollar_brace/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_with_dollar_brace_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/string_with_hash/Haskell.hs
+++ b/tests/integration/cases/string_with_hash/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_with_hash_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/string_with_percent/Haskell.hs
+++ b/tests/integration/cases/string_with_percent/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_string_with_percent_Haskell where
 data Val = HStr String | HList [Val]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/cases/triple_sequence/Haskell.hs
+++ b/tests/integration/cases/triple_sequence/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_triple_sequence_Haskell where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/triple_sequence/Haskell_sequence_tuple_triple.hs
+++ b/tests/integration/cases/triple_sequence/Haskell_sequence_tuple_triple.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_triple_sequence_Haskell_sequence_tuple_triple where
 data Val = HBool Bool | HInt Integer | HStr String | HList [Val]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/type_hints/Haskell.hs
+++ b/tests/integration/cases/type_hints/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_type_hints_Haskell where
 import Data.Time (Day, fromGregorian, UTCTime(..), secondsToDiffTime)
 data Val = HNull | HBool Bool | HInt Integer | HStr String | HMap [(String, Val)] | HDate Day | HDatetime UTCTime
 instance Num Val where

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Haskell.hs
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_uniform_mixed_num_dicts_in_seq_Haskell where
 data Val = HInt Integer | HFloat Double | HStr String | HList [Val] | HMap [(String, Val)]
 instance Num Val where
     fromInteger = HInt

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Haskell.hs
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Haskell.hs
@@ -1,4 +1,4 @@
-module Check where
+module Fixture_uniform_string_dicts_in_seq_Haskell where
 data Val = HStr String | HList [Val] | HMap [(String, Val)]
 my_data :: Val
 my_data = HList [

--- a/tests/integration/language_specs.py
+++ b/tests/integration/language_specs.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from beartype import beartype
 
 import literalizer
-from literalizer.languages import ALL_LANGUAGES, Erlang, Scala
+from literalizer.languages import ALL_LANGUAGES, Erlang, Haskell, Scala
 
 
 @beartype
@@ -44,6 +44,19 @@ def scala_module_name(*, golden_path: Path) -> str:
 
 
 @beartype
+def haskell_module_name(*, golden_path: Path) -> str:
+    """Return the Haskell module name for *golden_path*.
+
+    Produces a deterministic, per-fixture name so every compiled
+    ``.hs`` file in CI has a unique module declaration without needing
+    ``sed`` rewriting.
+    """
+    dir_name = golden_path.parent.name
+    stem = golden_path.stem
+    return f"Fixture_{dir_name}_{stem}"
+
+
+@beartype
 def with_per_fixture_module_name(
     *,
     spec: literalizer.Language,
@@ -51,14 +64,19 @@ def with_per_fixture_module_name(
 ) -> literalizer.Language:
     """Return *spec* with a per-fixture ``module_name`` if applicable.
 
-    Languages whose CI lint requires unique module names (Erlang, Scala)
-    get a deterministic name derived from *golden_path*; all other
+    Languages whose CI lint requires unique module names (Erlang, Haskell,
+    Scala) get a deterministic name derived from *golden_path*; all other
     languages are returned unchanged.
     """
     if isinstance(spec, Erlang):
         return dataclasses.replace(
             spec,
             module_name=erlang_module_name(golden_path=golden_path),
+        )
+    if isinstance(spec, Haskell):
+        return dataclasses.replace(
+            spec,
+            module_name=haskell_module_name(golden_path=golden_path),
         )
     if isinstance(spec, Scala):
         return dataclasses.replace(


### PR DESCRIPTION
Adds `Haskell` to the per-fixture module-name set in `language_specs.py`, so each golden now declares `module Fixture_<dir>_<stem> where` instead of `module Check where`. All 203 Haskell golden files are regenerated accordingly.

Replaces the per-fixture `mktemp -d` + `Check.hs` copy in `lint-haskell-family` with a single workspace; each fixture is copied as `Fixture_<dir>_<stem>.hs` and compiled in its own build dir for parallel safety. The `MODULE_PLACEHOLDER` token in `haskell_main.hs` is `sed`-substituted per fixture. The inline `bash -c '...'` body (which required a `shellcheck disable=SC2016`) is extracted into a checked-in `.github/scripts/haskell_run_fixture.sh`.

Closes #1737.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewires the Haskell CI lint/run pipeline (parallel compilation, temp dirs, `-main-is` behavior) and mass-regenerates fixture modules, which could cause CI-only failures if naming or wrapper logic is off.
> 
> **Overview**
> Haskell integration goldens now declare unique modules (`Fixture_<dir>_<stem>`) instead of a shared `Check`, enabled by adding Haskell to the per-fixture `module_name` logic in `tests/integration/language_specs.py` and regenerating the `.hs` fixtures accordingly.
> 
> The Haskell CI lint step is reworked to avoid per-fixture `sed`/copy hacks: fixtures are copied into a workspace under their module name, then each is compiled and executed via a new `.github/scripts/haskell_run_fixture.sh` helper that creates an isolated build dir per run and uses a templated `haskell_main.hs` wrapper to force evaluation of `<module>.my_data` when no `main` is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f77960687f839b683d5d523b6870b842e1bbac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->