### PR TITLE
Use config indent in preamble/stub generators

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import textwrap
 from collections.abc import Callable, Sequence
-from functools import cached_property
+from functools import cached_property, partial
 from typing import ClassVar, assert_never, cast
 
 from beartype import beartype
@@ -122,6 +122,8 @@ def _mojo_call_preamble_stub(
     _params: Sequence[str],
     _stub_return: StubReturn,
     /,
+    *,
+    indent: str,
 ) -> tuple[str, ...]:
     """Return Mojo file-scope stubs for a call name.
 
@@ -131,15 +133,14 @@ def _mojo_call_preamble_stub(
     next inner type.
     """
     if len(parts) == 1:
-        return (f"fn {parts[0]}[*Ts: AnyType](*args: *Ts):\n    pass",)
+        return (f"fn {parts[0]}[*Ts: AnyType](*args: *Ts):\n{indent}pass",)
     root = parts[0]
     method = parts[-1]
     fields = parts[1:-1]
-    indent = "    "
     struct_header = "(Copyable, Movable)"
     method_stub = (
         f"{indent}fn {method}[*Ts: AnyType](self, *args: *Ts):\n"
-        f"{indent}    pass"
+        f"{indent}{indent}pass"
     )
     if not fields:
         type_name = f"_{root.capitalize()}Type"
@@ -796,7 +797,7 @@ class Mojo(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return _mojo_call_preamble_stub
+        return partial(_mojo_call_preamble_stub, indent=self.indent)
 
     @cached_property
     def format_call_target(self) -> Callable[[Sequence[str]], str]:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -279,7 +279,7 @@ class _HeterogeneousStrategyConfig:
 
     build_behavior: Callable[[str, str, str], HeterogeneousBehavior]
     build_preamble: Callable[
-        [str, str, str],
+        [str, str, str, str],
         Callable[[Value], tuple[str, ...]],
     ]
 
@@ -298,6 +298,7 @@ def _build_error_preamble(
     _variant_name: str,
     _date_type: str,
     _datetime_type: str,
+    _indent: str,
     /,
 ) -> Callable[[Value], tuple[str, ...]]:
     """ERROR strategy: no data-dependent preamble."""
@@ -357,6 +358,7 @@ def _build_object_variant_preamble(
     variant_name: str,
     date_type: str,
     datetime_type: str,
+    indent: str,
     /,
 ) -> Callable[[Value], tuple[str, ...]]:
     """OBJECT_VARIANT strategy: emit an object-variant ``type`` block."""
@@ -379,20 +381,21 @@ def _build_object_variant_preamble(
                 continue
             seen.add(signature.kind_name)
             variants.append(signature)
+        half_indent = " " * (len(indent) // 2)
         kind_type = f"{variant_name}Kind"
         lines: list[str] = [
             "type",
-            f"  {kind_type} = enum",
-            "    " + ", ".join(v.kind_name for v in variants),
-            f"  {variant_name} = object",
-            f"    case kind: {kind_type}",
+            f"{half_indent}{kind_type} = enum",
+            f"{indent}{', '.join(v.kind_name for v in variants)}",
+            f"{half_indent}{variant_name} = object",
+            f"{indent}case kind: {kind_type}",
         ]
         for variant in variants:
             if variant.field_name is None:
-                lines.append(f"    of {variant.kind_name}: discard")
+                lines.append(f"{indent}of {variant.kind_name}: discard")
             else:
                 lines.append(
-                    f"    of {variant.kind_name}: "
+                    f"{indent}of {variant.kind_name}: "
                     f"{variant.field_name}: {variant.field_type}"
                 )
         return tuple(lines)
@@ -997,6 +1000,7 @@ class Nim(metaclass=LanguageCls):
             self.heterogeneous_value_variant_name,
             self._heterogeneous_variant_date_type,
             self._heterogeneous_variant_datetime_type,
+            self.indent,
         )
         if self._uses_object_variant:
             return strategy_preamble

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Sequence
-from functools import cached_property
+from functools import cached_property, partial
 from types import MappingProxyType
 from typing import ClassVar
 
@@ -221,16 +221,21 @@ def _build_sml_declaration(
     return _format
 
 
-def _format_sml_preamble_lines(lines: list[str]) -> tuple[str, ...]:
+def _format_sml_preamble_lines(
+    lines: list[str],
+    *,
+    indent: str,
+) -> tuple[str, ...]:
     """Format deduplicated preamble lines with SML ``datatype`` syntax.
 
     The first constructor is indented; subsequent constructors are
     prefixed with ``|``.
     """
+    pipe_prefix = " " * max(0, len(indent) - 2) + "| "
     return (
         lines[0],
-        "    " + lines[1],
-        *(f"  | {line}" for line in lines[2:]),
+        indent + lines[1],
+        *(f"{pipe_prefix}{line}" for line in lines[2:]),
     )
 
 
@@ -882,5 +887,8 @@ class Sml(metaclass=LanguageCls):
         """Compute body-preamble lines from the scalar map."""
         return body_preamble_from_scalars(
             scalar_body_preamble=self.scalar_body_preamble,
-            format_lines=_format_sml_preamble_lines,
+            format_lines=partial(
+                _format_sml_preamble_lines,
+                indent=self.indent,
+            ),
         )

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import textwrap
 from collections.abc import Callable, Sequence
-from functools import cached_property
+from functools import cached_property, partial
 from types import MappingProxyType
 from typing import ClassVar
 
@@ -205,6 +205,8 @@ def _v_call_preamble_stub(
     _params: Sequence[str],
     stub_return: StubReturn,
     /,
+    *,
+    indent: str,
 ) -> tuple[str, ...]:
     """Return V preamble stub declarations for a call name.
 
@@ -251,10 +253,14 @@ def _v_call_preamble_stub(
         for i in range(len(fields) - 2, -1, -1):
             curr_type = _cap_type(fields[i])
             field = fields[i + 1]
-            lines.append(f"struct {curr_type} {{\n\t{field} {prev_type}\n}}")
+            lines.append(
+                f"struct {curr_type} {{\n{indent}{field} {prev_type}\n}}"
+            )
             prev_type = curr_type
         root_type = _cap_type(root)
-        lines.append(f"struct {root_type} {{\n\t{fields[0]} {prev_type}\n}}")
+        lines.append(
+            f"struct {root_type} {{\n{indent}{fields[0]} {prev_type}\n}}"
+        )
 
     return tuple(lines)
 
@@ -561,8 +567,8 @@ class V(metaclass=LanguageCls):
     validate_spec_for_data = no_validate_spec_for_data
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
-    @staticmethod
     def wrap_in_file(
+        self,
         content: str,
         variable_name: str,
         body_preamble: tuple[str, ...],
@@ -572,19 +578,21 @@ class V(metaclass=LanguageCls):
             content=content,
             body_preamble=body_preamble,
         )
-        indented = textwrap.indent(text=content, prefix="\t")
-        use_line = f"\n\t_ = {variable_name}" if variable_name else ""
+        indented = textwrap.indent(text=content, prefix=self.indent)
+        use_line = (
+            f"\n{self.indent}_ = {variable_name}" if variable_name else ""
+        )
         return f"\nfn main() {{\n{indented}{use_line}\n}}"
 
-    @staticmethod
     def wrap_combined_in_file(
+        self,
         declaration: str,
         assignment: str,
         variable_name: str,
         body_preamble: tuple[str, ...],
     ) -> str:
         """Wrap V declaration + assignment in ``fn main()``."""
-        return V.wrap_in_file(
+        return self.wrap_in_file(
             content=declaration + "\n" + assignment,
             variable_name=variable_name,
             body_preamble=body_preamble,
@@ -684,7 +692,7 @@ class V(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return file-scope stubs for a call expression."""
-        return _v_call_preamble_stub
+        return partial(_v_call_preamble_stub, indent=self.indent)
 
     @cached_property
     def format_call_target(self) -> Callable[[Sequence[str]], str]:

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import textwrap
 from collections.abc import Callable, Sequence
-from functools import cached_property
+from functools import cached_property, partial
 from typing import ClassVar
 
 from beartype import beartype
@@ -164,6 +164,8 @@ def _vb_call_stub(
     params: Sequence[str],
     _stub_return: StubReturn,
     /,
+    *,
+    indent: str,
 ) -> tuple[str, ...]:
     """Return Visual Basic stub declarations for a call name.
 
@@ -181,13 +183,13 @@ def _vb_call_stub(
     param_list = ", ".join(f"{p} As Object" for p in params)
     method_block = (
         f"Public Function {{method}}({param_list}) As Object\n"
-        "    Return Nothing\n"
+        f"{indent}Return Nothing\n"
         "End Function"
     )
     if len(parts) == 1:
         return (
             f"Function {parts[0]}({param_list}) As Object\n"
-            "    Return Nothing\n"
+            f"{indent}Return Nothing\n"
             "End Function",
         )
     root = parts[0]
@@ -195,7 +197,7 @@ def _vb_call_stub(
     fields = parts[1:-1]
     method_body = textwrap.indent(
         text=method_block.format(method=method),
-        prefix="    ",
+        prefix=indent,
     )
     if not fields:
         type_name = _vb_unique_class_name(segment=root, position=0)
@@ -651,7 +653,7 @@ class VisualBasic(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return _vb_call_stub
+        return partial(_vb_call_stub, indent=self.indent)
 
     @cached_property
     def call_style_config(self) -> CallStyle:


### PR DESCRIPTION
## Summary

- Five language modules (SML, VB, Nim, Mojo, V) hardcoded indentation strings in preamble and stub generation functions that had no access to the language config's `indent` field.
- Each function now accepts `indent` as a keyword-only parameter and is bound to `self.indent` via `partial` at the class property level (matching the existing pattern used by Nim's `_nim_call_stub`).
- For Nim's object-variant strategy, `indent` is passed through the factory function and a derived `half_indent` is used for the outer type-body level.
- V's `wrap_in_file` and `wrap_combined_in_file` are converted from `@staticmethod` to instance methods so they can read `self.indent` directly.

## Test plan

- [ ] All 1933 existing tests pass (`uv run pytest`)
- [ ] No change to generated output for any language with default `indent` settings (hardcoded defaults matched config defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches code generation formatting across multiple languages, so indentation/output snapshots may change for non-default `indent` settings and could break downstream expectations. No security- or data-sensitive logic changes.
> 
> **Overview**
> Updates several language backends to stop hardcoding indentation in generated preambles and call stubs, and instead thread `indent` from the language config.
> 
> Mojo/V/VB call preamble/body stub helpers now take keyword-only `indent` and are exposed via `partial(..., indent=self.indent)`; SML’s datatype preamble formatting similarly binds `indent` when building body preambles. Nim’s heterogeneous OBJECT_VARIANT preamble factory now accepts `indent` and uses it (plus a derived `half_indent`) when emitting the `type` block.
> 
> V’s `wrap_in_file`/`wrap_combined_in_file` are converted from static methods to instance methods so wrapping `fn main()` uses `self.indent` consistently (including the `_ = var` use line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205c299883e30963b8674bf744ce5af2504b1a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->