### PR TITLE
Add supports_module_name flag to LanguageCls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -479,6 +479,8 @@ ignore_names = [
     "UNORDERED_MAP",
     "VERBATIM",
     "ZONED",
+    # Used by downstream consumers
+    "supports_module_name",
     # Used in documentation code examples
     "custom",
     "result",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -503,6 +503,7 @@ class LanguageCls(type):
     allows_bare_call_statement: bool = True
     call_returns_expression: bool
     supports_inline_multiline_dict_args: bool
+    supports_module_name: bool
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -215,6 +215,7 @@ class Ada(metaclass=LanguageCls):
     allows_bare_call_statement = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -191,6 +191,7 @@ class Bash(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Bash."""

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -219,6 +219,7 @@ class C(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for C."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -105,6 +105,7 @@ class Clojure(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Clojure."""

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -333,6 +333,7 @@ class Cobol(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = False
     supports_inline_multiline_dict_args = False
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -114,6 +114,7 @@ class CommonLisp(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for CommonLisp."""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -871,6 +871,7 @@ class Cpp(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for C++."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -175,6 +175,7 @@ class Crystal(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for Crystal."""

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -358,6 +358,7 @@ class CSharp(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     _opener_config = TypedOpenerConfig(
         str_type="string",

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -161,6 +161,7 @@ class D(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for D."""

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -279,6 +279,7 @@ class Dart(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -522,6 +522,7 @@ class Dhall(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Dhall."""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -202,6 +202,7 @@ class Elixir(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Elixir."""

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -494,6 +494,7 @@ class Elm(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Elm."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -196,6 +196,7 @@ class Erlang(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for Erlang."""

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -195,6 +195,7 @@ class Forth(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -314,6 +314,7 @@ class Fortran(metaclass=LanguageCls):
     allows_bare_call_statement = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -255,6 +255,7 @@ class FSharp(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for FSharp."""

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -509,6 +509,7 @@ class Gleam(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Gleam."""

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -258,6 +258,7 @@ class Go(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Go."""

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -138,6 +138,7 @@ class Groovy(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Groovy."""

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -934,6 +934,7 @@ class Haskell(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for Haskell."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -142,6 +142,7 @@ class Hcl(metaclass=LanguageCls):
     supports_dotted_calls = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Hcl."""

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -574,6 +574,7 @@ class Java(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -125,6 +125,7 @@ class JavaScript(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for JavaScript."""

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -118,6 +118,7 @@ class Json5(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Json5."""

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -134,6 +134,7 @@ class Jsonnet(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Jsonnet."""

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -153,6 +153,7 @@ class Julia(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for Julia."""

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -429,6 +429,7 @@ class Kotlin(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -139,6 +139,7 @@ class Lua(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Lua."""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -206,6 +206,7 @@ class Matlab(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Matlab."""

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -387,6 +387,7 @@ class Mojo(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Mojo."""

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -532,6 +532,7 @@ class Nim(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Nim."""

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -186,6 +186,7 @@ class Nix(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Nix."""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -90,6 +90,7 @@ class Norg(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Norg."""

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -267,6 +267,7 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -243,6 +243,7 @@ class OCaml(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -100,6 +100,7 @@ class Occam(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -210,6 +210,7 @@ class Odin(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Odin."""

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -149,6 +149,7 @@ class Perl(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Perl."""

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -148,6 +148,7 @@ class Php(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Php."""

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -164,6 +164,7 @@ class PowerShell(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for PowerShell."""

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -646,6 +646,7 @@ class PureScript(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for PureScript."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -521,6 +521,7 @@ class Python(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for Python."""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -163,6 +163,7 @@ class R(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for R."""

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -106,6 +106,7 @@ class Racket(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Racket."""

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -182,6 +182,7 @@ class Raku(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Raku."""

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -509,6 +509,7 @@ class Roc(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
     supports_special_floats = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -160,6 +160,7 @@ class Ruby(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Ruby."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -687,6 +687,7 @@ class Rust(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Rust."""

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -209,6 +209,7 @@ class Scala(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
     module_name: str = "Check"
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -102,6 +102,7 @@ class Scheme(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Scheme."""

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -300,6 +300,7 @@ class Sml(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset({"op"})
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -326,6 +326,7 @@ class Swift(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Swift."""

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -234,6 +234,7 @@ class SystemVerilog(metaclass=LanguageCls):
     allows_bare_call_statement = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = True
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -147,6 +147,7 @@ class Tcl(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -118,6 +118,7 @@ class Toml(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Toml."""

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -245,6 +245,7 @@ class TypeScript(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date formatting options for TypeScript."""

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -315,6 +315,7 @@ class V(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for V."""

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -266,6 +266,7 @@ class VisualBasic(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for VisualBasic."""

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -165,6 +165,7 @@ class Wren(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Wren."""

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -92,6 +92,7 @@ class Yaml(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Yaml."""

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -234,6 +234,7 @@ class Zig(metaclass=LanguageCls):
     supports_dotted_calls = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_module_name = False
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""


### PR DESCRIPTION
Closes #1829

## Summary

- Adds `supports_module_name: bool` to `LanguageCls` in `literalizer/_language.py`, matching the convention of existing `supports_*` capability flags
- Sets it `True` on the 14 language classes that define a `module_name` dataclass field (Ada, C, C++, Crystal, D, Erlang, Fortran, F#, Haskell, Java, Objective-C, Occam, Scala, SystemVerilog) and `False` on all others
- Adds `supports_module_name` to the vulture `ignore_names` allowlist since it is consumed by downstream code (e.g. `sphinx-literalizer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API/typing surface of `LanguageCls` changes and every language spec is touched; risk is mainly downstream breakage if consumers assume the flag or `module_name` behavior differently.
> 
> **Overview**
> Adds a new `supports_module_name: bool` capability on `LanguageCls` so downstream tooling can reliably detect whether a language supports a configurable `module_name`.
> 
> All language specs are updated to explicitly set `supports_module_name` (enabled for languages that expose a `module_name` field, disabled otherwise), and the new symbol is allowlisted in vulture’s `ignore_names` to avoid false unused-code reports for downstream consumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e79b6f212e962f9ab8202a895b5457c81d9536c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->