### PR TITLE
Add allows_bare_call_statement flag to LanguageCls (#1810)

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -499,6 +499,7 @@ class LanguageCls(type):
     supports_special_floats: bool
     supports_variable_names: bool
     supports_dotted_calls: bool
+    allows_bare_call_statement: bool = True
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -212,6 +212,7 @@ class Ada(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    allows_bare_call_statement = False
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -311,6 +311,7 @@ class Fortran(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    allows_bare_call_statement = False
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -231,6 +231,7 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    allows_bare_call_statement = False
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -42,7 +42,6 @@ from literalizer.languages import (
     Raku,
     Roc,
     Sml,
-    SystemVerilog,
     Wren,
 )
 
@@ -395,13 +394,6 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # identifier, so no valid stub can be produced.  COBOL cannot pass
     # multi-line DATA DIVISION entries inline in a CALL statement.
     "call_mixed_type_dicts": frozenset({Cobol, Sml}),
-    # Ada and Fortran do not allow function-call results to be silently
-    # discarded: a function call cannot appear as a statement.  The
-    # identity call_transform (lambda c: c) causes a VALUE stub but the
-    # call is used as a bare statement, which both compilers reject.
-    # SystemVerilog requires void'(...) to discard a function return value;
-    # a bare function call as a statement is non-standard.
-    "call_transform_no_wrapper": frozenset({Ada, Fortran, SystemVerilog}),
     # call_transform wraps output as "emit(inner)", which is invalid in
     # Wren (no free-function call syntax) and COBOL (CALL statement
     # produces no expression value that can be passed to another call).
@@ -485,6 +477,13 @@ def discover_call_cases() -> list[CallCase]:
                 continue
             has_dotted_target = "." in config.target_function
             if has_dotted_target and not lang_cls.supports_dotted_calls:
+                continue
+            _probe = "__probe__"
+            if (
+                config.call_transform is not None
+                and config.call_transform(_probe) == _probe
+                and not lang_cls.allows_bare_call_statement
+            ):
                 continue
             if lang_cls in CASE_LANGUAGE_INCOMPATIBLE.get(
                 config.case_dir_name, frozenset()


### PR DESCRIPTION
Closes #1810.

## Summary

- Added `allows_bare_call_statement: bool = True` to `LanguageCls` metaclass (default `True`, so all existing languages get it for free)
- Set `allows_bare_call_statement = False` on `Ada`, `Fortran`, and `SystemVerilog`
- Updated `discover_call_cases()` to skip cases where `call_transform` is the identity function and the language does not allow bare call statements
- Removed the `"call_transform_no_wrapper": frozenset({Ada, Fortran, SystemVerilog})` entry from `CASE_LANGUAGE_INCOMPATIBLE` and removed the now-unused `SystemVerilog` import

## Test plan

- All 1011 existing call golden-file tests pass
- `test_no_dead_golden_files` passes (no orphan golden files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new per-language capability flag and only changes test-case discovery logic to skip invalid call scenarios for certain languages, without altering core literal rendering behavior.
> 
> **Overview**
> Introduces a new `LanguageCls.allows_bare_call_statement` capability flag (defaulting to `True`) to model languages that disallow discarding function return values as standalone statements.
> 
> Marks `Ada`, `Fortran`, and `SystemVerilog` as not allowing bare call statements, and updates call golden-case discovery to automatically skip identity `call_transform` scenarios for those languages (removing the prior hard-coded incompatibility list entry and the now-unused `SystemVerilog` test import).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a7bf965f335e4384e0931d214f69b250de29e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->