### PR TITLE
[codex] Use language capability for zero-parameter calls

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -505,6 +505,7 @@ class LanguageCls(type):
     allows_empty_call_parens: bool
     supports_dotted_call_stub: bool
     call_returns_expression: bool
+    supports_zero_parameter_calls: bool
     supports_inline_multiline_dict_args: bool
     supports_standalone_comments_in_wrapped_calls: bool
     supports_commented_dict_call_args: bool

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -222,6 +222,7 @@ class Ada(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -197,6 +197,7 @@ class Bash(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -227,6 +227,7 @@ class C(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -111,6 +111,7 @@ class Clojure(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -339,6 +339,7 @@ class Cobol(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = False
+    supports_zero_parameter_calls = False
     supports_inline_multiline_dict_args = False
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = False

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -120,6 +120,7 @@ class CommonLisp(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -875,6 +875,7 @@ class Cpp(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -181,6 +181,7 @@ class Crystal(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -363,6 +363,7 @@ class CSharp(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -167,6 +167,7 @@ class D(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -289,6 +289,7 @@ class Dart(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -528,6 +528,7 @@ class Dhall(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = False
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = False

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -208,6 +208,7 @@ class Elixir(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -514,6 +514,7 @@ class Elm(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = False
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -202,6 +202,7 @@ class Erlang(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -205,6 +205,7 @@ class Forth(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -329,6 +329,7 @@ class Fortran(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -287,6 +287,7 @@ class FSharp(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -529,6 +529,7 @@ class Gleam(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -264,6 +264,7 @@ class Go(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -144,6 +144,7 @@ class Groovy(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -954,6 +954,7 @@ class Haskell(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -148,6 +148,7 @@ class Hcl(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -579,6 +579,7 @@ class Java(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -131,6 +131,7 @@ class JavaScript(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -124,6 +124,7 @@ class Json5(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -140,6 +140,7 @@ class Jsonnet(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -159,6 +159,7 @@ class Julia(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -435,6 +435,7 @@ class Kotlin(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -145,6 +145,7 @@ class Lua(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -212,6 +212,7 @@ class Matlab(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -427,6 +427,7 @@ class Mojo(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = False

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -538,6 +538,7 @@ class Nim(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -192,6 +192,7 @@ class Nix(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -96,6 +96,7 @@ class Norg(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -282,6 +282,7 @@ class ObjectiveC(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -258,6 +258,7 @@ class OCaml(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -108,6 +108,7 @@ class Occam(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -216,6 +216,7 @@ class Odin(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -155,6 +155,7 @@ class Perl(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -154,6 +154,7 @@ class Php(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -170,6 +170,7 @@ class PowerShell(metaclass=LanguageCls):
     allows_empty_call_parens = False
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -671,6 +671,7 @@ class PureScript(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -537,6 +537,7 @@ class Python(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -169,6 +169,7 @@ class R(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -112,6 +112,7 @@ class Racket(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -188,6 +188,7 @@ class Raku(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -529,6 +529,7 @@ class Roc(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = False
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -191,6 +191,7 @@ class Ruby(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -698,6 +698,7 @@ class Rust(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -231,6 +231,7 @@ class Scala(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -108,6 +108,7 @@ class Scheme(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -313,6 +313,7 @@ class Sml(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -332,6 +332,7 @@ class Swift(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -241,6 +241,7 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -153,6 +153,7 @@ class Tcl(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -124,6 +124,7 @@ class Toml(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -251,6 +251,7 @@ class TypeScript(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -341,6 +341,7 @@ class V(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -272,6 +272,7 @@ class VisualBasic(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -171,6 +171,7 @@ class Wren(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -98,6 +98,7 @@ class Yaml(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -240,6 +240,7 @@ class Zig(metaclass=LanguageCls):
     allows_empty_call_parens = True
     supports_dotted_call_stub = True
     call_returns_expression = True
+    supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -23,9 +23,6 @@ from literalizer.exceptions import (
     HeterogeneousCollectionError,
 )
 from literalizer.languages import (
-    Cobol,
-    Dhall,
-    Elm,
     Mojo,
 )
 
@@ -609,13 +606,6 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 # names, or call_transform wrapper use syntax that is invalid in a given
 # language, making a valid lint-passing output impossible to generate.
 CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
-    "call_no_params_transform": frozenset({Cobol, Elm}),
-    # COBOL CALL "PROCESS" USING. is invalid with no parameters (USING
-    # requires at least one).  Dhall zero-parameter stubs would need to
-    # be plain values rather than functions, which the stub generator does
-    # not support.  Elm zero-parameter "functions" are values, not callable
-    # expressions.
-    "call_no_params": frozenset({Cobol, Dhall, Elm}),
     # Mojo rejects the transfer operator (^) on trivial register types such as
     # Int, so a $ref inside a dict literal (which requires ^) cannot compile.
     "call_ref_nested_in_dict": frozenset({Mojo}),
@@ -674,6 +664,11 @@ def _lang_satisfies_config_constraints(
     if (
         config.requires_call_returns_expression
         and not lang_cls.call_returns_expression
+    ):
+        return False
+    if (
+        len(config.parameter_names) == 0
+        and not lang_cls.supports_zero_parameter_calls
     ):
         return False
     if (

--- a/tests/integration/test_calls.py
+++ b/tests/integration/test_calls.py
@@ -11,7 +11,11 @@ from pathlib import Path
 import pytest
 from pytest_regressions.file_regression import FileRegressionFixture
 
-from .call_cases import CallCase, discover_call_cases, run_call_golden_case
+from .call_cases import (
+    CallCase,
+    discover_call_cases,
+    run_call_golden_case,
+)
 from .call_variant_cases import CallVariantCase, build_call_variant_cases
 from .language_specs import make_spec
 

--- a/tests/test_class_enum_access.py
+++ b/tests/test_class_enum_access.py
@@ -32,3 +32,4 @@ def test_format_enums_populated(*, language_cls: LanguageCls) -> None:
     assert len(language_cls.TrailingCommas) >= 1
     assert len(language_cls.CallStyles) >= 0
     assert len(language_cls.identifier_cases) >= 1
+    assert isinstance(language_cls.supports_zero_parameter_calls, bool)


### PR DESCRIPTION
## Summary

- Add an explicit `supports_zero_parameter_calls` language capability to every language class.
- Mark COBOL, Dhall, and Elm as not supporting zero-parameter calls; all other languages opt in explicitly.
- Derive zero-parameter call-case skips from `len(parameter_names) == 0` and the language capability, removing the `call_no_params` and `call_no_params_transform` name-based exclusions.
- Keep class-level capability exposure covered by the existing language metadata test.

## Validation

- `uv run --extra dev ruff check $(git diff --name-only)`
- `uv run --extra dev pytest tests/test_class_enum_access.py::test_format_enums_populated tests/integration/test_orphan_golden_files.py::test_no_dead_golden_files`
- Earlier on this branch: `uv run --extra dev pytest tests/integration/test_calls.py tests/test_class_enum_access.py::test_format_enums_populated tests/integration/test_orphan_golden_files.py::test_no_dead_golden_files`
- Push hooks: mypy, check-manifest, pyright, ty, pyrefly, pyright-verifytypes

Closes #1876.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly adds a new per-language boolean capability and uses it to gate call integration tests; behavior changes are limited to which languages run zero-arg call cases (notably excluding Cobol/Dhall/Elm).
> 
> **Overview**
> Adds a new language capability flag, `supports_zero_parameter_calls`, to `LanguageCls` and sets it across all language specs (explicitly `False` for Cobol/Dhall/Elm; `True` elsewhere).
> 
> Updates call integration-case selection to skip zero-parameter call cases based on this capability rather than hardcoded case-name exclusions, and extends the language metadata test to assert the new flag is present and boolean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff068bfec62ae91655ecae9da1e9e2e91c0b0673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->