### PR TITLE
[codex] Make call arg hook explicit

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -116,6 +116,7 @@ YAMLError
 ZKV
 ZVal
 Zig
+accessor
 backtick
 backticks
 beartype
@@ -142,6 +143,7 @@ formatter
 formatters
 fromhex
 frozenset
+getter
 ghc
 gnatmake
 gofmt
@@ -194,6 +196,7 @@ postfix
 pragma
 pre
 prepended
+proc
 pyjson5
 pyrefly
 pyright
@@ -201,6 +204,7 @@ pytest
 pytest's
 rakudo
 regen
+renderer
 repo
 reportAttributeAccessIssue
 reportMissingTypeStubs

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -259,6 +259,9 @@ CallStyle = (
 )
 """Tagged union describing how a language passes call arguments."""
 
+type FormatCallArg = Callable[[Value, str], str]
+"""Callable that rewrites a formatted direct call argument."""
+
 
 class CallSupport(enum.Enum):
     """Sentinel describing why a language does not have a
@@ -437,6 +440,16 @@ values.
 """
 
 
+@beartype
+def _identity_call_arg(_value: Value, formatted: str, /) -> str:
+    """Return *formatted* unchanged for languages with no argument wrapper."""
+    return formatted
+
+
+identity_call_arg: FormatCallArg = _identity_call_arg
+"""Shared callable for languages that need no call-argument wrapping."""
+
+
 @dataclasses.dataclass(frozen=True)
 class ModifierCombination:
     """A named combination of declaration modifiers for a language.
@@ -509,6 +522,7 @@ class LanguageCls(type):
     supports_standalone_comments_in_wrapped_calls: bool
     supports_commented_dict_call_args: bool
     supports_module_name: bool
+    format_call_arg: FormatCallArg
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""
@@ -1236,6 +1250,18 @@ class Language(Protocol):
         Most languages accept dotted member-access as-is and use
         :data:`identity_call_target`.  PHP overrides this to produce
         ``$app->client->fetch``.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def format_call_arg(self) -> FormatCallArg:
+        """Rewrite a formatted direct call argument.
+
+        Called as ``format_call_arg(value, formatted)`` after *value*
+        has been formatted as a literal or reference.  Languages that
+        do not need wrapping set this to :data:`identity_call_arg`;
+        languages such as C and Objective-C override this to wrap each
+        argument in a canonical parameter type.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1767,17 +1767,6 @@ def literalize(
 
 
 @beartype
-def _identity_call_arg(_value: Value, formatted: str) -> str:
-    """Return *formatted* unchanged.
-
-    Default for :func:`_format_call_args` when a language does not
-    define ``format_call_arg``.  C and Objective-C override this to
-    wrap each argument in their canonical parameter type.
-    """
-    return formatted
-
-
-@beartype
 def _identity_call_statement(statement: str) -> str:
     """Return *statement* unchanged.
 
@@ -2028,11 +2017,7 @@ def _format_call_args(
     *ref_case*, when not ``None``, converts each ``{"$ref": "name"}``
     identifier to that :class:`IdentifierCase` before emitting it.
     """
-    wrap_arg: Callable[[Value, str], str] = getattr(
-        language,
-        "format_call_arg",
-        _identity_call_arg,
-    )
+    wrap_arg = language.format_call_arg
     formatted = [
         _format_single_call_arg(
             value=arg_value,

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -201,6 +202,13 @@ class Bash(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Bash."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -115,6 +116,13 @@ class Clojure(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Clojure."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -124,6 +125,13 @@ class CommonLisp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for CommonLisp."""

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -879,6 +880,13 @@ class Cpp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for C++."""

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -185,6 +186,13 @@ class Crystal(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Crystal."""

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -78,6 +78,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -367,6 +368,13 @@ class CSharp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     _opener_config = TypedOpenerConfig(
         str_type="string",

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -171,6 +172,13 @@ class D(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for D."""

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -68,6 +68,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -293,6 +294,13 @@ class Dart(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -230,7 +230,7 @@ def _dhall_call_stub(
 
 
 @beartype
-def _dhall_format_call_arg(original: Scalar, formatted: str, /) -> str:
+def _dhall_format_call_arg(original: Value, formatted: str, /) -> str:
     """Wrap a formatted scalar in the appropriate ``DVal`` constructor.
 
     Booleans, integers, floats, and strings each get their own
@@ -246,8 +246,11 @@ def _dhall_format_call_arg(original: Scalar, formatted: str, /) -> str:
             return f"DVal.DDouble {formatted}"
         case str() | bytes() | datetime.datetime() | datetime.date() | None:
             return f"DVal.DText {formatted}"
-        case _ as unreachable:
-            assert_never(unreachable)
+        case _:
+            raise CallArgNotSupportedError(
+                language_name="Dhall",
+                reason="Dhall call stubs only support scalar arguments",
+            )
 
 
 @beartype
@@ -934,7 +937,7 @@ class Dhall(metaclass=LanguageCls):
         return _dhall_call_preamble_stub
 
     @cached_property
-    def format_call_arg(self) -> Callable[[Scalar, str], str]:
+    def format_call_arg(self) -> Callable[[Value, str], str]:
         """Wrap each scalar call argument in the ``DVal`` union tag."""
         return _dhall_format_call_arg
 

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -63,6 +63,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_data_preamble,
@@ -212,6 +213,13 @@ class Elixir(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Elixir."""

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
+    identity_call_arg,
     identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
@@ -518,6 +519,13 @@ class Elm(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Elm."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -206,6 +207,13 @@ class Erlang(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Erlang."""

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -43,6 +43,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -209,6 +210,13 @@ class Forth(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -291,6 +292,13 @@ class FSharp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for FSharp."""

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     no_call_stub,
     no_type_hint_preamble,
@@ -533,6 +534,13 @@ class Gleam(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Gleam."""

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -268,6 +269,13 @@ class Go(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Go."""

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -148,6 +149,13 @@ class Groovy(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Groovy."""

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     date_scalar_preamble,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_data_preamble,
@@ -958,6 +959,13 @@ class Haskell(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Haskell."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -152,6 +153,13 @@ class Hcl(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Hcl."""

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -583,6 +584,13 @@ class Java(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -135,6 +136,13 @@ class JavaScript(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date formatting options for JavaScript."""

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -128,6 +129,13 @@ class Json5(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Json5."""

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -144,6 +145,13 @@ class Jsonnet(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Jsonnet."""

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -66,6 +66,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -163,6 +164,13 @@ class Julia(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date formatting options for Julia."""

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -79,6 +79,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -439,6 +440,13 @@ class Kotlin(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     _opener_config = TypedOpenerConfig(
         str_type="String",

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -149,6 +150,13 @@ class Lua(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Lua."""

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -216,6 +217,13 @@ class Matlab(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Matlab."""

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_data_preamble,
@@ -431,6 +432,13 @@ class Mojo(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = False
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Mojo."""

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -542,6 +543,13 @@ class Nim(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Nim."""

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -196,6 +197,13 @@ class Nix(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Nix."""

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -100,6 +101,13 @@ class Norg(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Norg."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -64,6 +64,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
@@ -262,6 +263,13 @@ class OCaml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -112,6 +113,13 @@ class Occam(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_data_preamble,
@@ -220,6 +221,13 @@ class Odin(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Odin."""

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -159,6 +160,13 @@ class Perl(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Perl."""

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -158,6 +159,13 @@ class Php(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Php."""

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -174,6 +175,13 @@ class PowerShell(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for PowerShell."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -541,6 +542,13 @@ class Python(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date formatting options for Python."""

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -173,6 +174,13 @@ class R(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date formatting options for R."""

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -116,6 +117,13 @@ class Racket(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Racket."""

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -66,6 +66,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -192,6 +193,13 @@ class Raku(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Raku."""

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -195,6 +196,13 @@ class Ruby(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Ruby."""

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -72,6 +72,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -702,6 +703,13 @@ class Rust(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Rust."""

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -68,6 +68,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -235,6 +236,14 @@ class Scala(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
+
     module_name: str = "Check"
 
     _opener_config = TypedOpenerConfig(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -112,6 +113,13 @@ class Scheme(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Scheme."""

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -63,6 +63,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -317,6 +318,13 @@ class Sml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -336,6 +337,13 @@ class Swift(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Swift."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -157,6 +158,13 @@ class Tcl(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options."""

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -128,6 +129,13 @@ class Toml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Toml."""

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -255,6 +256,13 @@ class TypeScript(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date formatting options for TypeScript."""

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_data_preamble,
@@ -345,6 +346,13 @@ class V(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for V."""

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -65,6 +65,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -276,6 +277,13 @@ class VisualBasic(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for VisualBasic."""

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     no_call_stub,
     no_data_preamble,
@@ -175,6 +176,13 @@ class Wren(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Wren."""

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
     no_call_stub,
@@ -102,6 +103,13 @@ class Yaml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Yaml."""

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -42,6 +42,7 @@ from literalizer.languages import (
     Bash,
     Cobol,
     Dart,
+    Dhall,
     Fortran,
     FSharp,
     Gleam,
@@ -138,6 +139,21 @@ def test_sml_negative_epoch_datetime_parenthesizes_int_constructor() -> None:
 
     assert "SInt (~" in result.code
     assert "SInt ~" not in result.code
+
+
+def test_dhall_literalize_call_rejects_non_scalar_arg() -> None:
+    """Dhall call argument wrapping is restricted to scalar values."""
+    with pytest.raises(
+        expected_exception=CallArgNotSupportedError,
+        match="Dhall call stubs only support scalar arguments",
+    ):
+        literalize_call(
+            source="[[[]]]",
+            input_format=InputFormat.JSON,
+            language=Dhall(),
+            target_function="consume",
+            parameter_names=["value"],
+        )
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
## Summary
Make `format_call_arg` an explicit language hook instead of looking it up dynamically with `getattr`. Languages that do not wrap call arguments now declare the shared identity hook directly, while languages with custom wrapping keep their overrides. Dhall's hook signature now matches the shared language protocol and rejects unsupported non-scalar call arguments explicitly.

## Checks
`uv run ruff check src/literalizer/_language.py src/literalizer/_literalize.py src/literalizer/languages`; `uv run ty check src/literalizer/_language.py src/literalizer/_literalize.py src/literalizer/languages`; `uv run --extra dev mypy .`; `uv run --extra dev pyright --verifytypes literalizer`; `uv run --extra dev pyrefly check src/literalizer/_language.py src/literalizer/_literalize.py src/literalizer/languages`; `uv run --extra dev python -m pytest tests/integration/test_calls.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the cross-language call rendering pipeline by making `Language.format_call_arg` mandatory; any downstream custom language specs that relied on the previous dynamic defaulting may break at runtime or type-check time. Behavior changes are intended but could surface in edge-case call argument formatting across many languages.
> 
> **Overview**
> Makes `format_call_arg` a first-class required `Language` hook (typed as `FormatCallArg`) and removes the `_literalize._format_call_args` fallback `getattr` lookup, so call rendering always uses `language.format_call_arg`.
> 
> Adds a shared `identity_call_arg` implementation in `_language.py` and updates languages that don’t wrap call args to explicitly declare it. Updates Dhall’s call-arg wrapper to accept `Value` (not just `Scalar`) and to **explicitly reject non-scalar arguments** with `CallArgNotSupportedError`, with a new unit test covering this case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fb678281730e4a4fb68f94bfae73f9d81d729e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->