### PR TITLE
Express COBOL CALL-statement incompatibilities as language properties

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -499,6 +499,8 @@ class LanguageCls(type):
     supports_special_floats: bool
     supports_variable_names: bool
     supports_dotted_calls: bool
+    call_returns_expression: bool
+    supports_inline_multiline_dict_args: bool
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -212,6 +212,8 @@ class Ada(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -189,6 +189,8 @@ class Bash(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Bash."""

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -217,6 +217,8 @@ class C(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for C."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -103,6 +103,8 @@ class Clojure(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Clojure."""

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -331,6 +331,8 @@ class Cobol(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = False
+    supports_inline_multiline_dict_args = False
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -112,6 +112,8 @@ class CommonLisp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for CommonLisp."""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -868,6 +868,8 @@ class Cpp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for C++."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -173,6 +173,8 @@ class Crystal(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Crystal."""

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -356,6 +356,8 @@ class CSharp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     _opener_config = TypedOpenerConfig(
         str_type="string",

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -159,6 +159,8 @@ class D(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for D."""

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -277,6 +277,8 @@ class Dart(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -520,6 +520,8 @@ class Dhall(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Dhall."""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -200,6 +200,8 @@ class Elixir(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Elixir."""

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -492,6 +492,8 @@ class Elm(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Elm."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -194,6 +194,8 @@ class Erlang(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Erlang."""

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -193,6 +193,8 @@ class Forth(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -311,6 +311,8 @@ class Fortran(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -253,6 +253,8 @@ class FSharp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for FSharp."""

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -507,6 +507,8 @@ class Gleam(metaclass=LanguageCls):
     supports_special_floats = False
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Gleam."""

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -256,6 +256,8 @@ class Go(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Go."""

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -136,6 +136,8 @@ class Groovy(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Groovy."""

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -932,6 +932,8 @@ class Haskell(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Haskell."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -140,6 +140,8 @@ class Hcl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = False
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Hcl."""

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -572,6 +572,8 @@ class Java(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -123,6 +123,8 @@ class JavaScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for JavaScript."""

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -116,6 +116,8 @@ class Json5(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Json5."""

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -132,6 +132,8 @@ class Jsonnet(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Jsonnet."""

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -151,6 +151,8 @@ class Julia(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for Julia."""

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -427,6 +427,8 @@ class Kotlin(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -137,6 +137,8 @@ class Lua(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Lua."""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -204,6 +204,8 @@ class Matlab(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Matlab."""

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -384,6 +384,8 @@ class Mojo(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Mojo."""

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -530,6 +530,8 @@ class Nim(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Nim."""

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -184,6 +184,8 @@ class Nix(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Nix."""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -88,6 +88,8 @@ class Norg(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Norg."""

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -265,6 +265,8 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -241,6 +241,8 @@ class OCaml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -98,6 +98,8 @@ class Occam(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -208,6 +208,8 @@ class Odin(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Odin."""

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -147,6 +147,8 @@ class Perl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Perl."""

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -146,6 +146,8 @@ class Php(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Php."""

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -162,6 +162,8 @@ class PowerShell(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for PowerShell."""

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -644,6 +644,8 @@ class PureScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for PureScript."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -519,6 +519,8 @@ class Python(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for Python."""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -161,6 +161,8 @@ class R(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for R."""

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -104,6 +104,8 @@ class Racket(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Racket."""

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -180,6 +180,8 @@ class Raku(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Raku."""

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -507,6 +507,8 @@ class Roc(metaclass=LanguageCls):
     supports_default_ordered_map_value_type = False
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
     supports_special_floats = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -158,6 +158,8 @@ class Ruby(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Ruby."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -685,6 +685,8 @@ class Rust(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Rust."""

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -207,6 +207,8 @@ class Scala(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
     module_name: str = "Check"
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -100,6 +100,8 @@ class Scheme(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Scheme."""

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -297,6 +297,8 @@ class Sml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -324,6 +324,8 @@ class Swift(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Swift."""

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -231,6 +231,8 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -145,6 +145,8 @@ class Tcl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -116,6 +116,8 @@ class Toml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Toml."""

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -243,6 +243,8 @@ class TypeScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date formatting options for TypeScript."""

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -313,6 +313,8 @@ class V(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for V."""

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -264,6 +264,8 @@ class VisualBasic(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for VisualBasic."""

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -163,6 +163,8 @@ class Wren(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Wren."""

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -90,6 +90,8 @@ class Yaml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Yaml."""

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -232,6 +232,8 @@ class Zig(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_dotted_calls = True
+    call_returns_expression = True
+    supports_inline_multiline_dict_args = True
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -510,7 +510,7 @@ def _lang_satisfies_config_constraints(
     lang_cls: literalizer.LanguageCls,
     config: CallCaseConfig,
 ) -> bool:
-    """Return False if *lang_cls* cannot fulfil *config*'s language
+    """Return False if *lang_cls* does not satisfy *config*'s language
     constraints.
     """
     _probe = "__probe__"

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -117,6 +117,8 @@ class CallCaseConfig:
     # directly instead of wrapping manually with injected stubs.
     wrap_in_file: bool
     ref_case_per_language: bool
+    requires_call_returns_expression: bool
+    requires_inline_multiline_dict_args: bool
 
 
 CALL_STYLE_VARIANTS: list[tuple[str, type[literalizer.CallStyle]]] = [
@@ -138,6 +140,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=True,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_scalar_args",
@@ -150,6 +154,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_comments",
@@ -162,6 +168,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_comments_dict_args",
@@ -174,6 +182,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=True,
     ),
     CallCaseConfig(
         case_dir_name="call_negative_int",
@@ -186,6 +196,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_multi_args",
@@ -198,6 +210,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_dotted_method",
@@ -210,6 +224,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_deep_dotted_method",
@@ -222,6 +238,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_snake_dotted_method",
@@ -234,6 +252,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_deep_dotted_transformed",
@@ -246,6 +266,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=True,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_dotted_transform_stub",
@@ -258,6 +280,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=True,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_transform_no_wrapper",
@@ -270,6 +294,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_per_element_false",
@@ -282,6 +308,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args",
@@ -297,6 +325,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         },
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args_converted",
@@ -312,6 +342,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         },
         wrap_in_file=False,
         ref_case_per_language=True,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args_converted_whole",
@@ -326,6 +358,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         },
         wrap_in_file=False,
         ref_case_per_language=True,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args_converted_nonsnake",
@@ -341,6 +375,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         },
         wrap_in_file=False,
         ref_case_per_language=True,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
         case_dir_name="call_mixed_type_dicts",
@@ -353,6 +389,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=False,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=True,
     ),
     CallCaseConfig(
         # Drive ``literalize_call(..., wrap_in_file=True)`` directly so
@@ -367,6 +405,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         ref_declarations={},
         wrap_in_file=True,
         ref_case_per_language=False,
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
     ),
     *[
         CallCaseConfig(
@@ -380,6 +420,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
             ref_declarations={},
             wrap_in_file=False,
             ref_case_per_language=False,
+            requires_call_returns_expression=True,
+            requires_inline_multiline_dict_args=False,
         )
         for name, cls in CALL_STYLE_VARIANTS
     ],
@@ -392,9 +434,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # target_function "app.mgr.op" has "op" as the innermost name; "op"
     # is a reserved word in SML and cannot be used as a fun or val
-    # identifier, so no valid stub can be produced.  COBOL cannot pass
-    # multi-line DATA DIVISION entries inline in a CALL statement.
-    "call_mixed_type_dicts": frozenset({Cobol, Sml}),
+    # identifier, so no valid stub can be produced.
+    "call_mixed_type_dicts": frozenset({Sml}),
     # Ada and Fortran do not allow function-call results to be silently
     # discarded: a function call cannot appear as a statement.  The
     # identity call_transform (lambda c: c) causes a VALUE stub but the
@@ -403,10 +444,9 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # a bare function call as a statement is non-standard.
     "call_transform_no_wrapper": frozenset({Ada, Fortran, SystemVerilog}),
     # call_transform wraps output as "emit(inner)", which is invalid in
-    # Wren (no free-function call syntax) and COBOL (CALL statement
-    # produces no expression value that can be passed to another call).
-    "call_keyword_args": frozenset({Cobol, Wren}),
-    "call_deep_dotted_transformed": frozenset({Cobol, Wren}),
+    # Wren (no free-function call syntax).
+    "call_keyword_args": frozenset({Wren}),
+    "call_deep_dotted_transformed": frozenset({Wren}),
     # call_transform wraps output as "tracer.emit(inner)" — a dotted method
     # call — and transform_stub_names=["tracer.emit"] requires a struct/object
     # stub whose syntax is invalid or unsupported in several languages.
@@ -452,7 +492,6 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     ),
     "call_comments_dict_args": frozenset(
         {
-            Cobol,
             Dhall,
             Elm,
             Erlang,
@@ -474,6 +513,25 @@ class CallCase:
     lang_cls: literalizer.LanguageCls
 
 
+@beartype
+def _lang_satisfies_config_constraints(
+    lang_cls: literalizer.LanguageCls,
+    config: CallCaseConfig,
+) -> bool:
+    """Return False if *lang_cls* cannot fulfil *config*'s language
+    constraints.
+    """
+    if (
+        config.requires_call_returns_expression
+        and not lang_cls.call_returns_expression
+    ):
+        return False
+    return not (
+        config.requires_inline_multiline_dict_args
+        and not lang_cls.supports_inline_multiline_dict_args
+    )
+
+
 @functools.cache
 @beartype
 def discover_call_cases() -> list[CallCase]:
@@ -489,6 +547,8 @@ def discover_call_cases() -> list[CallCase]:
             if lang_cls in CASE_LANGUAGE_INCOMPATIBLE.get(
                 config.case_dir_name, frozenset()
             ):
+                continue
+            if not _lang_satisfies_config_constraints(lang_cls, config):
                 continue
             if config.call_style_type is not None:
                 # Only include languages that have this as a

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -548,7 +548,9 @@ def discover_call_cases() -> list[CallCase]:
                 config.case_dir_name, frozenset()
             ):
                 continue
-            if not _lang_satisfies_config_constraints(lang_cls, config):
+            if not _lang_satisfies_config_constraints(
+                lang_cls=lang_cls, config=config
+            ):
                 continue
             if config.call_style_type is not None:
                 # Only include languages that have this as a


### PR DESCRIPTION
Closes #1812.

## Summary

- Add `call_returns_expression: bool` and `supports_inline_multiline_dict_args: bool` to `LanguageCls` and every language class. COBOL gets `False` for both; all others get `True`.
- Add `requires_call_returns_expression: bool` and `requires_inline_multiline_dict_args: bool` to `CallCaseConfig` (no defaults; all call sites pass explicitly).
- Add `_lang_satisfies_config_constraints()` helper and call it from `discover_call_cases()` to derive per-language skips from the new language properties.
- Remove COBOL from the `call_mixed_type_dicts`, `call_keyword_args`, `call_deep_dotted_transformed`, and `call_comments_dict_args` entries in `CASE_LANGUAGE_INCOMPATIBLE` -- those exclusions are now derived automatically.

## Test plan

- All 2046 existing tests pass with no golden-file changes (COBOL is still excluded from the same cases, now via language properties instead of hard-coded set membership).
- All pre-commit hooks (ruff, mypy, pyright, ty, pyrefly) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `LanguageCls` interface and requires all language implementations to define new attributes, which could break external/custom language specs. Runtime behavior changes are limited to test-case discovery/exclusion logic.
> 
> **Overview**
> Adds two new per-language capability flags, `call_returns_expression` and `supports_inline_multiline_dict_args`, to `LanguageCls` and wires them into every language spec (COBOL sets both `False`, others `True`).
> 
> Updates call golden-test configuration to declare per-case requirements (`requires_call_returns_expression`, `requires_inline_multiline_dict_args`) and centralizes the filtering logic in `_lang_satisfies_config_constraints()` within `discover_call_cases()`, allowing several COBOL-specific entries to be removed from `CASE_LANGUAGE_INCOMPATIBLE` in favor of capability-driven skipping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166efeaefb9603245306c260c12fb2641db6aa08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->