### PR TITLE
Fix Gleam call stubs: panic -> Nil so they run without crashing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -478,7 +478,7 @@ jobs:
         env:
           LINT_GLEAM_PRIMED_DIR: ${{ runner.temp }}/lint-gleam-primed
         run: |-
-          grep -zEv 'float_special_values|_call\.gleam' /tmp/files-gleam > /tmp/files-gleam-run || true
+          grep -zEv 'float_special_values' /tmp/files-gleam > /tmp/files-gleam-run || true
           xargs -0 -P "$(nproc)" -n1 uv run --no-project python .github/scripts/run_gleam.py < /tmp/files-gleam-run
 
       # Fixtures only declare `defmodule Check` with a `def x` body, so

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -350,16 +350,14 @@ def _gleam_call_preamble_stub(
     identifiers cannot contain ``.``, so ``app.client.fetch`` becomes
     ``app_client_fetch``.  Each parameter gets a fresh type variable
     so the stub is polymorphic across call sites that pass different
-    argument types.  Return type is ``Nil``; ``panic`` fills the body
-    so the stub unifies with any return-position type at the call
-    site.
+    argument types.  Return type is ``Nil``.
     """
     flat_name = "_".join(parts)
     param_list = ", ".join(
         f"_{p}: {_gleam_type_var(index=i)}"
         for i, p in enumerate(iterable=params)
     )
-    return (f"pub fn {flat_name}({param_list}) -> Nil {{ panic }}",)
+    return (f"pub fn {flat_name}({param_list}) -> Nil {{ Nil }}",)
 
 
 def _gleam_format_call_target(parts: Sequence[str]) -> str:

--- a/tests/integration/cases/call_deep_dotted_method/Gleam_call.gleam
+++ b/tests/integration/cases/call_deep_dotted_method/Gleam_call.gleam
@@ -4,7 +4,7 @@ pub type GVal {
   GStr(String)
   GList(List(GVal))
 }
-pub fn obj_api_client_post(_data: a) -> Nil { panic }
+pub fn obj_api_client_post(_data: a) -> Nil { Nil }
 
 pub fn main() {
   obj_api_client_post(GStr("hello"))

--- a/tests/integration/cases/call_deep_dotted_transformed/Gleam_call.gleam
+++ b/tests/integration/cases/call_deep_dotted_transformed/Gleam_call.gleam
@@ -4,8 +4,8 @@ pub type GVal {
   GStr(String)
   GList(List(GVal))
 }
-pub fn app_client_fetch(_payload: a) -> Nil { panic }
-pub fn emit(__arg: a) -> Nil { panic }
+pub fn app_client_fetch(_payload: a) -> Nil { Nil }
+pub fn emit(__arg: a) -> Nil { Nil }
 
 pub fn main() {
   emit(app_client_fetch(GStr("hello")))

--- a/tests/integration/cases/call_dotted_method/Gleam_call.gleam
+++ b/tests/integration/cases/call_dotted_method/Gleam_call.gleam
@@ -4,7 +4,7 @@ pub type GVal {
   GStr(String)
   GList(List(GVal))
 }
-pub fn app_client_fetch(_payload: a) -> Nil { panic }
+pub fn app_client_fetch(_payload: a) -> Nil { Nil }
 
 pub fn main() {
   app_client_fetch(GStr("hello"))

--- a/tests/integration/cases/call_keyword_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_keyword_args/Gleam_call.gleam
@@ -3,8 +3,8 @@ pub type GVal {
   GStr(String)
   GList(List(GVal))
 }
-pub fn throttler_check(_user_id: a, _ts: b) -> Nil { panic }
-pub fn emit(__arg: a) -> Nil { panic }
+pub fn throttler_check(_user_id: a, _ts: b) -> Nil { Nil }
+pub fn emit(__arg: a) -> Nil { Nil }
 
 pub fn main() {
   emit(throttler_check(GStr("user_1"), GFloat(1000.0)))

--- a/tests/integration/cases/call_mixed_type_dicts/Gleam_call.gleam
+++ b/tests/integration/cases/call_mixed_type_dicts/Gleam_call.gleam
@@ -4,7 +4,7 @@ pub type GVal {
   GList(List(GVal))
   GDict(List(#(String, GVal)))
 }
-pub fn app_mgr_op(_operation: a) -> Nil { panic }
+pub fn app_mgr_op(_operation: a) -> Nil { Nil }
 
 pub fn main() {
   app_mgr_op(GDict([#("type", GStr("create")), #("pr_id", GStr("pr_1")), #("draft", GBool(True))]))

--- a/tests/integration/cases/call_multi_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_multi_args/Gleam_call.gleam
@@ -2,7 +2,7 @@ pub type GVal {
   GInt(Int)
   GList(List(GVal))
 }
-pub fn process(_value: a, _count: b) -> Nil { panic }
+pub fn process(_value: a, _count: b) -> Nil { Nil }
 
 pub fn main() {
   process(GInt(1), GInt(42))

--- a/tests/integration/cases/call_per_element_false/Gleam_call.gleam
+++ b/tests/integration/cases/call_per_element_false/Gleam_call.gleam
@@ -1,7 +1,7 @@
 pub type GVal {
   GInt(Int)
 }
-pub fn process(_data: a) -> Nil { panic }
+pub fn process(_data: a) -> Nil { Nil }
 
 pub fn main() {
   process(GInt(1))

--- a/tests/integration/cases/call_ref_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_ref_args/Gleam_call.gleam
@@ -2,7 +2,7 @@ pub type GVal {
   GInt(Int)
   GList(List(GVal))
 }
-pub fn process(_data: a, _count: b) -> Nil { panic }
+pub fn process(_data: a, _count: b) -> Nil { Nil }
 
 pub fn main() {
   let my_var = GList([

--- a/tests/integration/cases/call_ref_args_converted/Gleam_call.gleam
+++ b/tests/integration/cases/call_ref_args_converted/Gleam_call.gleam
@@ -2,7 +2,7 @@ pub type GVal {
   GInt(Int)
   GList(List(GVal))
 }
-pub fn process(_data: a, _count: b) -> Nil { panic }
+pub fn process(_data: a, _count: b) -> Nil { Nil }
 
 pub fn main() {
   let my_var = GList([

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Gleam_call.gleam
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Gleam_call.gleam
@@ -2,7 +2,7 @@ pub type GVal {
   GInt(Int)
   GList(List(GVal))
 }
-pub fn process(_data: a, _count: b) -> Nil { panic }
+pub fn process(_data: a, _count: b) -> Nil { Nil }
 
 pub fn main() {
   let my_var = GList([

--- a/tests/integration/cases/call_ref_args_converted_whole/Gleam_call.gleam
+++ b/tests/integration/cases/call_ref_args_converted_whole/Gleam_call.gleam
@@ -2,7 +2,7 @@ pub type GVal {
   GInt(Int)
   GList(List(GVal))
 }
-pub fn process(_data: a) -> Nil { panic }
+pub fn process(_data: a) -> Nil { Nil }
 
 pub fn main() {
   let my_var = GList([

--- a/tests/integration/cases/call_scalar_args/Gleam_call.gleam
+++ b/tests/integration/cases/call_scalar_args/Gleam_call.gleam
@@ -4,7 +4,7 @@ pub type GVal {
   GStr(String)
   GList(List(GVal))
 }
-pub fn process(_value: a) -> Nil { panic }
+pub fn process(_value: a) -> Nil { Nil }
 
 pub fn main() {
   process(GStr("hello"))

--- a/tests/integration/cases/call_snake_dotted_method/Gleam_call.gleam
+++ b/tests/integration/cases/call_snake_dotted_method/Gleam_call.gleam
@@ -4,7 +4,7 @@ pub type GVal {
   GStr(String)
   GList(List(GVal))
 }
-pub fn my_app_http_client_fetch(_payload: a) -> Nil { panic }
+pub fn my_app_http_client_fetch(_payload: a) -> Nil { Nil }
 
 pub fn main() {
   my_app_http_client_fetch(GStr("hello"))

--- a/tests/integration/cases/call_transform_no_wrapper/Gleam_call.gleam
+++ b/tests/integration/cases/call_transform_no_wrapper/Gleam_call.gleam
@@ -4,7 +4,7 @@ pub type GVal {
   GStr(String)
   GList(List(GVal))
 }
-pub fn process(_value: a) -> Nil { panic }
+pub fn process(_value: a) -> Nil { Nil }
 
 pub fn main() {
   process(GStr("hello"))

--- a/tests/integration/cases/call_wrap_in_file/Gleam_call.gleam
+++ b/tests/integration/cases/call_wrap_in_file/Gleam_call.gleam
@@ -2,7 +2,7 @@ pub type GVal {
   GInt(Int)
   GList(List(GVal))
 }
-pub fn process(_a: a, _b: b) -> Nil { panic }
+pub fn process(_a: a, _b: b) -> Nil { Nil }
 
 pub fn main() {
   process(GInt(1), GInt(2))


### PR DESCRIPTION
Gleam call fixtures used `panic` as the stub body for generated callee functions, but since the return type is always `Nil`, returning `Nil` works equally well and does not crash at runtime. This change fixes `_gleam_call_preamble_stub` in the generator and regenerates all 15 `Gleam_call.gleam` golden files accordingly. The `_call\.gleam` exclusion is removed from the "Run Gleam files" CI step so these fixtures are now executed as well as syntax-checked. The `float_special_values` exclusion is retained as a separate known limitation (tracked in #1761).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect Gleam fixture stub generation and CI execution of those fixtures, with minimal blast radius outside tests/linting.
> 
> **Overview**
> Fixes generated Gleam call preamble stubs to return `Nil` instead of `panic`, and regenerates the affected `Gleam_call.gleam` golden fixtures accordingly.
> 
> Updates the `lint-beam` workflow to **run** all Gleam fixtures (except the existing `float_special_values` skip), removing the previous exclusion that prevented `*_call.gleam` fixtures from being executed in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0cd23c14a6488dacb100657a96e6ab1a249217b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->