### PR TITLE
Bump setup-cobol-action to v1.6.2, remove /tmp workaround

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -714,13 +714,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      # Install before writing /tmp/files-to-lint because the action wipes /tmp.
-      # https://github.com/fabasoad/setup-cobol-action/issues/146
-      - name: Install GnuCOBOL
-        uses: fabasoad/setup-cobol-action@v1
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name '*.cob' -print0 > /tmp/files-to-lint
+      - name: Install GnuCOBOL
+        uses: fabasoad/setup-cobol-action@v1.6.2
       - name: Check COBOL syntax
         run: xargs -0 -P "$(nproc)" -n1 cobc -free -fsyntax-only < /tmp/files-to-lint
       - name: Run COBOL files


### PR DESCRIPTION
Bumps `fabasoad/setup-cobol-action` from `v1` to `v1.6.2`.

The action previously wiped all of `/tmp` during install (fabasoad/setup-cobol-action#146), requiring a workaround where the action ran before the "Find files to lint" step. That bug is now fixed, so the steps are restored to natural order and the workaround comment is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: updates the COBOL setup GitHub Action and reorders steps in the COBOL lint job; main impact is potential CI behavior differences if the new action version behaves unexpectedly.
> 
> **Overview**
> Updates the `lint-cobol` GitHub Actions job to use `fabasoad/setup-cobol-action@v1.6.2` instead of the floating `@v1` tag.
> 
> Removes the prior `/tmp`-wiping workaround by moving the GnuCOBOL install step after the file discovery step and deleting the associated comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f222b68afd7f302d254891b86b403aaa05d3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->