### PR TITLE
Use supports_module_name in test specs

### DIFF
--- a/tests/integration/language_specs.py
+++ b/tests/integration/language_specs.py
@@ -160,10 +160,7 @@ def make_spec(
     ``module_name`` constructor argument; default it to ``"check"`` so
     fixture output matches the historic golden files.
     """
-    has_module_name = "module_name" in getattr(
-        lang_cls, "__dataclass_fields__", {}
-    )
-    if has_module_name and "module_name" not in kwargs:
+    if lang_cls.supports_module_name and "module_name" not in kwargs:
         kwargs["module_name"] = lang_cls.module_name_case.convert(name="main")
     return cached_spec(
         lang_cls=lang_cls,


### PR DESCRIPTION
## Summary

Use the existing `supports_module_name` language capability in integration test spec creation instead of inspecting dataclass fields for `module_name`.

This keeps the helper aligned with the public language-class metadata and removes an implementation-detail check.

## Validation

- `uv run --extra=dev python -c 'from tests.integration.language_specs import sorted_languages; mismatches=[cls.__name__ for cls in sorted_languages() if cls.supports_module_name != ("module_name" in getattr(cls, "__dataclass_fields__", {}))]; assert not mismatches, mismatches; print("supports_module_name matches dataclass module_name fields")'`
- `uv run --extra=dev pytest tests/integration/test_literalize_ref_golden.py -q -k 'Java or Python'`
- commit hooks and pre-push hooks passed, including Ruff, mypy, pyright, ty, pyrefly, and check-manifest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that swaps an implementation-detail check for the public `supports_module_name` capability when defaulting `module_name` in integration specs.
> 
> **Overview**
> Updates integration test spec construction in `tests/integration/language_specs.py` to default `module_name` based on `lang_cls.supports_module_name` instead of inspecting dataclass fields.
> 
> This aligns the helper with the language class’s public capability metadata while keeping the existing default module naming behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b99026203bcf9b37b30f5118874ce67e56321d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->