### PR TITLE
Pin uv in setup-uv actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -51,6 +54,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -282,6 +285,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -332,6 +338,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -505,6 +514,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       # Populate a shared primed project once up front so each parallel
@@ -625,6 +637,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -681,6 +696,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
@@ -699,6 +717,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
@@ -1128,6 +1149,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install Mojo
@@ -1341,6 +1365,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check V syntax

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # Pin uv because otherwise setup-uv looks up the latest
+          # version, and that lookup sometimes fails.
+          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 


### PR DESCRIPTION
Pins uv 0.11.7 for every astral-sh/setup-uv@v7 usage in CI, lint, and release workflows.

This avoids setup-uv looking up the latest uv version at runtime, which can fail intermittently. The pin matches the uv version already used by pre-commit tooling.

Validated with `uv run --extra=dev actionlint` and the commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that pins the `uv` installer version to reduce CI flakiness; no runtime/product code is modified.
> 
> **Overview**
> Pins `astral-sh/setup-uv@v7` to `uv` `0.11.7` across CI, lint, benchmark, and release GitHub Actions workflows to avoid intermittent failures from resolving the latest `uv` version at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc93dedd4bdef28fcc30a956011f3d97d0180c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->