### PR TITLE
[codex] Add idiomatic Go line endings

### DIFF
--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -500,7 +500,50 @@ class Go(metaclass=LanguageCls):
     class LineEndings(enum.Enum):
         """Line ending options."""
 
-        SEMICOLON = enum.auto()
+        SEMICOLON = ";"
+        NONE = ""
+
+        @property
+        def statement_terminator(self) -> str:
+            """Terminator appended to complete call statements."""
+            return self.value
+
+        def wrap_declaration_formatter(
+            self,
+            formatter: Callable[[str, str, Value, frozenset[enum.Enum]], str],
+        ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+            """Wrap a declaration formatter with this line ending."""
+            if not self.value:
+                return formatter
+
+            def with_semicolon(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Format with a trailing semicolon."""
+                return formatter(name, value, data, modifiers) + self.value
+
+            return with_semicolon
+
+        def wrap_assignment_formatter(
+            self,
+            formatter: Callable[[str, str, Value], str],
+        ) -> Callable[[str, str, Value], str]:
+            """Wrap an assignment formatter with this line ending."""
+            if not self.value:
+                return formatter
+
+            def with_semicolon(
+                name: str,
+                value: str,
+                data: Value,
+            ) -> str:
+                """Format with a trailing semicolon."""
+                return formatter(name, value, data) + self.value
+
+            return with_semicolon
 
     line_endings = LineEndings
 
@@ -593,7 +636,7 @@ class Go(metaclass=LanguageCls):
     numeric_style: NumericStyles = NumericStyles.OVERLOADED
     string_format: StringFormats = StringFormats.DOUBLE
     trailing_comma: TrailingCommas = TrailingCommas.YES
-    line_ending: LineEndings = LineEndings.SEMICOLON
+    line_ending: LineEndings = LineEndings.NONE
     call_style: CallStyles = CallStyles.POSITIONAL
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
@@ -610,7 +653,6 @@ class Go(metaclass=LanguageCls):
     supports_collection_comments: ClassVar[bool] = True
     supports_scalar_before_comments: ClassVar[bool] = False
     supports_scalar_inline_comments: ClassVar[bool] = True
-    statement_terminator: ClassVar[str] = ";"
     static_preamble: ClassVar[Sequence[str]] = ("package main",)
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ('import "math"',)
@@ -846,12 +888,19 @@ class Go(metaclass=LanguageCls):
         return braced_dict_entry(format_value=passthrough_sequence_entry)
 
     @cached_property
+    def statement_terminator(self) -> str:
+        """String appended to each call expression."""
+        return self.line_ending.statement_terminator
+
+    @cached_property
     def format_variable_declaration(
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a new variable declaration."""
-        return _nil_safe_declaration(
-            base_formatter=self.declaration_style.value.formatter,
+        return self.line_ending.wrap_declaration_formatter(
+            formatter=_nil_safe_declaration(
+                base_formatter=self.declaration_style.value.formatter,
+            ),
         )
 
     @cached_property
@@ -859,7 +908,9 @@ class Go(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, str, Value], str]:
         """Callable that formats an assignment to an existing variable."""
-        return variable_formatter(template="{name} = {value}")
+        return self.line_ending.wrap_assignment_formatter(
+            formatter=variable_formatter(template="{name} = {value}"),
+        )
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/tests/integration/call_variant_cases.py
+++ b/tests/integration/call_variant_cases.py
@@ -1,8 +1,8 @@
 """``literalize_call`` golden-file cases driven by language variants.
 
-Covers call inputs that the language's default heterogeneous strategy
-rejects, but which a non-default variant (e.g. Rust's ``TAGGED_ENUM``)
-can represent.  Sibling to :mod:`call_cases`.
+Covers call inputs that need a non-default language spec, such as
+inputs that a default heterogeneous strategy rejects or calls rendered
+with a non-default line ending.  Sibling to :mod:`call_cases`.
 """
 
 import dataclasses
@@ -12,6 +12,7 @@ from collections.abc import Callable, Iterable
 from beartype import beartype
 
 from .call_cases import CALL_CASE_CONFIGS, CallCaseConfig
+from .language_specs import make_spec, sorted_languages
 from .variant_cases import (
     Variant,
     build_heterogeneous_value_name_variants,
@@ -33,7 +34,34 @@ class CallVariantCase:
 # directory and pairs it with the variant builders that produce a spec
 # capable of representing that case's heterogeneous input — which the
 # default spec rejects, causing :func:`test_call_golden_file` to skip.
+@functools.cache
+@beartype
+def build_line_ending_call_variants() -> list[Variant]:
+    """Return variants for every non-default call line ending."""
+    variants: list[Variant] = []
+    for lang_cls in sorted_languages():
+        spec = make_spec(lang_cls=lang_cls)
+        default_line_ending = spec.line_ending
+        variants.extend(
+            Variant(
+                name=(
+                    f"{lang_cls.__name__}_line_ending"
+                    f"_{line_ending.name.lower()}"
+                ),
+                spec=make_spec(
+                    lang_cls=lang_cls,
+                    line_ending=line_ending,
+                ),
+                lang_cls=lang_cls,
+            )
+            for line_ending in spec.line_endings
+            if line_ending is not default_line_ending
+        )
+    return variants
+
+
 CALL_VARIANT_SOURCES: list[tuple[str, Callable[[], Iterable[Variant]]]] = [
+    ("call_scalar_args", build_line_ending_call_variants),
     ("call_mixed_type_dicts", build_heterogeneous_value_name_variants),
 ]
 

--- a/tests/integration/cases/call_comments/Go_call.go
+++ b/tests/integration/cases/call_comments/Go_call.go
@@ -3,7 +3,7 @@ func process(args ...any) any { return nil }
 
 func main() {
 // Test cases
-process("hello");  // single word
-process("hello world");  // two words
+process("hello")  // single word
+process("hello world")  // two words
 // trailing comment
 }

--- a/tests/integration/cases/call_comments_dict_args/Go_call.go
+++ b/tests/integration/cases/call_comments_dict_args/Go_call.go
@@ -3,8 +3,8 @@ func process(args ...any) any { return nil }
 
 func main() {
 // Test cases
-process(map[string]string{"type": "create", "pr_id": "pr_1"});  // first case
-process(map[string]string{"type": "update", "pr_id": "pr_2"});  // second case
+process(map[string]string{"type": "create", "pr_id": "pr_1"})  // first case
+process(map[string]string{"type": "update", "pr_id": "pr_2"})  // second case
 // third case
-process(map[string]string{"type": "delete", "pr_id": "pr_3"});
+process(map[string]string{"type": "delete", "pr_id": "pr_3"})
 }

--- a/tests/integration/cases/call_deep_dotted_method/Go_call.go
+++ b/tests/integration/cases/call_deep_dotted_method/Go_call.go
@@ -6,7 +6,7 @@ type objType_ struct{ api apiType_ }
 var obj objType_
 
 func main() {
-obj.api.client.post("hello");
-obj.api.client.post(42);
-obj.api.client.post(true);
+obj.api.client.post("hello")
+obj.api.client.post(42)
+obj.api.client.post(true)
 }

--- a/tests/integration/cases/call_deep_dotted_transformed/Go_call.go
+++ b/tests/integration/cases/call_deep_dotted_transformed/Go_call.go
@@ -6,7 +6,7 @@ var app appType_
 func emit(args ...any) any { return nil }
 
 func main() {
-emit(app.client.fetch("hello"));
-emit(app.client.fetch(42));
-emit(app.client.fetch(true));
+emit(app.client.fetch("hello"))
+emit(app.client.fetch(42))
+emit(app.client.fetch(true))
 }

--- a/tests/integration/cases/call_dotted_method/Go_call.go
+++ b/tests/integration/cases/call_dotted_method/Go_call.go
@@ -5,7 +5,7 @@ type appType_ struct{ client clientType_ }
 var app appType_
 
 func main() {
-app.client.fetch("hello");
-app.client.fetch(42);
-app.client.fetch(true);
+app.client.fetch("hello")
+app.client.fetch(42)
+app.client.fetch(true)
 }

--- a/tests/integration/cases/call_dotted_transform_stub/Go_call.go
+++ b/tests/integration/cases/call_dotted_transform_stub/Go_call.go
@@ -5,7 +5,7 @@ func (tracerType_) emit(args ...any) any { return nil }
 var tracer tracerType_
 
 func main() {
-tracer.emit(process("hello"));
-tracer.emit(process(42));
-tracer.emit(process(true));
+tracer.emit(process("hello"))
+tracer.emit(process(42))
+tracer.emit(process(true))
 }

--- a/tests/integration/cases/call_keyword_args/Go_call.go
+++ b/tests/integration/cases/call_keyword_args/Go_call.go
@@ -5,6 +5,6 @@ var throttler throttlerType_
 func emit(args ...any) any { return nil }
 
 func main() {
-emit(throttler.check("user_1", 1000.0));
-emit(throttler.check("user_2", 2000.5));
+emit(throttler.check("user_1", 1000.0))
+emit(throttler.check("user_2", 2000.5))
 }

--- a/tests/integration/cases/call_mixed_type_dicts/Go_call.go
+++ b/tests/integration/cases/call_mixed_type_dicts/Go_call.go
@@ -5,6 +5,6 @@ type appType_ struct{ mgr mgrType_ }
 var app appType_
 
 func main() {
-app.mgr.run(map[string]any{"type": "create", "pr_id": "pr_1", "draft": true});
-app.mgr.run(map[string]any{"type": "create", "pr_id": "pr_2"});
+app.mgr.run(map[string]any{"type": "create", "pr_id": "pr_1", "draft": true})
+app.mgr.run(map[string]any{"type": "create", "pr_id": "pr_2"})
 }

--- a/tests/integration/cases/call_multi_args/Go_call.go
+++ b/tests/integration/cases/call_multi_args/Go_call.go
@@ -2,6 +2,6 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process(1, 42);
-process(2, 100);
+process(1, 42)
+process(2, 100)
 }

--- a/tests/integration/cases/call_negative_int/Go_call.go
+++ b/tests/integration/cases/call_negative_int/Go_call.go
@@ -2,7 +2,7 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process(-1);
-process(-2);
-process(-3);
+process(-1)
+process(-2)
+process(-3)
 }

--- a/tests/integration/cases/call_no_params/Go_call.go
+++ b/tests/integration/cases/call_no_params/Go_call.go
@@ -2,6 +2,6 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process();
-process();
+process()
+process()
 }

--- a/tests/integration/cases/call_no_params_transform/Go_call.go
+++ b/tests/integration/cases/call_no_params_transform/Go_call.go
@@ -3,6 +3,6 @@ func process(args ...any) any { return nil }
 func emit(args ...any) any { return nil }
 
 func main() {
-emit(process());
-emit(process());
+emit(process())
+emit(process())
 }

--- a/tests/integration/cases/call_per_element_false/Go_call.go
+++ b/tests/integration/cases/call_per_element_false/Go_call.go
@@ -2,5 +2,5 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process(1);
+process(1)
 }

--- a/tests/integration/cases/call_ref_args/Go_call.go
+++ b/tests/integration/cases/call_ref_args/Go_call.go
@@ -12,6 +12,6 @@ my_other := []int{
 	5,
 	6,
 }
-process(my_var, 42);
-process(my_other, 7);
+process(my_var, 42)
+process(my_other, 7)
 }

--- a/tests/integration/cases/call_ref_args_converted/Go_call.go
+++ b/tests/integration/cases/call_ref_args_converted/Go_call.go
@@ -12,6 +12,6 @@ MyOther := []int{
 	5,
 	6,
 }
-process(MyVar, 42);
-process(MyOther, 7);
+process(MyVar, 42)
+process(MyOther, 7)
 }

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Go_call.go
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Go_call.go
@@ -12,6 +12,6 @@ MyOther := []int{
 	5,
 	6,
 }
-process(MyVar, 42);
-process(MyOther, 7);
+process(MyVar, 42)
+process(MyOther, 7)
 }

--- a/tests/integration/cases/call_ref_args_converted_whole/Go_call.go
+++ b/tests/integration/cases/call_ref_args_converted_whole/Go_call.go
@@ -7,5 +7,5 @@ MyVar := []int{
 	2,
 	3,
 }
-process(MyVar);
+process(MyVar)
 }

--- a/tests/integration/cases/call_ref_args_escaped_quote/Go_call.go
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Go_call.go
@@ -3,5 +3,5 @@ func process(args ...any) any { return nil }
 
 func main() {
 my_str := "a\"b"
-process(my_str);
+process(my_str)
 }

--- a/tests/integration/cases/call_ref_args_reused/Go_call.go
+++ b/tests/integration/cases/call_ref_args_reused/Go_call.go
@@ -8,7 +8,7 @@ single_var := []int{
 	6,
 }
 repeated_var := 1
-process(repeated_var, 1);
-process(single_var, 0);
-process(repeated_var, 8);
+process(repeated_var, 1)
+process(single_var, 0)
+process(repeated_var, 8)
 }

--- a/tests/integration/cases/call_ref_nested_converted/Go_call.go
+++ b/tests/integration/cases/call_ref_nested_converted/Go_call.go
@@ -3,5 +3,5 @@ func process(args ...any) any { return nil }
 
 func main() {
 MyVar := 42
-process([]any{MyVar, 42, "static"});
+process([]any{MyVar, 42, "static"})
 }

--- a/tests/integration/cases/call_ref_nested_in_dict/Go_call.go
+++ b/tests/integration/cases/call_ref_nested_in_dict/Go_call.go
@@ -3,5 +3,5 @@ func process(args ...any) any { return nil }
 
 func main() {
 my_var := 42
-process(map[string]int{"key": my_var, "count": 42});
+process(map[string]int{"key": my_var, "count": 42})
 }

--- a/tests/integration/cases/call_ref_nested_in_list/Go_call.go
+++ b/tests/integration/cases/call_ref_nested_in_list/Go_call.go
@@ -4,6 +4,6 @@ func process(args ...any) any { return nil }
 func main() {
 my_var := 42
 my_other := 7
-process([]any{my_var, 42, "static"});
-process([]any{my_other, 7, "label"});
+process([]any{my_var, 42, "static"})
+process([]any{my_other, 7, "label"})
 }

--- a/tests/integration/cases/call_scalar_args/Go_line_ending_semicolon_call.go
+++ b/tests/integration/cases/call_scalar_args/Go_line_ending_semicolon_call.go
@@ -2,7 +2,7 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process("hello")
-process(42)
-process(true)
+process("hello");
+process(42);
+process(true);
 }

--- a/tests/integration/cases/call_scalar_args/JavaScript_line_ending_none_call.js
+++ b/tests/integration/cases/call_scalar_args/JavaScript_line_ending_none_call.js
@@ -1,0 +1,4 @@
+function process() {}
+process({ value: "hello" });
+process({ value: 42 });
+process({ value: true });

--- a/tests/integration/cases/call_scalar_args/TypeScript_line_ending_none_call.ts
+++ b/tests/integration/cases/call_scalar_args/TypeScript_line_ending_none_call.ts
@@ -1,0 +1,5 @@
+const process: any = () => {};
+process({ value: "hello" });
+process({ value: 42 });
+process({ value: true });
+export {};

--- a/tests/integration/cases/call_snake_dotted_method/Go_call.go
+++ b/tests/integration/cases/call_snake_dotted_method/Go_call.go
@@ -5,7 +5,7 @@ type my_appType_ struct{ http_client http_clientType_ }
 var my_app my_appType_
 
 func main() {
-my_app.http_client.fetch("hello");
-my_app.http_client.fetch(42);
-my_app.http_client.fetch(true);
+my_app.http_client.fetch("hello")
+my_app.http_client.fetch(42)
+my_app.http_client.fetch(true)
 }

--- a/tests/integration/cases/call_transform_no_wrapper/Go_call.go
+++ b/tests/integration/cases/call_transform_no_wrapper/Go_call.go
@@ -2,7 +2,7 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process("hello");
-process(42);
-process(true);
+process("hello")
+process(42)
+process(true)
 }

--- a/tests/integration/cases/call_wrap_in_file/Go_call.go
+++ b/tests/integration/cases/call_wrap_in_file/Go_call.go
@@ -2,6 +2,6 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process(1, 2);
-process(3, 4);
+process(1, 2)
+process(3, 4)
 }

--- a/tests/integration/cases/call_wrap_in_file_escaped_quote/Go_call.go
+++ b/tests/integration/cases/call_wrap_in_file_escaped_quote/Go_call.go
@@ -2,5 +2,5 @@ package main
 func process(args ...any) any { return nil }
 
 func main() {
-process("a\"b");
+process("a\"b")
 }

--- a/tests/integration/cases/set/Go_line_ending_semicolon_set.go
+++ b/tests/integration/cases/set/Go_line_ending_semicolon_set.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+my_data := map[string]struct{}{
+	"apple": struct{}{},
+	"banana": struct{}{},
+	"cherry": struct{}{},
+};
+_ = my_data
+}

--- a/tests/integration/cases/simple_dict/Go_line_ending_semicolon_dict.go
+++ b/tests/integration/cases/simple_dict/Go_line_ending_semicolon_dict.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+my_data := map[string]any{
+	"name": "Alice",
+	"age": 30,
+	"active": true,
+	"score": nil,
+};
+_ = my_data
+}

--- a/tests/integration/cases/simple_dict/Go_line_ending_semicolon_simple_dict.go
+++ b/tests/integration/cases/simple_dict/Go_line_ending_semicolon_simple_dict.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+my_data := map[string]any{
+	"name": "Alice",
+	"age": 30,
+	"active": true,
+	"score": nil,
+};
+my_data = map[string]any{
+	"name": "Alice",
+	"age": 30,
+	"active": true,
+	"score": nil,
+};
+_ = my_data
+}

--- a/tests/integration/cases/simple_sequence/Go_line_ending_semicolon.go
+++ b/tests/integration/cases/simple_sequence/Go_line_ending_semicolon.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+my_data := []any{
+	1,
+	"hello",
+	true,
+	nil,
+};
+_ = my_data
+}

--- a/tests/integration/cases/simple_sequence/Go_line_ending_semicolon_decl_var.go
+++ b/tests/integration/cases/simple_sequence/Go_line_ending_semicolon_decl_var.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+var my_data = []any{
+	1,
+	"hello",
+	true,
+	nil,
+};
+_ = my_data
+}

--- a/tests/integration/cases/simple_sequence/Go_line_ending_semicolon_simple_sequence.go
+++ b/tests/integration/cases/simple_sequence/Go_line_ending_semicolon_simple_sequence.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+my_data := []any{
+	1,
+	"hello",
+	true,
+	nil,
+};
+my_data = []any{
+	1,
+	"hello",
+	true,
+	nil,
+};
+_ = my_data
+}

--- a/tests/integration/test_calls.py
+++ b/tests/integration/test_calls.py
@@ -65,11 +65,8 @@ def test_call_variant_golden_file(
 ) -> None:
     """Test ``literalize_call`` for a non-default language spec.
 
-    Covers call inputs that the language's default
-    :attr:`Language.heterogeneous_strategy` rejects, which
-    :func:`test_call_golden_file` skips — in particular the
-    sibling-widening behavior of Rust's ``TAGGED_ENUM`` across
-    per-element call arguments.
+    Covers call inputs that need a non-default language option, such as
+    line endings or heterogeneous strategies.
     """
     run_call_golden_case(
         config=call_variant_case.config,

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -640,7 +640,7 @@ def test_literalize_call_wrap_in_file_emits_stubs() -> None:
         func process(args ...any) any { return nil }
 
         func main() {
-        process(1, 2);
+        process(1, 2)
         }""",
     )
     assert go_result.code == expected_go
@@ -1035,7 +1035,7 @@ def test_literalize_call_arg_ref_all_refs() -> None:
         target_function="combine",
         parameter_names=["x", "y"],
     )
-    assert result.code == "combine(a, b);"
+    assert result.code == "combine(a, b)"
 
 
 def test_literalize_call_arg_ref_top_level_element() -> None:
@@ -1050,7 +1050,7 @@ def test_literalize_call_arg_ref_top_level_element() -> None:
         target_function="run",
         parameter_names=["x"],
     )
-    assert result.code == "run(a);\nrun(b);"
+    assert result.code == "run(a)\nrun(b)"
 
 
 def test_literalize_call_arg_ref_per_element_false() -> None:


### PR DESCRIPTION
Adds Go.LineEndings.NONE and makes it the default so generated Go call statements omit explicit semicolons. Keeps Go.LineEndings.SEMICOLON available and routes Go calls, declarations, and assignments through the line-ending setting. Extends call variant golden coverage to exercise non-default line endings and updates Go golden files intentionally. Validated with targeted pytest suites, the full integration call suite, orphan-golden checks, Ruff, and commit/push hooks. Closes #1874.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Go code generation defaults to omit explicit semicolons and threads this through declarations/assignments, which may affect downstream golden expectations or consumers relying on semicolon-terminated output.
> 
> **Overview**
> Go output is now **line-ending configurable** via `Go.LineEndings`, adding `NONE` (default) and making `SEMICOLON` an explicit option. Call statements, variable declarations, and assignments are routed through this setting so generated Go code no longer includes trailing `;` unless configured.
> 
> Integration and unit golden tests are updated accordingly (removing semicolons from existing Go call fixtures) and expanded to cover **non-default line-ending variants**, adding new golden cases for semicolon-terminated Go and for `line_ending=NONE` variants in JS/TS call rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b68e0bb2bee3961a99680634620d475c4e43c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->