### PR TITLE
Preserve tzinfo in Python datetime renderer for aware datetimes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,6 +61,7 @@ htmlhelp_basename = "literalizerdoc"
 spelling_word_list_filename = "../../spelling_private_dict.txt"
 
 linkcheck_ignore = [
+    r"https://dhall-lang\.org/",
     r"https://json5\.org/",
 ]
 

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -157,7 +157,7 @@ class Nix(metaclass=LanguageCls):
     """Nix language specification.
 
     Produces Nix values — attribute sets for mappings, and lists for
-    sequences and sets — following `Nix <https://nixos.org/manual/nix/stable/language/>`_
+    sequences and sets — following `Nix <https://nix.dev/manual/nix/stable/language/>`_
     syntax.
 
     Nix is a purely functional, lazy language used primarily for the Nix

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -104,12 +104,9 @@ def _format_datetime_python(value: datetime.datetime) -> str:
             abs_seconds = abs(total_seconds)
             hours = sign * (abs_seconds // 3600)
             minutes = sign * ((abs_seconds % 3600) // 60)
-            seconds = sign * (abs_seconds % 60)
             td_parts = [f"hours={hours}"]
-            if minutes or seconds:
+            if minutes:
                 td_parts.append(f"minutes={minutes}")
-            if seconds:
-                td_parts.append(f"seconds={seconds}")
             td_args = ", ".join(td_parts)
             parts.append(
                 f"tzinfo=datetime.timezone(offset=datetime.timedelta({td_args}))"

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -95,6 +95,25 @@ def _format_datetime_python(value: datetime.datetime) -> str:
     ]
     if value.microsecond:
         parts.append(f"microsecond={value.microsecond}")
+    if value.tzinfo is not None and (offset := value.utcoffset()) is not None:
+        if offset == datetime.timedelta():
+            parts.append("tzinfo=datetime.UTC")
+        else:
+            total_seconds = int(offset.total_seconds())
+            sign = -1 if total_seconds < 0 else 1
+            abs_seconds = abs(total_seconds)
+            hours = sign * (abs_seconds // 3600)
+            minutes = sign * ((abs_seconds % 3600) // 60)
+            seconds = sign * (abs_seconds % 60)
+            td_parts = [f"hours={hours}"]
+            if minutes or seconds:
+                td_parts.append(f"minutes={minutes}")
+            if seconds:
+                td_parts.append(f"seconds={seconds}")
+            td_args = ", ".join(td_parts)
+            parts.append(
+                f"tzinfo=datetime.timezone(offset=datetime.timedelta({td_args}))"
+            )
     args = ", ".join(parts)
     return f"datetime.datetime({args})"
 

--- a/tests/integration/cases/dates/Python.py
+++ b/tests/integration/cases/dates/Python.py
@@ -1,5 +1,5 @@
 import datetime
 my_data = {
     "date": datetime.date(year=2024, month=1, day=15),
-    "datetime": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0),
+    "datetime": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC),
 }

--- a/tests/integration/cases/dates/Python_combined.py
+++ b/tests/integration/cases/dates/Python_combined.py
@@ -1,9 +1,9 @@
 import datetime
 my_data = {
     "date": datetime.date(year=2024, month=1, day=15),
-    "datetime": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0),
+    "datetime": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC),
 }
 my_data = {
     "date": datetime.date(year=2024, month=1, day=15),
-    "datetime": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0),
+    "datetime": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC),
 }

--- a/tests/integration/cases/datetime_list/Python.py
+++ b/tests/integration/cases/datetime_list/Python.py
@@ -1,5 +1,5 @@
 import datetime
 my_data = (
-    datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456),
-    datetime.datetime(year=2024, month=6, day=1, hour=8, minute=0, second=0),
+    datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456, tzinfo=datetime.UTC),
+    datetime.datetime(year=2024, month=6, day=1, hour=8, minute=0, second=0, tzinfo=datetime.UTC),
 )

--- a/tests/integration/cases/datetime_list/Python_combined.py
+++ b/tests/integration/cases/datetime_list/Python_combined.py
@@ -1,9 +1,9 @@
 import datetime
 my_data = (
-    datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456),
-    datetime.datetime(year=2024, month=6, day=1, hour=8, minute=0, second=0),
+    datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456, tzinfo=datetime.UTC),
+    datetime.datetime(year=2024, month=6, day=1, hour=8, minute=0, second=0, tzinfo=datetime.UTC),
 )
 my_data = (
-    datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456),
-    datetime.datetime(year=2024, month=6, day=1, hour=8, minute=0, second=0),
+    datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456, tzinfo=datetime.UTC),
+    datetime.datetime(year=2024, month=6, day=1, hour=8, minute=0, second=0, tzinfo=datetime.UTC),
 )

--- a/tests/integration/cases/scalar_datetime/Python.py
+++ b/tests/integration/cases/scalar_datetime/Python.py
@@ -1,2 +1,2 @@
 import datetime
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime/Python_combined.py
+++ b/tests/integration/cases/scalar_datetime/Python_combined.py
@@ -1,3 +1,3 @@
 import datetime
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime/Python_type_hints_always.py
+++ b/tests/integration/cases/scalar_datetime/Python_type_hints_always.py
@@ -1,2 +1,2 @@
 import datetime
-my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)
+my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime/Python_type_hints_always_date_iso.py
+++ b/tests/integration/cases/scalar_datetime/Python_type_hints_always_date_iso.py
@@ -1,2 +1,2 @@
 import datetime
-my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)
+my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime/Python_type_hints_always_seq_list.py
+++ b/tests/integration/cases/scalar_datetime/Python_type_hints_always_seq_list.py
@@ -1,2 +1,2 @@
 import datetime
-my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)
+my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime/Python_type_hints_always_set_frozenset.py
+++ b/tests/integration/cases/scalar_datetime/Python_type_hints_always_set_frozenset.py
@@ -1,2 +1,2 @@
 import datetime
-my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0)
+my_data: datetime.datetime = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime_microsecond/Python.py
+++ b/tests/integration/cases/scalar_datetime_microsecond/Python.py
@@ -1,2 +1,2 @@
 import datetime
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime_microsecond/Python_combined.py
+++ b/tests/integration/cases/scalar_datetime_microsecond/Python_combined.py
@@ -1,3 +1,3 @@
 import datetime
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456)
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456, tzinfo=datetime.UTC)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, microsecond=123456, tzinfo=datetime.UTC)

--- a/tests/integration/cases/scalar_datetime_non_utc/Python.py
+++ b/tests/integration/cases/scalar_datetime_non_utc/Python.py
@@ -1,2 +1,2 @@
 import datetime
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=18, minute=0, second=0)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=18, minute=0, second=0, tzinfo=datetime.timezone(offset=datetime.timedelta(hours=5, minutes=30)))

--- a/tests/integration/cases/scalar_datetime_non_utc/Python_combined.py
+++ b/tests/integration/cases/scalar_datetime_non_utc/Python_combined.py
@@ -1,3 +1,3 @@
 import datetime
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=18, minute=0, second=0)
-my_data = datetime.datetime(year=2024, month=1, day=15, hour=18, minute=0, second=0)
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=18, minute=0, second=0, tzinfo=datetime.timezone(offset=datetime.timedelta(hours=5, minutes=30)))
+my_data = datetime.datetime(year=2024, month=1, day=15, hour=18, minute=0, second=0, tzinfo=datetime.timezone(offset=datetime.timedelta(hours=5, minutes=30)))

--- a/tests/integration/cases/type_hints/Python.py
+++ b/tests/integration/cases/type_hints/Python.py
@@ -5,6 +5,6 @@ my_data = {
     "active": True,
     "score": None,
     "joined": datetime.date(year=2024, month=1, day=15),
-    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0),
+    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC),
     "avatar": "48656c6c6f",
 }

--- a/tests/integration/cases/type_hints/Python_combined.py
+++ b/tests/integration/cases/type_hints/Python_combined.py
@@ -5,7 +5,7 @@ my_data = {
     "active": True,
     "score": None,
     "joined": datetime.date(year=2024, month=1, day=15),
-    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0),
+    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC),
     "avatar": "48656c6c6f",
 }
 my_data = {
@@ -14,6 +14,6 @@ my_data = {
     "active": True,
     "score": None,
     "joined": datetime.date(year=2024, month=1, day=15),
-    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0),
+    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC),
     "avatar": "48656c6c6f",
 }

--- a/tests/integration/cases/type_hints/Python_type_hints_always.py
+++ b/tests/integration/cases/type_hints/Python_type_hints_always.py
@@ -5,6 +5,6 @@ my_data: dict[str, str | int | bool | None | datetime.date | datetime.datetime] 
     "active": True,
     "score": None,
     "joined": datetime.date(year=2024, month=1, day=15),
-    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0),
+    "last_login": datetime.datetime(year=2024, month=1, day=15, hour=12, minute=30, second=0, tzinfo=datetime.UTC),
     "avatar": "48656c6c6f",
 }

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -652,3 +652,23 @@ def test_dhall_backtick_label_unescaping() -> None:
         } in my_data"""
     )
     assert result.code == expected
+
+
+def test_python_datetime_whole_hour_offset() -> None:
+    """Python datetime with a whole-hour UTC offset includes only hours in
+    timedelta.
+    """
+    result = literalize(
+        source="2024-01-15T12:00:00+01:00\n",
+        input_format=InputFormat.YAML,
+        language=PYTHON,
+        pre_indent_level=0,
+        include_delimiters=False,
+        variable_form=None,
+    )
+    expected = (
+        "datetime.datetime("
+        "year=2024, month=1, day=15, hour=12, minute=0, second=0, "
+        "tzinfo=datetime.timezone(offset=datetime.timedelta(hours=1)))"
+    )
+    assert result.code == expected

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -655,8 +655,8 @@ def test_dhall_backtick_label_unescaping() -> None:
 
 
 def test_python_datetime_whole_hour_offset() -> None:
-    """Python datetime with a whole-hour UTC offset includes only hours in
-    timedelta.
+    """Python datetime with a whole-hour UTC offset includes only hours, no
+    minutes.
     """
     result = literalize(
         source="2024-01-15T12:00:00+01:00\n",


### PR DESCRIPTION
Fixes #1838.

## Summary

- `_format_datetime_python` now checks `value.tzinfo` and appends a `tzinfo=` argument when the datetime is timezone-aware
- UTC datetimes render as `tzinfo=datetime.UTC`
- Fixed-offset datetimes render as `tzinfo=datetime.timezone(offset=datetime.timedelta(hours=..., minutes=...))`
- Naive datetimes are unchanged

## Test plan

- All existing integration tests updated and passing (1985 passed, 560 skipped)
- All pre-push hooks pass including mypy, pyright, ty, ruff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to Python datetime string formatting plus expected-output/test updates; no security- or data-model changes, with good test coverage for new behavior.
> 
> **Overview**
> Python `datetime` rendering now preserves timezone info for *aware* datetimes by emitting an explicit `tzinfo=` argument: UTC becomes `datetime.UTC`, and fixed offsets become `datetime.timezone(offset=datetime.timedelta(...))` (omitting minutes when zero).
> 
> Integration fixtures are updated to expect timezone-aware outputs, and a new YAML unit test asserts whole-hour offsets don’t include `minutes=`. Docs/linkcheck settings and the Nix manual reference link are also updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b99c2d02683266a879cb3c32d4fa2c53d45d12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->