### PR TITLE
Fix Ruby $ref call args rejected in literalize_call

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1202,12 +1202,35 @@ class Language(Protocol):
         """Rewrite a ``{"$ref": "name"}`` identifier into the form
         required by this language's call expression syntax.
 
+        Used when a ``$ref`` appears as a value inside a data structure
+        (e.g. an element of a list passed to
+        :func:`~literalizer.literalize`).  Languages that cannot support
+        bare variable references in that context raise
+        :exc:`~literalizer.exceptions.CallArgNotSupportedError` here.
+
         Called after :func:`~literalizer.literalize_call`'s ``ref_case``
         normalization, so *name* is already in the requested identifier
         case.  Most languages emit ref identifiers bare and use
         :data:`identity_call_ref_identifier`.  Languages where variable
         references carry a sigil (e.g. PHP ``$name``, Perl ``$name``)
         override this to prepend the sigil.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier used as a direct
+        call argument (via :func:`~literalizer.literalize_call`).
+
+        In the call-argument context the referenced variable has already
+        been emitted at the same top-level scope, so some languages that
+        reject ``$ref`` in the value context (see
+        :attr:`format_call_ref_identifier`) can accept it here.
+
+        The default implementation (provided by every language class)
+        delegates to :attr:`format_call_ref_identifier`.  Override this
+        to allow call-argument ``$ref`` values that would otherwise be
+        rejected.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1770,7 +1770,12 @@ def _format_single_call_arg(
     if ref_name is not None:
         if ref_case is not None:
             ref_name = ref_case.convert(name=ref_name)
-        return language.format_call_ref_identifier(ref_name)
+        format_call_arg_ref: Callable[[str], str] = getattr(
+            language,
+            "format_call_arg_ref_identifier",
+            language.format_call_ref_identifier,
+        )
+        return format_call_arg_ref(ref_name)
     return wrap_arg(
         value,
         _format_value(

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1770,12 +1770,7 @@ def _format_single_call_arg(
     if ref_name is not None:
         if ref_case is not None:
             ref_name = ref_case.convert(name=ref_name)
-        format_call_arg_ref: Callable[[str], str] = getattr(
-            language,
-            "format_call_arg_ref_identifier",
-            language.format_call_ref_identifier,
-        )
-        return format_call_arg_ref(ref_name)
+        return language.format_call_arg_ref_identifier(ref_name)
     return wrap_arg(
         value,
         _format_value(

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -621,6 +621,16 @@ class Ada(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return dataclasses.replace(

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -545,6 +545,16 @@ class Bash(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -567,6 +567,16 @@ class C(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:
         """Wrap each call argument in the ``CVal`` union so call sites
         match the concrete prototype emitted by :func:`_c_call_stub`.

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -460,6 +460,16 @@ class Clojure(metaclass=LanguageCls):
         return _raise_for_clojure_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -653,6 +653,16 @@ class Cobol(metaclass=LanguageCls):
         return _raise_for_cobol_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return dataclasses.replace(

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -482,6 +482,16 @@ class CommonLisp(metaclass=LanguageCls):
         return _raise_for_common_lisp_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1356,6 +1356,16 @@ class Cpp(metaclass=LanguageCls):
         return _format_cpp_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _cpp_date_type(self) -> str:
         """Resolved C++ type name for the chosen date format."""
         return self.date_format.cpp_type

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -575,6 +575,16 @@ class Crystal(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return dataclasses.replace(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -877,6 +877,16 @@ class CSharp(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _date_tp(self) -> type:
         """Python type produced by the chosen date format."""
         return self.date_format.value.type_produced

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -535,6 +535,16 @@ class D(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return dataclasses.replace(

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -801,6 +801,16 @@ class Dart(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _date_tp(self) -> type:
         """Python type produced by the chosen date format."""
         return self.date_format.value.type_produced

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -966,6 +966,16 @@ class Dhall(metaclass=LanguageCls):
         return _dhall_reject_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return dataclasses.replace(

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -613,6 +613,16 @@ class Elixir(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def call_style_config(self) -> CallStyle:
         """Return the call style configuration."""
         return self.call_style.value

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -877,6 +877,16 @@ class Elm(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def null_literal(self) -> str:
         """Literal representing ``None``."""
         return f"{self.constructor_prefix}Null"

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -582,6 +582,16 @@ class Erlang(metaclass=LanguageCls):
         return _erlang_format_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -537,6 +537,16 @@ class Forth(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -718,6 +718,16 @@ class Fortran(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     def wrap_calls_with_declarations(
         self,
         declarations: tuple[str, ...],

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -629,6 +629,16 @@ class FSharp(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _entry_formatter(self) -> Callable[[Value, str], str]:
         """Shared entry formatter with the configured constructor
         prefix.

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -931,6 +931,16 @@ class Gleam(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def null_literal(self) -> str:
         """Literal representing ``None``."""
         return f"{self.constructor_prefix}Null"

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -650,6 +650,16 @@ class Go(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _init_element_to_type(
         self,
     ) -> Callable[[type | ListType | DictType], str | None]:

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -487,6 +487,16 @@ class Groovy(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1574,3 +1574,13 @@ class Haskell(metaclass=LanguageCls):
         language's call expression syntax.
         """
         return identity_call_ref_identifier
+
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -503,6 +503,16 @@ class Hcl(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1152,6 +1152,16 @@ class Java(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _suffix_is_auto(self) -> bool:
         """Whether the numeric-literal suffix is AUTO (long suffix)."""
         return self.numeric_literal_suffix.name == "AUTO"

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -554,6 +554,16 @@ class JavaScript(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -455,6 +455,16 @@ class Json5(metaclass=LanguageCls):
         return _raise_for_json5_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -509,6 +509,16 @@ class Jsonnet(metaclass=LanguageCls):
         return _raise_for_jsonnet_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -587,6 +587,16 @@ class Julia(metaclass=LanguageCls):
         return _raise_for_julia_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -939,6 +939,16 @@ class Kotlin(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _date_type_name(self) -> str | None:
         """Resolved Kotlin type name for the chosen date format."""
         return self._opener_config.type_name(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -480,6 +480,16 @@ class Lua(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -567,6 +567,16 @@ class Matlab(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -821,6 +821,16 @@ class Mojo(metaclass=LanguageCls):
         return _format_mojo_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def call_style_config(self) -> CallStyle:
         """Configuration for the chosen call style."""
         config: CallStyle = self.call_style.value

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1090,6 +1090,16 @@ class Nim(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format.
 

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -524,6 +524,16 @@ class Nix(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -427,6 +427,16 @@ class Norg(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -637,6 +637,16 @@ class ObjectiveC(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:
         """Box each call argument as an ``id`` so call sites match the
         concrete prototype emitted by :func:`_objc_call_stub`.

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -582,6 +582,16 @@ class OCaml(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def null_literal(self) -> str:
         """Null literal using the configured constructor prefix."""
         return f"{self.constructor_prefix}Null"

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -463,6 +463,16 @@ class Occam(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -597,6 +597,16 @@ class Odin(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -523,6 +523,16 @@ class Perl(metaclass=LanguageCls):
         return _perl_format_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -530,6 +530,16 @@ class Php(metaclass=LanguageCls):
         return _php_format_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def format_call_preamble_stub(
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -511,6 +511,16 @@ class PowerShell(metaclass=LanguageCls):
         return _powershell_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -1021,6 +1021,16 @@ class PureScript(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1028,6 +1028,16 @@ class Python(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
     @cached_property

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -537,6 +537,16 @@ class R(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -471,6 +471,16 @@ class Racket(metaclass=LanguageCls):
         return _raise_for_racket_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -561,6 +561,16 @@ class Raku(metaclass=LanguageCls):
         """
         return _raku_format_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
     @cached_property

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -931,6 +931,16 @@ class Roc(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def null_literal(self) -> str:
         """Literal representing ``None``."""
         return f"{self.constructor_prefix}Null"

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -66,6 +66,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -563,6 +564,18 @@ class Ruby(metaclass=LanguageCls):
             )
 
         return _raise_for_ruby_ref
+
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` call-argument identifier.
+
+        Unlike :attr:`format_call_ref_identifier`, this is used only when
+        the ``$ref`` appears as a direct call argument (via
+        :func:`~literalizer.literalize_call`).  In that context the
+        referenced variable has already been emitted at the same top-level
+        scope, so the reference is valid.
+        """
+        return identity_call_ref_identifier
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1388,6 +1388,16 @@ class Rust(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
     def __post_init__(self) -> None:

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -656,6 +656,16 @@ class Scala(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
     @cached_property

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -466,6 +466,16 @@ class Scheme(metaclass=LanguageCls):
         return _raise_for_scheme_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -664,6 +664,16 @@ class Sml(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
     @cached_property

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -814,6 +814,16 @@ class Swift(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
     @cached_property

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -523,6 +523,16 @@ class SystemVerilog(metaclass=LanguageCls):
         """
         return identity_call_ref_identifier
 
+    @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -490,6 +490,16 @@ class Tcl(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -472,6 +472,16 @@ class Toml(metaclass=LanguageCls):
         return _raise_for_toml_ref
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -733,6 +733,16 @@ class TypeScript(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -708,6 +708,16 @@ class V(metaclass=LanguageCls):
         return _format_v_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -681,6 +681,16 @@ class VisualBasic(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def _element_to_type(
         self,
     ) -> Callable[[type | ListType | DictType], str | None]:

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -514,6 +514,16 @@ class Wren(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -428,6 +428,16 @@ class Yaml(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -641,6 +641,16 @@ class Zig(metaclass=LanguageCls):
         return identity_call_ref_identifier
 
     @cached_property
+    def format_call_arg_ref_identifier(self) -> Callable[[str], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+
+        Delegates to :attr:`format_call_ref_identifier`.  Override this to
+        allow call-argument ``$ref`` values that would otherwise be rejected.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
         return self.sequence_format.value

--- a/tests/integration/cases/call_ref_args/Ruby_call.rb
+++ b/tests/integration/cases/call_ref_args/Ruby_call.rb
@@ -1,0 +1,13 @@
+def process(*a); end
+my_var = [
+  1,
+  2,
+  3,
+]
+my_other = [
+  4,
+  5,
+  6,
+]
+process(data: my_var, count: 42)
+process(data: my_other, count: 7)

--- a/tests/integration/cases/call_ref_args_converted/Ruby_call.rb
+++ b/tests/integration/cases/call_ref_args_converted/Ruby_call.rb
@@ -1,0 +1,13 @@
+def process(*a); end
+my_var = [
+  1,
+  2,
+  3,
+]
+my_other = [
+  4,
+  5,
+  6,
+]
+process(data: my_var, count: 42)
+process(data: my_other, count: 7)

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Ruby_call.rb
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Ruby_call.rb
@@ -1,0 +1,13 @@
+def process(*a); end
+my_var = [
+  1,
+  2,
+  3,
+]
+my_other = [
+  4,
+  5,
+  6,
+]
+process(data: my_var, count: 42)
+process(data: my_other, count: 7)

--- a/tests/integration/cases/call_ref_args_converted_whole/Ruby_call.rb
+++ b/tests/integration/cases/call_ref_args_converted_whole/Ruby_call.rb
@@ -1,0 +1,7 @@
+def process(*a); end
+my_var = [
+  1,
+  2,
+  3,
+]
+process(data: my_var)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -459,6 +459,7 @@ def test_protocol_properties_accessible(
     assert callable(spec.format_call_preamble_stub)
     assert callable(spec.format_call_target)
     assert callable(spec.format_call_ref_identifier)
+    assert callable(spec.format_call_arg_ref_identifier)
     assert callable(spec.format_variable_declaration)
     assert callable(spec.format_variable_assignment)
     assert callable(spec.type_hint_collection_preamble_lines)


### PR DESCRIPTION
## Summary

- Fixes #1798: `literalize_call` with `$ref` arguments now works for Ruby when the referenced variable has already been emitted at top-level scope.
- Adds `format_call_arg_ref_identifier` to `Ruby`, returning `identity_call_ref_identifier` (no raise). `_format_single_call_arg` uses `getattr` to prefer this method, falling back to `format_call_ref_identifier` — consistent with the existing `format_call_arg` pattern at line 1842.
- `format_call_ref_identifier` still raises for the `literalize` context (refs inside values), preserving the correct skip behavior for `literalize_ref_*` golden tests where Ruby cannot inject stubs.
- Adds 4 new Ruby golden files for `call_ref_args`, `call_ref_args_converted`, `call_ref_args_converted_whole`, and `call_ref_args_converted_nonsnake` — all pass `ruby -c` and execute cleanly.

## Test plan

- [ ] `uv run --extra dev pytest tests/ --ignore=tests/benchmarks` — all pass
- [ ] `ruby -c` on all new `Ruby_call.rb` golden files — syntax OK
- [ ] `ruby` on all new `Ruby_call.rb` golden files — runs cleanly
- [ ] `literalize_ref_in_list/Ruby` still skips (stubs cannot be injected for Ruby in the `literalize` context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core call-argument formatting path and adds a new required language hook, so regressions could affect `$ref` rendering across many languages, though most implementations simply delegate to existing behavior.
> 
> **Overview**
> Fixes `literalize_call` handling of `{"$ref": "name"}` by splitting `$ref` formatting into two contexts: *value* refs (`format_call_ref_identifier`) vs *direct call-argument* refs (`format_call_arg_ref_identifier`). `_format_single_call_arg` now uses the new call-arg hook, enabling languages to accept `$ref` only when it appears as a top-level call argument.
> 
> All language specs are updated to expose `format_call_arg_ref_identifier` (defaulting to `format_call_ref_identifier`), and Ruby overrides it to return a bare identifier while still rejecting `$ref` when it appears inside data literals. Adds Ruby integration golden tests covering `$ref` call arguments (including case-conversion variants) and updates the language interface coverage test to assert the new hook exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb60963307e1ac5f7e46f16567d74dff2c37f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->