### PR TITLE
Express call comment skips as language capabilities

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -506,6 +506,8 @@ class LanguageCls(type):
     supports_dotted_call_stub: bool
     call_returns_expression: bool
     supports_inline_multiline_dict_args: bool
+    supports_standalone_comments_in_wrapped_calls: bool
+    supports_commented_dict_call_args: bool
     supports_module_name: bool
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
@@ -1156,6 +1158,20 @@ class Language(Protocol):
     @property
     def allows_empty_call_parens(self) -> bool:
         """Whether an empty argument list is written as ``()``."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def supports_standalone_comments_in_wrapped_calls(self) -> bool:
+        """Whether manually wrapped call output can contain standalone
+        comment lines between call statements.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def supports_commented_dict_call_args(self) -> bool:
+        """Whether manually wrapped call output can pass commented dict
+        literals as call arguments.
+        """
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -220,6 +220,8 @@ class Ada(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -197,6 +197,8 @@ class Bash(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -225,6 +225,8 @@ class C(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -111,6 +111,8 @@ class Clojure(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -339,6 +339,8 @@ class Cobol(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = False
     supports_inline_multiline_dict_args = False
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = False
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -120,6 +120,8 @@ class CommonLisp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -875,6 +875,8 @@ class Cpp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -181,6 +181,8 @@ class Crystal(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -363,6 +363,8 @@ class CSharp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -167,6 +167,8 @@ class D(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -289,6 +289,8 @@ class Dart(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -528,6 +528,8 @@ class Dhall(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = False
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -208,6 +208,8 @@ class Elixir(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -500,6 +500,8 @@ class Elm(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = False
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -202,6 +202,8 @@ class Erlang(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = False
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -201,6 +201,8 @@ class Forth(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -319,6 +319,8 @@ class Fortran(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -261,6 +261,8 @@ class FSharp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -515,6 +515,8 @@ class Gleam(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -264,6 +264,8 @@ class Go(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -144,6 +144,8 @@ class Groovy(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -940,6 +940,8 @@ class Haskell(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = False
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -148,6 +148,8 @@ class Hcl(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -579,6 +579,8 @@ class Java(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -131,6 +131,8 @@ class JavaScript(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -124,6 +124,8 @@ class Json5(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -140,6 +140,8 @@ class Jsonnet(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = False
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -159,6 +159,8 @@ class Julia(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -435,6 +435,8 @@ class Kotlin(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -145,6 +145,8 @@ class Lua(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -212,6 +212,8 @@ class Matlab(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -427,6 +427,8 @@ class Mojo(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = False
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -538,6 +538,8 @@ class Nim(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -192,6 +192,8 @@ class Nix(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -96,6 +96,8 @@ class Norg(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -273,6 +273,8 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -249,6 +249,8 @@ class OCaml(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -106,6 +106,8 @@ class Occam(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -216,6 +216,8 @@ class Odin(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -155,6 +155,8 @@ class Perl(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -154,6 +154,8 @@ class Php(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -170,6 +170,8 @@ class PowerShell(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -652,6 +652,8 @@ class PureScript(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = False
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -543,6 +543,8 @@ class Python(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -169,6 +169,8 @@ class R(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -112,6 +112,8 @@ class Racket(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -188,6 +188,8 @@ class Raku(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -515,6 +515,8 @@ class Roc(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = False
+    supports_commented_dict_call_args = True
     supports_module_name = False
     supports_special_floats = True
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -191,6 +191,8 @@ class Ruby(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -693,6 +693,8 @@ class Rust(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -231,6 +231,8 @@ class Scala(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
     module_name: str = "Check"
 

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -108,6 +108,8 @@ class Scheme(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -305,6 +305,8 @@ class Sml(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -332,6 +332,8 @@ class Swift(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -239,6 +239,8 @@ class SystemVerilog(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -153,6 +153,8 @@ class Tcl(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -124,6 +124,8 @@ class Toml(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -251,6 +251,8 @@ class TypeScript(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -341,6 +341,8 @@ class V(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -272,6 +272,8 @@ class VisualBasic(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -171,6 +171,8 @@ class Wren(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -98,6 +98,8 @@ class Yaml(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -240,6 +240,8 @@ class Zig(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -26,12 +26,7 @@ from literalizer.languages import (
     Cobol,
     Dhall,
     Elm,
-    Erlang,
-    Haskell,
-    Jsonnet,
     Mojo,
-    PureScript,
-    Roc,
 )
 
 from .check_golden import check_golden
@@ -628,40 +623,18 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # expressions.
     "call_no_params": frozenset({Cobol, Dhall, Elm}),
     "call_deep_dotted_transformed": frozenset({Cobol}),
-    # Languages whose default call wrappers prepend a token to each
-    # statement (Elm, Haskell, and PureScript ``_ = ``/``_ <- ``, Roc
-    # ``dbg(...)``) or whose comment syntax interacts with the
-    # statement separator (Erlang trailing ``.``, Jsonnet array
-    # comma being swallowed by ``//``). These cannot represent a
-    # standalone comment line in the wrapped self-contained file even
-    # though :func:`literalizer.literalize_call` itself produces
-    # syntactically valid per-call comments.
-    "call_comments": frozenset(
-        {
-            Elm,
-            Erlang,
-            Haskell,
-            Jsonnet,
-            PureScript,
-            Roc,
-        }
-    ),
-    "call_comments_dict_args": frozenset(
-        {
-            Dhall,
-            Elm,
-            Erlang,
-            Haskell,
-            Jsonnet,
-            Mojo,
-            PureScript,
-            Roc,
-        }
-    ),
     # Mojo rejects the transfer operator (^) on trivial register types such as
     # Int, so a $ref inside a dict literal (which requires ^) cannot compile.
     "call_ref_nested_in_dict": frozenset({Mojo}),
 }
+
+
+_CASES_REQUIRING_STANDALONE_WRAPPED_COMMENTS = frozenset(
+    {"call_comments", "call_comments_dict_args"}
+)
+_CASES_REQUIRING_COMMENTED_DICT_CALL_ARGS = frozenset(
+    {"call_comments_dict_args"}
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -710,9 +683,19 @@ def _lang_satisfies_config_constraints(
         and not lang_cls.call_returns_expression
     ):
         return False
-    return not (
+    if (
         config.requires_inline_multiline_dict_args
         and not lang_cls.supports_inline_multiline_dict_args
+    ):
+        return False
+    if (
+        config.case_dir_name in _CASES_REQUIRING_STANDALONE_WRAPPED_COMMENTS
+        and not lang_cls.supports_standalone_comments_in_wrapped_calls
+    ):
+        return False
+    return not (
+        config.case_dir_name in _CASES_REQUIRING_COMMENTED_DICT_CALL_ARGS
+        and not lang_cls.supports_commented_dict_call_args
     )
 
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -480,6 +480,8 @@ def test_protocol_properties_accessible(
     assert callable(spec.format_variable_assignment)
     assert callable(spec.type_hint_collection_preamble_lines)
     assert isinstance(spec.scalar_body_preamble, dict)
+    assert isinstance(spec.supports_standalone_comments_in_wrapped_calls, bool)
+    assert isinstance(spec.supports_commented_dict_call_args, bool)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1814.

Adds language capability flags for standalone wrapped-call comments and commented dict call arguments, then uses them in call-case discovery instead of hard-coded skip-table entries. The affected languages now declare their limitations directly while all other language classes opt in explicitly. Tests cover the derived skip behavior and protocol accessibility, with pre-commit hooks plus targeted pytest and orphan-golden checks run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many language specs and the call-case discovery logic; while changes are mostly boolean capability wiring, mis-set flags could change which integration call tests run or hide regressions for specific languages.
> 
> **Overview**
> Adds two new per-language capability flags—`supports_standalone_comments_in_wrapped_calls` and `supports_commented_dict_call_args`—to the `Language`/`LanguageCls` contract, and populates them across all language specs.
> 
> Updates call integration case discovery to derive skips for `call_comments`/`call_comments_dict_args` from these capabilities instead of maintaining a hard-coded per-language skip table, and extends `test_languages` to assert the new flags are exposed on every language spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b61c2acbedbb0ef09de6cf97b1511e72e19975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->