### PR TITLE
Remove call argument cast

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Sequence
-from typing import assert_never, cast
+from typing import assert_never
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedSeq
@@ -1998,7 +1998,7 @@ def _format_prefix_call_args(
 @beartype
 def _format_call_args(
     *,
-    values: list[Value],
+    values: Sequence[Value],
     params: Sequence[str],
     language: Language,
     wrap_ids: frozenset[int],
@@ -2310,7 +2310,7 @@ def _render_call_per_element(
             _compute_wrap_ids(data=non_ref_args, spec=language) | slot_wrap_ids
         )
         args_str = _format_call_args(
-            values=cast("list[Value]", arg_values),
+            values=arg_values,
             params=parameter_names,
             language=language,
             wrap_ids=call_wrap_ids,


### PR DESCRIPTION
Updates call argument formatting to accept a read-only Sequence of values, matching how the helper is used. This removes the per-element call-site cast and the now-unused cast import without adding type ignores.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-signature cleanup limited to call-argument formatting; behavior should be unchanged aside from improved type correctness.
> 
> **Overview**
> Updates `_format_call_args` to accept a read-only `Sequence[Value]` instead of `list[Value]`, matching how call arguments are passed around.
> 
> Removes the now-unnecessary call-site `cast("list[Value]", ...)` and drops the unused `cast` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f8fd34576d48968bc4331c743d7748daaca57c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->