### PR TITLE
Add CHANGELOG entry for PureScript literalize_call support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 Next
 ----
 
+- Added ``literalize_call`` support for ``PureScript``.
+  ``PureScript.CallStyles.COMMAND`` renders calls as space-separated
+  arguments (``process (PStr "hello") (PInt 1)``); each argument is
+  wrapped in parentheses so curried application parses correctly.
+  ``format_call_stub`` emits a type signature and a wildcard-binding
+  definition at module scope (e.g. ``process :: Val -> Unit`` /
+  ``process _ = unit``); dotted targets like ``app.client.fetch``
+  produce a nested record stub (``app :: { client :: { fetch :: Val ->
+  Unit } }``).  Call expressions are placed in a ``let ... in unit``
+  block inside a ``main :: Unit`` declaration.  PureScript is excluded
+  from the ``call_comments`` and ``call_comments_dict_args`` test cases
+  because its ``_ = ...`` binding prefix cannot accommodate a
+  standalone comment line in the wrapped output.
 - :func:`~literalizer.literalize` now accepts a ``ref_case`` parameter
   (:class:`~literalizer.IdentifierCase`).  When set, any
   ``{"$ref": "name"}`` mapping in the input data -- at the top level or


### PR DESCRIPTION
Closes #1139

## Summary

- Adds the missing CHANGELOG entry documenting `literalize_call` support for PureScript, which was implemented in #1760 but not recorded in the changelog.

## Test plan

- All 17 existing PureScript call golden-file tests continue to pass.
- No code changes; CHANGELOG only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates `CHANGELOG.rst` to document existing `literalize_call` support for PureScript, including its call rendering style, stub generation behavior, and noted test exclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192ef1afe3c09b8cc7e33915d18f35235db622f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->