### PR TITLE
Add configurable ref_key parameter to literalize and literalize_call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- :func:`~literalizer.literalize` and :func:`~literalizer.literalize_call`
+  now accept a ``ref_key`` parameter (``str``, default ``"ref"``).  The
+  marker key used to identify variable-reference mappings in the input data
+  is now user-configurable: a single-key dict whose key equals *ref_key*
+  and whose value is a string is treated as a ref marker when *ref_case* is
+  set.  The previous hard-coded key ``"$ref"`` is no longer the default;
+  callers that relied on ``$ref`` must pass ``ref_key="$ref"`` explicitly.
+
 2026.04.30
 ----------
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -286,6 +286,7 @@ def _format_ordered_map_value(
     spec: Language,
     wrap_ids: frozenset[int],
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format an ordered map as a native language literal."""
     ordered_map_cfg = spec.ordered_map_format_config
@@ -316,6 +317,7 @@ def _format_ordered_map_value(
                 wrap_ids=wrap_ids,
                 sequence_open_override=None,
                 ref_case=ref_case,
+                ref_key=ref_key,
             ),
             v,
             _maybe_wrap_child(
@@ -329,6 +331,7 @@ def _format_ordered_map_value(
                     outer_sequence_override=outer_sequence_override,
                     position_overrides=position_overrides,
                     ref_case=ref_case,
+                    ref_key=ref_key,
                 ),
                 spec=spec,
             ),
@@ -348,6 +351,7 @@ def _format_dict_value(
     open_override: str | None,
     wrap_ids: frozenset[int],
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format a dict as a native language literal."""
     dict_cfg = spec.dict_format_config
@@ -385,6 +389,7 @@ def _format_dict_value(
                 wrap_ids=wrap_ids,
                 sequence_open_override=None,
                 ref_case=ref_case,
+                ref_key=ref_key,
             ),
             raw_value=v,
             formatted_value=_maybe_wrap_child(
@@ -398,6 +403,7 @@ def _format_dict_value(
                     outer_sequence_override=outer_sequence_override,
                     position_overrides=position_overrides,
                     ref_case=ref_case,
+                    ref_key=ref_key,
                 ),
                 spec=spec,
             ),
@@ -423,6 +429,7 @@ def _format_dict_entry_value(
     outer_sequence_override: str | None,
     position_overrides: Sequence[str | None],
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format a dict entry's value, threading sequence-opener overrides
     into list-typed values so the outer and inner sequences render with
@@ -442,6 +449,7 @@ def _format_dict_entry_value(
             sequence_open_override=outer_sequence_override,
             child_sequence_open_overrides=position_overrides,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
     return _format_value(
         value=value,
@@ -450,6 +458,7 @@ def _format_dict_entry_value(
         wrap_ids=wrap_ids,
         sequence_open_override=None,
         ref_case=ref_case,
+        ref_key=ref_key,
     )
 
 
@@ -505,12 +514,13 @@ def _compute_dict_open_override(
 def _gather_call_slot_values(
     *,
     elements: list[Value],
+    ref_key: str,
 ) -> list[list[Value]]:
     """Group non-ref argument values by positional slot across calls.
 
-    ``{"$ref": "name"}`` markers are filtered out: the marker isn't
-    rendered as a real value at the call site, so its shape must not
-    influence sibling-aware widening.
+    Ref markers are filtered out: the marker isn't rendered as a real
+    value at the call site, so its shape must not influence
+    sibling-aware widening.
     """
     slots: list[list[Value]] = []
     for element in elements:
@@ -518,7 +528,10 @@ def _gather_call_slot_values(
         for slot_index, arg_value in enumerate(iterable=arg_values):
             if slot_index >= len(slots):
                 slots.append([])
-            if _extract_call_arg_ref_name(value=arg_value) is None:
+            is_ref = _extract_call_arg_ref_name(
+                value=arg_value, ref_key=ref_key
+            )
+            if is_ref is None:
                 slots[slot_index].append(arg_value)
     return slots
 
@@ -528,6 +541,7 @@ def _compute_call_slot_overrides(
     *,
     elements: list[Value],
     spec: Language,
+    ref_key: str,
 ) -> list[str | None]:
     """Compute per-slot dict-open overrides across sibling calls.
 
@@ -539,7 +553,7 @@ def _compute_call_slot_overrides(
     each dict still needs its own full opener, just widened when
     sibling dicts differ in inferred value type.
     """
-    slots = _gather_call_slot_values(elements=elements)
+    slots = _gather_call_slot_values(elements=elements, ref_key=ref_key)
     return [
         _compute_dict_open_override(items=slot_values, spec=spec)
         for slot_values in slots
@@ -551,6 +565,7 @@ def _compute_call_per_element_wrap_ids(
     *,
     elements: list[Value],
     spec: Language,
+    ref_key: str,
 ) -> frozenset[int]:
     """Compute wrap_ids spanning sibling per-element calls.
 
@@ -563,7 +578,7 @@ def _compute_call_per_element_wrap_ids(
     triggers wrapping in every sibling at that slot, not just the
     ones whose own argument is locally mixed.
     """
-    slots = _gather_call_slot_values(elements=elements)
+    slots = _gather_call_slot_values(elements=elements, ref_key=ref_key)
     return frozenset[int]().union(
         *(
             _compute_wrap_ids(data=slot_values, spec=spec)
@@ -727,6 +742,7 @@ def _format_sequence_child(
     dict_open_override: str | None,
     child_sequence_open_overrides: Sequence[str | None],
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format a single sequence child with sibling-aware typed empty.
 
@@ -778,6 +794,7 @@ def _format_sequence_child(
             parent_override if parent_override is not None else sibling_open
         ),
         ref_case=ref_case,
+        ref_key=ref_key,
     )
 
 
@@ -790,6 +807,7 @@ def _format_list_value(
     sequence_open_override: str | None,
     child_sequence_open_overrides: Sequence[str | None],
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format a list as a native language literal.
 
@@ -838,6 +856,7 @@ def _format_list_value(
                         child_sequence_open_overrides
                     ),
                     ref_case=ref_case,
+                    ref_key=ref_key,
                 ),
                 spec=spec,
             ),
@@ -874,6 +893,7 @@ def _format_value(
     wrap_ids: frozenset[int],
     sequence_open_override: str | None,
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format any JSON value as a native language literal.
 
@@ -894,15 +914,15 @@ def _format_value(
     :attr:`~literalizer._language.HeterogeneousBehavior.wrap_scalar`
     hook.
 
-    When *ref_case* is set, ``{"$ref": "name"}`` markers anywhere in
-    the value tree are rendered as bare identifiers via
+    When *ref_case* is set, ref markers anywhere in the value tree are
+    rendered as bare identifiers via
     :attr:`~literalizer._language.Language.format_call_ref_identifier`,
     with the identifier name converted to *ref_case* first.  When
-    *ref_case* is ``None``, ``{"$ref": "name"}`` dicts are formatted as
-    ordinary literal dicts.
+    *ref_case* is ``None``, ref dicts are formatted as ordinary literal
+    dicts.
     """
     if ref_case is not None:
-        ref_name = _extract_call_arg_ref_name(value=value)
+        ref_name = _extract_call_arg_ref_name(value=value, ref_key=ref_key)
         if ref_name is not None:
             ref_name = ref_case.convert(name=ref_name)
             return spec.format_call_ref_identifier(ref_name)
@@ -913,6 +933,7 @@ def _format_value(
                 spec=spec,
                 wrap_ids=wrap_ids,
                 ref_case=ref_case,
+                ref_key=ref_key,
             )
         case dict():
             return _format_dict_value(
@@ -921,6 +942,7 @@ def _format_value(
                 open_override=dict_open_override,
                 wrap_ids=wrap_ids,
                 ref_case=ref_case,
+                ref_key=ref_key,
             )
         case set():
             return _format_set_value(value=value, spec=spec, wrap_ids=wrap_ids)
@@ -932,6 +954,7 @@ def _format_value(
                 sequence_open_override=sequence_open_override,
                 child_sequence_open_overrides=(),
                 ref_case=ref_case,
+                ref_key=ref_key,
             )
         case _:
             return _format_scalar(value=value, spec=spec)
@@ -1000,6 +1023,7 @@ def _format_collection_lines(
     is_ordered_map: bool,
     wrap_ids: frozenset[int],
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> list[str]:
     """Format collection elements as indented lines."""
     lines: list[str] = []
@@ -1031,6 +1055,7 @@ def _format_collection_lines(
                     wrap_ids=wrap_ids,
                     sequence_open_override=None,
                     ref_case=ref_case,
+                    ref_key=ref_key,
                 )
                 formatted_val = _maybe_wrap_child(
                     parent_id=parent_id,
@@ -1043,6 +1068,7 @@ def _format_collection_lines(
                         outer_sequence_override=outer_sequence_override,
                         position_overrides=position_overrides,
                         ref_case=ref_case,
+                        ref_key=ref_key,
                     ),
                     spec=spec,
                 )
@@ -1090,6 +1116,7 @@ def _format_collection_lines(
                             wrap_ids=wrap_ids,
                             sequence_open_override=None,
                             ref_case=ref_case,
+                            ref_key=ref_key,
                         ),
                         spec=spec,
                     ),
@@ -1132,6 +1159,7 @@ def _format_collection_lines(
                             dict_open_override=dict_open_override,
                             child_sequence_open_overrides=(),
                             ref_case=ref_case,
+                            ref_key=ref_key,
                         ),
                         spec=spec,
                     ),
@@ -1162,7 +1190,8 @@ def _literalize(
     language: Language,
     line_prefix: str,
     include_delimiters: bool,
-    ref_case: IdentifierCase | None = None,
+    ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     r"""Convert data to native language literal text.
 
@@ -1188,11 +1217,12 @@ def _literalize(
         include_delimiters: If True, include the collection delimiters
             (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
             Ignored for scalar values.
-        ref_case: When set, any ``{"$ref": "name"}`` mapping is rendered
-            as a bare identifier instead of a literal dict.
+        ref_case: When set, any ref mapping is rendered as a bare
+            identifier instead of a literal dict.
+        ref_key: The key used to identify ref markers in the input.
     """
     if ref_case is not None:
-        ref_name = _extract_call_arg_ref_name(value=data)
+        ref_name = _extract_call_arg_ref_name(value=data, ref_key=ref_key)
         if ref_name is not None:
             ref_name = ref_case.convert(name=ref_name)
             identifier = language.format_call_ref_identifier(ref_name)
@@ -1228,6 +1258,7 @@ def _literalize(
             wrap_ids=wrap_ids,
             sequence_open_override=None,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
         return f"{line_prefix}{formatted}"
 
@@ -1250,6 +1281,7 @@ def _literalize(
             wrap_ids=wrap_ids,
             sequence_open_override=None,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
         return f"{line_prefix}{formatted}"
 
@@ -1267,6 +1299,7 @@ def _literalize(
         is_ordered_map=is_ordered_map,
         wrap_ids=wrap_ids,
         ref_case=ref_case,
+        ref_key=ref_key,
     )
 
     body = "\n".join(lines)
@@ -1348,7 +1381,8 @@ def _literalize_pre_form(
     language: Language,
     pre_indent_level: int,
     include_delimiters: bool,
-    ref_case: IdentifierCase | None = None,
+    ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> _PreFormState:
     """Run the variable-form-independent phase of :func:`literalize`.
 
@@ -1367,6 +1401,7 @@ def _literalize_pre_form(
         line_prefix=line_prefix,
         include_delimiters=include_delimiters,
         ref_case=ref_case,
+        ref_key=ref_key,
     )
 
     comment_line_prefix = (
@@ -1500,7 +1535,8 @@ def _literalize_both_forms(
     pre_indent_level: int,
     include_delimiters: bool,
     variable_form: BothVariableForms,
-    ref_case: IdentifierCase | None = None,
+    ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> LiteralizeResult:
     """Produce combined declaration + assignment output."""
     pre_form = _literalize_pre_form(
@@ -1510,6 +1546,7 @@ def _literalize_both_forms(
         pre_indent_level=pre_indent_level,
         include_delimiters=include_delimiters,
         ref_case=ref_case,
+        ref_key=ref_key,
     )
     declaration = _literalize_apply_form(
         pre_form=pre_form,
@@ -1558,6 +1595,7 @@ def literalize(
     variable_form: VariableForm | None = None,
     wrap_in_file: bool = False,
     ref_case: IdentifierCase | None = None,
+    ref_key: str = "ref",
 ) -> LiteralizeResult:
     r"""Convert a JSON, JSON5, YAML, or TOML string to a native
     language literal.
@@ -1597,14 +1635,17 @@ def literalize(
             When set, :attr:`preamble` and :attr:`body_preamble`
             on the result are empty tuples (their content has been
             folded into :attr:`code`).
-        ref_case: When set, ``{"$ref": "name"}`` markers anywhere in
+        ref_case: When set, ``{ref_key: "name"}`` markers anywhere in
             the data are rendered as bare identifiers using the
             language's
             :attr:`~literalizer._language.Language.format_call_ref_identifier`
             hook, with the identifier name first converted to
-            *ref_case*.  When ``None`` (default), ``{"$ref": ...}``
-            dicts are treated as ordinary literal dicts with no special
-            handling.
+            *ref_case*.  When ``None`` (default), such dicts are treated
+            as ordinary literal dicts with no special handling.
+        ref_key: The dict key used to identify variable-reference
+            markers in the input data.  A single-key dict whose key
+            equals *ref_key* and whose value is a string is treated as a
+            ref marker when *ref_case* is set.  Defaults to ``"ref"``.
 
     Raises:
         JSONParseError: If *input_format* is ``JSON`` and *source* is
@@ -1650,6 +1691,7 @@ def literalize(
             include_delimiters=include_delimiters,
             variable_form=variable_form,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
 
     pre_form = _literalize_pre_form(
@@ -1659,6 +1701,7 @@ def literalize(
         pre_indent_level=pre_indent_level,
         include_delimiters=include_delimiters,
         ref_case=ref_case,
+        ref_key=ref_key,
     )
     return _literalize_apply_form(
         pre_form=pre_form,
@@ -1690,12 +1733,9 @@ def _identity_call_statement(statement: str) -> str:
     return statement
 
 
-_CALL_ARG_REF_KEY = "$ref"
-
-
 @beartype
-def _extract_call_arg_ref_name(*, value: Value) -> str | None:
-    """Return the identifier name for a ``{"$ref": "name"}`` marker.
+def _extract_call_arg_ref_name(*, value: Value, ref_key: str) -> str | None:
+    """Return the identifier name for a ``{ref_key: "name"}`` marker.
 
     Returns ``None`` when *value* is not a variable-reference marker.
     In :func:`literalize_call` such markers render as the bare
@@ -1703,7 +1743,7 @@ def _extract_call_arg_ref_name(*, value: Value) -> str | None:
     """
     if not isinstance(value, dict) or len(value) != 1:
         return None
-    ref_value = value.get(_CALL_ARG_REF_KEY)
+    ref_value = value.get(ref_key)
     if not isinstance(ref_value, str):
         return None
     return ref_value
@@ -1714,6 +1754,7 @@ def _strip_call_arg_refs_for_preamble(
     *,
     data: Value,
     per_element: bool,
+    ref_key: str,
 ) -> Value:
     """Return *data* with call-argument ref markers removed.
 
@@ -1737,13 +1778,17 @@ def _strip_call_arg_refs_for_preamble(
                     [
                         v
                         for v in element
-                        if _extract_call_arg_ref_name(value=v) is None
+                        if _extract_call_arg_ref_name(value=v, ref_key=ref_key)
+                        is None
                     ]
                 )
-            elif _extract_call_arg_ref_name(value=element) is None:
+            elif (
+                _extract_call_arg_ref_name(value=element, ref_key=ref_key)
+                is None
+            ):
                 result.append(element)
         return result
-    if _extract_call_arg_ref_name(value=data) is not None:
+    if _extract_call_arg_ref_name(value=data, ref_key=ref_key) is not None:
         return []
     return data
 
@@ -1757,16 +1802,16 @@ def _format_single_call_arg(
     wrap_arg: Callable[[Value, str], str],
     dict_open_override: str | None,
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format one argument value for a function call.
 
-    A ``{"$ref": "name"}`` marker renders as the bare identifier; the
-    ``format_call_arg`` hook is skipped for refs because the referenced
-    variable already has the call's parameter type.  When *ref_case*
-    is not ``None``, the ref name is converted to that case before
-    being emitted.
+    A ref marker renders as the bare identifier; the ``format_call_arg``
+    hook is skipped for refs because the referenced variable already has
+    the call's parameter type.  When *ref_case* is not ``None``, the ref
+    name is converted to that case before being emitted.
     """
-    ref_name = _extract_call_arg_ref_name(value=value)
+    ref_name = _extract_call_arg_ref_name(value=value, ref_key=ref_key)
     if ref_name is not None:
         if ref_case is not None:
             ref_name = ref_case.convert(name=ref_name)
@@ -1780,6 +1825,7 @@ def _format_single_call_arg(
             wrap_ids=wrap_ids,
             sequence_open_override=None,
             ref_case=None,
+            ref_key=ref_key,
         ),
     )
 
@@ -1819,6 +1865,7 @@ def _format_call_args(
     style: CallStyle,
     dict_open_overrides: Sequence[str | None],
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Format argument values for a single function call.
 
@@ -1852,6 +1899,7 @@ def _format_call_args(
             wrap_arg=wrap_arg,
             dict_open_override=dict_open_overrides[slot_index],
             ref_case=ref_case,
+            ref_key=ref_key,
         )
         for slot_index, arg_value in enumerate(iterable=values)
     ]
@@ -2057,6 +2105,7 @@ def _render_call_per_element(
     parameter_names: Sequence[str],
     call_transform: Callable[[str], str] | None,
     ref_case: IdentifierCase | None,
+    ref_key: str,
     collection_comments: CollectionComments | None = None,
 ) -> str:
     """Render one call per top-level list element.
@@ -2073,10 +2122,12 @@ def _render_call_per_element(
     slot_overrides = _compute_call_slot_overrides(
         elements=data,
         spec=language,
+        ref_key=ref_key,
     )
     slot_wrap_ids = _compute_call_per_element_wrap_ids(
         elements=data,
         spec=language,
+        ref_key=ref_key,
     )
     validate_call_arg: Callable[[Value], None] | None = getattr(
         language,
@@ -2094,7 +2145,7 @@ def _render_call_per_element(
         non_ref_args = [
             v
             for v in arg_values
-            if _extract_call_arg_ref_name(value=v) is None
+            if _extract_call_arg_ref_name(value=v, ref_key=ref_key) is None
         ]
         for value in non_ref_args:
             check_data(data=value, spec=language)
@@ -2111,6 +2162,7 @@ def _render_call_per_element(
             style=style,
             dict_open_overrides=slot_overrides,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
         rendered_elements.append(
             format_call_statement(
@@ -2144,13 +2196,14 @@ def _render_call_whole(
     parameter_names: Sequence[str],
     call_transform: Callable[[str], str] | None,
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> str:
     """Render a single call from the whole parsed value.
 
     A single top-level ref marker renders as just the identifier; in
     that case shape validation and wrap-id computation are skipped.
     """
-    if _extract_call_arg_ref_name(value=data) is None:
+    if _extract_call_arg_ref_name(value=data, ref_key=ref_key) is None:
         check_data(data=data, spec=language)
         validate_call_arg: Callable[[Value], None] | None = getattr(
             language,
@@ -2175,6 +2228,7 @@ def _render_call_whole(
         style=style,
         dict_open_overrides=[None],
         ref_case=ref_case,
+        ref_key=ref_key,
     )
     return format_call_statement(
         _assemble_call(
@@ -2199,6 +2253,7 @@ def literalize_call(
     per_element: bool = True,
     wrap_in_file: bool = False,
     ref_case: IdentifierCase | None = None,
+    ref_key: str = "ref",
 ) -> LiteralizeResult:
     r"""Convert data to function call expressions in the target language.
 
@@ -2234,24 +2289,27 @@ def literalize_call(
             When set, :attr:`preamble` and :attr:`body_preamble`
             on the result are empty tuples (their content has been
             folded into :attr:`code`).
-        ref_case: Optional :class:`IdentifierCase` controlling how
-            ``{"$ref": "name"}`` identifiers are cased in the
-            rendered output.  When ``None`` (default) ref names are
-            emitted verbatim.  When set, each ref identifier is
-            normalized to ``snake_case`` and then converted to the
-            requested case via ``pyhumps``, so the same source can
-            drive idiomatic identifiers across multiple languages.
-            When *language*'s ``identifier_cases`` does not expose
-            the requested case,
+        ref_case: Optional :class:`IdentifierCase` controlling how ref
+            identifiers are cased in the rendered output.  When
+            ``None`` (default) ref names are emitted verbatim.  When
+            set, each ref identifier is normalized to ``snake_case``
+            and then converted to the requested case via ``pyhumps``,
+            so the same source can drive idiomatic identifiers across
+            multiple languages.  When *language*'s ``identifier_cases``
+            does not expose the requested case,
             :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`
             is raised.
+        ref_key: The dict key used to identify variable-reference
+            markers in the input data.  A single-key dict whose key
+            equals *ref_key* and whose value is a string is treated as
+            a ref marker.  Defaults to ``"ref"``.
 
     .. note::
 
         When composing the output of this function with
         :func:`literalize` — for example, declaring a variable with
-        :func:`literalize` and then referencing it via a
-        ``{"$ref": "name"}`` marker in the call — the two halves each
+        :func:`literalize` and then referencing it via a ref marker in
+        the call — the two halves each
         compute :attr:`~LiteralizeResult.preamble` and
         :attr:`~LiteralizeResult.body_preamble` independently from the
         data they see.  Concatenating the results into a single file
@@ -2287,6 +2345,7 @@ def literalize_call(
     data_for_preamble = _strip_call_arg_refs_for_preamble(
         data=data,
         per_element=per_element,
+        ref_key=ref_key,
     )
 
     if per_element:
@@ -2313,6 +2372,7 @@ def literalize_call(
             parameter_names=parameter_names,
             call_transform=call_transform,
             ref_case=ref_case,
+            ref_key=ref_key,
             collection_comments=collection_comments,
         )
     else:
@@ -2324,6 +2384,7 @@ def literalize_call(
             parameter_names=parameter_names,
             call_transform=call_transform,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
     computed = compute_preamble(
         data=data_for_preamble,

--- a/tests/integration/cases/call_ref_args/input.yaml
+++ b/tests/integration/cases/call_ref_args/input.yaml
@@ -1,5 +1,5 @@
 ---
-- - { $ref: my_var }
+- - { ref: my_var }
   - 42
-- - { $ref: my_other }
+- - { ref: my_other }
   - 7

--- a/tests/integration/cases/call_ref_args_converted/input.yaml
+++ b/tests/integration/cases/call_ref_args_converted/input.yaml
@@ -1,5 +1,5 @@
 ---
-- - { $ref: my_var }
+- - { ref: my_var }
   - 42
-- - { $ref: my_other }
+- - { ref: my_other }
   - 7

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/input.yaml
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/input.yaml
@@ -1,5 +1,5 @@
 ---
-- - { $ref: myVar }
+- - { ref: myVar }
   - 42
-- - { $ref: MyOther }
+- - { ref: MyOther }
   - 7

--- a/tests/integration/cases/call_ref_args_converted_whole/input.yaml
+++ b/tests/integration/cases/call_ref_args_converted_whole/input.yaml
@@ -1,2 +1,2 @@
 ---
-$ref: my_var
+ref: my_var

--- a/tests/integration/cases/literalize_ref_in_dict/input.yaml
+++ b/tests/integration/cases/literalize_ref_in_dict/input.yaml
@@ -1,3 +1,3 @@
 ---
 key:
-  $ref: my_var
+  ref: my_var

--- a/tests/integration/cases/literalize_ref_in_list/input.yaml
+++ b/tests/integration/cases/literalize_ref_in_list/input.yaml
@@ -1,3 +1,3 @@
 ---
-- $ref: val_x
-- $ref: val_y
+- ref: val_x
+- ref: val_y

--- a/tests/integration/cases/literalize_ref_whole/input.yaml
+++ b/tests/integration/cases/literalize_ref_whole/input.yaml
@@ -1,2 +1,2 @@
 ---
-$ref: my_var
+ref: my_var

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -53,20 +53,24 @@ def discover_literalize_ref_cases() -> list[LiteralizeRefCase]:
     ]
 
 
-def _collect_ref_names(data: object) -> list[str]:
-    """Recursively collect all ``$ref`` name values from parsed data."""
+def _collect_ref_names(data: object, *, ref_key: str = "ref") -> list[str]:
+    """Recursively collect all ref name values from parsed data."""
     if isinstance(data, dict):
         typed_data = cast("dict[object, object]", data)
-        if len(typed_data) == 1 and "$ref" in typed_data:
-            name = typed_data["$ref"]
+        if len(typed_data) == 1 and ref_key in typed_data:
+            name = typed_data[ref_key]
             return [name] if isinstance(name, str) else []
         return [
-            n for v in typed_data.values() for n in _collect_ref_names(data=v)
+            n
+            for v in typed_data.values()
+            for n in _collect_ref_names(data=v, ref_key=ref_key)
         ]
     if isinstance(data, list):
         typed_list = cast("list[object]", data)
         return [
-            n for item in typed_list for n in _collect_ref_names(data=item)
+            n
+            for item in typed_list
+            for n in _collect_ref_names(data=item, ref_key=ref_key)
         ]
     return []
 

--- a/tests/integration/test_hcl_wrap_in_file.py
+++ b/tests/integration/test_hcl_wrap_in_file.py
@@ -44,7 +44,7 @@ def test_call_after_decl_with_escaped_quote_preserved() -> None:
         variable_form=literalizer.NewVariable(name="my_str"),
     )
     call = literalizer.literalize_call(
-        source="---\n- - {$ref: my_str}\n",
+        source="---\n- - {ref: my_str}\n",
         input_format=literalizer.InputFormat.YAML,
         language=spec,
         target_function="process",

--- a/tests/integration/test_literalize_ref.py
+++ b/tests/integration/test_literalize_ref.py
@@ -1,4 +1,4 @@
-"""Tests for ``{"$ref": "name"}`` marker support in
+"""Tests for ``{ref_key: "name"}`` marker support in
 :func:`literalizer.literalize`.
 """
 
@@ -12,23 +12,21 @@ from .literalize_ref_cases import inject_stubs_before_variable
 
 
 def test_ref_without_ref_case_treated_as_literal() -> None:
-    """Without ref_case, $ref dicts are treated as ordinary literal
+    """Without ref_case, ref dicts are treated as ordinary literal
     dicts.
     """
     result = literalizer.literalize(
-        source='{"$ref": "my_var"}',
+        source='{"ref": "my_var"}',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
     )
-    assert result.bare_code == '{\n    "$ref": "my_var",\n}'
+    assert result.bare_code == '{\n    "ref": "my_var",\n}'
 
 
 def test_ref_with_mixed_list() -> None:
-    """$ref among non-ref elements in a list renders as bare
-    identifier.
-    """
+    """Ref among non-ref elements in a list renders as bare identifier."""
     result = literalizer.literalize(
-        source='[{"$ref": "x"}, 1, 2]',
+        source='[{"ref": "x"}, 1, 2]',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
         ref_case=literalizer.IdentifierCase.SNAKE,
@@ -39,7 +37,7 @@ def test_ref_with_mixed_list() -> None:
 def test_ref_with_case_conversion() -> None:
     """Ref_case converts the identifier name."""
     result = literalizer.literalize(
-        source='{"$ref": "myVar"}',
+        source='{"ref": "myVar"}',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
         ref_case=literalizer.IdentifierCase.SNAKE,
@@ -48,9 +46,9 @@ def test_ref_with_case_conversion() -> None:
 
 
 def test_ref_deep_nesting() -> None:
-    """$ref at arbitrary depth renders as bare identifier."""
+    """Ref at arbitrary depth renders as bare identifier."""
     result = literalizer.literalize(
-        source='{"a": {"b": {"c": {"$ref": "deep"}}}}',
+        source='{"a": {"b": {"c": {"ref": "deep"}}}}',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
         ref_case=literalizer.IdentifierCase.SNAKE,
@@ -64,7 +62,7 @@ def test_unsupported_ref_case_raises() -> None:
     """
     with pytest.raises(expected_exception=UnsupportedIdentifierCaseError):
         literalizer.literalize(
-            source='{"$ref": "my_var"}',
+            source='{"ref": "my_var"}',
             input_format=literalizer.InputFormat.JSON,
             language=Python(),
             ref_case=literalizer.IdentifierCase.KEBAB,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -429,7 +429,7 @@ def test_nix_control_char_key_error_json() -> None:
 def test_dhall_backtick_label_unescaping_json() -> None:
     """Dhall backtick labels contain raw content, not escape sequences."""
     result = literalize(
-        source=json.dumps(obj={"$ref": "value"}),
+        source=json.dumps(obj={"$other": "value"}),
         input_format=InputFormat.JSON,
         language=Dhall(),
         pre_indent_level=0,
@@ -439,7 +439,7 @@ def test_dhall_backtick_label_unescaping_json() -> None:
     expected = textwrap.dedent(
         text="""\
         let my_data = {
-          `$ref` = "value",
+          `$other` = "value",
         } in my_data"""
     )
     assert result.code == expected

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -942,7 +942,7 @@ def test_literalize_call_arg_ref_all_refs() -> None:
     the empty non-ref list must not break wrap-id computation.
     """
     result = literalize_call(
-        source='[[{"$ref": "a"}, {"$ref": "b"}]]',
+        source='[[{"ref": "a"}, {"ref": "b"}]]',
         input_format=InputFormat.JSON,
         language=Go(),
         target_function="combine",
@@ -957,7 +957,7 @@ def test_literalize_call_arg_ref_top_level_element() -> None:
     call whose argument is the referenced identifier.
     """
     result = literalize_call(
-        source='[{"$ref": "a"}, {"$ref": "b"}]',
+        source='[{"ref": "a"}, {"ref": "b"}]',
         input_format=InputFormat.JSON,
         language=Go(),
         target_function="run",
@@ -971,7 +971,7 @@ def test_literalize_call_arg_ref_per_element_false() -> None:
     as the single argument.
     """
     result = literalize_call(
-        source='{"$ref": "payload"}',
+        source='{"ref": "payload"}',
         input_format=InputFormat.JSON,
         language=Python(),
         target_function="publish",
@@ -982,26 +982,25 @@ def test_literalize_call_arg_ref_per_element_false() -> None:
 
 
 def test_literalize_call_arg_ref_non_ref_dict_still_literalized() -> None:
-    """A dict without the exact ``{"$ref": str}`` shape renders as a
-    normal dict literal (e.g. two-key dicts, or non-string ``$ref``
-    values).
+    """A dict without the exact ``{ref_key: str}`` shape renders as a
+    normal dict literal (e.g. two-key dicts, or non-string ref values).
     """
     two_key = literalize_call(
-        source='[[{"$ref": "x", "extra": 1}]]',
+        source='[[{"ref": "x", "extra": 1}]]',
         input_format=InputFormat.JSON,
         language=Python(),
         target_function="process",
         parameter_names=["data"],
     )
-    assert two_key.code == 'process(data={"$ref": "x", "extra": 1})'
+    assert two_key.code == 'process(data={"ref": "x", "extra": 1})'
     non_string_ref = literalize_call(
-        source='[[{"$ref": 42}]]',
+        source='[[{"ref": 42}]]',
         input_format=InputFormat.JSON,
         language=Python(),
         target_function="process",
         parameter_names=["data"],
     )
-    assert non_string_ref.code == 'process(data={"$ref": 42})'
+    assert non_string_ref.code == 'process(data={"ref": 42})'
 
 
 def test_literalize_call_arg_ref_parameter_count_still_validated() -> None:
@@ -1011,7 +1010,7 @@ def test_literalize_call_arg_ref_parameter_count_still_validated() -> None:
         match=r"^Expected 1 parameters but got 2 values$",
     ):
         literalize_call(
-            source='[[{"$ref": "a"}, {"$ref": "b"}]]',
+            source='[[{"ref": "a"}, {"ref": "b"}]]',
             input_format=InputFormat.JSON,
             language=Python(),
             target_function="f",
@@ -1026,7 +1025,7 @@ def test_literalize_call_ref_case_unsupported_raises() -> None:
         match=r"^Python does not support identifier case 'CAMEL'$",
     ):
         literalize_call(
-            source='[[{"$ref": "user_obj"}, 42]]',
+            source='[[{"ref": "user_obj"}, 42]]',
             input_format=InputFormat.JSON,
             language=Python(),
             target_function="process",

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -699,7 +699,7 @@ def test_nix_control_char_key_error() -> None:
 
 def test_dhall_backtick_label_unescaping() -> None:
     """Dhall backtick labels contain raw content, not escape sequences."""
-    yaml_string = '{"$ref": "value"}\n'
+    yaml_string = '{"$other": "value"}\n'
     result = literalize(
         source=yaml_string,
         input_format=InputFormat.YAML,
@@ -711,7 +711,7 @@ def test_dhall_backtick_label_unescaping() -> None:
     expected = textwrap.dedent(
         text="""\
         let my_data = {
-          `$ref` = "value",
+          `$other` = "value",
         } in my_data"""
     )
     assert result.code == expected


### PR DESCRIPTION
## Summary

- `literalize` and `literalize_call` now accept a `ref_key: str` parameter (default `"ref"`) that controls which dict key identifies variable-reference markers in the input data.
- The previously hard-coded key `"$ref"` is no longer the default; callers relying on it must now pass `ref_key="$ref"` explicitly.
- `ref_key` is threaded through all 19 internal formatting functions in `_literalize.py`; private helpers have no default, public entry points default to `"ref"`.
- All integration test fixtures and unit tests updated to use the new default key.

## Test plan

- [ ] All existing tests pass (`1987 passed, 468 skipped`)
- [ ] Verify `literalize(..., ref_key="$ref")` still works for callers using the old convention
- [ ] Verify `literalize(..., ref_key="ref")` (default) works with `{"ref": "name"}` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes by default (`$ref` no longer treated specially unless `ref_key="$ref"`), which can break existing callers and golden fixtures. Implementation touches core formatting paths by threading `ref_key` through many helpers, increasing the chance of subtle missed call sites.
> 
> **Overview**
> **Adds configurable `ref_key` support for ref markers** in both `literalize` and `literalize_call`, threading the key through internal formatting/validation so single-key dicts like `{ref_key: "name"}` can render as identifier references when `ref_case` is set.
> 
> **Breaking change:** the default ref marker key changes from `"$ref"` to `"ref"`; callers must pass `ref_key="$ref"` to preserve prior behavior. Tests and integration fixtures are updated accordingly, and a couple Dhall backtick-label tests are adjusted to avoid accidental ref-marker interpretation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f40265b9eed8821048d3c6ea475196924aa904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->