### PR TITLE
[codex] Remove getattr call hooks

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -460,6 +460,27 @@ identity_call_arg: FormatCallArg = _identity_call_arg
 """Shared callable for languages that need no call-argument wrapping."""
 
 
+@beartype
+def _no_validate_call_arg(_value: Value, /) -> None:
+    """Accept every call argument."""
+
+
+no_validate_call_arg: Callable[[Value], None] = _no_validate_call_arg
+"""Shared callable for languages with no call-argument constraints."""
+
+
+@beartype
+def _identity_call_statement(statement: str, /) -> str:
+    """Return *statement* unchanged for languages with bare call
+    statements.
+    """
+    return statement
+
+
+identity_call_statement: Callable[[str], str] = _identity_call_statement
+"""Shared callable for languages whose calls need no statement wrapper."""
+
+
 @dataclasses.dataclass(frozen=True)
 class ModifierCombination:
     """A named combination of declaration modifiers for a language.
@@ -535,6 +556,9 @@ class LanguageCls(type):
     supports_module_name: bool
     supports_call_refs_in_dict_literals: bool
     format_call_arg: FormatCallArg
+    validate_call_arg: Callable[[Value], None]
+    format_call_statement: Callable[[str], str]
+    call_data_dependent_preamble: Callable[[Value], tuple[str, ...]]
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""
@@ -1132,6 +1156,18 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Data-dependent preamble lines used for call rendering.
+
+        Most languages set this to the same callable as
+        :attr:`data_dependent_preamble`.  Languages whose declaration
+        preamble does not apply to inline call arguments override it.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Describes how this language handles heterogeneous scalar
         collections.
@@ -1274,6 +1310,26 @@ class Language(Protocol):
         do not need wrapping set this to :data:`identity_call_arg`;
         languages such as C and Objective-C override this to wrap each
         argument in a canonical parameter type.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Validate a direct call argument after references are removed.
+
+        Languages that accept every supported literal set this to
+        :data:`no_validate_call_arg`; languages with additional call
+        argument restrictions override it.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Rewrite an assembled call expression into a valid statement.
+
+        Languages that allow bare call statements set this to
+        :data:`identity_call_statement`; languages that need a wrapper
+        such as ``let _ = ...`` override it.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1980,17 +1980,6 @@ def literalize(
 
 
 @beartype
-def _identity_call_statement(statement: str) -> str:
-    """Return *statement* unchanged.
-
-    Default when a language does not define ``format_call_statement``.
-    Languages that require call expressions to be wrapped in a
-    statement form (e.g. SML's ``val _ = expr``) override this.
-    """
-    return statement
-
-
-@beartype
 def _extract_call_arg_ref_name(*, value: Value, ref_key: str) -> str | None:
     """Return the identifier name for a ``{ref_key: "name"}`` marker.
 
@@ -2481,16 +2470,6 @@ def _render_call_per_element(
         spec=language,
         ref_key=ref_key,
     )
-    validate_call_arg: Callable[[Value], None] | None = getattr(
-        language,
-        "validate_call_arg",
-        None,
-    )
-    format_call_statement: Callable[[str], str] = getattr(
-        language,
-        "format_call_statement",
-        _identity_call_statement,
-    )
     single_use_ref_names = _compute_call_arg_ref_single_use_names(
         elements=data,
         ref_key=ref_key,
@@ -2508,8 +2487,7 @@ def _render_call_per_element(
                 value=value, ref_key=ref_key
             )
             check_data(data=stripped_value, spec=language)
-            if validate_call_arg is not None:
-                validate_call_arg(stripped_value)
+            language.validate_call_arg(stripped_value)
         call_wrap_ids = (
             _compute_wrap_ids(data=non_ref_args, spec=language) | slot_wrap_ids
         )
@@ -2527,7 +2505,7 @@ def _render_call_per_element(
             collection_layout=collection_layout,
         )
         rendered_elements.append(
-            format_call_statement(
+            language.format_call_statement(
                 _assemble_call(
                     target_function=target_function,
                     args_str=args_str,
@@ -2570,21 +2548,10 @@ def _render_call_whole(
     if _extract_call_arg_ref_name(value=data, ref_key=ref_key) is None:
         stripped_data = _strip_refs_from_value(value=data, ref_key=ref_key)
         check_data(data=stripped_data, spec=language)
-        validate_call_arg: Callable[[Value], None] | None = getattr(
-            language,
-            "validate_call_arg",
-            None,
-        )
-        if validate_call_arg is not None:
-            validate_call_arg(stripped_data)
+        language.validate_call_arg(stripped_data)
         call_wrap_ids = _compute_wrap_ids(data=[data], spec=language)
     else:
         call_wrap_ids = frozenset[int]()
-    format_call_statement: Callable[[str], str] = getattr(
-        language,
-        "format_call_statement",
-        _identity_call_statement,
-    )
     args_str = _format_call_args(
         values=[data],
         params=parameter_names,
@@ -2601,7 +2568,7 @@ def _render_call_whole(
         ref_key=ref_key,
         collection_layout=collection_layout,
     )
-    return format_call_statement(
+    return language.format_call_statement(
         _assemble_call(
             target_function=target_function,
             args_str=args_str,
@@ -2782,16 +2749,11 @@ def literalize_call(
         language=language,
         has_variable_declaration=False,
     )
-    _call_ddp: Callable[[Value], tuple[str, ...]] = getattr(
-        language,
-        "call_data_dependent_preamble",
-        language.data_dependent_preamble,
-    )
     preamble = deduplicate_preamble_entries(
         entries=(
             tuple(language.static_preamble)
             + computed.header
-            + _call_ddp(data_for_preamble)
+            + language.call_data_dependent_preamble(data_for_preamble)
         )
     )
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -55,9 +55,11 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     identity_call_ref_identifier,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -440,6 +442,16 @@ class Ada(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     def wrap_calls_with_declarations(
         self,
         declarations: tuple[str, ...],
@@ -605,6 +617,13 @@ class Ada(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
@@ -426,6 +427,12 @@ class Bash(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = _bash_validate_spec_for_data
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -543,6 +550,13 @@ class Bash(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -59,10 +59,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -461,6 +463,17 @@ class C(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -560,6 +573,13 @@ class C(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -54,10 +54,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -339,6 +341,17 @@ class Clojure(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -444,6 +457,13 @@ class Clojure(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -554,6 +555,12 @@ class Cobol(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     _PROGRAM_PREFIX: ClassVar[str] = (
@@ -708,6 +715,13 @@ class Cobol(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -53,10 +53,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -356,6 +358,17 @@ class CommonLisp(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -466,6 +479,13 @@ class CommonLisp(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -71,9 +71,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -1215,6 +1217,17 @@ class Cpp(metaclass=LanguageCls):
         ),
     )
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     class VariableTypeHints(enum.Enum):
@@ -1346,6 +1359,13 @@ class Cpp(metaclass=LanguageCls):
     def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
         """Format an assignment to an existing variable."""
         return variable_formatter(template="{name} = {value};")
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -67,10 +67,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -470,6 +472,17 @@ class Crystal(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -574,6 +587,13 @@ class Crystal(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -80,10 +80,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
     wrap_combined_in_file_noop,
@@ -672,6 +674,17 @@ class CSharp(metaclass=LanguageCls):
         ),
     )
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     class VariableTypeHints(enum.Enum):
@@ -874,6 +887,13 @@ class CSharp(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -59,10 +59,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -426,6 +428,17 @@ class D(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -534,6 +547,13 @@ class D(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -70,10 +70,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     value_contains,
     wrap_in_file_noop,
 )
@@ -725,6 +727,16 @@ class Dart(metaclass=LanguageCls):
 
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid code for *data*.
 
@@ -798,6 +810,13 @@ class Dart(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     body_preamble_from_scalars,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
@@ -779,6 +780,11 @@ class Dhall(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
     @staticmethod
     def wrap_in_file(
         content: str,
@@ -909,6 +915,13 @@ class Dhall(metaclass=LanguageCls):
         return self.heterogeneous_strategy.value.build_behavior(
             self.heterogeneous_value_union_name,
         )
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -65,9 +65,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -489,6 +491,17 @@ class Elixir(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -612,6 +625,13 @@ class Elixir(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -58,9 +58,11 @@ from literalizer._language import (
     TrailingCommaConfig,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
 )
 from literalizer._types import Value
@@ -754,6 +756,16 @@ class Elm(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     @staticmethod
     def wrap_in_file(
         content: str,
@@ -882,6 +894,13 @@ class Elm(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -58,9 +58,11 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -450,6 +452,17 @@ class Erlang(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -576,6 +589,13 @@ class Erlang(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -45,10 +45,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -438,6 +440,17 @@ class Forth(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -540,6 +553,13 @@ class Forth(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -553,6 +554,11 @@ class Fortran(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
     def wrap_in_file(
         self,
         content: str,
@@ -703,6 +709,13 @@ class Fortran(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -67,10 +67,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -558,6 +560,17 @@ class FSharp(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -654,6 +667,13 @@ class FSharp(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -64,8 +64,10 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     no_call_stub,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -844,6 +846,17 @@ class Gleam(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -945,6 +958,13 @@ class Gleam(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -72,10 +72,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -592,6 +594,17 @@ class Go(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -691,6 +704,13 @@ class Go(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -59,10 +59,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -383,6 +385,17 @@ class Groovy(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -484,6 +497,13 @@ class Groovy(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -64,9 +64,11 @@ from literalizer._language import (
     date_scalar_preamble,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
 )
 from literalizer._types import Value
@@ -1233,6 +1235,16 @@ class Haskell(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     def wrap_in_file(
         self,
         content: str,
@@ -1373,6 +1385,13 @@ class Haskell(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -56,10 +56,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
     wrap_in_file_noop,
@@ -377,6 +379,17 @@ class Hcl(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -502,6 +515,13 @@ class Hcl(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -71,9 +71,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -926,6 +928,17 @@ class Java(metaclass=LanguageCls):
         ),
     )
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     class VariableTypeHints(enum.Enum):
@@ -1149,6 +1162,13 @@ class Java(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -69,10 +69,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -463,6 +465,17 @@ class JavaScript(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -553,6 +566,13 @@ class JavaScript(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -57,10 +57,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
@@ -346,6 +348,17 @@ class Json5(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -441,6 +454,13 @@ class Json5(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -55,10 +55,12 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
@@ -371,6 +373,16 @@ class Jsonnet(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     def wrap_calls_with_declarations(
         self,
         declarations: tuple[str, ...],
@@ -495,6 +507,13 @@ class Jsonnet(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -67,10 +67,12 @@ from literalizer._language import (
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -476,6 +478,17 @@ class Julia(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -571,6 +584,13 @@ class Julia(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -81,9 +81,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -835,6 +837,17 @@ class Kotlin(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -938,6 +951,13 @@ class Kotlin(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -58,10 +58,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -389,6 +391,17 @@ class Lua(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -479,6 +492,13 @@ class Lua(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -55,10 +55,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -466,6 +468,17 @@ class Matlab(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -561,6 +574,13 @@ class Matlab(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -67,9 +67,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -703,6 +705,17 @@ class Mojo(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -836,6 +849,13 @@ class Mojo(metaclass=LanguageCls):
         return self.heterogeneous_strategy.value.build_behavior(
             self.heterogeneous_value_variant_name,
         )
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -69,10 +69,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -884,6 +886,17 @@ class Nim(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -59,10 +59,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
@@ -415,6 +417,17 @@ class Nix(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -523,6 +536,13 @@ class Nix(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -55,10 +55,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
@@ -319,6 +321,17 @@ class Norg(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -426,6 +439,13 @@ class Norg(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -55,9 +55,11 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -520,6 +522,17 @@ class ObjectiveC(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -637,6 +650,13 @@ class ObjectiveC(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -544,6 +545,12 @@ class OCaml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -627,6 +634,13 @@ class OCaml(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -55,10 +55,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -337,6 +339,17 @@ class Occam(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -464,6 +477,13 @@ class Occam(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -64,9 +64,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -488,6 +490,17 @@ class Odin(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -596,6 +609,13 @@ class Odin(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -66,10 +66,12 @@ from literalizer._language import (
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -432,6 +434,17 @@ class Perl(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -522,6 +535,13 @@ class Perl(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -68,9 +68,11 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -441,6 +443,17 @@ class Php(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -536,6 +549,13 @@ class Php(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -53,9 +53,11 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -400,6 +402,17 @@ class PowerShell(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -505,6 +518,13 @@ class PowerShell(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -60,10 +60,12 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
 )
 from literalizer._types import Value
@@ -906,6 +908,16 @@ class PureScript(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     def wrap_calls_with_declarations(
         self,
         declarations: tuple[str, ...],
@@ -1027,6 +1039,13 @@ class PureScript(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -72,9 +72,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -944,6 +946,17 @@ class Python(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -1216,6 +1229,13 @@ class Python(metaclass=LanguageCls):
             scalar_body_preamble=self.scalar_body_preamble,
             format_lines=tuple,
         )
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -59,10 +59,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -435,6 +437,17 @@ class R(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -536,6 +549,13 @@ class R(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -54,10 +54,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -345,6 +347,17 @@ class Racket(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -450,6 +463,13 @@ class Racket(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -67,9 +67,11 @@ from literalizer._language import (
     date_scalar_preamble,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -466,6 +468,17 @@ class Raku(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -561,6 +574,13 @@ class Raku(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -60,9 +60,11 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     identity_call_ref_identifier,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
 )
 from literalizer._types import Value
@@ -764,6 +766,16 @@ class Roc(metaclass=LanguageCls):
 
     validate_spec_for_data = no_validate_spec_for_data
 
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     def wrap_in_file(
         self,
         content: str,
@@ -929,6 +941,13 @@ class Roc(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -69,10 +69,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -482,6 +484,17 @@ class Ruby(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -572,6 +585,13 @@ class Ruby(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -74,10 +74,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     prepend_body_preamble,
     value_contains,
 )
@@ -1396,6 +1398,13 @@ class Rust(metaclass=LanguageCls):
         )
 
     @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
+
+    @cached_property
     def type_hint_collection_preamble_lines(
         self,
     ) -> Callable[[frozenset[type]], tuple[str, ...]]:
@@ -1471,6 +1480,16 @@ class Rust(metaclass=LanguageCls):
             raise IncompatibleFormatsError(msg)
 
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
 
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid code for *data*.

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -70,10 +70,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -573,6 +575,17 @@ class Scala(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -673,6 +686,13 @@ class Scala(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -54,10 +54,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -340,6 +342,17 @@ class Scheme(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -450,6 +463,13 @@ class Scheme(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -574,6 +575,12 @@ class Sml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -665,6 +672,13 @@ class Sml(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -71,10 +71,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -707,6 +709,17 @@ class Swift(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -814,6 +827,13 @@ class Swift(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -56,10 +56,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -468,6 +470,17 @@ class SystemVerilog(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -606,6 +619,13 @@ class SystemVerilog(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -54,10 +54,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -384,6 +386,17 @@ class Tcl(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -484,6 +497,13 @@ class Tcl(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -59,10 +59,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_arg,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
@@ -353,6 +355,17 @@ class Toml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -458,6 +471,13 @@ class Toml(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -72,10 +72,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -642,6 +644,17 @@ class TypeScript(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -732,6 +745,13 @@ class TypeScript(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -67,9 +67,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -623,6 +625,17 @@ class V(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -731,6 +744,13 @@ class V(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value.build_behavior()
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -67,10 +67,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -515,6 +517,17 @@ class VisualBasic(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -676,6 +689,13 @@ class VisualBasic(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -57,9 +57,11 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
@@ -413,6 +415,17 @@ class Wren(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -508,6 +521,13 @@ class Wren(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -59,10 +59,12 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     wrap_in_file_noop,
 )
@@ -327,6 +329,17 @@ class Yaml(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
@@ -427,6 +440,13 @@ class Yaml(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -64,10 +64,12 @@ from literalizer._language import (
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
+    identity_call_statement,
     identity_call_target,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
@@ -498,6 +500,17 @@ class Zig(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     def wrap_in_file(
@@ -619,6 +632,13 @@ class Zig(metaclass=LanguageCls):
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the heterogeneous-behavior config."""
         return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
 
     @cached_property
     def type_hint_collection_preamble_lines(

--- a/tests/integration/test_language_metadata.py
+++ b/tests/integration/test_language_metadata.py
@@ -63,6 +63,9 @@ def test_protocol_properties_accessible(
 ) -> None:
     """Every Language exposes its Protocol attributes for any language."""
     spec = language_cls()
+    assert callable(spec.validate_call_arg)
+    assert callable(spec.format_call_statement)
+    assert callable(spec.call_data_dependent_preamble)
     assert callable(spec.format_call_stub)
     assert callable(spec.format_call_preamble_stub)
     assert callable(spec.format_call_target)


### PR DESCRIPTION
This removes `getattr`-based optional call hook lookup and makes the call hooks explicit on the language protocol and metaclass.
Every language now declares typed call validation, call statement formatting, and call-specific data preamble hooks, with Nim and the statement-wrapping languages preserving their specialized behavior.
This keeps call rendering statically typed without adding casts or type-ignore comments.
Validated with ruff, mypy, pyright, ty, pyright --verifytypes, the pre-commit/pre-push hooks, and the focused call integration tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core call rendering by removing `getattr` fallbacks and requiring every language to provide `validate_call_arg`, `format_call_statement`, and `call_data_dependent_preamble`, so missing/incorrect implementations could break call generation across languages.
> 
> **Overview**
> Call rendering no longer uses `getattr` fallbacks for `validate_call_arg`, `format_call_statement`, or call-specific preamble; these hooks are now required, typed attributes on `Language`/`LanguageCls`.
> 
> Adds shared defaults (`no_validate_call_arg`, `identity_call_statement`) and updates each language spec to explicitly expose `validate_call_arg`, `format_call_statement`, and `call_data_dependent_preamble` (usually delegating to existing behavior). Integration tests now assert these protocol properties are present and callable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee11482f4d193f1f1fb815ab15cc90666ebef4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->