### PR TITLE
Use enum.auto() for format enum members whose string values are unused

### DIFF
--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -323,7 +323,7 @@ class Ada(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -343,7 +343,7 @@ class Ada(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -378,7 +378,7 @@ class Ada(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -296,7 +296,7 @@ class Bash(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -356,7 +356,7 @@ class Bash(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -363,7 +363,7 @@ class C(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -399,7 +399,7 @@ class C(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -216,7 +216,7 @@ class Clojure(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -236,7 +236,7 @@ class Clojure(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -271,7 +271,7 @@ class Clojure(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -442,7 +442,7 @@ class Cobol(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -462,7 +462,7 @@ class Cobol(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -497,7 +497,7 @@ class Cobol(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -233,7 +233,7 @@ class CommonLisp(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -253,7 +253,7 @@ class CommonLisp(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -288,7 +288,7 @@ class CommonLisp(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1136,7 +1136,7 @@ class Cpp(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -1203,7 +1203,7 @@ class Cpp(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -365,7 +365,7 @@ class Crystal(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -401,7 +401,7 @@ class Crystal(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -662,7 +662,7 @@ class CSharp(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -322,7 +322,7 @@ class D(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -358,7 +358,7 @@ class D(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -565,7 +565,7 @@ class Dart(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -638,7 +638,7 @@ class Dhall(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -658,7 +658,7 @@ class Dhall(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -669,7 +669,7 @@ class Dhall(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -386,7 +386,7 @@ class Elixir(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -422,7 +422,7 @@ class Elixir(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -638,7 +638,7 @@ class Elm(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -673,7 +673,7 @@ class Elm(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -349,7 +349,7 @@ class Erlang(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -384,7 +384,7 @@ class Erlang(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -309,7 +309,7 @@ class Forth(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -368,7 +368,7 @@ class Forth(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        NONE = "none"
+        NONE = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -428,7 +428,7 @@ class Fortran(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -448,7 +448,7 @@ class Fortran(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -483,7 +483,7 @@ class Fortran(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -430,7 +430,7 @@ class FSharp(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -465,7 +465,7 @@ class FSharp(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -728,7 +728,7 @@ class Gleam(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -764,7 +764,7 @@ class Gleam(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        NONE = "none"
+        NONE = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -448,7 +448,7 @@ class Go(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -483,7 +483,7 @@ class Go(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -259,7 +259,7 @@ class Groovy(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -279,7 +279,7 @@ class Groovy(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -315,7 +315,7 @@ class Groovy(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1108,16 +1108,16 @@ class Haskell(metaclass=LanguageCls):
         instances.
         """
 
-        OVERLOADED = "overloaded"
-        EXPLICIT = "explicit"
+        OVERLOADED = enum.auto()
+        EXPLICIT = enum.auto()
 
     numeric_styles = NumericStyles
 
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
-        EXPLICIT = "explicit"
+        DOUBLE = enum.auto()
+        EXPLICIT = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -1151,7 +1151,7 @@ class Haskell(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -257,7 +257,7 @@ class Hcl(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -277,7 +277,7 @@ class Hcl(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -312,7 +312,7 @@ class Hcl(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -846,7 +846,7 @@ class Java(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -961,7 +961,7 @@ class Java(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -212,7 +212,7 @@ class JavaScript(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
         NONE = "none"
 
         def wrap_formatter(

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -227,7 +227,7 @@ class Json5(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -247,7 +247,7 @@ class Json5(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -258,7 +258,7 @@ class Json5(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -249,7 +249,7 @@ class Jsonnet(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -269,7 +269,7 @@ class Jsonnet(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -280,7 +280,7 @@ class Jsonnet(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -373,7 +373,7 @@ class Julia(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -409,7 +409,7 @@ class Julia(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -683,7 +683,7 @@ class Kotlin(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -767,7 +767,7 @@ class Kotlin(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -323,7 +323,7 @@ class Lua(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -344,7 +344,7 @@ class Matlab(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -364,7 +364,7 @@ class Matlab(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -399,7 +399,7 @@ class Matlab(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -530,7 +530,7 @@ class Mojo(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -550,7 +550,7 @@ class Mojo(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -585,7 +585,7 @@ class Mojo(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -747,7 +747,7 @@ class Nim(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -783,7 +783,7 @@ class Nim(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -297,7 +297,7 @@ class Nix(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -317,7 +317,7 @@ class Nix(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -327,7 +327,7 @@ class Nix(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     date_formats = DateFormats
     datetime_formats = DatetimeFormats

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -201,7 +201,7 @@ class Norg(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -221,7 +221,7 @@ class Norg(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -256,7 +256,7 @@ class Norg(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -416,7 +416,7 @@ class ObjectiveC(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -452,7 +452,7 @@ class ObjectiveC(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -434,7 +434,7 @@ class OCaml(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -469,7 +469,7 @@ class OCaml(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -215,7 +215,7 @@ class Occam(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -235,7 +235,7 @@ class Occam(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -270,7 +270,7 @@ class Occam(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -385,7 +385,7 @@ class Odin(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -421,7 +421,7 @@ class Odin(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -366,7 +366,7 @@ class Perl(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -372,7 +372,7 @@ class Php(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -279,7 +279,7 @@ class PowerShell(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -299,7 +299,7 @@ class PowerShell(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -334,7 +334,7 @@ class PowerShell(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -790,7 +790,7 @@ class PureScript(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -825,7 +825,7 @@ class PureScript(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -868,7 +868,7 @@ class Python(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -327,7 +327,7 @@ class R(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options.
@@ -367,7 +367,7 @@ class R(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -221,7 +221,7 @@ class Racket(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -241,7 +241,7 @@ class Racket(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -276,7 +276,7 @@ class Racket(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -399,7 +399,7 @@ class Raku(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -652,7 +652,7 @@ class Roc(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -688,7 +688,7 @@ class Roc(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        NONE = "none"
+        NONE = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -391,7 +391,7 @@ class Ruby(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1152,7 +1152,7 @@ class Rust(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -451,7 +451,7 @@ class Scala(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -487,7 +487,7 @@ class Scala(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -217,7 +217,7 @@ class Scheme(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -237,7 +237,7 @@ class Scheme(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -272,7 +272,7 @@ class Scheme(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -464,7 +464,7 @@ class Sml(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -499,7 +499,7 @@ class Sml(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -555,7 +555,7 @@ class Swift(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -640,7 +640,7 @@ class Swift(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -300,7 +300,7 @@ class SystemVerilog(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -335,7 +335,7 @@ class SystemVerilog(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -256,7 +256,7 @@ class Tcl(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -315,7 +315,7 @@ class Tcl(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -235,7 +235,7 @@ class Toml(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -255,7 +255,7 @@ class Toml(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -290,7 +290,7 @@ class Toml(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -345,7 +345,7 @@ class TypeScript(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
         NONE = "none"
 
         def wrap_formatter(

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -487,7 +487,7 @@ class V(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        SINGLE = "single"
+        SINGLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -523,7 +523,7 @@ class V(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        NEWLINE = "newline"
+        NEWLINE = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -299,7 +299,7 @@ class VisualBasic(metaclass=LanguageCls):
     class SequenceFormats(enum.Enum):
         """Sequence type options for Visual Basic."""
 
-        ARRAY = "array"
+        ARRAY = enum.auto()
 
     class SetFormats(enum.Enum):
         """Set type options for Visual Basic."""
@@ -393,7 +393,7 @@ class VisualBasic(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -413,7 +413,7 @@ class VisualBasic(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -448,7 +448,7 @@ class VisualBasic(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -346,7 +346,7 @@ class Wren(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        NEWLINE = "newline"
+        NEWLINE = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -209,7 +209,7 @@ class Yaml(metaclass=LanguageCls):
     class IntegerFormats(enum.Enum):
         """Integer format options."""
 
-        DECIMAL = "decimal"
+        DECIMAL = enum.auto()
 
     class NumericLiteralSuffixes(enum.Enum):
         """Numeric literal suffix options."""
@@ -229,7 +229,7 @@ class Yaml(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -264,7 +264,7 @@ class Yaml(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -403,7 +403,7 @@ class Zig(metaclass=LanguageCls):
     class StringFormats(enum.Enum):
         """String format options."""
 
-        DOUBLE = "double"
+        DOUBLE = enum.auto()
 
     class TrailingCommas(enum.Enum):
         """Trailing comma options."""
@@ -439,7 +439,7 @@ class Zig(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = "semicolon"
+        SEMICOLON = enum.auto()
 
     line_endings = LineEndings
 


### PR DESCRIPTION
## Summary

- Replace plain string values (e.g. `SEMICOLON = "semicolon"`, `DOUBLE = "double"`, `DECIMAL = "decimal"`) with `enum.auto()` across 63 language files, wherever the string value is never accessed via `.value`
- Affects `LineEndings`, `StringFormats`, `IntegerFormats`, `SequenceFormats`, and `NumericStyles` inner enum classes
- `javascript.py` and `typescript.py` retain `NONE = "none"` as a plain string since `wrap_formatter` compares `self.value != "none"`; modifier enums in `java.py`, `csharp.py`, and `cpp.py` are also unchanged as their string values are used for code generation

## Test plan

- [x] All 539 non-integration tests pass
- [x] `pyrefly` type check reports 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Broad but mechanical change across many language specs, switching enum member values from fixed strings to `enum.auto()`; risk is limited to any hidden `.value` comparisons/serialization that might have relied on the old string values.
> 
> **Overview**
> Updates many `literalizer` language specification enums to stop hard-coding string values (e.g. `"decimal"`, `"double"`, `"semicolon"`) and instead use `enum.auto()` where the underlying `.value` is not consumed.
> 
> This touches formatting-option enums such as `IntegerFormats`, `StringFormats`, `LineEndings`, and a few similar option enums across dozens of language files, while preserving explicit string values where code depends on them (notably `LineEndings.NONE` in `javascript.py`/`typescript.py`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c540405a48a2324f9409d1df4738bfde781bf47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->