### PR TITLE
Remove redundant Cobol call skips

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -609,12 +609,6 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 # names, or call_transform wrapper use syntax that is invalid in a given
 # language, making a valid lint-passing output impossible to generate.
 CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
-    # COBOL cannot pass multi-line DATA DIVISION entries inline in a CALL
-    # statement.  SML is excluded via reserved_identifiers ("op").
-    "call_mixed_type_dicts": frozenset({Cobol}),
-    # COBOL CALL statement produces no expression value that can be passed
-    # to another call, so emit(inner) is invalid.
-    "call_keyword_args": frozenset({Cobol}),
     "call_no_params_transform": frozenset({Cobol, Elm}),
     # COBOL CALL "PROCESS" USING. is invalid with no parameters (USING
     # requires at least one).  Dhall zero-parameter stubs would need to
@@ -622,7 +616,6 @@ CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
     # not support.  Elm zero-parameter "functions" are values, not callable
     # expressions.
     "call_no_params": frozenset({Cobol, Dhall, Elm}),
-    "call_deep_dotted_transformed": frozenset({Cobol}),
     # Mojo rejects the transfer operator (^) on trivial register types such as
     # Int, so a $ref inside a dict literal (which requires ^) cannot compile.
     "call_ref_nested_in_dict": frozenset({Mojo}),


### PR DESCRIPTION
Removes three Cobol-specific call-case exclusions that are already covered by language capability flags. The affected cases continue to be filtered through discover_call_cases() via Cobol's call_returns_expression and supports_inline_multiline_dict_args settings, so the golden-file set should remain unchanged. Validated with the focused orphan golden-file test, ruff checks, and the repository hooks that ran during commit and push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness change only: it removes a few Cobol-specific skips and relies on existing language capability constraints for filtering, so behavior should be unchanged aside from potentially running/skipping those cases differently if the flags are wrong.
> 
> **Overview**
> Removes three Cobol-specific entries from `CASE_LANGUAGE_INCOMPATIBLE` in `tests/integration/call_cases.py` (for `call_mixed_type_dicts`, `call_keyword_args`, and `call_deep_dotted_transformed`). These cases are now excluded for Cobol only via the existing per-language capability checks in `discover_call_cases()` / `_lang_satisfies_config_constraints()` rather than hardcoded per-case skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40d03dafa96c3348abdf32fb7d8d95e214f4de5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->