### PR TITLE
Add reserved_identifiers to LanguageCls; derive SML op skip from it

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -499,6 +499,7 @@ class LanguageCls(type):
     supports_special_floats: bool
     supports_variable_names: bool
     supports_dotted_calls: bool
+    reserved_identifiers: frozenset[str] = frozenset()
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -297,7 +297,7 @@ class Sml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
-    reserved_identifiers = frozenset({"op"})
+    reserved_identifiers: ClassVar[frozenset[str]] = frozenset({"op"})
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -297,6 +297,7 @@ class Sml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    reserved_identifiers = frozenset({"op"})
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -487,7 +487,7 @@ def discover_call_cases() -> list[CallCase]:
                 config.case_dir_name, frozenset()
             ):
                 continue
-            innermost = config.target_function.split(".")[-1]
+            innermost = config.target_function.split(sep=".")[-1]
             if innermost in lang_cls.reserved_identifiers:
                 continue
             if config.call_style_type is not None:

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -41,7 +41,6 @@ from literalizer.languages import (
     PureScript,
     Raku,
     Roc,
-    Sml,
     SystemVerilog,
     Wren,
 )
@@ -390,11 +389,9 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 # names, or call_transform wrapper use syntax that is invalid in a given
 # language, making a valid lint-passing output impossible to generate.
 CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
-    # target_function "app.mgr.op" has "op" as the innermost name; "op"
-    # is a reserved word in SML and cannot be used as a fun or val
-    # identifier, so no valid stub can be produced.  COBOL cannot pass
-    # multi-line DATA DIVISION entries inline in a CALL statement.
-    "call_mixed_type_dicts": frozenset({Cobol, Sml}),
+    # COBOL cannot pass multi-line DATA DIVISION entries inline in a CALL
+    # statement.
+    "call_mixed_type_dicts": frozenset({Cobol}),
     # Ada and Fortran do not allow function-call results to be silently
     # discarded: a function call cannot appear as a statement.  The
     # identity call_transform (lambda c: c) causes a VALUE stub but the
@@ -489,6 +486,9 @@ def discover_call_cases() -> list[CallCase]:
             if lang_cls in CASE_LANGUAGE_INCOMPATIBLE.get(
                 config.case_dir_name, frozenset()
             ):
+                continue
+            innermost = config.target_function.split(".")[-1]
+            if innermost in lang_cls.reserved_identifiers:
                 continue
             if config.call_style_type is not None:
                 # Only include languages that have this as a


### PR DESCRIPTION
Closes #1809.

## Summary

- Adds `reserved_identifiers: frozenset[str] = frozenset()` to `LanguageCls` (default empty, so all other language classes require no changes)
- Sets `reserved_identifiers: ClassVar[frozenset[str]] = frozenset({"op"})` on `Sml`
- In `discover_call_cases()`, skips a language when the innermost segment of `config.target_function` is in `lang_cls.reserved_identifiers`
- Removes the hard-coded `Sml` entry from `CASE_LANGUAGE_INCOMPATIBLE["call_mixed_type_dicts"]` (and removes the now-unused `Sml` import)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive metadata plus a test-case selection tweak; runtime behavior is unchanged except for which integration golden cases run for certain languages.
> 
> **Overview**
> Adds `reserved_identifiers` (default empty) to `LanguageCls` so language specs can declare reserved words that cannot appear as generated stub identifiers.
> 
> Updates the call golden-case harness to automatically skip a language when the *innermost* segment of `target_function` is reserved, and migrates SML’s `op` exclusion to this mechanism (removing the hard-coded `Sml` incompatibility entry and import).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9f03a5668133fb703ad3c2845f735a3f523e91e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->