### PR TITLE
Add function call rendering to V

### DIFF
--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -224,14 +224,14 @@ def _v_call_preamble_stub(
             f"fn {parts[0]}(args ...ICallArg_) ICallArg_ {{ return 0 }}",
         )
 
-    def _type_name(base: str) -> str:
-        """Return a V struct name for *base* starting with a capital."""
-        return base[0].upper() + base[1:] + "Type_"
+    def _cap_type(name: str, /) -> str:
+        """Return *name* capitalised and suffixed with ``Type_``."""
+        return name[0].upper() + name[1:] + "Type_"
 
     root = parts[0]
     method = parts[-1]
     fields = parts[1:-1]
-    receiver_type = _type_name(fields[-1]) if fields else _type_name(root)
+    receiver_type = _cap_type(fields[-1]) if fields else _cap_type(root)
 
     if stub_return is StubReturn.VOID:
         method_line = (
@@ -248,11 +248,11 @@ def _v_call_preamble_stub(
     if fields:
         prev_type = receiver_type
         for i in range(len(fields) - 2, -1, -1):
-            curr_type = _type_name(fields[i])
+            curr_type = _cap_type(fields[i])
             field = fields[i + 1]
             lines.append(f"struct {curr_type} {{\n\t{field} {prev_type}\n}}")
             prev_type = curr_type
-        root_type = _type_name(root)
+        root_type = _cap_type(root)
         lines.append(f"struct {root_type} {{\n\t{fields[0]} {prev_type}\n}}")
 
     return tuple(lines)

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -224,10 +224,14 @@ def _v_call_preamble_stub(
             f"fn {parts[0]}(args ...ICallArg_) ICallArg_ {{ return 0 }}",
         )
 
+    def _type_name(base: str) -> str:
+        """Return a V struct name for *base* starting with a capital."""
+        return base[0].upper() + base[1:] + "Type_"
+
     root = parts[0]
     method = parts[-1]
     fields = parts[1:-1]
-    receiver_type = f"{fields[-1]}Type_" if fields else f"{root}Type_"
+    receiver_type = _type_name(fields[-1]) if fields else _type_name(root)
 
     if stub_return is StubReturn.VOID:
         method_line = (
@@ -244,11 +248,11 @@ def _v_call_preamble_stub(
     if fields:
         prev_type = receiver_type
         for i in range(len(fields) - 2, -1, -1):
-            curr_type = f"{fields[i]}Type_"
+            curr_type = _type_name(fields[i])
             field = fields[i + 1]
             lines.append(f"struct {curr_type} {{\n\t{field} {prev_type}\n}}")
             prev_type = curr_type
-        root_type = f"{root}Type_"
+        root_type = _type_name(root)
         lines.append(f"struct {root_type} {{\n\t{fields[0]} {prev_type}\n}}")
 
     return tuple(lines)
@@ -271,7 +275,7 @@ def _v_call_stub(
     if len(parts) == 1:
         return ()
     root = parts[0]
-    root_type = f"{root}Type_"
+    root_type = root[0].upper() + root[1:] + "Type_"
     return (f"{root} := {root_type}{{}}",)
 
 

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -46,7 +46,6 @@ from literalizer._heterogeneous import collect_heterogeneous_container_ids
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -57,6 +56,7 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -65,7 +65,6 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_target,
-    no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_spec_for_data,
@@ -199,6 +198,81 @@ def _build_v_interface_preamble() -> Callable[[Value], tuple[str, ...]]:
         return (_V_IFACE_DECL,)
 
     return _preamble
+
+
+@beartype
+def _v_call_preamble_stub(
+    parts: Sequence[str],
+    _params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return V preamble stub declarations for a call name.
+
+    Includes ``interface ICallArg_ {}`` in every result so that
+    the caller can deduplicate across multiple combined stubs.
+    For dotted targets like ``app.client.fetch``, one struct per
+    prefix level is emitted together with the method declaration.
+    """
+    iface = "interface ICallArg_ {}"
+
+    if len(parts) == 1:
+        if stub_return is StubReturn.VOID:
+            return (iface, f"fn {parts[0]}(args ...ICallArg_) {{}}")
+        return (
+            iface,
+            f"fn {parts[0]}(args ...ICallArg_) ICallArg_ {{ return 0 }}",
+        )
+
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    receiver_type = f"{fields[-1]}Type_" if fields else f"{root}Type_"
+
+    if stub_return is StubReturn.VOID:
+        method_line = (
+            f"fn (r {receiver_type}) {method}(args ...ICallArg_) {{}}"
+        )
+    else:
+        method_line = (
+            f"fn (r {receiver_type}) {method}(args ...ICallArg_)"
+            f" ICallArg_ {{ return 0 }}"
+        )
+
+    lines: list[str] = [iface, f"struct {receiver_type} {{}}", method_line]
+
+    if fields:
+        prev_type = receiver_type
+        for i in range(len(fields) - 2, -1, -1):
+            curr_type = f"{fields[i]}Type_"
+            field = fields[i + 1]
+            lines.append(f"struct {curr_type} {{\n\t{field} {prev_type}\n}}")
+            prev_type = curr_type
+        root_type = f"{root}Type_"
+        lines.append(f"struct {root_type} {{\n\t{fields[0]} {prev_type}\n}}")
+
+    return tuple(lines)
+
+
+@beartype
+def _v_call_stub(
+    parts: Sequence[str],
+    _params: Sequence[str],
+    _stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return V body-level variable stubs for a call name.
+
+    For dotted targets the root variable is declared inside ``fn main``
+    so it is in scope when the call expression is evaluated.  Simple
+    one-part targets are declared at file level (preamble) and need no
+    body stub.
+    """
+    if len(parts) == 1:
+        return ()
+    root = parts[0]
+    root_type = f"{root}Type_"
+    return (f"{root} := {root_type}{{}}",)
 
 
 @beartype
@@ -445,6 +519,8 @@ class V(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """V call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -492,7 +568,8 @@ class V(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
         indented = textwrap.indent(text=content, prefix="\t")
-        return f"\nfn main() {{\n{indented}\n\t_ = {variable_name}\n}}"
+        use_line = f"\n\t_ = {variable_name}" if variable_name else ""
+        return f"\nfn main() {{\n{indented}{use_line}\n}}"
 
     @staticmethod
     def wrap_combined_in_file(
@@ -532,6 +609,7 @@ class V(metaclass=LanguageCls):
         HeterogeneousStrategies.INTERFACE
     )
     indent: str = "\t"
+    call_style: CallStyles = CallStyles.POSITIONAL
 
     null_literal: ClassVar[str] = "unsafe { nil }"
     true_literal: ClassVar[str] = "true"
@@ -546,9 +624,11 @@ class V(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ("import math",)
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Return the active call-style configuration."""
+        return self.call_style.value
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -592,14 +672,14 @@ class V(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _v_call_stub
 
     @cached_property
     def format_call_preamble_stub(
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return no_call_stub
+        return _v_call_preamble_stub
 
     @cached_property
     def format_call_target(self) -> Callable[[Sequence[str]], str]:

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -225,7 +225,9 @@ def _v_call_preamble_stub(
         )
 
     def _cap_type(name: str, /) -> str:
-        """Return *name* capitalised and suffixed with ``Type_``."""
+        """Return *name* with an upper-case first letter and ``Type_``
+        suffix.
+        """
         return name[0].upper() + name[1:] + "Type_"
 
     root = parts[0]

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -210,7 +210,7 @@ def _v_call_preamble_stub(
     """Return V preamble stub declarations for a call name.
 
     Includes ``interface ICallArg_ {}`` in every result so that
-    the caller can deduplicate across multiple combined stubs.
+    duplicate copies can be dropped when multiple stubs are combined.
     For dotted targets like ``app.client.fetch``, one struct per
     prefix level is emitted together with the method declaration.
     """

--- a/tests/integration/cases/call_deep_dotted_method/V_call.v
+++ b/tests/integration/cases/call_deep_dotted_method/V_call.v
@@ -1,16 +1,16 @@
 interface IVal {}
 interface ICallArg_ {}
-struct clientType_ {}
-fn (r clientType_) post(args ...ICallArg_) {}
-struct apiType_ {
-	client clientType_
+struct ClientType_ {}
+fn (r ClientType_) post(args ...ICallArg_) {}
+struct ApiType_ {
+	client ClientType_
 }
-struct objType_ {
-	api apiType_
+struct ObjType_ {
+	api ApiType_
 }
 
 fn main() {
-	obj := objType_{}
+	obj := ObjType_{}
 	obj.api.client.post('hello');
 	obj.api.client.post(42);
 	obj.api.client.post(true);

--- a/tests/integration/cases/call_deep_dotted_method/V_call.v
+++ b/tests/integration/cases/call_deep_dotted_method/V_call.v
@@ -1,0 +1,17 @@
+interface IVal {}
+interface ICallArg_ {}
+struct clientType_ {}
+fn (r clientType_) post(args ...ICallArg_) {}
+struct apiType_ {
+	client clientType_
+}
+struct objType_ {
+	api apiType_
+}
+
+fn main() {
+	obj := objType_{}
+	obj.api.client.post('hello');
+	obj.api.client.post(42);
+	obj.api.client.post(true);
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/V_call.v
+++ b/tests/integration/cases/call_deep_dotted_transformed/V_call.v
@@ -1,14 +1,14 @@
 interface IVal {}
 interface ICallArg_ {}
-struct clientType_ {}
-fn (r clientType_) fetch(args ...ICallArg_) ICallArg_ { return 0 }
-struct appType_ {
-	client clientType_
+struct ClientType_ {}
+fn (r ClientType_) fetch(args ...ICallArg_) ICallArg_ { return 0 }
+struct AppType_ {
+	client ClientType_
 }
 fn emit(args ...ICallArg_) {}
 
 fn main() {
-	app := appType_{}
+	app := AppType_{}
 	emit(app.client.fetch('hello'));
 	emit(app.client.fetch(42));
 	emit(app.client.fetch(true));

--- a/tests/integration/cases/call_deep_dotted_transformed/V_call.v
+++ b/tests/integration/cases/call_deep_dotted_transformed/V_call.v
@@ -1,0 +1,15 @@
+interface IVal {}
+interface ICallArg_ {}
+struct clientType_ {}
+fn (r clientType_) fetch(args ...ICallArg_) ICallArg_ { return 0 }
+struct appType_ {
+	client clientType_
+}
+fn emit(args ...ICallArg_) {}
+
+fn main() {
+	app := appType_{}
+	emit(app.client.fetch('hello'));
+	emit(app.client.fetch(42));
+	emit(app.client.fetch(true));
+}

--- a/tests/integration/cases/call_dotted_method/V_call.v
+++ b/tests/integration/cases/call_dotted_method/V_call.v
@@ -1,0 +1,14 @@
+interface IVal {}
+interface ICallArg_ {}
+struct clientType_ {}
+fn (r clientType_) fetch(args ...ICallArg_) {}
+struct appType_ {
+	client clientType_
+}
+
+fn main() {
+	app := appType_{}
+	app.client.fetch('hello');
+	app.client.fetch(42);
+	app.client.fetch(true);
+}

--- a/tests/integration/cases/call_dotted_method/V_call.v
+++ b/tests/integration/cases/call_dotted_method/V_call.v
@@ -1,13 +1,13 @@
 interface IVal {}
 interface ICallArg_ {}
-struct clientType_ {}
-fn (r clientType_) fetch(args ...ICallArg_) {}
-struct appType_ {
-	client clientType_
+struct ClientType_ {}
+fn (r ClientType_) fetch(args ...ICallArg_) {}
+struct AppType_ {
+	client ClientType_
 }
 
 fn main() {
-	app := appType_{}
+	app := AppType_{}
 	app.client.fetch('hello');
 	app.client.fetch(42);
 	app.client.fetch(true);

--- a/tests/integration/cases/call_keyword_args/V_call.v
+++ b/tests/integration/cases/call_keyword_args/V_call.v
@@ -1,0 +1,11 @@
+interface IVal {}
+interface ICallArg_ {}
+struct throttlerType_ {}
+fn (r throttlerType_) check(args ...ICallArg_) ICallArg_ { return 0 }
+fn emit(args ...ICallArg_) {}
+
+fn main() {
+	throttler := throttlerType_{}
+	emit(throttler.check('user_1', 1000.0));
+	emit(throttler.check('user_2', 2000.5));
+}

--- a/tests/integration/cases/call_keyword_args/V_call.v
+++ b/tests/integration/cases/call_keyword_args/V_call.v
@@ -1,11 +1,11 @@
 interface IVal {}
 interface ICallArg_ {}
-struct throttlerType_ {}
-fn (r throttlerType_) check(args ...ICallArg_) ICallArg_ { return 0 }
+struct ThrottlerType_ {}
+fn (r ThrottlerType_) check(args ...ICallArg_) ICallArg_ { return 0 }
 fn emit(args ...ICallArg_) {}
 
 fn main() {
-	throttler := throttlerType_{}
+	throttler := ThrottlerType_{}
 	emit(throttler.check('user_1', 1000.0));
 	emit(throttler.check('user_2', 2000.5));
 }

--- a/tests/integration/cases/call_mixed_type_dicts/V_call.v
+++ b/tests/integration/cases/call_mixed_type_dicts/V_call.v
@@ -1,13 +1,13 @@
 interface IVal {}
 interface ICallArg_ {}
-struct mgrType_ {}
-fn (r mgrType_) op(args ...ICallArg_) {}
-struct appType_ {
-	mgr mgrType_
+struct MgrType_ {}
+fn (r MgrType_) op(args ...ICallArg_) {}
+struct AppType_ {
+	mgr MgrType_
 }
 
 fn main() {
-	app := appType_{}
+	app := AppType_{}
 	app.mgr.op({'type': IVal('create'), 'pr_id': IVal('pr_1'), 'draft': IVal(true)});
 	app.mgr.op({'type': IVal('create'), 'pr_id': IVal('pr_2')});
 }

--- a/tests/integration/cases/call_mixed_type_dicts/V_call.v
+++ b/tests/integration/cases/call_mixed_type_dicts/V_call.v
@@ -1,0 +1,13 @@
+interface IVal {}
+interface ICallArg_ {}
+struct mgrType_ {}
+fn (r mgrType_) op(args ...ICallArg_) {}
+struct appType_ {
+	mgr mgrType_
+}
+
+fn main() {
+	app := appType_{}
+	app.mgr.op({'type': IVal('create'), 'pr_id': IVal('pr_1'), 'draft': IVal(true)});
+	app.mgr.op({'type': IVal('create'), 'pr_id': IVal('pr_2')});
+}

--- a/tests/integration/cases/call_multi_args/V_call.v
+++ b/tests/integration/cases/call_multi_args/V_call.v
@@ -1,0 +1,7 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	process(1, 42);
+	process(2, 100);
+}

--- a/tests/integration/cases/call_per_element_false/V_call.v
+++ b/tests/integration/cases/call_per_element_false/V_call.v
@@ -1,0 +1,6 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	process(1);
+}

--- a/tests/integration/cases/call_ref_args/V_call.v
+++ b/tests/integration/cases/call_ref_args/V_call.v
@@ -1,0 +1,17 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	my_var := [
+		1,
+		2,
+		3,
+	]
+	my_other := [
+		4,
+		5,
+		6,
+	]
+	process(my_var, 42);
+	process(my_other, 7);
+}

--- a/tests/integration/cases/call_ref_args_converted/V_call.v
+++ b/tests/integration/cases/call_ref_args_converted/V_call.v
@@ -1,0 +1,17 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	my_var := [
+		1,
+		2,
+		3,
+	]
+	my_other := [
+		4,
+		5,
+		6,
+	]
+	process(my_var, 42);
+	process(my_other, 7);
+}

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/V_call.v
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/V_call.v
@@ -1,0 +1,17 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	my_var := [
+		1,
+		2,
+		3,
+	]
+	my_other := [
+		4,
+		5,
+		6,
+	]
+	process(my_var, 42);
+	process(my_other, 7);
+}

--- a/tests/integration/cases/call_ref_args_converted_whole/V_call.v
+++ b/tests/integration/cases/call_ref_args_converted_whole/V_call.v
@@ -1,0 +1,12 @@
+interface IVal {}
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	my_var := [
+		1,
+		2,
+		3,
+	]
+	process(my_var);
+}

--- a/tests/integration/cases/call_scalar_args/V_call.v
+++ b/tests/integration/cases/call_scalar_args/V_call.v
@@ -1,0 +1,9 @@
+interface IVal {}
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	process('hello');
+	process(42);
+	process(true);
+}

--- a/tests/integration/cases/call_snake_dotted_method/V_call.v
+++ b/tests/integration/cases/call_snake_dotted_method/V_call.v
@@ -1,0 +1,14 @@
+interface IVal {}
+interface ICallArg_ {}
+struct http_clientType_ {}
+fn (r http_clientType_) fetch(args ...ICallArg_) {}
+struct my_appType_ {
+	http_client http_clientType_
+}
+
+fn main() {
+	my_app := my_appType_{}
+	my_app.http_client.fetch('hello');
+	my_app.http_client.fetch(42);
+	my_app.http_client.fetch(true);
+}

--- a/tests/integration/cases/call_snake_dotted_method/V_call.v
+++ b/tests/integration/cases/call_snake_dotted_method/V_call.v
@@ -1,13 +1,13 @@
 interface IVal {}
 interface ICallArg_ {}
-struct http_clientType_ {}
-fn (r http_clientType_) fetch(args ...ICallArg_) {}
-struct my_appType_ {
-	http_client http_clientType_
+struct Http_clientType_ {}
+fn (r Http_clientType_) fetch(args ...ICallArg_) {}
+struct My_appType_ {
+	http_client Http_clientType_
 }
 
 fn main() {
-	my_app := my_appType_{}
+	my_app := My_appType_{}
 	my_app.http_client.fetch('hello');
 	my_app.http_client.fetch(42);
 	my_app.http_client.fetch(true);

--- a/tests/integration/cases/call_transform_no_wrapper/V_call.v
+++ b/tests/integration/cases/call_transform_no_wrapper/V_call.v
@@ -1,0 +1,9 @@
+interface IVal {}
+interface ICallArg_ {}
+fn process(args ...ICallArg_) ICallArg_ { return 0 }
+
+fn main() {
+	process('hello');
+	process(42);
+	process(true);
+}

--- a/tests/integration/cases/call_wrap_in_file/V_call.v
+++ b/tests/integration/cases/call_wrap_in_file/V_call.v
@@ -1,0 +1,7 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	process(1, 2);
+	process(3, 4);
+}


### PR DESCRIPTION
## Summary

- Adds `literalize_call` support to the V language module by implementing `_v_call_preamble_stub` and `_v_call_stub`
- Uses `PositionalCallStyle` and an `ICallArg_` empty interface for stub type signatures, avoiding conflicts with V's existing `IVal` heterogeneous interface
- Fixes `wrap_in_file` to omit the `_ = ` use-line when `variable_name` is empty (needed for call mode)
- Adds 15 golden-file fixtures covering all call case variants

## Test plan

- [ ] All 15 new V call golden-file tests pass (`test_call_golden_file[call_*/V]`)
- [ ] Full test suite passes (1437 passed, 399 skipped)
- [ ] Type checking clean (pyright, mypy, ty, pyrefly)

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes V code generation behavior (new call-style config, stub emission, and `wrap_in_file` output), which could affect generated code correctness across call cases.
> 
> **Overview**
> Adds V support for `literalize_call` by introducing a **positional call style** and emitting V-compatible **call stubs**: file-scope function/method/struct declarations via `_v_call_preamble_stub` and, for dotted targets, in-`main` root variable stubs via `_v_call_stub` using an `ICallArg_` interface type.
> 
> Adjusts `V.wrap_in_file` to omit the `_ = <var>` use-line when `variable_name` is empty (needed for call-mode output), and adds golden integration fixtures covering scalar, multi-arg, keyword-arg rendering, `$ref` args, and deep dotted method calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 503bef7496e2ea93502c476c30a66748eef57fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->