### PR TITLE
Add function call rendering to SystemVerilog

### DIFF
--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime
 import enum
+import functools
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import ClassVar
@@ -151,6 +152,7 @@ def _sv_call_stub(
     params: Sequence[str],
     stub_return: StubReturn,
     /,
+    indent: str,
 ) -> tuple[str, ...]:
     """Return SystemVerilog stub declarations for a call expression.
 
@@ -166,7 +168,7 @@ def _sv_call_stub(
             return (f"task {name}({param_str}); endtask",)
         return (
             f"function _VVal {name}({param_str});\n"
-            f"    {name} = {_SV_NULL};\n"
+            f"{indent}{name} = {_SV_NULL};\n"
             f"endfunction",
         )
 
@@ -175,12 +177,12 @@ def _sv_call_stub(
     fields = list(parts[1:-1])
 
     if stub_return is StubReturn.VOID:
-        method_decl = f"    task {method}({param_str}); endtask"
+        method_decl = f"{indent}task {method}({param_str}); endtask"
     else:
         method_decl = (
-            f"    function _VVal {method}({param_str});\n"
-            f"        {method} = {_SV_NULL};\n"
-            f"    endfunction"
+            f"{indent}function _VVal {method}({param_str});\n"
+            f"{indent}{indent}{method} = {_SV_NULL};\n"
+            f"{indent}endfunction"
         )
 
     if not fields:
@@ -198,13 +200,15 @@ def _sv_call_stub(
         curr_type = f"{fields[i].title()}Type_"
         lines.append(
             f"class {curr_type};\n"
-            f"    {prev_type} {fields[i + 1]} = new();\n"
+            f"{indent}{prev_type} {fields[i + 1]} = new();\n"
             f"endclass"
         )
         prev_type = curr_type
     root_type = f"{root.title()}Type_"
     lines.append(
-        f"class {root_type};\n    {prev_type} {fields[0]} = new();\nendclass"
+        f"class {root_type};\n"
+        f"{indent}{prev_type} {fields[0]} = new();\n"
+        f"endclass"
     )
     lines.append(f"{root_type} {root} = new();")
     return tuple(lines)
@@ -585,7 +589,8 @@ class SystemVerilog(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return _sv_call_stub
+        indent = self.indent
+        return functools.partial(_sv_call_stub, indent=indent)
 
     @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -35,7 +35,6 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -46,6 +45,7 @@ from literalizer._language import (
     IdentifierCase,
     LanguageCls,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -140,6 +140,74 @@ def _format_variable_assignment(name: str, value: str, data: Value) -> str:
         return f"{name} = {value};"
     wrapped = _format_sv_entry(original=data, formatted=value)
     return f"{name} = {wrapped};"
+
+
+_SV_NULL = '_VVal\'{tag: _VVAL_STR, i: 0, r: 0.0, s: ""}'
+
+
+@beartype
+def _sv_call_stub(
+    parts: Sequence[str],
+    params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+) -> tuple[str, ...]:
+    """Return SystemVerilog stub declarations for a call expression.
+
+    VOID stubs emit a ``task``; VALUE stubs emit a ``function`` that
+    returns ``_VVal`` via the null literal.  Dotted names generate
+    nested class declarations with a module-level instance variable.
+    """
+    param_str = ", ".join(f"input _VVal {p}" for p in params)
+
+    if len(parts) == 1:
+        name = parts[0]
+        if stub_return is StubReturn.VOID:
+            return (f"task {name}({param_str}); endtask",)
+        return (
+            f"function _VVal {name}({param_str});\n"
+            f"    {name} = {_SV_NULL};\n"
+            f"endfunction",
+        )
+
+    method = parts[-1]
+    root = parts[0]
+    fields = list(parts[1:-1])
+
+    if stub_return is StubReturn.VOID:
+        method_decl = f"    task {method}({param_str}); endtask"
+    else:
+        method_decl = (
+            f"    function _VVal {method}({param_str});\n"
+            f"        {method} = {_SV_NULL};\n"
+            f"    endfunction"
+        )
+
+    if not fields:
+        type_name = f"{root.title()}Type_"
+        return (
+            f"class {type_name};\n{method_decl}\nendclass",
+            f"{type_name} {root} = new();",
+        )
+
+    lines: list[str] = []
+    inner_type = f"{fields[-1].title()}Type_"
+    lines.append(f"class {inner_type};\n{method_decl}\nendclass")
+    prev_type = inner_type
+    for i in range(len(fields) - 2, -1, -1):
+        curr_type = f"{fields[i].title()}Type_"
+        lines.append(
+            f"class {curr_type};\n"
+            f"    {prev_type} {fields[i + 1]} = new();\n"
+            f"endclass"
+        )
+        prev_type = curr_type
+    root_type = f"{root.title()}Type_"
+    lines.append(
+        f"class {root_type};\n    {prev_type} {fields[0]} = new();\nendclass"
+    )
+    lines.append(f"{root_type} {root} = new();")
+    return tuple(lines)
 
 
 @beartype
@@ -342,6 +410,8 @@ class SystemVerilog(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """SystemVerilog call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -373,12 +443,29 @@ class SystemVerilog(metaclass=LanguageCls):
         variable_name: str,
         body_preamble: tuple[str, ...],
     ) -> str:
-        """Wrap a SystemVerilog declaration in a module."""
-        del variable_name
-        content = prepend_body_preamble(
-            content=content,
-            body_preamble=body_preamble,
-        )
+        """Wrap a SystemVerilog declaration in a module.
+
+        In call mode (``variable_name`` is empty), *body_preamble* holds
+        task/function stubs that go at module scope outside
+        ``initial begin``.  In declaration mode, *body_preamble* is
+        prepended inside ``initial begin`` as usual.
+        """
+        if variable_name:
+            content = prepend_body_preamble(
+                content=content,
+                body_preamble=body_preamble,
+            )
+            return (
+                f"module {self.module_name};\n"
+                f"initial begin\n{content}\nend\nendmodule"
+            )
+        if body_preamble:
+            stubs = "\n".join(body_preamble)
+            return (
+                f"module {self.module_name};\n"
+                f"{stubs}\n"
+                f"initial begin\n{content}\nend\nendmodule"
+            )
         return (
             f"module {self.module_name};\n"
             f"initial begin\n{content}\nend\nendmodule"
@@ -421,6 +508,7 @@ class SystemVerilog(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    call_style: CallStyles = CallStyles.POSITIONAL
     indent: str = "    "
 
     null_literal: ClassVar[str] = (
@@ -440,23 +528,27 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_scalar_inline_comments: ClassVar[bool] = False
     statement_terminator: ClassVar[str] = ";"
     static_preamble: ClassVar[Sequence[str]] = (
-        "typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;",
-        "typedef struct {",
-        "    _VTag tag;",
-        "    longint i;",
-        "    real r;",
-        "    string s;",
-        "} _VVal;",
-        "typedef struct {",
-        "    string k;",
-        "    _VVal v;",
-        "} _VKV;",
+        (
+            "typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;\n"
+            "typedef struct {\n"
+            "    _VTag tag;\n"
+            "    longint i;\n"
+            "    real r;\n"
+            "    string s;\n"
+            "} _VVal;\n"
+            "typedef struct {\n"
+            "    string k;\n"
+            "    _VVal v;\n"
+            "} _VKV;"
+        ),
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -500,7 +592,12 @@ class SystemVerilog(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return _sv_call_stub
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Wrap each call argument in the ``_VVal`` struct literal."""
+        return _format_sv_entry
 
     @cached_property
     def format_call_preamble_stub(

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -455,19 +455,12 @@ class SystemVerilog(metaclass=LanguageCls):
                 content=content,
                 body_preamble=body_preamble,
             )
-            return (
-                f"module {self.module_name};\n"
-                f"initial begin\n{content}\nend\nendmodule"
-            )
-        if body_preamble:
-            stubs = "\n".join(body_preamble)
-            return (
-                f"module {self.module_name};\n"
-                f"{stubs}\n"
-                f"initial begin\n{content}\nend\nendmodule"
-            )
+            stubs_block = ""
+        else:
+            stubs_block = "".join(f"{s}\n" for s in body_preamble)
         return (
             f"module {self.module_name};\n"
+            f"{stubs_block}"
             f"initial begin\n{content}\nend\nendmodule"
         )
 

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -40,6 +40,7 @@ from literalizer.languages import (
     Raku,
     Roc,
     Sml,
+    SystemVerilog,
     Wren,
 )
 
@@ -395,7 +396,9 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # discarded: a function call cannot appear as a statement.  The
     # identity call_transform (lambda c: c) causes a VALUE stub but the
     # call is used as a bare statement, which both compilers reject.
-    "call_transform_no_wrapper": frozenset({Ada, Fortran}),
+    # SystemVerilog requires void'(...) to discard a function return value;
+    # a bare function call as a statement is non-standard.
+    "call_transform_no_wrapper": frozenset({Ada, Fortran, SystemVerilog}),
     # call_transform wraps output as "emit(inner)", which is invalid in
     # Wren: Wren has no free-function call syntax, so a bare call like
     # "name(value)" is a parse error at the top level.

--- a/tests/integration/cases/call_comments/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_comments/SystemVerilog_call.sv
@@ -1,0 +1,20 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal value); endtask
+initial begin
+// Test cases
+process(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello"});  // single word
+process(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello world"});  // two words
+// trailing comment
+end
+endmodule

--- a/tests/integration/cases/call_comments_dict_args/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_comments_dict_args/SystemVerilog_call.sv
@@ -1,0 +1,21 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal value); endtask
+initial begin
+// Test cases
+process(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "'{_VKV'{k: \"type\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"create\"}}, _VKV'{k: \"pr_id\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"pr_1\"}}}"});  // first case
+process(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "'{_VKV'{k: \"type\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"update\"}}, _VKV'{k: \"pr_id\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"pr_2\"}}}"});  // second case
+// third case
+process(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "'{_VKV'{k: \"type\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"delete\"}}, _VKV'{k: \"pr_id\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"pr_3\"}}}"});
+end
+endmodule

--- a/tests/integration/cases/call_deep_dotted_method/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_deep_dotted_method/SystemVerilog_call.sv
@@ -1,0 +1,28 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+class ClientType_;
+    task post(input _VVal data); endtask
+endclass
+class ApiType_;
+    ClientType_ client = new();
+endclass
+class ObjType_;
+    ApiType_ api = new();
+endclass
+ObjType_ obj = new();
+initial begin
+obj.api.client.post(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello"});
+obj.api.client.post(_VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+obj.api.client.post(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_deep_dotted_transformed/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_deep_dotted_transformed/SystemVerilog_call.sv
@@ -1,0 +1,28 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+class ClientType_;
+    function _VVal fetch(input _VVal payload);
+        fetch = _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: ""};
+    endfunction
+endclass
+class AppType_;
+    ClientType_ client = new();
+endclass
+AppType_ app = new();
+task emit(input _VVal _arg); endtask
+initial begin
+emit(app.client.fetch(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello"}));
+emit(app.client.fetch(_VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""}));
+emit(app.client.fetch(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""}));
+end
+endmodule

--- a/tests/integration/cases/call_dotted_method/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_dotted_method/SystemVerilog_call.sv
@@ -1,0 +1,25 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+class ClientType_;
+    task fetch(input _VVal payload); endtask
+endclass
+class AppType_;
+    ClientType_ client = new();
+endclass
+AppType_ app = new();
+initial begin
+app.client.fetch(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello"});
+app.client.fetch(_VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+app.client.fetch(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_dotted_transform_stub/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_dotted_transform_stub/SystemVerilog_call.sv
@@ -1,0 +1,25 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+function _VVal process(input _VVal value);
+    process = _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: ""};
+endfunction
+class TracerType_;
+    task emit(input _VVal _arg); endtask
+endclass
+TracerType_ tracer = new();
+initial begin
+tracer.emit(process(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello"}));
+tracer.emit(process(_VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""}));
+tracer.emit(process(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""}));
+end
+endmodule

--- a/tests/integration/cases/call_keyword_args/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_keyword_args/SystemVerilog_call.sv
@@ -1,0 +1,24 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+class ThrottlerType_;
+    function _VVal check(input _VVal user_id, input _VVal ts);
+        check = _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: ""};
+    endfunction
+endclass
+ThrottlerType_ throttler = new();
+task emit(input _VVal _arg); endtask
+initial begin
+emit(throttler.check(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "user_1"}, _VVal'{tag: _VVAL_REAL, i: 0, r: 1000.0, s: ""}));
+emit(throttler.check(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "user_2"}, _VVal'{tag: _VVAL_REAL, i: 0, r: 2000.5, s: ""}));
+end
+endmodule

--- a/tests/integration/cases/call_mixed_type_dicts/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_mixed_type_dicts/SystemVerilog_call.sv
@@ -1,0 +1,24 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+class MgrType_;
+    task op(input _VVal operation); endtask
+endclass
+class AppType_;
+    MgrType_ mgr = new();
+endclass
+AppType_ app = new();
+initial begin
+app.mgr.op(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "'{_VKV'{k: \"type\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"create\"}}, _VKV'{k: \"pr_id\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"pr_1\"}}, _VKV'{k: \"draft\", v: _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: \"\"}}}"});
+app.mgr.op(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "'{_VKV'{k: \"type\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"create\"}}, _VKV'{k: \"pr_id\", v: _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: \"pr_2\"}}}"});
+end
+endmodule

--- a/tests/integration/cases/call_multi_args/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_multi_args/SystemVerilog_call.sv
@@ -1,0 +1,18 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal value, input _VVal count); endtask
+initial begin
+process(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""}, _VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+process(_VVal'{tag: _VVAL_INT, i: 2, r: 0.0, s: ""}, _VVal'{tag: _VVAL_INT, i: 100, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_negative_int/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_negative_int/SystemVerilog_call.sv
@@ -1,0 +1,19 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal value); endtask
+initial begin
+process(_VVal'{tag: _VVAL_INT, i: -1, r: 0.0, s: ""});
+process(_VVal'{tag: _VVAL_INT, i: -2, r: 0.0, s: ""});
+process(_VVal'{tag: _VVAL_INT, i: -3, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_per_element_false/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_per_element_false/SystemVerilog_call.sv
@@ -1,0 +1,17 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal data); endtask
+initial begin
+process(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_ref_args/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_ref_args/SystemVerilog_call.sv
@@ -1,0 +1,28 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal data, input _VVal count); endtask
+initial begin
+static _VVal my_var[] = '{
+    _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 2, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 3, r: 0.0, s: ""}
+};
+static _VVal my_other[] = '{
+    _VVal'{tag: _VVAL_INT, i: 4, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 5, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 6, r: 0.0, s: ""}
+};
+process(my_var, _VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+process(my_other, _VVal'{tag: _VVAL_INT, i: 7, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_ref_args_converted/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_ref_args_converted/SystemVerilog_call.sv
@@ -1,0 +1,28 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal data, input _VVal count); endtask
+initial begin
+static _VVal my_var[] = '{
+    _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 2, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 3, r: 0.0, s: ""}
+};
+static _VVal my_other[] = '{
+    _VVal'{tag: _VVAL_INT, i: 4, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 5, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 6, r: 0.0, s: ""}
+};
+process(my_var, _VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+process(my_other, _VVal'{tag: _VVAL_INT, i: 7, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/SystemVerilog_call.sv
@@ -1,0 +1,28 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal data, input _VVal count); endtask
+initial begin
+static _VVal my_var[] = '{
+    _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 2, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 3, r: 0.0, s: ""}
+};
+static _VVal my_other[] = '{
+    _VVal'{tag: _VVAL_INT, i: 4, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 5, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 6, r: 0.0, s: ""}
+};
+process(my_var, _VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+process(my_other, _VVal'{tag: _VVAL_INT, i: 7, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_ref_args_converted_whole/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_ref_args_converted_whole/SystemVerilog_call.sv
@@ -1,0 +1,22 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal data); endtask
+initial begin
+static _VVal my_var[] = '{
+    _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 2, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 3, r: 0.0, s: ""}
+};
+process(my_var);
+end
+endmodule

--- a/tests/integration/cases/call_scalar_args/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_scalar_args/SystemVerilog_call.sv
@@ -1,0 +1,19 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal value); endtask
+initial begin
+process(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello"});
+process(_VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+process(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_snake_dotted_method/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_snake_dotted_method/SystemVerilog_call.sv
@@ -1,0 +1,25 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+class Http_ClientType_;
+    task fetch(input _VVal payload); endtask
+endclass
+class My_AppType_;
+    Http_ClientType_ http_client = new();
+endclass
+My_AppType_ my_app = new();
+initial begin
+my_app.http_client.fetch(_VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: "hello"});
+my_app.http_client.fetch(_VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+my_app.http_client.fetch(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_wrap_in_file/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_wrap_in_file/SystemVerilog_call.sv
@@ -1,0 +1,18 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal a, input _VVal b); endtask
+initial begin
+process(_VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""}, _VVal'{tag: _VVAL_INT, i: 2, r: 0.0, s: ""});
+process(_VVal'{tag: _VVAL_INT, i: 3, r: 0.0, s: ""}, _VVal'{tag: _VVAL_INT, i: 4, r: 0.0, s: ""});
+end
+endmodule


### PR DESCRIPTION
Closes #1145

## Summary

- Adds `literalize_call` support to the SystemVerilog language module by implementing `format_call_stub`, `format_call_arg`, and `call_style_config`
- Uses `PositionalCallStyle` with `task` stubs (VOID) and `function` stubs returning `_VVal` (VALUE)
- Dotted call targets (e.g. `app.client.fetch`) generate nested `class` declarations with module-level instance variables, placed at module scope outside `initial begin` via an overridden `wrap_in_file`
- Each call argument is wrapped in the `_VVal` struct literal via `_format_sv_entry` (consistent with data formatting)
- Excludes `call_transform_no_wrapper` (bare function-call-as-statement is non-standard SV; requires `void'(...)`)
- Restructures `static_preamble` into a single multi-line block to prevent `_dedupe_preamble_blocks` from dropping the second `typedef struct {` header

## Test plan

- [ ] All 18 new `SystemVerilog_call.sv` golden files generated and verified to be syntactically valid SystemVerilog
- [ ] Full test suite passes: 1951 passed, 468 skipped, 15095 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new code-generation paths (stub synthesis, dotted-call class scaffolding, and module-scope wrapping) that could affect SystemVerilog call outputs and lintability.
> 
> **Overview**
> Adds `literalize_call` support for **SystemVerilog** by introducing a positional call style and generating appropriate stubs: VOID calls emit `task` declarations, while VALUE calls emit `_VVal`-returning `function`s (defaulting to a null `_VVal`).
> 
> Extends dotted-call support by synthesizing nested `class` declarations plus a module-scope instance chain for targets like `a.b.c`, and updates `wrap_in_file` so call-mode stubs are emitted at module scope (outside `initial begin`) while declaration-mode preambles stay inside. Also consolidates `static_preamble` into a single multi-line block to avoid duplicate-header deduplication issues.
> 
> Integration coverage is expanded by enabling SystemVerilog in the call golden harness, adding new SystemVerilog golden outputs for call cases, and excluding `call_transform_no_wrapper` for SystemVerilog due to non-standard bare function-call statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a903ac837a41a5e40edc863a81a7e59827e2926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->