### PR TITLE
Add has_free_function_calls flag; skip free-function call cases for Wren

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -272,7 +272,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install npm-sourced linters
-        run: npm install -g json5 tree-sitter-cli typescript tsx elm-format elm
+        run: |
+          for i in 1 2 3; do
+            npm install -g json5 tree-sitter-cli typescript tsx elm-format elm && break
+            [ "$i" -lt 3 ] && echo "Retry $i..." && sleep 15
+          done
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -499,6 +499,7 @@ class LanguageCls(type):
     supports_special_floats: bool
     supports_variable_names: bool
     supports_dotted_calls: bool
+    has_free_function_calls: bool
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -212,6 +212,7 @@ class Ada(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -189,6 +189,7 @@ class Bash(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Bash."""

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -217,6 +217,7 @@ class C(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for C."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -103,6 +103,7 @@ class Clojure(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Clojure."""

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -331,6 +331,7 @@ class Cobol(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -112,6 +112,7 @@ class CommonLisp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for CommonLisp."""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -868,6 +868,7 @@ class Cpp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for C++."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -173,6 +173,7 @@ class Crystal(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Crystal."""

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -356,6 +356,7 @@ class CSharp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     _opener_config = TypedOpenerConfig(
         str_type="string",

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -159,6 +159,7 @@ class D(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for D."""

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -277,6 +277,7 @@ class Dart(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -520,6 +520,7 @@ class Dhall(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Dhall."""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -200,6 +200,7 @@ class Elixir(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Elixir."""

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -492,6 +492,7 @@ class Elm(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Elm."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -194,6 +194,7 @@ class Erlang(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Erlang."""

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -193,6 +193,7 @@ class Forth(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -311,6 +311,7 @@ class Fortran(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -253,6 +253,7 @@ class FSharp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for FSharp."""

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -507,6 +507,7 @@ class Gleam(metaclass=LanguageCls):
     supports_special_floats = False
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Gleam."""

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -256,6 +256,7 @@ class Go(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Go."""

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -136,6 +136,7 @@ class Groovy(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Groovy."""

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -932,6 +932,7 @@ class Haskell(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Haskell."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -140,6 +140,7 @@ class Hcl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = False
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Hcl."""

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -572,6 +572,7 @@ class Java(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -123,6 +123,7 @@ class JavaScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for JavaScript."""

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -116,6 +116,7 @@ class Json5(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Json5."""

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -132,6 +132,7 @@ class Jsonnet(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Jsonnet."""

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -151,6 +151,7 @@ class Julia(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for Julia."""

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -427,6 +427,7 @@ class Kotlin(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -137,6 +137,7 @@ class Lua(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Lua."""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -204,6 +204,7 @@ class Matlab(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Matlab."""

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -384,6 +384,7 @@ class Mojo(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Mojo."""

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -530,6 +530,7 @@ class Nim(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Nim."""

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -184,6 +184,7 @@ class Nix(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Nix."""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -88,6 +88,7 @@ class Norg(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Norg."""

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -265,6 +265,7 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -241,6 +241,7 @@ class OCaml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -98,6 +98,7 @@ class Occam(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -208,6 +208,7 @@ class Odin(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Odin."""

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -147,6 +147,7 @@ class Perl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Perl."""

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -146,6 +146,7 @@ class Php(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Php."""

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -162,6 +162,7 @@ class PowerShell(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for PowerShell."""

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -644,6 +644,7 @@ class PureScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for PureScript."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -519,6 +519,7 @@ class Python(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for Python."""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -161,6 +161,7 @@ class R(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for R."""

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -104,6 +104,7 @@ class Racket(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Racket."""

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -180,6 +180,7 @@ class Raku(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Raku."""

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -507,6 +507,7 @@ class Roc(metaclass=LanguageCls):
     supports_default_ordered_map_value_type = False
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
     supports_special_floats = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -158,6 +158,7 @@ class Ruby(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Ruby."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -685,6 +685,7 @@ class Rust(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Rust."""

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -207,6 +207,7 @@ class Scala(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
     module_name: str = "Check"
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -100,6 +100,7 @@ class Scheme(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Scheme."""

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -297,6 +297,7 @@ class Sml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -324,6 +324,7 @@ class Swift(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Swift."""

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -231,6 +231,7 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -145,6 +145,7 @@ class Tcl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -116,6 +116,7 @@ class Toml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Toml."""

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -243,6 +243,7 @@ class TypeScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for TypeScript."""

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -313,6 +313,7 @@ class V(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for V."""

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -264,6 +264,7 @@ class VisualBasic(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for VisualBasic."""

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -163,6 +163,7 @@ class Wren(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = False
 
     class DateFormats(enum.Enum):
         """Date format options for Wren."""

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -90,6 +90,7 @@ class Yaml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Yaml."""

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -232,6 +232,7 @@ class Zig(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    has_free_function_calls = True
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -43,7 +43,6 @@ from literalizer.languages import (
     Roc,
     Sml,
     SystemVerilog,
-    Wren,
 )
 
 from .check_golden import check_golden
@@ -402,11 +401,10 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # SystemVerilog requires void'(...) to discard a function return value;
     # a bare function call as a statement is non-standard.
     "call_transform_no_wrapper": frozenset({Ada, Fortran, SystemVerilog}),
-    # call_transform wraps output as "emit(inner)", which is invalid in
-    # Wren (no free-function call syntax) and COBOL (CALL statement
-    # produces no expression value that can be passed to another call).
-    "call_keyword_args": frozenset({Cobol, Wren}),
-    "call_deep_dotted_transformed": frozenset({Cobol, Wren}),
+    # COBOL CALL statement produces no expression value that can be passed
+    # to another call, so emit(inner) is invalid.
+    "call_keyword_args": frozenset({Cobol}),
+    "call_deep_dotted_transformed": frozenset({Cobol}),
     # call_transform wraps output as "tracer.emit(inner)" — a dotted method
     # call — and transform_stub_names=["tracer.emit"] requires a struct/object
     # stub whose syntax is invalid or unsupported in several languages.
@@ -485,6 +483,10 @@ def discover_call_cases() -> list[CallCase]:
                 continue
             has_dotted_target = "." in config.target_function
             if has_dotted_target and not lang_cls.supports_dotted_calls:
+                continue
+            if not lang_cls.has_free_function_calls and any(
+                "." not in name for name in config.transform_stub_names
+            ):
                 continue
             if lang_cls in CASE_LANGUAGE_INCOMPATIBLE.get(
                 config.case_dir_name, frozenset()

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -41,7 +41,6 @@ from literalizer.languages import (
     PureScript,
     Raku,
     Roc,
-    Sml,
 )
 
 from .check_golden import check_golden
@@ -488,11 +487,9 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 # names, or call_transform wrapper use syntax that is invalid in a given
 # language, making a valid lint-passing output impossible to generate.
 CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
-    # target_function "app.mgr.op" has "op" as the innermost name; "op"
-    # is a reserved word in SML and cannot be used as a fun or val
-    # identifier, so no valid stub can be produced.  COBOL cannot pass
-    # multi-line DATA DIVISION entries inline in a CALL statement.
-    "call_mixed_type_dicts": frozenset({Cobol, Sml}),
+    # COBOL cannot pass multi-line DATA DIVISION entries inline in a CALL
+    # statement.  SML is excluded via reserved_identifiers ("op").
+    "call_mixed_type_dicts": frozenset({Cobol}),
     # COBOL CALL statement produces no expression value that can be passed
     # to another call, so emit(inner) is invalid.
     "call_keyword_args": frozenset({Cobol}),

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -493,7 +493,7 @@ def discover_call_cases() -> list[CallCase]:
         for lang_cls in sorted_languages():
             if len(lang_cls.CallStyles) == 0:
                 continue
-            if not _lang_supports_case(config, lang_cls):
+            if not _lang_supports_case(config=config, lang_cls=lang_cls):
                 continue
             if lang_cls in CASE_LANGUAGE_INCOMPATIBLE.get(
                 config.case_dir_name, frozenset()


### PR DESCRIPTION
$(cat <<'EOF'
Closes #1811.

## Summary

- Added `has_free_function_calls: bool` to `LanguageCls` (declared alongside `supports_dotted_calls`)
- Set `has_free_function_calls = True` on all 63 language classes
- Set `has_free_function_calls = False` on `Wren`
- In `discover_call_cases()`, skip cases whose `transform_stub_names` contain an undotted name (i.e. a free-function call wrapper like `emit`) for languages where `has_free_function_calls` is `False`
- Removed `Wren` from the `call_keyword_args` and `call_deep_dotted_transformed` entries in `CASE_LANGUAGE_INCOMPATIBLE`

## Test plan

- [ ] All existing call golden-file tests pass (1011 passed, 43 skipped)
- [ ] Wren-specific call tests (17) all pass
- [ ] mypy, pyright, ty, pyrefly all pass
EOF
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly metadata and test-case filtering changes; behavior impact is limited to which call fixtures are generated/run, not core literalization output.
> 
> **Overview**
> Adds a new per-language capability flag, `LanguageCls.has_free_function_calls`, and populates it across all language specs (**`False` for `Wren`, `True` elsewhere**) to distinguish languages that can’t emit free-function wrapper calls.
> 
> Updates call golden-case discovery to skip configurations whose `call_transform` requires an undotted wrapper stub (e.g. `emit(...)`) when the target language lacks free-function calls, and refines per-case exclusions by removing Wren-specific exceptions and tightening them for COBOL where nested/wrapped calls or inline multi-line args aren’t representable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b61669fcee26569a60f2a42cf6e11b3618d7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->