### PR TITLE
Remove defaults from _collect_ref_names and LiteralizeRefCaseConfig

### DIFF
--- a/tests/integration/case_discovery.py
+++ b/tests/integration/case_discovery.py
@@ -32,13 +32,26 @@ class LiteralizeRefCaseConfig:
     """
 
     case_dir_name: str
+    ref_key: str
 
 
 LITERALIZE_REF_CASE_CONFIGS: list[LiteralizeRefCaseConfig] = [
-    LiteralizeRefCaseConfig(case_dir_name="literalize_ref_whole"),
-    LiteralizeRefCaseConfig(case_dir_name="literalize_ref_in_dict"),
-    LiteralizeRefCaseConfig(case_dir_name="literalize_ref_in_list"),
-    LiteralizeRefCaseConfig(case_dir_name="literalize_ref_heterogeneous"),
+    LiteralizeRefCaseConfig(
+        case_dir_name="literalize_ref_whole",
+        ref_key="ref",
+    ),
+    LiteralizeRefCaseConfig(
+        case_dir_name="literalize_ref_in_dict",
+        ref_key="ref",
+    ),
+    LiteralizeRefCaseConfig(
+        case_dir_name="literalize_ref_in_list",
+        ref_key="ref",
+    ),
+    LiteralizeRefCaseConfig(
+        case_dir_name="literalize_ref_heterogeneous",
+        ref_key="ref",
+    ),
 ]
 
 

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -53,7 +53,7 @@ def discover_literalize_ref_cases() -> list[LiteralizeRefCase]:
     ]
 
 
-def _collect_ref_names(data: object, *, ref_key: str = "ref") -> list[str]:
+def _collect_ref_names(data: object, *, ref_key: str) -> list[str]:
     """Recursively collect all ref name values from parsed data."""
     match data:
         case dict():
@@ -311,6 +311,7 @@ def run_literalize_ref_golden_case(
             variable_form=wrap_variable_form(lang_cls=lang_cls),
             wrap_in_file=True,
             ref_case=ref_case,
+            ref_key=config.ref_key,
         )
     except HeterogeneousCollectionError:
         golden_path.unlink(missing_ok=True)
@@ -329,7 +330,10 @@ def run_literalize_ref_golden_case(
             stream=yaml_string,
         )
         stub_entries: list[tuple[str, str]] = []
-        for raw_name in _collect_ref_names(data=raw_data):
+        for raw_name in _collect_ref_names(
+            data=raw_data,
+            ref_key=config.ref_key,
+        ):
             converted_name = ref_case.convert(name=raw_name)
             stub = literalizer.literalize(
                 source='{"_": "_"}',


### PR DESCRIPTION
## Summary

- Remove the default value from `ref_key` in `_collect_ref_names` so all callers must pass it explicitly.
- Add `ref_key` as a required field on `LiteralizeRefCaseConfig` (no default), with all existing configs passing `ref_key="ref"` explicitly.
- Thread `ref_key=config.ref_key` through `run_literalize_ref_golden_case` to both the `literalize` call and `_collect_ref_names`.

## Test plan

- [ ] Existing test suite passes (no behaviour change, only explicitness enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that make `ref_key` explicit; behavior should remain the same aside from potential failures where callers previously relied on defaults.
> 
> **Overview**
> Makes `ref_key` an explicit, required part of literalize-ref integration test configuration.
> 
> `LiteralizeRefCaseConfig` now includes a required `ref_key`, `_collect_ref_names` no longer defaults to `"ref"`, and `run_literalize_ref_golden_case` threads `config.ref_key` into both `literalizer.literalize` and stub generation so all ref handling is driven by the per-case config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608c55b9b150d399240208fdacf19167b2b98670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->