### PR TITLE
Change default ref_key from "ref" to "$ref"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,12 +5,11 @@ Next
 ----
 
 - :func:`~literalizer.literalize` and :func:`~literalizer.literalize_call`
-  now accept a ``ref_key`` parameter (``str``, default ``"ref"``).  The
+  now accept a ``ref_key`` parameter (``str``, default ``"$ref"``).  The
   marker key used to identify variable-reference mappings in the input data
   is now user-configurable: a single-key dict whose key equals *ref_key*
   and whose value is a string is treated as a ref marker when *ref_case* is
-  set.  The previous hard-coded key ``"$ref"`` is no longer the default;
-  callers that relied on ``$ref`` must pass ``ref_key="$ref"`` explicitly.
+  set.
 - Every built-in language class now exposes a ``VersionFormats`` enum and a
   configurable ``language_version`` constructor parameter that selects which
   version of the target language the generated code is written for.  For

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1595,7 +1595,7 @@ def literalize(
     variable_form: VariableForm | None = None,
     wrap_in_file: bool = False,
     ref_case: IdentifierCase | None = None,
-    ref_key: str = "ref",
+    ref_key: str = "$ref",
 ) -> LiteralizeResult:
     r"""Convert a JSON, JSON5, YAML, or TOML string to a native
     language literal.
@@ -1645,7 +1645,7 @@ def literalize(
         ref_key: The dict key used to identify variable-reference
             markers in the input data.  A single-key dict whose key
             equals *ref_key* and whose value is a string is treated as a
-            ref marker when *ref_case* is set.  Defaults to ``"ref"``.
+            ref marker when *ref_case* is set.  Defaults to ``"$ref"``.
 
     Raises:
         JSONParseError: If *input_format* is ``JSON`` and *source* is
@@ -2253,7 +2253,7 @@ def literalize_call(
     per_element: bool = True,
     wrap_in_file: bool = False,
     ref_case: IdentifierCase | None = None,
-    ref_key: str = "ref",
+    ref_key: str = "$ref",
 ) -> LiteralizeResult:
     r"""Convert data to function call expressions in the target language.
 
@@ -2302,7 +2302,7 @@ def literalize_call(
         ref_key: The dict key used to identify variable-reference
             markers in the input data.  A single-key dict whose key
             equals *ref_key* and whose value is a string is treated as
-            a ref marker.  Defaults to ``"ref"``.
+            a ref marker.  Defaults to ``"$ref"``.
 
     .. note::
 

--- a/tests/integration/case_discovery.py
+++ b/tests/integration/case_discovery.py
@@ -38,19 +38,19 @@ class LiteralizeRefCaseConfig:
 LITERALIZE_REF_CASE_CONFIGS: list[LiteralizeRefCaseConfig] = [
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_whole",
-        ref_key="ref",
+        ref_key="$ref",
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_in_dict",
-        ref_key="ref",
+        ref_key="$ref",
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_in_list",
-        ref_key="ref",
+        ref_key="$ref",
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_heterogeneous",
-        ref_key="ref",
+        ref_key="$ref",
     ),
 ]
 

--- a/tests/integration/cases/call_ref_args/input.yaml
+++ b/tests/integration/cases/call_ref_args/input.yaml
@@ -1,5 +1,4 @@
----
-- - { ref: my_var }
+- - { $ref: my_var }
   - 42
-- - { ref: my_other }
+- - { $ref: my_other }
   - 7

--- a/tests/integration/cases/call_ref_args_converted/input.yaml
+++ b/tests/integration/cases/call_ref_args_converted/input.yaml
@@ -1,5 +1,4 @@
----
-- - { ref: my_var }
+- - { $ref: my_var }
   - 42
-- - { ref: my_other }
+- - { $ref: my_other }
   - 7

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/input.yaml
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/input.yaml
@@ -1,5 +1,4 @@
----
-- - { ref: myVar }
+- - { $ref: myVar }
   - 42
-- - { ref: MyOther }
+- - { $ref: MyOther }
   - 7

--- a/tests/integration/cases/call_ref_args_converted_whole/input.yaml
+++ b/tests/integration/cases/call_ref_args_converted_whole/input.yaml
@@ -1,2 +1,1 @@
----
-ref: my_var
+$ref: my_var

--- a/tests/integration/cases/literalize_ref_in_dict/input.yaml
+++ b/tests/integration/cases/literalize_ref_in_dict/input.yaml
@@ -1,3 +1,2 @@
----
 key:
-  ref: my_var
+  $ref: my_var

--- a/tests/integration/cases/literalize_ref_in_list/input.yaml
+++ b/tests/integration/cases/literalize_ref_in_list/input.yaml
@@ -1,3 +1,2 @@
----
-- ref: val_x
-- ref: val_y
+- $ref: val_x
+- $ref: val_y

--- a/tests/integration/cases/literalize_ref_whole/input.yaml
+++ b/tests/integration/cases/literalize_ref_whole/input.yaml
@@ -1,2 +1,1 @@
----
-ref: my_var
+$ref: my_var

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -53,7 +53,7 @@ def discover_literalize_ref_cases() -> list[LiteralizeRefCase]:
     ]
 
 
-def _collect_ref_names(data: object, *, ref_key: str = "ref") -> list[str]:
+def _collect_ref_names(data: object, *, ref_key: str = "$ref") -> list[str]:
     """Recursively collect all ref name values from parsed data."""
     match data:
         case dict():

--- a/tests/integration/test_hcl_wrap_in_file.py
+++ b/tests/integration/test_hcl_wrap_in_file.py
@@ -44,7 +44,7 @@ def test_call_after_decl_with_escaped_quote_preserved() -> None:
         variable_form=literalizer.NewVariable(name="my_str"),
     )
     call = literalizer.literalize_call(
-        source="---\n- - {ref: my_str}\n",
+        source="---\n- - {$ref: my_str}\n",
         input_format=literalizer.InputFormat.YAML,
         language=spec,
         target_function="process",

--- a/tests/integration/test_literalize_ref.py
+++ b/tests/integration/test_literalize_ref.py
@@ -16,17 +16,17 @@ def test_ref_without_ref_case_treated_as_literal() -> None:
     dicts.
     """
     result = literalizer.literalize(
-        source='{"ref": "my_var"}',
+        source='{"$ref": "my_var"}',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
     )
-    assert result.bare_code == '{\n    "ref": "my_var",\n}'
+    assert result.bare_code == '{\n    "$ref": "my_var",\n}'
 
 
 def test_ref_with_mixed_list() -> None:
     """Ref among non-ref elements in a list renders as bare identifier."""
     result = literalizer.literalize(
-        source='[{"ref": "x"}, 1, 2]',
+        source='[{"$ref": "x"}, 1, 2]',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
         ref_case=literalizer.IdentifierCase.SNAKE,
@@ -37,7 +37,7 @@ def test_ref_with_mixed_list() -> None:
 def test_ref_with_case_conversion() -> None:
     """Ref_case converts the identifier name."""
     result = literalizer.literalize(
-        source='{"ref": "myVar"}',
+        source='{"$ref": "myVar"}',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
         ref_case=literalizer.IdentifierCase.SNAKE,
@@ -48,7 +48,7 @@ def test_ref_with_case_conversion() -> None:
 def test_ref_deep_nesting() -> None:
     """Ref at arbitrary depth renders as bare identifier."""
     result = literalizer.literalize(
-        source='{"a": {"b": {"c": {"ref": "deep"}}}}',
+        source='{"a": {"b": {"c": {"$ref": "deep"}}}}',
         input_format=literalizer.InputFormat.JSON,
         language=Python(),
         ref_case=literalizer.IdentifierCase.SNAKE,
@@ -62,7 +62,7 @@ def test_unsupported_ref_case_raises() -> None:
     """
     with pytest.raises(expected_exception=UnsupportedIdentifierCaseError):
         literalizer.literalize(
-            source='{"ref": "my_var"}',
+            source='{"$ref": "my_var"}',
             input_format=literalizer.InputFormat.JSON,
             language=Python(),
             ref_case=literalizer.IdentifierCase.KEBAB,

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -958,7 +958,7 @@ def test_literalize_call_arg_ref_all_refs() -> None:
     the empty non-ref list must not break wrap-id computation.
     """
     result = literalize_call(
-        source='[[{"ref": "a"}, {"ref": "b"}]]',
+        source='[[{"$ref": "a"}, {"$ref": "b"}]]',
         input_format=InputFormat.JSON,
         language=Go(),
         target_function="combine",
@@ -973,7 +973,7 @@ def test_literalize_call_arg_ref_top_level_element() -> None:
     call whose argument is the referenced identifier.
     """
     result = literalize_call(
-        source='[{"ref": "a"}, {"ref": "b"}]',
+        source='[{"$ref": "a"}, {"$ref": "b"}]',
         input_format=InputFormat.JSON,
         language=Go(),
         target_function="run",
@@ -987,7 +987,7 @@ def test_literalize_call_arg_ref_per_element_false() -> None:
     as the single argument.
     """
     result = literalize_call(
-        source='{"ref": "payload"}',
+        source='{"$ref": "payload"}',
         input_format=InputFormat.JSON,
         language=Python(),
         target_function="publish",
@@ -1026,7 +1026,7 @@ def test_literalize_call_arg_ref_parameter_count_still_validated() -> None:
         match=r"^Expected 1 parameters but got 2 values$",
     ):
         literalize_call(
-            source='[[{"ref": "a"}, {"ref": "b"}]]',
+            source='[[{"$ref": "a"}, {"$ref": "b"}]]',
             input_format=InputFormat.JSON,
             language=Python(),
             target_function="f",
@@ -1041,7 +1041,7 @@ def test_literalize_call_ref_case_unsupported_raises() -> None:
         match=r"^Python does not support identifier case 'CAMEL'$",
     ):
         literalize_call(
-            source='[[{"ref": "user_obj"}, 42]]',
+            source='[[{"$ref": "user_obj"}, 42]]',
             input_format=InputFormat.JSON,
             language=Python(),
             target_function="process",


### PR DESCRIPTION
## Summary

- Changes the default value of the `ref_key` parameter in `literalize()` and `literalize_call()` from `"ref"` to `"$ref"`, aligning the default with the JSON Schema convention.
- Updates all test fixtures (unit tests, integration tests, and YAML input files) to use `$ref` as the ref marker key.
- Updates the CHANGELOG to reflect the new default.

## Test plan

- All 839 non-golden tests pass.
- All 221 `literalize_ref` golden file tests pass.
- All 197 `call_ref` integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a behavior change to the public API default that can break callers relying on implicit `ref` markers. Code changes are small, but they affect reference-marker parsing across all formats and languages.
> 
> **Overview**
> **Changes the default ref marker key from `"ref"` to `"$ref"`** for both `literalize()` and `literalize_call()`, aligning reference detection with JSON Schema conventions while keeping the key configurable via `ref_key`.
> 
> Updates the changelog and rewrites unit/integration test inputs and expectations (including YAML fixtures and golden-case discovery configs) to use `$ref` as the default marker, plus adjusts an HCL wrap regression test to reference the new default marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4cafa74a479175345a50820876db1c093135c53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->