### PR TITLE
Add literalize_call support to Nim

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2234,10 +2234,15 @@ def literalize_call(
         language=language,
         has_variable_declaration=False,
     )
+    _call_ddp: Callable[[Value], tuple[str, ...]] = getattr(
+        language,
+        "call_data_dependent_preamble",
+        language.data_dependent_preamble,
+    )
     preamble = (
         tuple(language.static_preamble)
         + computed.header
-        + language.data_dependent_preamble(data_for_preamble)
+        + _call_ddp(data_for_preamble)
     )
 
     if wrap_in_file:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -424,9 +424,11 @@ def _nim_call_stub(
         return_clause = ": untyped"
         body = "0"
     if len(parts) == 1:
-        return (
-            f"proc {method}(args: varargs[untyped]){return_clause} = {body}",
+        tmpl = (
+            f"template {method}(args: varargs[untyped])"
+            f"{return_clause} = {body}"
         )
+        return (tmpl,)
     chain = list(parts[:-1])
     holder = chain[-1]
     holder_type = f"{holder.title()}Type"
@@ -442,11 +444,11 @@ def _nim_call_stub(
                 f"{indent}{inner}: {inner_type}",
             ]
         )
-    proc_sig = (
-        f"proc {method}(self: {holder_type};"
+    tmpl_sig = (
+        f"template {method}(self: {holder_type};"
         f" args: varargs[untyped]){return_clause} = {body}"
     )
-    lines.append(proc_sig)
+    lines.append(tmpl_sig)
     root = chain[0]
     root_type = f"{root.title()}Type"
     lines.append(f"var {root}: {root_type}")

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Sequence
-from functools import cached_property
+from functools import cached_property, partial
 from types import MappingProxyType
 from typing import ClassVar, assert_never, cast
 
@@ -48,7 +48,6 @@ from literalizer._heterogeneous import (
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -59,6 +58,7 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -401,6 +401,59 @@ def _build_object_variant_preamble(
 
 
 @beartype
+def _nim_call_stub(
+    parts: Sequence[str],
+    _params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+    *,
+    indent: str,
+) -> tuple[str, ...]:
+    """Return Nim stub declarations for a call name.
+
+    For a single-part name a top-level proc with a varargs parameter is
+    emitted.  For dotted names object types are built bottom-up so that
+    Nim's Uniform Function Call Syntax lets the caller write
+    ``app.client.fetch(x)`` as sugar for ``fetch(app.client, x)``.
+    """
+    method = parts[-1]
+    if stub_return is StubReturn.VOID:
+        return_clause = ""
+        body = "discard"
+    else:
+        return_clause = ": untyped"
+        body = "0"
+    if len(parts) == 1:
+        return (
+            f"proc {method}(_args: varargs[untyped]){return_clause} = {body}",
+        )
+    chain = list(parts[:-1])
+    holder = chain[-1]
+    holder_type = f"{holder.title()}Type_"
+    lines: list[str] = [f"type {holder_type} = object"]
+    for i in range(len(chain) - 2, -1, -1):
+        outer = chain[i]
+        inner = chain[i + 1]
+        inner_type = f"{inner.title()}Type_"
+        outer_type = f"{outer.title()}Type_"
+        lines.extend(
+            [
+                f"type {outer_type} = object",
+                f"{indent}{inner}: {inner_type}",
+            ]
+        )
+    proc_sig = (
+        f"proc {method}(self: {holder_type};"
+        f" _args: varargs[untyped]){return_clause} = {body}"
+    )
+    lines.append(proc_sig)
+    root = chain[0]
+    root_type = f"{root.title()}Type_"
+    lines.append(f"var {root}: {root_type}")
+    return tuple(lines)
+
+
+@beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Nim(metaclass=LanguageCls):
     """Nim language specification.
@@ -692,6 +745,8 @@ class Nim(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Nim call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -803,6 +858,7 @@ class Nim(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     heterogeneous_value_variant_name: str = "Value"
+    call_style: CallStyles = CallStyles.POSITIONAL
     indent: str = "    "
 
     def __post_init__(self) -> None:
@@ -840,9 +896,11 @@ class Nim(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -953,7 +1011,7 @@ class Nim(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return partial(_nim_call_stub, indent=self.indent)
 
     @cached_property
     def format_call_preamble_stub(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -411,28 +411,60 @@ def _nim_call_stub(
 ) -> tuple[str, ...]:
     """Return Nim stub declarations for a call name.
 
-    For a single-part name a top-level proc with a varargs parameter is
-    emitted.  For dotted names object types are built bottom-up so that
-    Nim's Uniform Function Call Syntax lets the caller write
+    VOID stubs use templates with ``varargs[untyped]``.  VALUE stubs use
+    generic procs with ``{.discardable.}`` because templates do not
+    support that pragma in Nim 2.x, and calling a value-returning
+    template at statement level raises a compiler error without it.
+
+    For single-part names the stub is emitted at module scope.  For
+    dotted names object types are built bottom-up so that Nim's Uniform
+    Function Call Syntax lets the caller write
     ``app.client.fetch(x)`` as sugar for ``fetch(app.client, x)``.
     """
     method = parts[-1]
+
     if stub_return is StubReturn.VOID:
-        return_clause = ""
-        body = "discard"
-    else:
-        return_clause = ": untyped {.discardable.}"
-        body = "0"
-    if len(parts) == 1:
-        tmpl = (
-            f"template {method}(args: varargs[untyped])"
-            f"{return_clause} = {body}"
+        if len(parts) == 1:
+            return (f"template {method}(args: varargs[untyped]) = discard",)
+        chain = list(parts[:-1])
+        holder = chain[-1]
+        holder_type = f"{holder.title()}Type"
+        lines: list[str] = [f"type {holder_type} = object"]
+        for i in range(len(chain) - 2, -1, -1):
+            outer = chain[i]
+            inner = chain[i + 1]
+            inner_type = f"{inner.title()}Type"
+            outer_type = f"{outer.title()}Type"
+            lines.extend(
+                [
+                    f"type {outer_type} = object",
+                    f"{indent}{inner}: {inner_type}",
+                ]
+            )
+        lines.append(
+            f"template {method}(self: {holder_type};"
+            f" args: varargs[untyped]) = discard"
         )
-        return (tmpl,)
+        root = chain[0]
+        root_type = f"{root.title()}Type"
+        lines.append(f"var {root}: {root_type}")
+        return tuple(lines)
+
+    # VALUE: generic procs so {.discardable.} is valid
+    type_params = [f"T{i}" for i in range(len(_params))]
+    type_clause = f"[{', '.join(type_params)}]" if type_params else ""
+    if len(parts) == 1:
+        params_str = "; ".join(
+            f"{p}: {t}" for p, t in zip(_params, type_params, strict=True)
+        )
+        return (
+            f"proc {method}{type_clause}"
+            f"({params_str}): int {{.discardable.}} = 0",
+        )
     chain = list(parts[:-1])
     holder = chain[-1]
     holder_type = f"{holder.title()}Type"
-    lines: list[str] = [f"type {holder_type} = object"]
+    lines = [f"type {holder_type} = object"]
     for i in range(len(chain) - 2, -1, -1):
         outer = chain[i]
         inner = chain[i + 1]
@@ -444,11 +476,18 @@ def _nim_call_stub(
                 f"{indent}{inner}: {inner_type}",
             ]
         )
-    tmpl_sig = (
-        f"template {method}(self: {holder_type};"
-        f" args: varargs[untyped]){return_clause} = {body}"
+    params_str = "; ".join(
+        f"{p}: {t}" for p, t in zip(_params, type_params, strict=True)
     )
-    lines.append(tmpl_sig)
+    self_and_params = (
+        f"self: {holder_type}; {params_str}"
+        if params_str
+        else f"self: {holder_type}"
+    )
+    lines.append(
+        f"proc {method}{type_clause}"
+        f"({self_and_params}): int {{.discardable.}} = 0"
+    )
     root = chain[0]
     root_type = f"{root.title()}Type"
     lines.append(f"var {root}: {root_type}")

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -425,17 +425,17 @@ def _nim_call_stub(
         body = "0"
     if len(parts) == 1:
         return (
-            f"proc {method}(_args: varargs[untyped]){return_clause} = {body}",
+            f"proc {method}(args: varargs[untyped]){return_clause} = {body}",
         )
     chain = list(parts[:-1])
     holder = chain[-1]
-    holder_type = f"{holder.title()}Type_"
+    holder_type = f"{holder.title()}Type"
     lines: list[str] = [f"type {holder_type} = object"]
     for i in range(len(chain) - 2, -1, -1):
         outer = chain[i]
         inner = chain[i + 1]
-        inner_type = f"{inner.title()}Type_"
-        outer_type = f"{outer.title()}Type_"
+        inner_type = f"{inner.title()}Type"
+        outer_type = f"{outer.title()}Type"
         lines.extend(
             [
                 f"type {outer_type} = object",
@@ -444,11 +444,11 @@ def _nim_call_stub(
         )
     proc_sig = (
         f"proc {method}(self: {holder_type};"
-        f" _args: varargs[untyped]){return_clause} = {body}"
+        f" args: varargs[untyped]){return_clause} = {body}"
     )
     lines.append(proc_sig)
     root = chain[0]
-    root_type = f"{root.title()}Type_"
+    root_type = f"{root.title()}Type"
     lines.append(f"var {root}: {root_type}")
     return tuple(lines)
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -421,7 +421,7 @@ def _nim_call_stub(
         return_clause = ""
         body = "discard"
     else:
-        return_clause = ": untyped"
+        return_clause = ": untyped {.discardable.}"
         body = "0"
     if len(parts) == 1:
         tmpl = (
@@ -1021,6 +1021,19 @@ class Nim(metaclass=LanguageCls):
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
         return no_call_stub
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """No data-dependent preamble for call context.
+
+        Nim's ``data_dependent_preamble`` adds ``import json`` for
+        variable declarations that use ``%*``.  Call arguments are
+        formatted as inline literals and never use ``%*``, so
+        ``import json`` is never needed in a call context.
+        """
+        return no_data_preamble
 
     @cached_property
     def format_call_target(self) -> Callable[[Sequence[str]], str]:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -412,13 +412,14 @@ def _nim_call_stub(
     """Return Nim stub declarations for a call name.
 
     VOID stubs use templates with ``varargs[untyped]``.  VALUE stubs use
-    generic procs with ``{.discardable.}`` because templates do not
-    support that pragma in Nim 2.x, and calling a value-returning
-    template at statement level raises a compiler error without it.
+    generic ``proc`` definitions with ``{.discardable.}`` because the
+    ``{.discardable.}`` pragma is not valid on templates in Nim 2.x, and
+    calling a value-returning template at statement level raises a
+    compiler error without it.
 
     For single-part names the stub is emitted at module scope.  For
-    dotted names object types are built bottom-up so that Nim's Uniform
-    Function Call Syntax lets the caller write
+    dotted names object types are built bottom-up so that the Uniform
+    Function Call Syntax of Nim lets the caller write
     ``app.client.fetch(x)`` as sugar for ``fetch(app.client, x)``.
     """
     method = parts[-1]
@@ -450,7 +451,7 @@ def _nim_call_stub(
         lines.append(f"var {root}: {root_type}")
         return tuple(lines)
 
-    # VALUE: generic procs so {.discardable.} is valid
+    # VALUE: use a generic proc instead of a template
     type_params = [f"T{i}" for i in range(len(_params))]
     type_clause = f"[{', '.join(type_params)}]" if type_params else ""
     if len(parts) == 1:
@@ -1067,10 +1068,10 @@ class Nim(metaclass=LanguageCls):
     ) -> Callable[[Value], tuple[str, ...]]:
         """No data-dependent preamble for call context.
 
-        Nim's ``data_dependent_preamble`` adds ``import json`` for
-        variable declarations that use ``%*``.  Call arguments are
-        formatted as inline literals and never use ``%*``, so
-        ``import json`` is never needed in a call context.
+        The ``data_dependent_preamble`` method of Nim adds
+        ``import json`` for variable declarations that use ``%*``.
+        Call arguments are formatted as inline literals and never use
+        ``%*``, so ``import json`` is never needed in a call context.
         """
         return no_data_preamble
 

--- a/tests/integration/cases/call_deep_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_method/Nim_call.nim
@@ -1,10 +1,10 @@
-type ClientType_ = object
-type ApiType_ = object
-    client: ClientType_
-type ObjType_ = object
-    api: ApiType_
-proc post(self: ClientType_; _args: varargs[untyped]) = discard
-var obj: ObjType_
+type ClientType = object
+type ApiType = object
+    client: ClientType
+type ObjType = object
+    api: ApiType
+proc post(self: ClientType; args: varargs[untyped]) = discard
+var obj: ObjType
 obj.api.client.post("hello")
 obj.api.client.post(42)
 obj.api.client.post(true)

--- a/tests/integration/cases/call_deep_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_method/Nim_call.nim
@@ -3,7 +3,7 @@ type ApiType = object
     client: ClientType
 type ObjType = object
     api: ApiType
-proc post(self: ClientType; args: varargs[untyped]) = discard
+template post(self: ClientType; args: varargs[untyped]) = discard
 var obj: ObjType
 obj.api.client.post("hello")
 obj.api.client.post(42)

--- a/tests/integration/cases/call_deep_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_method/Nim_call.nim
@@ -1,0 +1,10 @@
+type ClientType_ = object
+type ApiType_ = object
+    client: ClientType_
+type ObjType_ = object
+    api: ApiType_
+proc post(self: ClientType_; _args: varargs[untyped]) = discard
+var obj: ObjType_
+obj.api.client.post("hello")
+obj.api.client.post(42)
+obj.api.client.post(true)

--- a/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
@@ -1,7 +1,7 @@
 type ClientType = object
 type AppType = object
     client: ClientType
-template fetch(self: ClientType; args: varargs[untyped]): untyped = 0
+template fetch(self: ClientType; args: varargs[untyped]): untyped {.discardable.} = 0
 var app: AppType
 template emit(args: varargs[untyped]) = discard
 emit(app.client.fetch("hello"))

--- a/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
@@ -1,0 +1,9 @@
+type ClientType_ = object
+type AppType_ = object
+    client: ClientType_
+proc fetch(self: ClientType_; _args: varargs[untyped]): untyped = 0
+var app: AppType_
+proc emit(_args: varargs[untyped]) = discard
+emit(app.client.fetch("hello"))
+emit(app.client.fetch(42))
+emit(app.client.fetch(true))

--- a/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
@@ -1,7 +1,7 @@
 type ClientType = object
 type AppType = object
     client: ClientType
-template fetch(self: ClientType; args: varargs[untyped]): untyped {.discardable.} = 0
+proc fetch[T0](self: ClientType; payload: T0): int {.discardable.} = 0
 var app: AppType
 template emit(args: varargs[untyped]) = discard
 emit(app.client.fetch("hello"))

--- a/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
@@ -1,9 +1,9 @@
-type ClientType_ = object
-type AppType_ = object
-    client: ClientType_
-proc fetch(self: ClientType_; _args: varargs[untyped]): untyped = 0
-var app: AppType_
-proc emit(_args: varargs[untyped]) = discard
+type ClientType = object
+type AppType = object
+    client: ClientType
+proc fetch(self: ClientType; args: varargs[untyped]): untyped = 0
+var app: AppType
+proc emit(args: varargs[untyped]) = discard
 emit(app.client.fetch("hello"))
 emit(app.client.fetch(42))
 emit(app.client.fetch(true))

--- a/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
+++ b/tests/integration/cases/call_deep_dotted_transformed/Nim_call.nim
@@ -1,9 +1,9 @@
 type ClientType = object
 type AppType = object
     client: ClientType
-proc fetch(self: ClientType; args: varargs[untyped]): untyped = 0
+template fetch(self: ClientType; args: varargs[untyped]): untyped = 0
 var app: AppType
-proc emit(args: varargs[untyped]) = discard
+template emit(args: varargs[untyped]) = discard
 emit(app.client.fetch("hello"))
 emit(app.client.fetch(42))
 emit(app.client.fetch(true))

--- a/tests/integration/cases/call_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_dotted_method/Nim_call.nim
@@ -1,7 +1,7 @@
 type ClientType = object
 type AppType = object
     client: ClientType
-proc fetch(self: ClientType; args: varargs[untyped]) = discard
+template fetch(self: ClientType; args: varargs[untyped]) = discard
 var app: AppType
 app.client.fetch("hello")
 app.client.fetch(42)

--- a/tests/integration/cases/call_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_dotted_method/Nim_call.nim
@@ -1,8 +1,8 @@
-type ClientType_ = object
-type AppType_ = object
-    client: ClientType_
-proc fetch(self: ClientType_; _args: varargs[untyped]) = discard
-var app: AppType_
+type ClientType = object
+type AppType = object
+    client: ClientType
+proc fetch(self: ClientType; args: varargs[untyped]) = discard
+var app: AppType
 app.client.fetch("hello")
 app.client.fetch(42)
 app.client.fetch(true)

--- a/tests/integration/cases/call_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_dotted_method/Nim_call.nim
@@ -1,0 +1,8 @@
+type ClientType_ = object
+type AppType_ = object
+    client: ClientType_
+proc fetch(self: ClientType_; _args: varargs[untyped]) = discard
+var app: AppType_
+app.client.fetch("hello")
+app.client.fetch(42)
+app.client.fetch(true)

--- a/tests/integration/cases/call_keyword_args/Nim_call.nim
+++ b/tests/integration/cases/call_keyword_args/Nim_call.nim
@@ -1,0 +1,7 @@
+import json
+type ThrottlerType_ = object
+proc check(self: ThrottlerType_; _args: varargs[untyped]): untyped = 0
+var throttler: ThrottlerType_
+proc emit(_args: varargs[untyped]) = discard
+emit(throttler.check("user_1", 1000.0))
+emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_keyword_args/Nim_call.nim
+++ b/tests/integration/cases/call_keyword_args/Nim_call.nim
@@ -1,7 +1,7 @@
 import json
 type ThrottlerType = object
-proc check(self: ThrottlerType; args: varargs[untyped]): untyped = 0
+template check(self: ThrottlerType; args: varargs[untyped]): untyped = 0
 var throttler: ThrottlerType
-proc emit(args: varargs[untyped]) = discard
+template emit(args: varargs[untyped]) = discard
 emit(throttler.check("user_1", 1000.0))
 emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_keyword_args/Nim_call.nim
+++ b/tests/integration/cases/call_keyword_args/Nim_call.nim
@@ -1,5 +1,5 @@
 type ThrottlerType = object
-template check(self: ThrottlerType; args: varargs[untyped]): untyped {.discardable.} = 0
+proc check[T0, T1](self: ThrottlerType; user_id: T0; ts: T1): int {.discardable.} = 0
 var throttler: ThrottlerType
 template emit(args: varargs[untyped]) = discard
 emit(throttler.check("user_1", 1000.0))

--- a/tests/integration/cases/call_keyword_args/Nim_call.nim
+++ b/tests/integration/cases/call_keyword_args/Nim_call.nim
@@ -1,7 +1,7 @@
 import json
-type ThrottlerType_ = object
-proc check(self: ThrottlerType_; _args: varargs[untyped]): untyped = 0
-var throttler: ThrottlerType_
-proc emit(_args: varargs[untyped]) = discard
+type ThrottlerType = object
+proc check(self: ThrottlerType; args: varargs[untyped]): untyped = 0
+var throttler: ThrottlerType
+proc emit(args: varargs[untyped]) = discard
 emit(throttler.check("user_1", 1000.0))
 emit(throttler.check("user_2", 2000.5))

--- a/tests/integration/cases/call_keyword_args/Nim_call.nim
+++ b/tests/integration/cases/call_keyword_args/Nim_call.nim
@@ -1,6 +1,5 @@
-import json
 type ThrottlerType = object
-template check(self: ThrottlerType; args: varargs[untyped]): untyped = 0
+template check(self: ThrottlerType; args: varargs[untyped]): untyped {.discardable.} = 0
 var throttler: ThrottlerType
 template emit(args: varargs[untyped]) = discard
 emit(throttler.check("user_1", 1000.0))

--- a/tests/integration/cases/call_multi_args/Nim_call.nim
+++ b/tests/integration/cases/call_multi_args/Nim_call.nim
@@ -1,4 +1,4 @@
 import json
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 process(1, 42)
 process(2, 100)

--- a/tests/integration/cases/call_multi_args/Nim_call.nim
+++ b/tests/integration/cases/call_multi_args/Nim_call.nim
@@ -1,0 +1,4 @@
+import json
+proc process(_args: varargs[untyped]) = discard
+process(1, 42)
+process(2, 100)

--- a/tests/integration/cases/call_multi_args/Nim_call.nim
+++ b/tests/integration/cases/call_multi_args/Nim_call.nim
@@ -1,4 +1,3 @@
-import json
 template process(args: varargs[untyped]) = discard
 process(1, 42)
 process(2, 100)

--- a/tests/integration/cases/call_multi_args/Nim_call.nim
+++ b/tests/integration/cases/call_multi_args/Nim_call.nim
@@ -1,4 +1,4 @@
 import json
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 process(1, 42)
 process(2, 100)

--- a/tests/integration/cases/call_per_element_false/Nim_call.nim
+++ b/tests/integration/cases/call_per_element_false/Nim_call.nim
@@ -1,3 +1,3 @@
 import json
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 process(1)

--- a/tests/integration/cases/call_per_element_false/Nim_call.nim
+++ b/tests/integration/cases/call_per_element_false/Nim_call.nim
@@ -1,3 +1,2 @@
-import json
 template process(args: varargs[untyped]) = discard
 process(1)

--- a/tests/integration/cases/call_per_element_false/Nim_call.nim
+++ b/tests/integration/cases/call_per_element_false/Nim_call.nim
@@ -1,3 +1,3 @@
 import json
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 process(1)

--- a/tests/integration/cases/call_per_element_false/Nim_call.nim
+++ b/tests/integration/cases/call_per_element_false/Nim_call.nim
@@ -1,0 +1,3 @@
+import json
+proc process(_args: varargs[untyped]) = discard
+process(1)

--- a/tests/integration/cases/call_ref_args/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args/Nim_call.nim
@@ -1,4 +1,3 @@
-import json
 template process(args: varargs[untyped]) = discard
 var my_var = @[
     1,

--- a/tests/integration/cases/call_ref_args/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args/Nim_call.nim
@@ -1,0 +1,14 @@
+import json
+proc process(_args: varargs[untyped]) = discard
+var my_var = @[
+    1,
+    2,
+    3
+]
+var my_other = @[
+    4,
+    5,
+    6
+]
+process(my_var, 42)
+process(my_other, 7)

--- a/tests/integration/cases/call_ref_args/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 var my_var = @[
     1,
     2,

--- a/tests/integration/cases/call_ref_args/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 var my_var = @[
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted/Nim_call.nim
@@ -1,0 +1,14 @@
+import json
+proc process(_args: varargs[untyped]) = discard
+var myVar = @[
+    1,
+    2,
+    3
+]
+var myOther = @[
+    4,
+    5,
+    6
+]
+process(myVar, 42)
+process(myOther, 7)

--- a/tests/integration/cases/call_ref_args_converted/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted/Nim_call.nim
@@ -1,4 +1,3 @@
-import json
 template process(args: varargs[untyped]) = discard
 var myVar = @[
     1,

--- a/tests/integration/cases/call_ref_args_converted/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 var myVar = @[
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 var myVar = @[
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
@@ -1,0 +1,14 @@
+import json
+proc process(_args: varargs[untyped]) = discard
+var myVar = @[
+    1,
+    2,
+    3
+]
+var myOther = @[
+    4,
+    5,
+    6
+]
+process(myVar, 42)
+process(myOther, 7)

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
@@ -1,4 +1,3 @@
-import json
 template process(args: varargs[untyped]) = discard
 var myVar = @[
     1,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 var myVar = @[
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 var myVar = @[
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
@@ -1,0 +1,8 @@
+import json
+proc process(_args: varargs[untyped]) = discard
+var myVar = @[
+    1,
+    2,
+    3
+]
+process(myVar)

--- a/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
@@ -1,4 +1,3 @@
-import json
 template process(args: varargs[untyped]) = discard
 var myVar = @[
     1,

--- a/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 var myVar = @[
     1,
     2,

--- a/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_converted_whole/Nim_call.nim
@@ -1,5 +1,5 @@
 import json
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 var myVar = @[
     1,
     2,

--- a/tests/integration/cases/call_scalar_args/Nim_call.nim
+++ b/tests/integration/cases/call_scalar_args/Nim_call.nim
@@ -1,4 +1,4 @@
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 process("hello")
 process(42)
 process(true)

--- a/tests/integration/cases/call_scalar_args/Nim_call.nim
+++ b/tests/integration/cases/call_scalar_args/Nim_call.nim
@@ -1,0 +1,4 @@
+proc process(_args: varargs[untyped]) = discard
+process("hello")
+process(42)
+process(true)

--- a/tests/integration/cases/call_scalar_args/Nim_call.nim
+++ b/tests/integration/cases/call_scalar_args/Nim_call.nim
@@ -1,4 +1,4 @@
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 process("hello")
 process(42)
 process(true)

--- a/tests/integration/cases/call_snake_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_snake_dotted_method/Nim_call.nim
@@ -1,0 +1,8 @@
+type Http_ClientType_ = object
+type My_AppType_ = object
+    http_client: Http_ClientType_
+proc fetch(self: Http_ClientType_; _args: varargs[untyped]) = discard
+var my_app: My_AppType_
+my_app.http_client.fetch("hello")
+my_app.http_client.fetch(42)
+my_app.http_client.fetch(true)

--- a/tests/integration/cases/call_snake_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_snake_dotted_method/Nim_call.nim
@@ -1,7 +1,7 @@
 type Http_ClientType = object
 type My_AppType = object
     http_client: Http_ClientType
-proc fetch(self: Http_ClientType; args: varargs[untyped]) = discard
+template fetch(self: Http_ClientType; args: varargs[untyped]) = discard
 var my_app: My_AppType
 my_app.http_client.fetch("hello")
 my_app.http_client.fetch(42)

--- a/tests/integration/cases/call_snake_dotted_method/Nim_call.nim
+++ b/tests/integration/cases/call_snake_dotted_method/Nim_call.nim
@@ -1,8 +1,8 @@
-type Http_ClientType_ = object
-type My_AppType_ = object
-    http_client: Http_ClientType_
-proc fetch(self: Http_ClientType_; _args: varargs[untyped]) = discard
-var my_app: My_AppType_
+type Http_ClientType = object
+type My_AppType = object
+    http_client: Http_ClientType
+proc fetch(self: Http_ClientType; args: varargs[untyped]) = discard
+var my_app: My_AppType
 my_app.http_client.fetch("hello")
 my_app.http_client.fetch(42)
 my_app.http_client.fetch(true)

--- a/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
+++ b/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
@@ -1,4 +1,4 @@
-template process(args: varargs[untyped]): untyped = 0
+template process(args: varargs[untyped]): untyped {.discardable.} = 0
 process("hello")
 process(42)
 process(true)

--- a/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
+++ b/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
@@ -1,0 +1,4 @@
+proc process(_args: varargs[untyped]): untyped = 0
+process("hello")
+process(42)
+process(true)

--- a/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
+++ b/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
@@ -1,4 +1,4 @@
-proc process(_args: varargs[untyped]): untyped = 0
+proc process(args: varargs[untyped]): untyped = 0
 process("hello")
 process(42)
 process(true)

--- a/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
+++ b/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
@@ -1,4 +1,4 @@
-template process(args: varargs[untyped]): untyped {.discardable.} = 0
+proc process[T0](value: T0): int {.discardable.} = 0
 process("hello")
 process(42)
 process(true)

--- a/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
+++ b/tests/integration/cases/call_transform_no_wrapper/Nim_call.nim
@@ -1,4 +1,4 @@
-proc process(args: varargs[untyped]): untyped = 0
+template process(args: varargs[untyped]): untyped = 0
 process("hello")
 process(42)
 process(true)

--- a/tests/integration/cases/call_wrap_in_file/Nim_call.nim
+++ b/tests/integration/cases/call_wrap_in_file/Nim_call.nim
@@ -1,4 +1,4 @@
 import json
-proc process(_args: varargs[untyped]) = discard
+proc process(args: varargs[untyped]) = discard
 process(1, 2)
 process(3, 4)

--- a/tests/integration/cases/call_wrap_in_file/Nim_call.nim
+++ b/tests/integration/cases/call_wrap_in_file/Nim_call.nim
@@ -1,0 +1,4 @@
+import json
+proc process(_args: varargs[untyped]) = discard
+process(1, 2)
+process(3, 4)

--- a/tests/integration/cases/call_wrap_in_file/Nim_call.nim
+++ b/tests/integration/cases/call_wrap_in_file/Nim_call.nim
@@ -1,4 +1,4 @@
 import json
-proc process(args: varargs[untyped]) = discard
+template process(args: varargs[untyped]) = discard
 process(1, 2)
 process(3, 4)

--- a/tests/integration/cases/call_wrap_in_file/Nim_call.nim
+++ b/tests/integration/cases/call_wrap_in_file/Nim_call.nim
@@ -1,4 +1,3 @@
-import json
 template process(args: varargs[untyped]) = discard
 process(1, 2)
 process(3, 4)


### PR DESCRIPTION
## Summary

- Implements `_nim_call_stub` using Nim's Uniform Function Call Syntax: single-part names emit a top-level proc with `varargs`, dotted names build object types bottom-up so `app.client.fetch(x)` is valid Nim sugar for `fetch(app.client, x)`
- Adds `POSITIONAL` to `Nim.CallStyles`, a `call_style` dataclass field, and converts `call_style_config` from a `ClassVar` stub to a `@cached_property`
- Adds 14 golden test files covering all applicable call test cases (heterogeneous-dict case correctly skipped by the ERROR strategy)

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tweaks shared `literalize_call` preamble construction (new optional `call_data_dependent_preamble` hook) and adds new Nim call-stub generation logic that could affect generated code validity.
> 
> **Overview**
> Enables `literalize_call` for Nim by implementing Nim-specific call stubs (`_nim_call_stub`) that support both simple and dotted call targets (via UFCS-style `template` stubs and generated holder object chains).
> 
> Updates `literalize_call` to prefer a language-provided `call_data_dependent_preamble` (falling back to `data_dependent_preamble`), and adds a Nim implementation that suppresses call-context imports.
> 
> Adds Nim golden integration outputs covering scalar, multi-arg, ref-arg, transformed, and deep-dotted call cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566b2a756b100a33a2933f614bd9db998c331837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->