### PR TITLE
Add supports_dotted_call_stub to replace CASE_LANGUAGE_INCOMPATIBLE entry

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -503,6 +503,7 @@ class LanguageCls(type):
     reserved_identifiers: frozenset[str]
     allows_bare_call_statement: bool
     allows_empty_call_parens: bool
+    supports_dotted_call_stub: bool
     call_returns_expression: bool
     supports_inline_multiline_dict_args: bool
     supports_module_name: bool

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -216,6 +216,7 @@ class Ada(metaclass=LanguageCls):
     has_free_function_calls = True
     allows_bare_call_statement = False
     allows_empty_call_parens = False
+    supports_dotted_call_stub = False
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_inline_multiline_dict_args = True

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -194,6 +194,7 @@ class Bash(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -222,6 +222,7 @@ class C(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -108,6 +108,7 @@ class Clojure(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -336,6 +336,7 @@ class Cobol(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = False
     supports_inline_multiline_dict_args = False
     supports_module_name = False

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -117,6 +117,7 @@ class CommonLisp(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -872,6 +872,7 @@ class Cpp(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -178,6 +178,7 @@ class Crystal(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -360,6 +360,7 @@ class CSharp(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -164,6 +164,7 @@ class D(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -286,6 +286,7 @@ class Dart(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -525,6 +525,7 @@ class Dhall(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -205,6 +205,7 @@ class Elixir(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -497,6 +497,7 @@ class Elm(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -199,6 +199,7 @@ class Erlang(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -198,6 +198,7 @@ class Forth(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -315,6 +315,7 @@ class Fortran(metaclass=LanguageCls):
     has_free_function_calls = True
     allows_bare_call_statement = False
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_inline_multiline_dict_args = True

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -258,6 +258,7 @@ class FSharp(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -512,6 +512,7 @@ class Gleam(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -261,6 +261,7 @@ class Go(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -141,6 +141,7 @@ class Groovy(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -937,6 +937,7 @@ class Haskell(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -145,6 +145,7 @@ class Hcl(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -576,6 +576,7 @@ class Java(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -128,6 +128,7 @@ class JavaScript(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -121,6 +121,7 @@ class Json5(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -137,6 +137,7 @@ class Jsonnet(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -156,6 +156,7 @@ class Julia(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -432,6 +432,7 @@ class Kotlin(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -142,6 +142,7 @@ class Lua(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -209,6 +209,7 @@ class Matlab(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -424,6 +424,7 @@ class Mojo(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -535,6 +535,7 @@ class Nim(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -189,6 +189,7 @@ class Nix(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -93,6 +93,7 @@ class Norg(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -270,6 +270,7 @@ class ObjectiveC(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -246,6 +246,7 @@ class OCaml(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -103,6 +103,7 @@ class Occam(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -213,6 +213,7 @@ class Odin(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -152,6 +152,7 @@ class Perl(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -151,6 +151,7 @@ class Php(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -167,6 +167,7 @@ class PowerShell(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = False
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -649,6 +649,7 @@ class PureScript(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -524,6 +524,7 @@ class Python(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -166,6 +166,7 @@ class R(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -109,6 +109,7 @@ class Racket(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -185,6 +185,7 @@ class Raku(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -512,6 +512,7 @@ class Roc(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -163,6 +163,7 @@ class Ruby(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -690,6 +690,7 @@ class Rust(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -228,6 +228,7 @@ class Scala(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = True

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -105,6 +105,7 @@ class Scheme(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -302,6 +302,7 @@ class Sml(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset({"op"})
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -329,6 +329,7 @@ class Swift(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -235,6 +235,7 @@ class SystemVerilog(metaclass=LanguageCls):
     has_free_function_calls = True
     allows_bare_call_statement = False
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_inline_multiline_dict_args = True

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -150,6 +150,7 @@ class Tcl(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -121,6 +121,7 @@ class Toml(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -248,6 +248,7 @@ class TypeScript(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -338,6 +338,7 @@ class V(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -269,6 +269,7 @@ class VisualBasic(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -168,6 +168,7 @@ class Wren(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -95,6 +95,7 @@ class Yaml(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -237,6 +237,7 @@ class Zig(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     allows_bare_call_statement = True
     allows_empty_call_parens = True
+    supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
     supports_module_name = False

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -23,23 +23,14 @@ from literalizer.exceptions import (
     HeterogeneousCollectionError,
 )
 from literalizer.languages import (
-    Ada,
     Cobol,
     Dhall,
     Elm,
     Erlang,
-    Fortran,
-    Gleam,
     Haskell,
-    Hcl,
     Jsonnet,
     Mojo,
-    ObjectiveC,
-    OCaml,
-    Php,
-    PowerShell,
     PureScript,
-    Raku,
     Roc,
 )
 
@@ -637,31 +628,6 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # expressions.
     "call_no_params": frozenset({Cobol, Dhall, Elm}),
     "call_deep_dotted_transformed": frozenset({Cobol}),
-    # call_transform wraps output as "tracer.emit(inner)" — a dotted method
-    # call — and transform_stub_names=["tracer.emit"] requires a struct/object
-    # stub whose syntax is invalid or unsupported in several languages.
-    # OCaml module names must begin with an uppercase letter, so the stub
-    # is emitted as "module Tracer = struct" but the embedded call_transform
-    # produces the lowercase "tracer.emit(...)" which is unbound at the call
-    # site.
-    "call_dotted_transform_stub": frozenset(
-        {
-            Ada,
-            Cobol,
-            Elm,
-            Erlang,
-            Fortran,
-            Gleam,
-            Haskell,
-            Hcl,
-            OCaml,
-            ObjectiveC,
-            Php,
-            PowerShell,
-            Raku,
-            Roc,
-        }
-    ),
     # Languages whose default call wrappers prepend a token to each
     # statement (Elm, Haskell, and PureScript ``_ = ``/``_ <- ``, Roc
     # ``dbg(...)``) or whose comment syntax interacts with the
@@ -713,6 +679,11 @@ def _lang_supports_case(
 ) -> bool:
     """Return True if *lang_cls* can produce valid output for *config*."""
     if "." in config.target_function and not lang_cls.supports_dotted_calls:
+        return False
+    if (
+        any("." in name for name in config.transform_stub_names)
+        and not lang_cls.supports_dotted_call_stub
+    ):
         return False
     return lang_cls.has_free_function_calls or not any(
         "." not in name for name in config.transform_stub_names


### PR DESCRIPTION
## Summary

- Adds `supports_dotted_call_stub: bool` to the `LanguageCls` metaclass
- Sets the flag to `False` on the 14 languages that cannot produce a valid dotted-method call stub (Ada, Cobol, Elm, Erlang, Fortran, Gleam, Haskell, Hcl, OCaml, ObjectiveC, Php, PowerShell, Raku, Roc), and `True` on all others
- Replaces the `call_dotted_transform_stub` entry in `CASE_LANGUAGE_INCOMPATIBLE` with a check in `_lang_supports_case` that skips languages where any `transform_stub_names` entry contains a dot and `supports_dotted_call_stub` is `False`

Closes #1813 (sub-task of #1785).

## Test plan

- All `call_dotted_transform_stub` golden file tests pass (42 languages included, 14 excluded)
- Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a metadata/test-selection change that adds a new `LanguageCls` capability flag and uses it to skip incompatible golden tests, without altering core literalization logic.
> 
> **Overview**
> Adds a new `LanguageCls.supports_dotted_call_stub` capability flag and sets it across all language specs to indicate whether the language can generate stubs for dotted transform wrapper names (e.g. `tracer.emit`).
> 
> Updates call integration tests to *dynamically* exclude languages from the dotted-transform-stub case based on this flag, replacing the hardcoded `CASE_LANGUAGE_INCOMPATIBLE["call_dotted_transform_stub"]` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6c306bee7b09493285c0a4163d4aef3d4e68cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->