### PR TITLE
Replace bare NotImplementedError and remove unenforced supports_non_printable_ascii_dict_keys

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -495,7 +495,6 @@ class LanguageCls(type):
     supports_default_dict_value_type: bool
     supports_default_dict_key_type: bool
     supports_default_ordered_map_value_type: bool
-    supports_non_printable_ascii_dict_keys: bool
     supports_special_floats: bool
     supports_variable_names: bool
     supports_dotted_calls: bool

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -188,3 +188,14 @@ class UnsupportedIdentifierCaseError(Exception):
         )
         self.language_name = language_name
         self.case_name = case_name
+
+
+class WrapCombinedInFileNotSupportedError(Exception):
+    """Raised when a language does not support ``wrap_combined_in_file``.
+
+    Languages that raise this error do not support
+    :class:`~literalizer.BothVariableForms`; ``literalize()`` rejects
+    that form before reaching ``wrap_combined_in_file``, but each
+    language implementation still raises this typed exception as a
+    safety net.
+    """

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -167,7 +167,6 @@ class Ada(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -147,7 +147,6 @@ class Bash(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -214,7 +214,6 @@ class C(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -100,7 +100,6 @@ class Clojure(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -277,7 +277,6 @@ class Cobol(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -118,7 +118,6 @@ class CommonLisp(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -863,7 +863,6 @@ class Cpp(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -170,7 +170,6 @@ class Crystal(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -353,7 +353,6 @@ class CSharp(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -156,7 +156,6 @@ class D(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -75,7 +75,10 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
-from literalizer.exceptions import IncompatibleFormatsError
+from literalizer.exceptions import (
+    IncompatibleFormatsError,
+    WrapCombinedInFileNotSupportedError,
+)
 
 
 @beartype
@@ -271,7 +274,6 @@ class Dart(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -636,7 +638,7 @@ class Dart(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.DART
     datetime_format: DatetimeFormats = DatetimeFormats.DART

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -67,6 +67,7 @@ from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
     CallArgNotSupportedError,
     InvalidDictKeyError,
+    WrapCombinedInFileNotSupportedError,
 )
 
 _IDENTIFIER_RE = re.compile(pattern=r"^[A-Za-z_][A-Za-z0-9_/\-]*$")
@@ -516,7 +517,6 @@ class Dhall(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = False
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -786,7 +786,7 @@ class Dhall(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -196,7 +197,6 @@ class Elixir(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -510,7 +510,7 @@ class Elixir(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -488,7 +489,6 @@ class Elm(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -772,7 +772,7 @@ class Elm(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -190,7 +191,6 @@ class Erlang(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -467,7 +467,7 @@ class Erlang(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -190,7 +190,6 @@ class Forth(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -241,7 +241,6 @@ class Fortran(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -250,7 +250,6 @@ class FSharp(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -504,7 +504,6 @@ class Gleam(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = False
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -253,7 +253,6 @@ class Go(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = True
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -133,7 +133,6 @@ class Groovy(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -66,6 +66,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -928,7 +929,6 @@ class Haskell(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -1262,7 +1262,7 @@ class Haskell(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.HASKELL
     datetime_format: DatetimeFormats = DatetimeFormats.HASKELL

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 _HCL_DECLARATION_PATTERN = re.compile(pattern=r"^\s*[A-Za-z_]\w*\s*=")
 
@@ -136,7 +137,6 @@ class Hcl(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = False
@@ -392,7 +392,7 @@ class Hcl(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -569,7 +569,6 @@ class Java(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -120,7 +120,6 @@ class JavaScript(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -63,6 +63,7 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -110,7 +111,6 @@ class Json5(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
@@ -335,7 +335,7 @@ class Json5(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -126,7 +127,6 @@ class Jsonnet(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
@@ -391,7 +391,7 @@ class Jsonnet(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -148,7 +148,6 @@ class Julia(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -424,7 +424,6 @@ class Kotlin(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -134,7 +134,6 @@ class Lua(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -201,7 +201,6 @@ class Matlab(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -381,7 +381,6 @@ class Mojo(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -429,7 +429,6 @@ class Nim(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -64,7 +64,10 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
-from literalizer.exceptions import InvalidDictKeyError
+from literalizer.exceptions import (
+    InvalidDictKeyError,
+    WrapCombinedInFileNotSupportedError,
+)
 
 _IDENTIFIER_RE = re.compile(pattern=r"^[A-Za-z_][A-Za-z0-9_'-]*$")
 
@@ -178,7 +181,6 @@ class Nix(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = False
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -404,7 +406,7 @@ class Nix(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -84,7 +85,6 @@ class Norg(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -310,7 +310,7 @@ class Norg(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -262,7 +262,6 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -71,6 +71,7 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -200,7 +201,6 @@ class OCaml(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -488,7 +488,7 @@ class OCaml(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.OCAML
     datetime_format: DatetimeFormats = DatetimeFormats.OCAML

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -94,7 +95,6 @@ class Occam(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -335,7 +335,7 @@ class Occam(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -68,6 +68,7 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -204,7 +205,6 @@ class Odin(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -480,7 +480,7 @@ class Odin(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -144,7 +144,6 @@ class Perl(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -143,7 +143,6 @@ class Php(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -159,7 +159,6 @@ class PowerShell(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -66,7 +66,10 @@ from literalizer._language import (
     no_validate_spec_for_data,
 )
 from literalizer._types import Value
-from literalizer.exceptions import UnrepresentableIntegerError
+from literalizer.exceptions import (
+    UnrepresentableIntegerError,
+    WrapCombinedInFileNotSupportedError,
+)
 
 
 @beartype
@@ -500,7 +503,6 @@ class PureScript(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -738,7 +740,7 @@ class PureScript(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -516,7 +516,6 @@ class Python(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -158,7 +158,6 @@ class R(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -101,7 +101,6 @@ class Racket(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -177,7 +177,6 @@ class Raku(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -154,7 +154,6 @@ class Ruby(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -682,7 +682,6 @@ class Rust(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -204,7 +204,6 @@ class Scala(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -97,7 +97,6 @@ class Scheme(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -288,7 +289,6 @@ class Sml(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -553,7 +553,7 @@ class Sml(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.SML
     datetime_format: DatetimeFormats = DatetimeFormats.SML

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -321,7 +321,6 @@ class Swift(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -156,7 +156,6 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -142,7 +142,6 @@ class Tcl(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -110,7 +111,6 @@ class Toml(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
@@ -342,7 +342,7 @@ class Toml(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.TOML
     datetime_format: DatetimeFormats = DatetimeFormats.TOML

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -240,7 +240,6 @@ class TypeScript(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -222,7 +222,6 @@ class V(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -259,7 +259,6 @@ class VisualBasic(metaclass=LanguageCls):
     supports_default_dict_value_type = True
     supports_default_dict_key_type = True
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -86,7 +86,6 @@ class Wren(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
@@ -86,7 +87,6 @@ class Yaml(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
@@ -318,7 +318,7 @@ class Yaml(metaclass=LanguageCls):
         upstream.
         """
         del declaration, assignment, variable_name, body_preamble
-        raise NotImplementedError
+        raise WrapCombinedInFileNotSupportedError
 
     date_format: DateFormats = DateFormats.YAML
     datetime_format: DatetimeFormats = DatetimeFormats.YAML

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -228,7 +228,6 @@ class Zig(metaclass=LanguageCls):
     supports_default_dict_value_type = False
     supports_default_dict_key_type = False
     supports_default_ordered_map_value_type = False
-    supports_non_printable_ascii_dict_keys = True
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True

--- a/tests/integration/case_discovery.py
+++ b/tests/integration/case_discovery.py
@@ -15,6 +15,7 @@ from beartype import beartype
 from ruamel.yaml import YAML
 
 import literalizer
+from literalizer.exceptions import InvalidDictKeyError
 
 from .call_cases import CALL_CASE_CONFIGS
 from .language_specs import (
@@ -22,6 +23,28 @@ from .language_specs import (
     make_spec,
     sorted_languages,
 )
+
+
+@functools.cache
+def _lang_raises_for_non_printable_ascii_dict_keys(
+    lang_cls: literalizer.LanguageCls,
+) -> bool:
+    """Return ``True`` if the language raises :exc:`InvalidDictKeyError`
+    for a dict key containing a non-printable ASCII character.
+
+    Used to skip golden-file cases whose input contains such keys for
+    languages whose contract is to raise :exc:`InvalidDictKeyError` for
+    those inputs rather than produce rendered output.
+    """
+    try:
+        literalizer.literalize(
+            source='{"key\\u0001": 1}',
+            input_format=literalizer.InputFormat.JSON,
+            language=lang_cls(),
+        )
+    except InvalidDictKeyError:
+        return True
+    return False
 
 
 @beartype
@@ -123,9 +146,8 @@ def discover_cases(
         non_trivial = case_dir.name in non_trivial_key_cases
         special_float = case_dir.name in special_float_cases
         for lang_cls in sorted_languages():
-            if (
-                non_trivial
-                and not lang_cls.supports_non_printable_ascii_dict_keys
+            if non_trivial and _lang_raises_for_non_printable_ascii_dict_keys(
+                lang_cls
             ):
                 continue
             if special_float and not lang_cls.supports_special_floats:
@@ -187,9 +209,8 @@ def discover_combined_cases(cases_dir: Path) -> list[CombinedCase]:
         special_float = case_dir.name in special_float_cases
         for lang_cls in sorted_languages():
             lang_name = lang_cls.__name__
-            if (
-                non_trivial
-                and not lang_cls.supports_non_printable_ascii_dict_keys
+            if non_trivial and _lang_raises_for_non_printable_ascii_dict_keys(
+                lang_cls
             ):
                 continue
             if special_float and not lang_cls.supports_special_floats:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -36,6 +36,7 @@ from literalizer.exceptions import (
     PerElementNotListError,
     UnrepresentableSpecialFloatError,
     UnsupportedIdentifierCaseError,
+    WrapCombinedInFileNotSupportedError,
 )
 from literalizer.languages import (
     Bash,
@@ -688,7 +689,7 @@ def test_wrap_combined_in_file_unsupported_raises(
     these languages before reaching ``wrap_combined_in_file``, but the
     method itself must still satisfy the :class:`Language` protocol.
     """
-    with pytest.raises(expected_exception=NotImplementedError):
+    with pytest.raises(expected_exception=WrapCombinedInFileNotSupportedError):
         language_cls().wrap_combined_in_file(
             declaration="x = 1",
             assignment="x = 2",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Issue #1776**: Add `WrapCombinedInFileNotSupportedError` to `exceptions.py` and replace the bare `raise NotImplementedError` in `wrap_combined_in_file` across 18 language files (dhall, toml, purescript, hcl, dart, jsonnet, occam, elixir, nix, yaml, odin, json5, norg, haskell, elm, erlang, ocaml, sml). Callers can now catch this specific typed exception rather than the overly broad `NotImplementedError`.

- **Issue #1777**: Remove `supports_non_printable_ascii_dict_keys` from `LanguageCls` and all 62 language implementations. Replace the flag-based skip in test discovery with a probe function (`_lang_raises_for_non_printable_ascii_dict_keys`) that calls `literalize` with a non-printable ASCII key and detects `InvalidDictKeyError` — making the exception the documented contract rather than a parallel declarative flag.

## Test plan

- [ ] `test_wrap_combined_in_file_unsupported_raises` now expects `WrapCombinedInFileNotSupportedError` (was `NotImplementedError`) — 18 parametrized cases pass
- [ ] All 515 unit tests pass
- [ ] Ruff and mypy/pyright/ty checks pass
- [ ] Integration test case discovery still correctly skips non-printable ASCII dict key cases for Dhall and Nix via the probe function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to widespread mechanical edits across many language specs and test-discovery logic, though behavior changes are limited to exception typing and how non-printable dict-key cases are skipped.
> 
> **Overview**
> Standardizes unsupported combined-variable wrapping by introducing `WrapCombinedInFileNotSupportedError` and updating languages that don’t support `wrap_combined_in_file` to raise it (instead of a bare `NotImplementedError`), along with adjusting the corresponding unit test expectation.
> 
> Removes `supports_non_printable_ascii_dict_keys` from `LanguageCls` and all language implementations, and updates integration golden-case discovery to *probe* each language via `literalize()` and skip cases based on whether it raises `InvalidDictKeyError` for non-printable ASCII dict keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09fe72dc1ffb82b66c46cee434d7ecbd82960ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->