### PR TITLE
Add literalize_call support to Tcl

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -231,18 +231,22 @@ class PrefixCallStyle:
 class CommandCallStyle:
     """Shell-command-style calls: ``func value1 value2``.
 
-    Used by shell languages (Bash, POSIX sh) where the function name
-    is followed by space-separated positional arguments with no
+    Used by shell languages (Bash, POSIX sh) and Tcl where the function
+    name is followed by space-separated positional arguments with no
     surrounding parentheses.  *arg_separator* is the string between
     the target and each argument (typically a single space).
 
     When a ``call_transform`` like ``lambda c: f"emit({c})"`` is
     supplied, the wrapper word is extracted and the inner call is
-    wrapped in ``$(...)`` command substitution (e.g.
-    ``emit "$(target arg1 arg2)"``).
+    formatted using *wrapped_call_template*, a ``str.format``-style
+    template with ``{wrapper}`` and ``{inner}`` placeholders (e.g.
+    the default ``'{wrapper} "$({inner})"'`` produces
+    ``emit "$(target arg1 arg2)"`` for Bash; Tcl uses
+    ``'{wrapper} [{inner}]'`` instead).
     """
 
     arg_separator: str
+    wrapped_call_template: str = '{wrapper} "$({inner})"'
 
 
 CallStyle = (

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1874,12 +1874,13 @@ def _assemble_command_call(
     args_str: str,
     call_transform: Callable[[str], str] | None,
     arg_separator: str,
+    wrapped_call_template: str,
 ) -> str:
     """Build ``target arg1 arg2`` for :class:`CommandCallStyle`.
 
-    With a wrapper transform the inner call is captured via ``$(...)``
-    and passed as a quoted argument to the wrapper, e.g.
-    ``emit "$(target arg1 arg2)"``.
+    With a wrapper transform the inner call is formatted using
+    *wrapped_call_template* (e.g. ``emit "$(target arg1 arg2)"`` for
+    Bash or ``emit [target arg1 arg2]`` for Tcl).
     """
     call_expr = (
         f"{target_function}{arg_separator}{args_str}"
@@ -1891,7 +1892,10 @@ def _assemble_command_call(
             call_transform=call_transform,
         )
         if wrapper:
-            call_expr = f'{wrapper} "$({call_expr})"'
+            call_expr = wrapped_call_template.format(
+                wrapper=wrapper,
+                inner=call_expr,
+            )
     return call_expr
 
 
@@ -1927,12 +1931,16 @@ def _assemble_call(
                 call_transform=call_transform,
                 arg_separator=sep,
             )
-        case CommandCallStyle(arg_separator=sep):
+        case CommandCallStyle(
+            arg_separator=sep,
+            wrapped_call_template=wrapped_call_template,
+        ):
             call_expr = _assemble_command_call(
                 target_function=target_function,
                 args_str=args_str,
                 call_transform=call_transform,
                 arg_separator=sep,
+                wrapped_call_template=wrapped_call_template,
             )
         case _ as unreachable:
             assert_never(unreachable)

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -33,7 +33,7 @@ from literalizer._formatters.format_strings import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
+    CommandCallStyle,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -94,6 +94,19 @@ def _format_tcl_declaration(
     """Format a Tcl ``set`` variable declaration with continuation."""
     continued = _add_tcl_continuation(value=value)
     return f"set {name} {continued}"
+
+
+@beartype
+def _tcl_call_stub(
+    parts: Sequence[str],
+    _params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return a Tcl proc stub that accepts any arguments."""
+    name = ".".join(parts)
+    body = "return {}" if stub_return is StubReturn.VALUE else ""
+    return (f"proc {name} {{args}} {{{body}}}",)
 
 
 @beartype
@@ -309,6 +322,8 @@ class Tcl(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Tcl call style options."""
 
+        COMMAND = CommandCallStyle(arg_separator=" ")
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -381,6 +396,7 @@ class Tcl(metaclass=LanguageCls):
     string_format: StringFormats = StringFormats.DOUBLE
     trailing_comma: TrailingCommas = TrailingCommas.NO
     line_ending: LineEndings = LineEndings.SEMICOLON
+    call_style: CallStyles = CallStyles.COMMAND
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
@@ -399,9 +415,6 @@ class Tcl(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
 
     @cached_property
     def format_integer(self) -> Callable[[int], str]:
@@ -445,7 +458,12 @@ class Tcl(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _tcl_call_stub
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_call_preamble_stub(

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -322,7 +322,10 @@ class Tcl(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Tcl call style options."""
 
-        COMMAND = CommandCallStyle(arg_separator=" ")
+        COMMAND = CommandCallStyle(
+            arg_separator=" ",
+            wrapped_call_template="{wrapper} [{inner}]",
+        )
 
     call_styles = CallStyles
 

--- a/tests/integration/cases/call_deep_dotted_method/Tcl_call.tcl
+++ b/tests/integration/cases/call_deep_dotted_method/Tcl_call.tcl
@@ -1,0 +1,4 @@
+proc obj.api.client.post {args} {}
+obj.api.client.post "hello"
+obj.api.client.post 42
+obj.api.client.post 1

--- a/tests/integration/cases/call_deep_dotted_transformed/Tcl_call.tcl
+++ b/tests/integration/cases/call_deep_dotted_transformed/Tcl_call.tcl
@@ -1,5 +1,5 @@
 proc app.client.fetch {args} {return {}}
 proc emit {args} {}
-emit "$(app.client.fetch "hello")"
-emit "$(app.client.fetch 42)"
-emit "$(app.client.fetch 1)"
+emit [app.client.fetch "hello"]
+emit [app.client.fetch 42]
+emit [app.client.fetch 1]

--- a/tests/integration/cases/call_deep_dotted_transformed/Tcl_call.tcl
+++ b/tests/integration/cases/call_deep_dotted_transformed/Tcl_call.tcl
@@ -1,0 +1,5 @@
+proc app.client.fetch {args} {return {}}
+proc emit {args} {}
+emit "$(app.client.fetch "hello")"
+emit "$(app.client.fetch 42)"
+emit "$(app.client.fetch 1)"

--- a/tests/integration/cases/call_dotted_method/Tcl_call.tcl
+++ b/tests/integration/cases/call_dotted_method/Tcl_call.tcl
@@ -1,0 +1,4 @@
+proc app.client.fetch {args} {}
+app.client.fetch "hello"
+app.client.fetch 42
+app.client.fetch 1

--- a/tests/integration/cases/call_keyword_args/Tcl_call.tcl
+++ b/tests/integration/cases/call_keyword_args/Tcl_call.tcl
@@ -1,0 +1,4 @@
+proc throttler.check {args} {return {}}
+proc emit {args} {}
+emit "$(throttler.check "user_1" 1000.0)"
+emit "$(throttler.check "user_2" 2000.5)"

--- a/tests/integration/cases/call_keyword_args/Tcl_call.tcl
+++ b/tests/integration/cases/call_keyword_args/Tcl_call.tcl
@@ -1,4 +1,4 @@
 proc throttler.check {args} {return {}}
 proc emit {args} {}
-emit "$(throttler.check "user_1" 1000.0)"
-emit "$(throttler.check "user_2" 2000.5)"
+emit [throttler.check "user_1" 1000.0]
+emit [throttler.check "user_2" 2000.5]

--- a/tests/integration/cases/call_mixed_type_dicts/Tcl_call.tcl
+++ b/tests/integration/cases/call_mixed_type_dicts/Tcl_call.tcl
@@ -1,0 +1,3 @@
+proc app.mgr.op {args} {}
+app.mgr.op [dict create "type" "create" "pr_id" "pr_1" "draft" 1]
+app.mgr.op [dict create "type" "create" "pr_id" "pr_2"]

--- a/tests/integration/cases/call_multi_args/Tcl_call.tcl
+++ b/tests/integration/cases/call_multi_args/Tcl_call.tcl
@@ -1,0 +1,3 @@
+proc process {args} {}
+process 1 42
+process 2 100

--- a/tests/integration/cases/call_per_element_false/Tcl_call.tcl
+++ b/tests/integration/cases/call_per_element_false/Tcl_call.tcl
@@ -1,0 +1,2 @@
+proc process {args} {}
+process 1

--- a/tests/integration/cases/call_ref_args/Tcl_call.tcl
+++ b/tests/integration/cases/call_ref_args/Tcl_call.tcl
@@ -1,0 +1,13 @@
+proc process {args} {}
+set my_var [list \
+    1 \
+    2 \
+    3 \
+]
+set my_other [list \
+    4 \
+    5 \
+    6 \
+]
+process my_var 42
+process my_other 7

--- a/tests/integration/cases/call_ref_args_converted/Tcl_call.tcl
+++ b/tests/integration/cases/call_ref_args_converted/Tcl_call.tcl
@@ -1,0 +1,13 @@
+proc process {args} {}
+set my_var [list \
+    1 \
+    2 \
+    3 \
+]
+set my_other [list \
+    4 \
+    5 \
+    6 \
+]
+process my_var 42
+process my_other 7

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Tcl_call.tcl
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Tcl_call.tcl
@@ -1,0 +1,13 @@
+proc process {args} {}
+set my_var [list \
+    1 \
+    2 \
+    3 \
+]
+set my_other [list \
+    4 \
+    5 \
+    6 \
+]
+process my_var 42
+process my_other 7

--- a/tests/integration/cases/call_ref_args_converted_whole/Tcl_call.tcl
+++ b/tests/integration/cases/call_ref_args_converted_whole/Tcl_call.tcl
@@ -1,0 +1,7 @@
+proc process {args} {}
+set my_var [list \
+    1 \
+    2 \
+    3 \
+]
+process my_var

--- a/tests/integration/cases/call_scalar_args/Tcl_call.tcl
+++ b/tests/integration/cases/call_scalar_args/Tcl_call.tcl
@@ -1,0 +1,4 @@
+proc process {args} {}
+process "hello"
+process 42
+process 1

--- a/tests/integration/cases/call_snake_dotted_method/Tcl_call.tcl
+++ b/tests/integration/cases/call_snake_dotted_method/Tcl_call.tcl
@@ -1,0 +1,4 @@
+proc my_app.http_client.fetch {args} {}
+my_app.http_client.fetch "hello"
+my_app.http_client.fetch 42
+my_app.http_client.fetch 1

--- a/tests/integration/cases/call_transform_no_wrapper/Tcl_call.tcl
+++ b/tests/integration/cases/call_transform_no_wrapper/Tcl_call.tcl
@@ -1,0 +1,4 @@
+proc process {args} {return {}}
+process "hello"
+process 42
+process 1

--- a/tests/integration/cases/call_wrap_in_file/Tcl_call.tcl
+++ b/tests/integration/cases/call_wrap_in_file/Tcl_call.tcl
@@ -1,0 +1,3 @@
+proc process {args} {}
+process 1 2
+process 3 4


### PR DESCRIPTION
Implements `literalize_call` for the Tcl language module, resolving #1146.

Adds `_tcl_call_stub` which emits `proc name {args} {}` (void) or `proc name {args} {return {}}` (value-returning) stubs, wires up `CommandCallStyle` for space-separated positional arguments, and includes 15 new golden files covering all call test cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared call-assembly logic for `CommandCallStyle`, which could affect existing shell languages’ transformed-call output, and adds new Tcl-specific call rendering and stub generation paths.
> 
> **Overview**
> Adds Tcl support for `literalize_call` by introducing a Tcl `COMMAND` call style (space-separated args) and emitting `proc ... {args}` stubs, including value-returning stubs when a transform consumes the call result.
> 
> Generalizes `CommandCallStyle` wrapping so transformed calls are rendered via a configurable `wrapped_call_template` (defaulting to Bash-style `$(...)` but using Tcl-style `[...]`), and adds golden integration fixtures covering the Tcl call cases (dotted targets, transforms, refs, and multi-arg calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c023eec6aa4e5d399d27ffb2c576c7fa6b779a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->