### PR TITLE
Remove call-case incompatibility map

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -24,11 +24,6 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     HeterogeneousCollectionError,
 )
-from literalizer.languages import (
-    Cobol,
-    Dhall,
-    Elm,
-)
 
 from .check_golden import check_golden
 from .language_specs import sorted_languages, with_per_fixture_module_name
@@ -603,20 +598,6 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 ]
 
 
-# Per-case language exclusions: cases whose target function, parameter
-# names, or call_transform wrapper use syntax that is invalid in a given
-# language, making a valid lint-passing output impossible to generate.
-CASE_LANGUAGE_INCOMPATIBLE: dict[str, frozenset[literalizer.LanguageCls]] = {
-    "call_no_params_transform": frozenset({Cobol, Elm}),
-    # COBOL CALL "PROCESS" USING. is invalid with no parameters (USING
-    # requires at least one).  Dhall zero-parameter stubs would need to
-    # be plain values rather than functions, which the stub generator does
-    # not support.  Elm zero-parameter "functions" are values, not callable
-    # expressions.
-    "call_no_params": frozenset({Cobol, Dhall, Elm}),
-}
-
-
 _CASES_REQUIRING_STANDALONE_WRAPPED_COMMENTS = frozenset(
     {"call_comments", "call_comments_dict_args"}
 )
@@ -787,10 +768,6 @@ def discover_call_cases() -> list[CallCase]:
             if len(lang_cls.CallStyles) == 0:
                 continue
             if not _lang_supports_case(config=config, lang_cls=lang_cls):
-                continue
-            if lang_cls in CASE_LANGUAGE_INCOMPATIBLE.get(
-                config.case_dir_name, frozenset()
-            ):
                 continue
             if not _lang_satisfies_config_constraints(
                 lang_cls=lang_cls, config=config


### PR DESCRIPTION
Removes CASE_LANGUAGE_INCOMPATIBLE and its lookup from call-case discovery now that language capabilities cover the remaining exclusions.

This keeps call-case skips driven by language properties instead of a case-name map.

Closes #1878 and closes #1785.

Validated with `uv run --extra=dev pytest tests/integration/test_orphan_golden_files.py::test_no_dead_golden_files tests/integration/test_calls.py`, ruff checks, and commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the integration test case discovery logic, but it may cause additional language/case combinations to run (and potentially require golden updates) if any language capabilities are mis-specified.
> 
> **Overview**
> Removes the hard-coded `CASE_LANGUAGE_INCOMPATIBLE` map (and related `Cobol`/`Dhall`/`Elm` imports) from call-case discovery.
> 
> Call golden tests are now filtered solely via per-language capability flags in `_lang_supports_case`/`_lang_satisfies_*` rather than by case-name exclusions, potentially expanding which languages participate in `call_no_params*` cases when they declare support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba32d58eee2d2207f4b927bb0851a9240b4c2ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->