### PR TITLE
Add literalize_call support to Dhall

### DIFF
--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -244,7 +244,7 @@ def _dhall_format_call_arg(original: Value, formatted: str, /) -> str:
         return f"DVal.DDouble {formatted}"
     if isinstance(original, (str, bytes, datetime.date)) or original is None:
         return f"DVal.DText {formatted}"
-    return formatted
+    return formatted  # pragma: no cover
 
 
 @beartype
@@ -293,7 +293,7 @@ def _dhall_validate_call_stmt(call_expr: str) -> None:
         c = call_expr[i]
         next_prev_is_word = False
         if in_string:
-            if c == "\\":
+            if c == "\\":  # pragma: no cover
                 i += 2
                 continue
             if c == '"':

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -321,7 +321,7 @@ def _dhall_validate_call_stmt(stmt: str) -> None:
       positional argument, which Dhall cannot represent because it has
       no tuple type.
     """
-    if _DHALL_WORD_BEFORE_PAREN_RE.search(stmt):
+    if _DHALL_WORD_BEFORE_PAREN_RE.search(string=stmt):
         raise CallArgNotSupportedError(
             language_name="Dhall",
             reason=(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -274,7 +274,8 @@ _DHALL_DEPTH_DELTA: dict[str, tuple[str, int]] = {
 
 
 def _dhall_has_multi_arg_in_call(stmt: str) -> bool:
-    """Return True when *stmt* contains a top-level comma inside parens.
+    """Return True when *call_expr* contains a top-level comma in
+    parentheses.
 
     A top-level comma (at parenthesis depth 1, brace depth 0, bracket
     depth 0, outside any string literal) means the call was rendered
@@ -920,7 +921,9 @@ class Dhall(metaclass=LanguageCls):
         """
 
         def _wrap(stmt: str) -> str:
-            """Validate *stmt* then wrap it as a ``let _ =`` binding."""
+            """Validate *call_expr* then wrap it as a ``let _ =``
+            binding.
+            """
             _dhall_validate_call_stmt(stmt=stmt)
             return f"let _ = {stmt}"
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -242,7 +242,7 @@ def _dhall_format_call_arg(original: Value, formatted: str, /) -> str:
         return f"DVal.DInteger {formatted}"
     if isinstance(original, float):
         return f"DVal.DDouble {formatted}"
-    if isinstance(original, str):
+    if isinstance(original, (str, bytes, datetime.date)) or original is None:
         return f"DVal.DText {formatted}"
     return formatted
 
@@ -260,11 +260,9 @@ def _dhall_format_call_target(parts: Sequence[str], /) -> str:
     return ".".join(parts) + " "
 
 
-_DHALL_WORD_BEFORE_PAREN_RE = re.compile(pattern=r"[A-Za-z_0-9]\(")
-
-
-_DHALL_DEPTH_DELTA: dict[str, tuple[str, int]] = {
-    "(": ("paren", +1),
+# Maps closing/brace/bracket chars to their depth-tracking key and delta.
+# ``(`` is handled separately so the word-before-paren check fires first.
+_DHALL_BRACKET_DELTA: dict[str, tuple[str, int]] = {
     ")": ("paren", -1),
     "{": ("brace", +1),
     "}": ("brace", -1),
@@ -273,47 +271,12 @@ _DHALL_DEPTH_DELTA: dict[str, tuple[str, int]] = {
 }
 
 
-def _dhall_has_multi_arg_in_call(stmt: str) -> bool:
-    """Return True when *call_expr* contains a top-level comma in
-    parentheses.
-
-    A top-level comma (at parenthesis depth 1, brace depth 0, bracket
-    depth 0, outside any string literal) means the call was rendered
-    with more than one positional argument, which is invalid Dhall
-    because Dhall has no tuple type.
-    """
-    depths: dict[str, int] = {"paren": 0, "brace": 0, "bracket": 0}
-    in_string = False
-    i = 0
-    while i < len(stmt):
-        c = stmt[i]
-        if in_string:
-            if c == "\\":
-                i += 2
-                continue
-            if c == '"':
-                in_string = False
-        elif c == '"':
-            in_string = True
-        elif c in _DHALL_DEPTH_DELTA:
-            key, delta = _DHALL_DEPTH_DELTA[c]
-            depths[key] += delta
-        elif (
-            c == ","
-            and depths["paren"] >= 1
-            and depths["brace"] == 0
-            and depths["bracket"] == 0
-        ):
-            return True
-        i += 1
-    return False
-
-
-def _dhall_validate_call_stmt(stmt: str) -> None:
+def _dhall_validate_call_stmt(call_expr: str) -> None:
     """Raise :exc:`~literalizer.exceptions.CallArgNotSupportedError` for
     call expressions that cannot be represented as valid Dhall.
 
-    Two patterns are rejected:
+    Two patterns are rejected, both detected in a single pass that
+    tracks string-literal boundaries so quoted content is ignored:
 
     * A word character directly followed by ``(`` — a call-transform
       wrapper (e.g. ``emit(...)``) written without the whitespace that
@@ -322,23 +285,52 @@ def _dhall_validate_call_stmt(stmt: str) -> None:
       positional argument, which Dhall cannot represent because it has
       no tuple type.
     """
-    if _DHALL_WORD_BEFORE_PAREN_RE.search(string=stmt):
-        raise CallArgNotSupportedError(
-            language_name="Dhall",
-            reason=(
-                "call_transform produces a function application without "
-                "the whitespace Dhall requires before '(' "
-                f"(in: {stmt!r})"
-            ),
-        )
-    if _dhall_has_multi_arg_in_call(stmt=stmt):
-        raise CallArgNotSupportedError(
-            language_name="Dhall",
-            reason=(
-                "Dhall has no tuple type; PositionalCallStyle cannot "
-                "represent calls with more than one argument"
-            ),
-        )
+    depths: dict[str, int] = {"paren": 0, "brace": 0, "bracket": 0}
+    in_string = False
+    prev_is_word = False
+    i = 0
+    while i < len(call_expr):
+        c = call_expr[i]
+        next_prev_is_word = False
+        if in_string:
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+        elif c == '"':
+            in_string = True
+        elif c == "(":
+            if prev_is_word:
+                raise CallArgNotSupportedError(
+                    language_name="Dhall",
+                    reason=(
+                        "call_transform produces a function application "
+                        "without the whitespace Dhall requires before '(' "
+                        f"(in: {call_expr!r})"
+                    ),
+                )
+            depths["paren"] += 1
+        elif c in _DHALL_BRACKET_DELTA:
+            key, delta = _DHALL_BRACKET_DELTA[c]
+            depths[key] += delta
+        elif (
+            c == ","
+            and depths["paren"] >= 1
+            and depths["brace"] == 0
+            and depths["bracket"] == 0
+        ):
+            raise CallArgNotSupportedError(
+                language_name="Dhall",
+                reason=(
+                    "Dhall has no tuple type; PositionalCallStyle cannot "
+                    "represent calls with more than one argument"
+                ),
+            )
+        else:
+            next_prev_is_word = c.isalnum() or c == "_"
+        prev_is_word = next_prev_is_word
+        i += 1
 
 
 def _dhall_reject_ref_identifier(name: str) -> str:
@@ -924,7 +916,7 @@ class Dhall(metaclass=LanguageCls):
             """Validate *call_expr* then wrap it as a ``let _ =``
             binding.
             """
-            _dhall_validate_call_stmt(stmt=stmt)
+            _dhall_validate_call_stmt(call_expr=stmt)
             return f"let _ = {stmt}"
 
         return _wrap

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -754,12 +754,25 @@ class Dhall(metaclass=LanguageCls):
         variable_name: str,
         body_preamble: tuple[str, ...],
     ) -> str:
-        """Wrap code in a valid file (no-op)."""
-        return wrap_in_file_noop(
+        """Wrap code in a valid Dhall file.
+
+        When *variable_name* is empty the call is from a call context
+        (either :meth:`wrap_calls_with_declarations` or
+        :func:`~literalizer.literalize_call` with ``wrap_in_file=True``);
+        both need a closing ``in {=}`` to complete the ``let``-chain
+        into a valid Dhall expression.  When *variable_name* is set the
+        call is from a regular :func:`~literalizer.literalize` path
+        whose content already ends with the ``in <varname>`` clause
+        produced by the variable form.
+        """
+        wrapped = wrap_in_file_noop(
             content=content,
             variable_name=variable_name,
             body_preamble=body_preamble,
         )
+        if not variable_name:
+            wrapped += "\nin {=}"
+        return wrapped
 
     @staticmethod
     def wrap_combined_in_file(
@@ -922,16 +935,18 @@ class Dhall(metaclass=LanguageCls):
         calls: str,
         body_preamble: tuple[str, ...],
     ) -> str:
-        """Append ``in {=}`` after calls to complete the Dhall
-        expression.
+        """Join declarations and calls into a Dhall let-chain.
+
+        Delegates to :meth:`wrap_in_file` with an empty variable name,
+        which appends the ``in {=}`` terminator needed by both
+        this path and the ``wrap_in_file=True`` call path.
         """
         content = "\n".join((*declarations, calls)) if declarations else calls
-        wrapped = self.wrap_in_file(
+        return self.wrap_in_file(
             content=content,
             variable_name="",
             body_preamble=body_preamble,
         )
-        return wrapped + "\nin {=}"
 
     @cached_property
     def format_call_target(self) -> Callable[[Sequence[str]], str]:

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -227,24 +227,24 @@ def _dhall_call_stub(
 
 
 @beartype
-def _dhall_format_call_arg(original: Value, formatted: str, /) -> str:
+def _dhall_format_call_arg(original: Scalar, formatted: str, /) -> str:
     """Wrap a formatted scalar in the appropriate ``DVal`` constructor.
 
     Booleans, integers, floats, and strings each get their own
     ``DVal.DXxx`` tag so the stub (which accepts ``DVal``) type-checks
-    against heterogeneous call arguments.  Complex values (lists,
-    records) are left unwrapped; those cases are excluded from Dhall's
-    supported call test suite.
+    against heterogeneous call arguments.
     """
-    if isinstance(original, bool):
-        return f"DVal.DBool {formatted}"
-    if isinstance(original, int):
-        return f"DVal.DInteger {formatted}"
-    if isinstance(original, float):
-        return f"DVal.DDouble {formatted}"
-    if isinstance(original, (str, bytes, datetime.date)) or original is None:
-        return f"DVal.DText {formatted}"
-    return formatted  # pragma: no cover
+    match original:
+        case bool():
+            return f"DVal.DBool {formatted}"
+        case int():
+            return f"DVal.DInteger {formatted}"
+        case float():
+            return f"DVal.DDouble {formatted}"
+        case str() | bytes() | datetime.datetime() | datetime.date() | None:
+            return f"DVal.DText {formatted}"
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 @beartype
@@ -270,13 +270,16 @@ _DHALL_BRACKET_DELTA: dict[str, tuple[str, int]] = {
     "]": ("bracket", -1),
 }
 
+# Matches a Dhall double-quoted string literal including escape sequences,
+# so string contents are stripped before scanning for structural patterns.
+_DHALL_STRING_RE = re.compile(pattern=r'"(?:[^"\\]|\\.)*"')
+
 
 def _dhall_validate_call_stmt(call_expr: str) -> None:
     """Raise :exc:`~literalizer.exceptions.CallArgNotSupportedError` for
     call expressions that cannot be represented as valid Dhall.
 
-    Two patterns are rejected, both detected in a single pass that
-    tracks string-literal boundaries so quoted content is ignored:
+    Two patterns are rejected:
 
     * A word character directly followed by ``(`` — a call-transform
       wrapper (e.g. ``emit(...)``) written without the whitespace that
@@ -284,23 +287,16 @@ def _dhall_validate_call_stmt(call_expr: str) -> None:
     * A top-level comma inside parentheses — indicates more than one
       positional argument, which Dhall cannot represent because it has
       no tuple type.
+
+    String literals are stripped first so that quoted content is never
+    mistaken for one of these patterns.
     """
+    sanitized = _DHALL_STRING_RE.sub(repl="", string=call_expr)
     depths: dict[str, int] = {"paren": 0, "brace": 0, "bracket": 0}
-    in_string = False
     prev_is_word = False
-    i = 0
-    while i < len(call_expr):
-        c = call_expr[i]
+    for c in sanitized:
         next_prev_is_word = False
-        if in_string:
-            if c == "\\":  # pragma: no cover
-                i += 2
-                continue
-            if c == '"':
-                in_string = False
-        elif c == '"':
-            in_string = True
-        elif c == "(":
+        if c == "(":
             if prev_is_word:
                 raise CallArgNotSupportedError(
                     language_name="Dhall",
@@ -330,7 +326,6 @@ def _dhall_validate_call_stmt(call_expr: str) -> None:
         else:
             next_prev_is_word = c.isalnum() or c == "_"
         prev_is_word = next_prev_is_word
-        i += 1
 
 
 def _dhall_reject_ref_identifier(name: str) -> str:
@@ -899,7 +894,7 @@ class Dhall(metaclass=LanguageCls):
         return _dhall_call_preamble_stub
 
     @cached_property
-    def format_call_arg(self) -> Callable[[Value, str], str]:
+    def format_call_arg(self) -> Callable[[Scalar, str], str]:
         """Wrap each scalar call argument in the ``DVal`` union tag."""
         return _dhall_format_call_arg
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -42,7 +42,6 @@ from literalizer._heterogeneous import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -53,22 +52,22 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_wrap_calls_with_declarations,
-    identity_call_ref_identifier,
-    identity_call_target,
-    no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
 from literalizer._types import Scalar, Value
-from literalizer.exceptions import InvalidDictKeyError
+from literalizer.exceptions import (
+    CallArgNotSupportedError,
+    InvalidDictKeyError,
+)
 
 _IDENTIFIER_RE = re.compile(pattern=r"^[A-Za-z_][A-Za-z0-9_/\-]*$")
 
@@ -180,6 +179,182 @@ def _format_dhall_dict_entry(
         )
         raise InvalidDictKeyError(msg)
     return f"`{raw}` = {formatted_value}"
+
+
+_DHALL_DVAL_TYPE = (
+    "let DVal = "
+    "< DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >"
+)
+
+
+@beartype
+def _dhall_call_preamble_stub(
+    _parts: Sequence[str],
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return the ``DVal`` union-type definition for Dhall call stubs."""
+    return (_DHALL_DVAL_TYPE,)
+
+
+@beartype
+def _dhall_call_stub(
+    parts: Sequence[str],
+    _params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    r"""Return Dhall let-binding stub declarations for a call target.
+
+    Single-part targets produce ``let name = \(_ : DVal) -> body``.
+    Dotted targets nest record literals: ``app.client.fetch`` becomes
+    ``let app = { client = { fetch = \(_ : DVal) -> body } }``.
+    The *stub_return* controls the body: ``VOID`` stubs return ``{=}``;
+    ``VALUE`` stubs return ``DVal.DBool True`` so the result type
+    matches callers that consume the return value (e.g. a transform
+    wrapper like ``emit``).
+    """
+    body = "{=}" if stub_return is StubReturn.VOID else "DVal.DBool True"
+    fn_expr = f"\\(_ : DVal) -> {body}"
+    if len(parts) == 1:
+        return (f"let {parts[0]} = {fn_expr}",)
+    root = parts[0]
+    nested: str = fn_expr
+    for field in reversed(parts[1:]):
+        nested = f"{{ {field} = {nested} }}"
+    return (f"let {root} = {nested}",)
+
+
+@beartype
+def _dhall_format_call_arg(original: Value, formatted: str, /) -> str:
+    """Wrap a formatted scalar in the appropriate ``DVal`` constructor.
+
+    Booleans, integers, floats, and strings each get their own
+    ``DVal.DXxx`` tag so the stub (which accepts ``DVal``) type-checks
+    against heterogeneous call arguments.  Complex values (lists,
+    records) are left unwrapped; those cases are excluded from Dhall's
+    supported call test suite.
+    """
+    if isinstance(original, bool):
+        return f"DVal.DBool {formatted}"
+    if isinstance(original, int):
+        return f"DVal.DInteger {formatted}"
+    if isinstance(original, float):
+        return f"DVal.DDouble {formatted}"
+    if isinstance(original, str):
+        return f"DVal.DText {formatted}"
+    return formatted
+
+
+@beartype
+def _dhall_format_call_target(parts: Sequence[str], /) -> str:
+    """Join call target parts with dots and append a trailing space.
+
+    Dhall requires whitespace between a function expression and its
+    argument.  :class:`~literalizer._language.PositionalCallStyle`
+    emits ``target(args)`` with no gap; a trailing space on the target
+    string turns that into ``target (args)``, which is valid Dhall
+    function-application syntax.
+    """
+    return ".".join(parts) + " "
+
+
+_DHALL_WORD_BEFORE_PAREN_RE = re.compile(pattern=r"[A-Za-z_0-9]\(")
+
+
+_DHALL_DEPTH_DELTA: dict[str, tuple[str, int]] = {
+    "(": ("paren", +1),
+    ")": ("paren", -1),
+    "{": ("brace", +1),
+    "}": ("brace", -1),
+    "[": ("bracket", +1),
+    "]": ("bracket", -1),
+}
+
+
+def _dhall_has_multi_arg_in_call(stmt: str) -> bool:
+    """Return True when *stmt* contains a top-level comma inside parens.
+
+    A top-level comma (at parenthesis depth 1, brace depth 0, bracket
+    depth 0, outside any string literal) means the call was rendered
+    with more than one positional argument, which is invalid Dhall
+    because Dhall has no tuple type.
+    """
+    depths: dict[str, int] = {"paren": 0, "brace": 0, "bracket": 0}
+    in_string = False
+    i = 0
+    while i < len(stmt):
+        c = stmt[i]
+        if in_string:
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+        elif c == '"':
+            in_string = True
+        elif c in _DHALL_DEPTH_DELTA:
+            key, delta = _DHALL_DEPTH_DELTA[c]
+            depths[key] += delta
+        elif (
+            c == ","
+            and depths["paren"] >= 1
+            and depths["brace"] == 0
+            and depths["bracket"] == 0
+        ):
+            return True
+        i += 1
+    return False
+
+
+def _dhall_validate_call_stmt(stmt: str) -> None:
+    """Raise :exc:`~literalizer.exceptions.CallArgNotSupportedError` for
+    call expressions that cannot be represented as valid Dhall.
+
+    Two patterns are rejected:
+
+    * A word character directly followed by ``(`` — a call-transform
+      wrapper (e.g. ``emit(...)``) written without the whitespace that
+      Dhall requires before a function argument.
+    * A top-level comma inside parentheses — indicates more than one
+      positional argument, which Dhall cannot represent because it has
+      no tuple type.
+    """
+    if _DHALL_WORD_BEFORE_PAREN_RE.search(stmt):
+        raise CallArgNotSupportedError(
+            language_name="Dhall",
+            reason=(
+                "call_transform produces a function application without "
+                "the whitespace Dhall requires before '(' "
+                f"(in: {stmt!r})"
+            ),
+        )
+    if _dhall_has_multi_arg_in_call(stmt=stmt):
+        raise CallArgNotSupportedError(
+            language_name="Dhall",
+            reason=(
+                "Dhall has no tuple type; PositionalCallStyle cannot "
+                "represent calls with more than one argument"
+            ),
+        )
+
+
+def _dhall_reject_ref_identifier(name: str) -> str:
+    """Raise :exc:`~literalizer.exceptions.CallArgNotSupportedError` for
+    any ``$ref`` argument.
+
+    Dhall's stub parameter type is ``DVal``, but a ref variable holds a
+    concrete type (e.g. ``List Integer``) that Dhall's type-checker
+    cannot unify with ``DVal``.
+    """
+    raise CallArgNotSupportedError(
+        language_name="Dhall",
+        reason=(
+            f"ref variable {name!r} has a concrete type that cannot be "
+            "unified with the DVal stub parameter type"
+        ),
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -536,6 +711,8 @@ class Dhall(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Dhall call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -582,7 +759,6 @@ class Dhall(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
-    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(
@@ -635,6 +811,7 @@ class Dhall(metaclass=LanguageCls):
     )
     heterogeneous_value_union_name: str = "Value"
     indent: str = "  "
+    call_style: CallStyles = CallStyles.POSITIONAL
 
     null_literal: ClassVar[str] = '""'
     true_literal: ClassVar[str] = "True"
@@ -649,9 +826,6 @@ class Dhall(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -711,32 +885,79 @@ class Dhall(metaclass=LanguageCls):
         return no_type_hint_preamble
 
     @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
+
+    @cached_property
     def format_call_stub(
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _dhall_call_stub
 
     @cached_property
     def format_call_preamble_stub(
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
-        """Return file-scope stubs for a call expression."""
-        return no_call_stub
+        """Return the ``DVal`` union-type preamble for a call
+        expression.
+        """
+        return _dhall_call_preamble_stub
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Wrap each scalar call argument in the ``DVal`` union tag."""
+        return _dhall_format_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Validate and wrap a call expression as a ``let _ =`` binding.
+
+        Raises :exc:`~literalizer.exceptions.CallArgNotSupportedError`
+        if the rendered call contains a function application without the
+        required whitespace, or more than one positional argument.
+        """
+
+        def _wrap(stmt: str) -> str:
+            """Validate *stmt* then wrap it as a ``let _ =`` binding."""
+            _dhall_validate_call_stmt(stmt=stmt)
+            return f"let _ = {stmt}"
+
+        return _wrap
+
+    def wrap_calls_with_declarations(
+        self,
+        declarations: tuple[str, ...],
+        calls: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Append ``in {=}`` after calls to complete the Dhall
+        expression.
+        """
+        content = "\n".join((*declarations, calls)) if declarations else calls
+        wrapped = self.wrap_in_file(
+            content=content,
+            variable_name="",
+            body_preamble=body_preamble,
+        )
+        return wrapped + "\nin {=}"
 
     @cached_property
     def format_call_target(self) -> Callable[[Sequence[str]], str]:
         """Rewrite a dotted call target into the language's call
         syntax.
         """
-        return identity_call_target
+        return _dhall_format_call_target
 
     @cached_property
     def format_call_ref_identifier(self) -> Callable[[str], str]:
-        """Rewrite a ``{"$ref": "name"}`` identifier into the
-        language's call expression syntax.
+        """Raise for any ``$ref`` argument.
+
+        Dhall's stub parameter type is ``DVal``; a ref variable holds a
+        concrete type that Dhall's type-checker cannot unify with it.
         """
-        return identity_call_ref_identifier
+        return _dhall_reject_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -376,7 +376,8 @@ def _run_wrap_in_file_case(
     spec: literalizer.Language,
     yaml_string: str,
     effective_ref_case: literalizer.IdentifierCase | None,
-    lang_cls: type[literalizer.Language],
+    lang_name: str,
+    lang_extension: str,
     golden_path: Path,
     file_regression: FileRegressionFixture,
 ) -> None:
@@ -397,16 +398,14 @@ def _run_wrap_in_file_case(
         )
     except HeterogeneousCollectionError:
         golden_path.unlink(missing_ok=True)
-        pytest.skip(
-            f"{lang_cls.__name__} cannot represent this heterogeneous input"
-        )
+        pytest.skip(f"{lang_name} cannot represent this heterogeneous input")
     except CallArgNotSupportedError as exc:
         golden_path.unlink(missing_ok=True)
-        pytest.skip(f"{lang_cls.__name__} rejected call arg: {exc.reason}")
+        pytest.skip(f"{lang_name} rejected call arg: {exc.reason}")
     check_golden(
         file_regression=file_regression,
         contents=wrap_result.code + "\n",
-        extension=lang_cls.extension,
+        extension=lang_extension,
         newline="",
         golden_path=golden_path,
     )
@@ -453,7 +452,8 @@ def run_call_golden_case(
             spec=spec,
             yaml_string=yaml_string,
             effective_ref_case=effective_ref_case,
-            lang_cls=lang_cls,
+            lang_name=lang_cls.__name__,
+            lang_extension=lang_cls.extension,
             golden_path=golden_path,
             file_regression=file_regression,
         )

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -396,7 +396,7 @@ def _run_wrap_in_file_case(
             wrap_in_file=True,
             ref_case=effective_ref_case,
         )
-    except HeterogeneousCollectionError:
+    except HeterogeneousCollectionError:  # pragma: no cover
         golden_path.unlink(missing_ok=True)
         pytest.skip(f"{lang_name} cannot represent this heterogeneous input")
     except CallArgNotSupportedError as exc:

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -376,7 +376,7 @@ def _run_wrap_in_file_case(
     spec: literalizer.Language,
     yaml_string: str,
     effective_ref_case: literalizer.IdentifierCase | None,
-    lang_cls: literalizer.LanguageCls,
+    lang_cls: type[literalizer.Language],
     golden_path: Path,
     file_regression: FileRegressionFixture,
 ) -> None:

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -396,9 +396,6 @@ def _run_wrap_in_file_case(
             wrap_in_file=True,
             ref_case=effective_ref_case,
         )
-    except HeterogeneousCollectionError:  # pragma: no cover
-        golden_path.unlink(missing_ok=True)
-        pytest.skip(f"{lang_name} cannot represent this heterogeneous input")
     except CallArgNotSupportedError as exc:
         golden_path.unlink(missing_ok=True)
         pytest.skip(f"{lang_name} rejected call arg: {exc.reason}")

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -370,6 +370,49 @@ def discover_call_cases() -> list[CallCase]:
 
 
 @beartype
+def _run_wrap_in_file_case(
+    *,
+    config: CallCaseConfig,
+    spec: literalizer.Language,
+    yaml_string: str,
+    effective_ref_case: literalizer.IdentifierCase | None,
+    lang_cls: literalizer.LanguageCls,
+    golden_path: Path,
+    file_regression: FileRegressionFixture,
+) -> None:
+    """Run ``literalize_call(..., wrap_in_file=True)`` and check
+    golden.
+    """
+    try:
+        wrap_result = literalizer.literalize_call(
+            source=yaml_string,
+            input_format=literalizer.InputFormat.YAML,
+            language=spec,
+            target_function=config.target_function,
+            parameter_names=config.parameter_names,
+            call_transform=config.call_transform,
+            per_element=config.per_element,
+            wrap_in_file=True,
+            ref_case=effective_ref_case,
+        )
+    except HeterogeneousCollectionError:
+        golden_path.unlink(missing_ok=True)
+        pytest.skip(
+            f"{lang_cls.__name__} cannot represent this heterogeneous input"
+        )
+    except CallArgNotSupportedError as exc:
+        golden_path.unlink(missing_ok=True)
+        pytest.skip(f"{lang_cls.__name__} rejected call arg: {exc.reason}")
+    check_golden(
+        file_regression=file_regression,
+        contents=wrap_result.code + "\n",
+        extension=lang_cls.extension,
+        newline="",
+        golden_path=golden_path,
+    )
+
+
+@beartype
 def run_call_golden_case(
     *,
     config: CallCaseConfig,
@@ -405,23 +448,14 @@ def run_call_golden_case(
         effective_ref_case = None
         declarations = config.ref_declarations
     if config.wrap_in_file:
-        wrap_result = literalizer.literalize_call(
-            source=yaml_string,
-            input_format=literalizer.InputFormat.YAML,
-            language=spec,
-            target_function=config.target_function,
-            parameter_names=config.parameter_names,
-            call_transform=config.call_transform,
-            per_element=config.per_element,
-            wrap_in_file=True,
-            ref_case=effective_ref_case,
-        )
-        check_golden(
-            file_regression=file_regression,
-            contents=wrap_result.code + "\n",
-            extension=lang_cls.extension,
-            newline="",
+        _run_wrap_in_file_case(
+            config=config,
+            spec=spec,
+            yaml_string=yaml_string,
+            effective_ref_case=effective_ref_case,
+            lang_cls=lang_cls,
             golden_path=golden_path,
+            file_regression=file_regression,
         )
         return
     try:

--- a/tests/integration/cases/call_deep_dotted_method/Dhall_call.dhall
+++ b/tests/integration/cases/call_deep_dotted_method/Dhall_call.dhall
@@ -1,0 +1,6 @@
+let DVal = < DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >
+let obj = { api = { client = { post = \(_ : DVal) -> {=} } } }
+let _ = obj.api.client.post (DVal.DText "hello")
+let _ = obj.api.client.post (DVal.DInteger +42)
+let _ = obj.api.client.post (DVal.DBool True)
+in {=}

--- a/tests/integration/cases/call_dotted_method/Dhall_call.dhall
+++ b/tests/integration/cases/call_dotted_method/Dhall_call.dhall
@@ -1,0 +1,6 @@
+let DVal = < DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >
+let app = { client = { fetch = \(_ : DVal) -> {=} } }
+let _ = app.client.fetch (DVal.DText "hello")
+let _ = app.client.fetch (DVal.DInteger +42)
+let _ = app.client.fetch (DVal.DBool True)
+in {=}

--- a/tests/integration/cases/call_per_element_false/Dhall_call.dhall
+++ b/tests/integration/cases/call_per_element_false/Dhall_call.dhall
@@ -1,0 +1,4 @@
+let DVal = < DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >
+let process = \(_ : DVal) -> {=}
+let _ = process (DVal.DInteger +1)
+in {=}

--- a/tests/integration/cases/call_scalar_args/Dhall_call.dhall
+++ b/tests/integration/cases/call_scalar_args/Dhall_call.dhall
@@ -1,0 +1,6 @@
+let DVal = < DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >
+let process = \(_ : DVal) -> {=}
+let _ = process (DVal.DText "hello")
+let _ = process (DVal.DInteger +42)
+let _ = process (DVal.DBool True)
+in {=}

--- a/tests/integration/cases/call_snake_dotted_method/Dhall_call.dhall
+++ b/tests/integration/cases/call_snake_dotted_method/Dhall_call.dhall
@@ -1,0 +1,6 @@
+let DVal = < DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >
+let my_app = { http_client = { fetch = \(_ : DVal) -> {=} } }
+let _ = my_app.http_client.fetch (DVal.DText "hello")
+let _ = my_app.http_client.fetch (DVal.DInteger +42)
+let _ = my_app.http_client.fetch (DVal.DBool True)
+in {=}

--- a/tests/integration/cases/call_transform_no_wrapper/Dhall_call.dhall
+++ b/tests/integration/cases/call_transform_no_wrapper/Dhall_call.dhall
@@ -1,0 +1,6 @@
+let DVal = < DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >
+let process = \(_ : DVal) -> DVal.DBool True
+let _ = process (DVal.DText "hello")
+let _ = process (DVal.DInteger +42)
+let _ = process (DVal.DBool True)
+in {=}


### PR DESCRIPTION
## Summary

- Implements `literalize_call` for Dhall using `PositionalCallStyle` with a `DVal` union type (`< DBool : Bool | DDouble : Double | DInteger : Integer | DText : Text >`) to type-unify heterogeneous scalar arguments.
- A trailing space is appended to call targets so Dhall's required whitespace before `(` is respected (`process (arg)` not `process(arg)`).
- `CallArgNotSupportedError` is raised for unsupported cases: multi-arg calls (Dhall has no tuple type), `$ref` arguments (concrete type cannot unify with `DVal`), and `call_transform` wrappers that inject `(` without preceding whitespace.
- Adds six golden files covering scalar args, dotted methods, snake-cased methods, deep dotted methods, identity transforms, and per-element-false calls — all validated with `dhall < file.dhall`.
- Adds `CallArgNotSupportedError` handling to the `wrap_in_file` test branch in `run_call_golden_case`, which previously had no such guard.

## Test plan

- [ ] All existing tests pass (`uv run --extra=dev pytest tests/`)
- [ ] New Dhall call golden files pass `dhall < file.dhall > /dev/null`
- [ ] Previously excluded Dhall call cases now skip via `CallArgNotSupportedError` rather than via `CASE_LANGUAGE_INCOMPATIBLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Dhall call-rendering behavior (stubs, argument wrapping, and file wrapping) that could change generated Dhall output and introduce type/syntax regressions for call use-cases.
> 
> **Overview**
> Adds first-class `literalize_call` support for Dhall via `PositionalCallStyle`, generating a `DVal` union type preamble and let-bound function stubs (including nested-record stubs for dotted targets).
> 
> Call arguments are now wrapped in `DVal.*` constructors, call targets are formatted with required Dhall whitespace before `(`, and call statements are validated to reject unsupported patterns (multi-arg positional calls, `$ref` arguments, and wrapper transforms that would produce `name(` without whitespace).
> 
> Updates Dhall file wrapping to terminate call let-chains with `in {=}`, adjusts the integration call harness to skip `wrap_in_file` cases on `CallArgNotSupportedError`, and adds new Dhall call golden outputs covering scalar, dotted/deep-dotted, snake-cased, transform, and per-element cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb80f4ac44089d78a5e649db956751c84ca76eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->