### PR TITLE
Convert isinstance type-dispatch chains to match statements

### DIFF
--- a/src/literalizer/_formatters/format_integers.py
+++ b/src/literalizer/_formatters/format_integers.py
@@ -336,14 +336,18 @@ def data_has_out_of_range_int(*, data: Value) -> bool:
     need to add a preamble (e.g. an ``import`` statement) conditionally
     on the presence of a very large integer scalar.
     """
-    if isinstance(data, bool):
-        return False
-    if isinstance(data, int):
-        return not I64_MIN <= data <= I64_MAX
-    if isinstance(data, list):
-        return any(data_has_out_of_range_int(data=v) for v in data)
-    if isinstance(data, set):
-        return any(data_has_out_of_range_int(data=v) for v in data)
-    if isinstance(data, dict):
-        return any(data_has_out_of_range_int(data=v) for v in data.values())
-    return False
+    match data:
+        case bool():
+            return False
+        case int():
+            return not I64_MIN <= data <= I64_MAX
+        case list():
+            return any(data_has_out_of_range_int(data=v) for v in data)
+        case set():
+            return any(data_has_out_of_range_int(data=v) for v in data)
+        case dict():
+            return any(
+                data_has_out_of_range_int(data=v) for v in data.values()
+            )
+        case _:
+            return False

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -372,13 +372,15 @@ def _gleam_format_call_target(parts: Sequence[str]) -> str:
 @beartype
 def _scalar_gleam_type(*, value: Value) -> type:
     """Return the preamble-relevant type bucket for a scalar *value*."""
-    if isinstance(value, datetime.datetime):
-        return datetime.datetime
-    if isinstance(value, datetime.date):
-        return datetime.date
-    if value is None:
-        return type(None)
-    return type(value)
+    match value:
+        case datetime.datetime():
+            return datetime.datetime
+        case datetime.date():
+            return datetime.date
+        case None:
+            return type(None)
+        case _:
+            return type(value)
 
 
 @beartype

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -462,36 +462,40 @@ def _num_instance(
 
 def _has_microsecond_datetime(*, data: Value) -> bool:
     """Return whether *data* contains any datetime with microseconds."""
-    if isinstance(data, datetime.datetime):
-        return bool(data.microsecond)
-    if isinstance(data, datetime.date):
-        return False
-    if isinstance(data, (ordereddict, dict)):
-        return any(
-            _has_microsecond_datetime(data=v)  # pyright: ignore[reportUnknownArgumentType]
-            for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-        )
-    if isinstance(data, (list, set)):
-        return any(_has_microsecond_datetime(data=v) for v in data)
-    return False
+    match data:
+        case datetime.datetime():
+            return bool(data.microsecond)
+        case datetime.date():
+            return False
+        case ordereddict() | dict():
+            return any(
+                _has_microsecond_datetime(data=v)  # pyright: ignore[reportUnknownArgumentType]
+                for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            )
+        case list() | set():
+            return any(_has_microsecond_datetime(data=v) for v in data)
+        case _:
+            return False
 
 
 def _has_nonmicrosecond_datetime(*, data: Value) -> bool:
     """Return whether *data* contains any datetime without
     microseconds.
     """
-    if isinstance(data, datetime.datetime):
-        return not data.microsecond
-    if isinstance(data, datetime.date):
-        return False
-    if isinstance(data, (ordereddict, dict)):
-        return any(
-            _has_nonmicrosecond_datetime(data=v)  # pyright: ignore[reportUnknownArgumentType]
-            for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-        )
-    if isinstance(data, (list, set)):
-        return any(_has_nonmicrosecond_datetime(data=v) for v in data)
-    return False
+    match data:
+        case datetime.datetime():
+            return not data.microsecond
+        case datetime.date():
+            return False
+        case ordereddict() | dict():
+            return any(
+                _has_nonmicrosecond_datetime(data=v)  # pyright: ignore[reportUnknownArgumentType]
+                for v in data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            )
+        case list() | set():
+            return any(_has_nonmicrosecond_datetime(data=v) for v in data)
+        case _:
+            return False
 
 
 def _datetime_import_items(

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -165,21 +165,23 @@ def _purescript_has_large_int(val: Value) -> bool:
     """Return True if *val* contains an integer that overflows
     PureScript's 32-bit ``Int``.
     """
-    if isinstance(val, bool):
-        return False
-    if isinstance(val, int):
-        return not _purescript_int_fits_in_int32(value=val)
-    if isinstance(val, list):
-        return any(_purescript_has_large_int(val=v) for v in val)
-    if isinstance(val, dict):
-        return any(_purescript_has_large_int(val=v) for v in val.values())
-    if isinstance(val, set):
-        return any(
-            _purescript_has_large_int(val=v)
-            for v in val
-            if isinstance(v, int) and not isinstance(v, bool)
-        )
-    return False
+    match val:
+        case bool():
+            return False
+        case int():
+            return not _purescript_int_fits_in_int32(value=val)
+        case list():
+            return any(_purescript_has_large_int(val=v) for v in val)
+        case dict():
+            return any(_purescript_has_large_int(val=v) for v in val.values())
+        case set():
+            return any(
+                _purescript_has_large_int(val=v)
+                for v in val
+                if isinstance(v, int) and not isinstance(v, bool)
+            )
+        case _:
+            return False
 
 
 @beartype

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -123,12 +123,14 @@ def _format_variable_declaration(
     _modifiers: frozenset[enum.Enum],
 ) -> str:
     """Format a SystemVerilog variable declaration."""
-    if isinstance(data, (list, set)):
-        return f"static _VVal {name}[] = {value};"
-    if isinstance(data, dict):
-        return f"static _VKV {name}[] = {value};"
-    wrapped = _format_sv_entry(original=data, formatted=value)
-    return f"static _VVal {name} = {wrapped};"
+    match data:
+        case list() | set():
+            return f"static _VVal {name}[] = {value};"
+        case dict():
+            return f"static _VKV {name}[] = {value};"
+        case _:
+            wrapped = _format_sv_entry(original=data, formatted=value)
+            return f"static _VVal {name} = {wrapped};"
 
 
 @beartype


### PR DESCRIPTION
## Summary

- Converts 6 multi-branch `isinstance` type-dispatch chains to `match` statements across `format_integers.py`, `gleam.py`, `haskell.py`, `purescript.py`, and `systemverilog.py`
- Uses union patterns (`list() | set()`, `ordereddict() | dict()`) where the original code used tuple-form `isinstance` checks
- The `_needs_prelude` nested function in `purescript.py` was left as `isinstance` chains to stay within the enclosing function's complexity and return-count limits

## Test plan

- [ ] All existing unit tests pass (`uv run --extra dev pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily changes control-flow syntax for type dispatch; behavior should remain the same but depends on Python pattern-matching semantics (notably `bool` vs `int`) staying equivalent.
> 
> **Overview**
> Refactors several helper functions to use Python `match` pattern matching instead of multi-branch `isinstance` chains for type-based dispatch.
> 
> This update touches integer range detection (`data_has_out_of_range_int`), Gleam scalar type bucketing (`_scalar_gleam_type`), Haskell datetime scanning (`_has_microsecond_datetime` / `_has_nonmicrosecond_datetime`), PureScript large-int detection (`_purescript_has_large_int`), and SystemVerilog variable declaration formatting (`_format_variable_declaration`), including union-pattern equivalents like `list() | set()` and `ordereddict() | dict()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f18ff96f2d8b3fce6f0527cde8654c6fcef2c8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->