### PR TITLE
[codex] Add Occam call rendering

### DIFF
--- a/.github/scripts/check_elm_syntax.py
+++ b/.github/scripts/check_elm_syntax.py
@@ -2,12 +2,11 @@
 
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
-from elm_common import ELM_JSON
+from elm_common import ELM_JSON, run_elm_make
 
 
 def _check_fixture(
@@ -29,16 +28,13 @@ def _check_fixture(
             data=src.read_text(encoding="utf-8"),
             encoding="utf-8",
         )
-        result = subprocess.run(
+        result = run_elm_make(
             args=[
                 elm_path,
                 "make",
                 "src/Check.elm",
                 "--output=/dev/null",
             ],
-            capture_output=True,
-            text=True,
-            check=False,
             cwd=tmpdir,
             env=env,
         )

--- a/.github/scripts/elm_common.py
+++ b/.github/scripts/elm_common.py
@@ -1,6 +1,10 @@
 """Shared helpers for the Elm lint scripts."""
 
 import json
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
 
 ELM_JSON = json.dumps(
     obj={
@@ -14,3 +18,42 @@ ELM_JSON = json.dumps(
         "test-dependencies": {"direct": {}, "indirect": {}},
     },
 )
+
+_ELM_FILE_LOCK_MARKERS = (
+    "openBinaryFile",
+    "resource busy (file is locked)",
+)
+
+
+def _is_elm_file_lock_error(result: subprocess.CompletedProcess[str]) -> bool:
+    """Return True if Elm failed with its transient cache lock error."""
+    output = result.stderr + result.stdout
+    return all(marker in output for marker in _ELM_FILE_LOCK_MARKERS)
+
+
+def run_elm_make(
+    *,
+    args: Sequence[str],
+    cwd: str | Path,
+    env: Mapping[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run ``elm make``, retrying Elm's transient file-lock failure."""
+    attempts = 3
+    result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(attempts):
+        result = subprocess.run(
+            args=list(args),
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=cwd,
+            env=dict(env),
+        )
+        if result.returncode == 0 or not _is_elm_file_lock_error(result):
+            return result
+        if attempt + 1 < attempts:
+            time.sleep(0.2 * (attempt + 1))
+    if result is None:  # pragma: no cover
+        msg = "elm make was not attempted"
+        raise RuntimeError(msg)
+    return result

--- a/.github/scripts/run_elm.py
+++ b/.github/scripts/run_elm.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from elm_common import ELM_JSON
+from elm_common import ELM_JSON, run_elm_make
 
 # Wrap ``Check.my_data`` in a ``Platform.worker`` so loading the compiled
 # JavaScript evaluates the fixture's top-level value, surfacing runtime
@@ -89,16 +89,13 @@ def _run_fixture(
             data=src.read_text(encoding="utf-8"),
             encoding="utf-8",
         )
-        compile_result = subprocess.run(
+        compile_result = run_elm_make(
             args=[
                 elm_path,
                 "make",
                 "src/Main.elm",
                 f"--output={output_js}",
             ],
-            capture_output=True,
-            text=True,
-            check=False,
             cwd=tmpdir,
             env=env,
         )

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import textwrap
 from collections.abc import Callable, Sequence
-from functools import cached_property
+from functools import cached_property, partial
 from typing import ClassVar
 
 from beartype import beartype
@@ -35,7 +35,6 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
-    CallSupport,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -47,13 +46,13 @@ from literalizer._language import (
     LanguageCls,
     ModifierCombination,
     OrderedMapFormatConfig,
+    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
-    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
@@ -62,7 +61,6 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
-    prepend_body_preamble,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -86,6 +84,38 @@ def _format_occam_entry(original: Value, formatted: str) -> str:
             return f"MOBILE LIT(lit.str; MOBILE []BYTE {formatted})"
         case _:
             return formatted
+
+
+def _occam_stub_parameters(params: Sequence[str], /) -> str:
+    """Return an Occam parameter list for a generated call stub."""
+    if not params:
+        return "()"
+    formatted = ", ".join(f"VAL MOBILE LIT {param}" for param in params)
+    return f"({formatted})"
+
+
+def _occam_call_stub(
+    parts: Sequence[str],
+    params: Sequence[str],
+    stub_return: StubReturn,
+    /,
+    *,
+    indent: str,
+) -> tuple[str, ...]:
+    """Return top-level Occam call stub declarations."""
+    name = ".".join(parts)
+    stub_params = _occam_stub_parameters(params)
+    if stub_return is StubReturn.VALUE:
+        return (
+            f"MOBILE LIT FUNCTION {name} {stub_params}",
+            f"{indent}RESULT MOBILE LIT(lit.null)",
+            ":",
+        )
+    return (
+        f"PROC {name} {stub_params}",
+        f"{indent}SKIP",
+        ":",
+    )
 
 
 @beartype
@@ -117,13 +147,6 @@ class Occam(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
-
-    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
-        staticmethod(
-            identity_call_arg,
-        )
-    )
-    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""
@@ -308,6 +331,8 @@ class Occam(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Occam call style options."""
 
+        POSITIONAL = PositionalCallStyle()
+
     call_styles = CallStyles
 
     class Modifiers(enum.Enum):
@@ -360,13 +385,12 @@ class Occam(metaclass=LanguageCls):
     ) -> str:
         """Wrap an occam-pi VAL declaration in a PROC."""
         del variable_name
-        content = prepend_body_preamble(
-            content=content,
-            body_preamble=body_preamble,
+        top_level_preamble = (
+            "\n".join(body_preamble) + "\n" if body_preamble else ""
         )
         indented = textwrap.indent(text=content, prefix=self.indent)
         return (
-            f"\nPROC {self.module_name} ()\n"
+            f"\n{top_level_preamble}PROC {self.module_name} ()\n"
             + indented
             + "\n"
             + f"{self.indent}SEQ\n"
@@ -441,9 +465,12 @@ class Occam(metaclass=LanguageCls):
     )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
-    call_style_config: ClassVar[CallStyle | CallSupport] = (
-        CallSupport.NOT_IMPLEMENTED_BY_TOOL
-    )
+    call_style: CallStyles = CallStyles.POSITIONAL
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -458,6 +485,11 @@ class Occam(metaclass=LanguageCls):
     @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:
         """Format a sequence entry."""
+        return _format_occam_entry
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Wrap direct call arguments in ``MOBILE LIT`` constructors."""
         return _format_occam_entry
 
     @cached_property
@@ -499,7 +531,7 @@ class Occam(metaclass=LanguageCls):
         self,
     ) -> Callable[[Sequence[str], Sequence[str], StubReturn], tuple[str, ...]]:
         """Return stub declarations for a call expression."""
-        return no_call_stub
+        return partial(_occam_call_stub, indent=self.indent)
 
     @cached_property
     def format_call_preamble_stub(

--- a/tests/integration/cases/call_comments/Occam_call.occ
+++ b/tests/integration/cases/call_comments/Occam_call.occ
@@ -1,0 +1,24 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value)
+    SKIP
+:
+PROC main ()
+    -- Test cases
+    process(MOBILE LIT(lit.str; MOBILE []BYTE "hello"))  -- single word
+    process(MOBILE LIT(lit.str; MOBILE []BYTE "hello world"))  -- two words
+    -- trailing comment
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_comments_dict_args/Occam_call.occ
+++ b/tests/integration/cases/call_comments_dict_args/Occam_call.occ
@@ -1,0 +1,25 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value)
+    SKIP
+:
+PROC main ()
+    -- Test cases
+    process(MOBILE LIT(lit.map; MOBILE []MOBILE LIT [MOBILE LIT(lit.pair; MOBILE []BYTE "type"; MOBILE LIT(lit.str; MOBILE []BYTE "create")), MOBILE LIT(lit.pair; MOBILE []BYTE "pr_id"; MOBILE LIT(lit.str; MOBILE []BYTE "pr_1"))]))  -- first case
+    process(MOBILE LIT(lit.map; MOBILE []MOBILE LIT [MOBILE LIT(lit.pair; MOBILE []BYTE "type"; MOBILE LIT(lit.str; MOBILE []BYTE "update")), MOBILE LIT(lit.pair; MOBILE []BYTE "pr_id"; MOBILE LIT(lit.str; MOBILE []BYTE "pr_2"))]))  -- second case
+    -- third case
+    process(MOBILE LIT(lit.map; MOBILE []MOBILE LIT [MOBILE LIT(lit.pair; MOBILE []BYTE "type"; MOBILE LIT(lit.str; MOBILE []BYTE "delete")), MOBILE LIT(lit.pair; MOBILE []BYTE "pr_id"; MOBILE LIT(lit.str; MOBILE []BYTE "pr_3"))]))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_deep_dotted_method/Occam_call.occ
+++ b/tests/integration/cases/call_deep_dotted_method/Occam_call.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC obj.api.client.post (VAL MOBILE LIT data)
+    SKIP
+:
+PROC main ()
+    obj.api.client.post(MOBILE LIT(lit.str; MOBILE []BYTE "hello"))
+    obj.api.client.post(MOBILE LIT(lit.int; 42))
+    obj.api.client.post(MOBILE LIT(lit.bool; TRUE))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_deep_dotted_transformed/Occam_call.occ
+++ b/tests/integration/cases/call_deep_dotted_transformed/Occam_call.occ
@@ -1,0 +1,26 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+MOBILE LIT FUNCTION app.client.fetch (VAL MOBILE LIT payload)
+    RESULT MOBILE LIT(lit.null)
+:
+PROC emit (VAL MOBILE LIT _arg)
+    SKIP
+:
+PROC main ()
+    emit(app.client.fetch(MOBILE LIT(lit.str; MOBILE []BYTE "hello")))
+    emit(app.client.fetch(MOBILE LIT(lit.int; 42)))
+    emit(app.client.fetch(MOBILE LIT(lit.bool; TRUE)))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_dotted_method/Occam_call.occ
+++ b/tests/integration/cases/call_dotted_method/Occam_call.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC app.client.fetch (VAL MOBILE LIT payload)
+    SKIP
+:
+PROC main ()
+    app.client.fetch(MOBILE LIT(lit.str; MOBILE []BYTE "hello"))
+    app.client.fetch(MOBILE LIT(lit.int; 42))
+    app.client.fetch(MOBILE LIT(lit.bool; TRUE))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_dotted_transform_stub/Occam_call.occ
+++ b/tests/integration/cases/call_dotted_transform_stub/Occam_call.occ
@@ -1,0 +1,26 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+MOBILE LIT FUNCTION process (VAL MOBILE LIT value)
+    RESULT MOBILE LIT(lit.null)
+:
+PROC tracer.emit (VAL MOBILE LIT _arg)
+    SKIP
+:
+PROC main ()
+    tracer.emit(process(MOBILE LIT(lit.str; MOBILE []BYTE "hello")))
+    tracer.emit(process(MOBILE LIT(lit.int; 42)))
+    tracer.emit(process(MOBILE LIT(lit.bool; TRUE)))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_existing_ref_arg/Occam_call.occ
+++ b/tests/integration/cases/call_existing_ref_arg/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT existing IS 42:
+    process(existing)
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_keyword_args/Occam_call.occ
+++ b/tests/integration/cases/call_keyword_args/Occam_call.occ
@@ -1,0 +1,25 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+MOBILE LIT FUNCTION throttler.check (VAL MOBILE LIT user_id, VAL MOBILE LIT ts)
+    RESULT MOBILE LIT(lit.null)
+:
+PROC emit (VAL MOBILE LIT _arg)
+    SKIP
+:
+PROC main ()
+    emit(throttler.check(MOBILE LIT(lit.str; MOBILE []BYTE "user_1"), MOBILE LIT(lit.float; 1000.0(REAL32))))
+    emit(throttler.check(MOBILE LIT(lit.str; MOBILE []BYTE "user_2"), MOBILE LIT(lit.float; 2000.5(REAL32))))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_mixed_type_dicts/Occam_call.occ
+++ b/tests/integration/cases/call_mixed_type_dicts/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC app.mgr.run (VAL MOBILE LIT operation)
+    SKIP
+:
+PROC main ()
+    app.mgr.run(MOBILE LIT(lit.map; MOBILE []MOBILE LIT [MOBILE LIT(lit.pair; MOBILE []BYTE "type"; MOBILE LIT(lit.str; MOBILE []BYTE "create")), MOBILE LIT(lit.pair; MOBILE []BYTE "pr_id"; MOBILE LIT(lit.str; MOBILE []BYTE "pr_1")), MOBILE LIT(lit.pair; MOBILE []BYTE "draft"; MOBILE LIT(lit.bool; TRUE))]))
+    app.mgr.run(MOBILE LIT(lit.map; MOBILE []MOBILE LIT [MOBILE LIT(lit.pair; MOBILE []BYTE "type"; MOBILE LIT(lit.str; MOBILE []BYTE "create")), MOBILE LIT(lit.pair; MOBILE []BYTE "pr_id"; MOBILE LIT(lit.str; MOBILE []BYTE "pr_2"))]))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_multi_args/Occam_call.occ
+++ b/tests/integration/cases/call_multi_args/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value, VAL MOBILE LIT count)
+    SKIP
+:
+PROC main ()
+    process(MOBILE LIT(lit.int; 1), MOBILE LIT(lit.int; 42))
+    process(MOBILE LIT(lit.int; 2), MOBILE LIT(lit.int; 100))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_negative_int/Occam_call.occ
+++ b/tests/integration/cases/call_negative_int/Occam_call.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value)
+    SKIP
+:
+PROC main ()
+    process(MOBILE LIT(lit.int; -1))
+    process(MOBILE LIT(lit.int; -2))
+    process(MOBILE LIT(lit.int; -3))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_no_params/Occam_call.occ
+++ b/tests/integration/cases/call_no_params/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process ()
+    SKIP
+:
+PROC main ()
+    process()
+    process()
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_no_params_transform/Occam_call.occ
+++ b/tests/integration/cases/call_no_params_transform/Occam_call.occ
@@ -1,0 +1,25 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+MOBILE LIT FUNCTION process ()
+    RESULT MOBILE LIT(lit.null)
+:
+PROC emit (VAL MOBILE LIT _arg)
+    SKIP
+:
+PROC main ()
+    emit(process())
+    emit(process())
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_per_element_false/Occam_call.occ
+++ b/tests/integration/cases/call_per_element_false/Occam_call.occ
@@ -1,0 +1,21 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data)
+    SKIP
+:
+PROC main ()
+    process(MOBILE LIT(lit.int; 1))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_per_element_false_dict_arg/Occam_call.occ
+++ b/tests/integration/cases/call_per_element_false_dict_arg/Occam_call.occ
@@ -1,0 +1,21 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value)
+    SKIP
+:
+PROC main ()
+    process(MOBILE LIT(lit.map; MOBILE []MOBILE LIT [MOBILE LIT(lit.pair; MOBILE []BYTE "a"; MOBILE LIT(lit.int; 1)), MOBILE LIT(lit.pair; MOBILE []BYTE "b"; MOBILE LIT(lit.str; MOBILE []BYTE "x"))]))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_args/Occam_call.occ
+++ b/tests/integration/cases/call_ref_args/Occam_call.occ
@@ -1,0 +1,32 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data, VAL MOBILE LIT count)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT my_var IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 1),
+        MOBILE LIT(lit.int; 2),
+        MOBILE LIT(lit.int; 3)
+    ]):
+    VAL MOBILE LIT my_other IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 4),
+        MOBILE LIT(lit.int; 5),
+        MOBILE LIT(lit.int; 6)
+    ]):
+    process(my_var, MOBILE LIT(lit.int; 42))
+    process(my_other, MOBILE LIT(lit.int; 7))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_args_converted/Occam_call.occ
+++ b/tests/integration/cases/call_ref_args_converted/Occam_call.occ
@@ -1,0 +1,32 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data, VAL MOBILE LIT count)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT MY_VAR IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 1),
+        MOBILE LIT(lit.int; 2),
+        MOBILE LIT(lit.int; 3)
+    ]):
+    VAL MOBILE LIT MY_OTHER IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 4),
+        MOBILE LIT(lit.int; 5),
+        MOBILE LIT(lit.int; 6)
+    ]):
+    process(MY_VAR, MOBILE LIT(lit.int; 42))
+    process(MY_OTHER, MOBILE LIT(lit.int; 7))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Occam_call.occ
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Occam_call.occ
@@ -1,0 +1,32 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data, VAL MOBILE LIT count)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT MY_VAR IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 1),
+        MOBILE LIT(lit.int; 2),
+        MOBILE LIT(lit.int; 3)
+    ]):
+    VAL MOBILE LIT MY_OTHER IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 4),
+        MOBILE LIT(lit.int; 5),
+        MOBILE LIT(lit.int; 6)
+    ]):
+    process(MY_VAR, MOBILE LIT(lit.int; 42))
+    process(MY_OTHER, MOBILE LIT(lit.int; 7))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_args_converted_whole/Occam_call.occ
+++ b/tests/integration/cases/call_ref_args_converted_whole/Occam_call.occ
@@ -1,0 +1,26 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT MY_VAR IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 1),
+        MOBILE LIT(lit.int; 2),
+        MOBILE LIT(lit.int; 3)
+    ]):
+    process(MY_VAR)
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_args_escaped_quote/Occam_call.occ
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT v)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT my_str IS "a\"b":
+    process(my_str)
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_args_reused/Occam_call.occ
+++ b/tests/integration/cases/call_ref_args_reused/Occam_call.occ
@@ -1,0 +1,29 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data, VAL MOBILE LIT count)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT single_var IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 4),
+        MOBILE LIT(lit.int; 5),
+        MOBILE LIT(lit.int; 6)
+    ]):
+    VAL MOBILE LIT repeated_var IS 1:
+    process(repeated_var, MOBILE LIT(lit.int; 1))
+    process(single_var, MOBILE LIT(lit.int; 0))
+    process(repeated_var, MOBILE LIT(lit.int; 8))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_nested_converted/Occam_call.occ
+++ b/tests/integration/cases/call_ref_nested_converted/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT MY_VAR IS 42:
+    process(MOBILE LIT(lit.list; MOBILE []MOBILE LIT [MY_VAR, MOBILE LIT(lit.int; 42), MOBILE LIT(lit.str; MOBILE []BYTE "static")]))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_nested_in_dict/Occam_call.occ
+++ b/tests/integration/cases/call_ref_nested_in_dict/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT my_var IS 42:
+    process(MOBILE LIT(lit.map; MOBILE []MOBILE LIT [MOBILE LIT(lit.pair; MOBILE []BYTE "key"; my_var), MOBILE LIT(lit.pair; MOBILE []BYTE "count"; MOBILE LIT(lit.int; 42))]))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_nested_in_list/Occam_call.occ
+++ b/tests/integration/cases/call_ref_nested_in_list/Occam_call.occ
@@ -1,0 +1,24 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT data)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT my_var IS 42:
+    VAL MOBILE LIT my_other IS 7:
+    process(MOBILE LIT(lit.list; MOBILE []MOBILE LIT [my_var, MOBILE LIT(lit.int; 42), MOBILE LIT(lit.str; MOBILE []BYTE "static")]))
+    process(MOBILE LIT(lit.list; MOBILE []MOBILE LIT [my_other, MOBILE LIT(lit.int; 7), MOBILE LIT(lit.str; MOBILE []BYTE "label")]))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_reserved_target/Occam_call.occ
+++ b/tests/integration/cases/call_reserved_target/Occam_call.occ
@@ -1,0 +1,21 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC op (VAL MOBILE LIT value)
+    SKIP
+:
+PROC main ()
+    op(MOBILE LIT(lit.str; MOBILE []BYTE "hello"))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_scalar_args/Occam_call.occ
+++ b/tests/integration/cases/call_scalar_args/Occam_call.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value)
+    SKIP
+:
+PROC main ()
+    process(MOBILE LIT(lit.str; MOBILE []BYTE "hello"))
+    process(MOBILE LIT(lit.int; 42))
+    process(MOBILE LIT(lit.bool; TRUE))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_snake_dotted_method/Occam_call.occ
+++ b/tests/integration/cases/call_snake_dotted_method/Occam_call.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC my_app.http_client.fetch (VAL MOBILE LIT payload)
+    SKIP
+:
+PROC main ()
+    my_app.http_client.fetch(MOBILE LIT(lit.str; MOBILE []BYTE "hello"))
+    my_app.http_client.fetch(MOBILE LIT(lit.int; 42))
+    my_app.http_client.fetch(MOBILE LIT(lit.bool; TRUE))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_transform_no_wrapper/Occam_call.occ
+++ b/tests/integration/cases/call_transform_no_wrapper/Occam_call.occ
@@ -1,0 +1,23 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+MOBILE LIT FUNCTION process (VAL MOBILE LIT value)
+    RESULT MOBILE LIT(lit.null)
+:
+PROC main ()
+    process(MOBILE LIT(lit.str; MOBILE []BYTE "hello"))
+    process(MOBILE LIT(lit.int; 42))
+    process(MOBILE LIT(lit.bool; TRUE))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_wrap_in_file/Occam_call.occ
+++ b/tests/integration/cases/call_wrap_in_file/Occam_call.occ
@@ -1,0 +1,22 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT a, VAL MOBILE LIT b)
+    SKIP
+:
+PROC main ()
+    process(MOBILE LIT(lit.int; 1), MOBILE LIT(lit.int; 2))
+    process(MOBILE LIT(lit.int; 3), MOBILE LIT(lit.int; 4))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_wrap_in_file_escaped_quote/Occam_call.occ
+++ b/tests/integration/cases/call_wrap_in_file_escaped_quote/Occam_call.occ
@@ -1,0 +1,21 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT v)
+    SKIP
+:
+PROC main ()
+    process(MOBILE LIT(lit.str; MOBILE []BYTE "a\"b"))
+    SEQ
+        SKIP
+:


### PR DESCRIPTION
Adds `literalize_call` support for Occam by enabling positional call rendering, wrapping call arguments as `MOBILE LIT`, and generating Occam `PROC`/`FUNCTION` stubs.

The PR also adds Occam golden fixtures for the call integration cases now covered by discovery.

It hardens the Elm lint helpers by retrying Elm compiler runs that fail with the transient `openBinaryFile: resource busy (file is locked)` error seen in CI.

Closes #1134.

Validation: full call golden suite, orphan golden check, Occam structural checker, Ruff, ty, metadata/call-error tests, and all Elm syntax/run helpers locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands `Occam` code generation to support call rendering and stub generation, which can affect output correctness across many call-related integration scenarios. CI helper changes are low risk but alter retry behavior around Elm compilation failures.
> 
> **Overview**
> Adds Occam support for `literalize_call`: introduces a positional call style, wraps direct call arguments using `MOBILE LIT(...)`, and generates appropriate `PROC`/`MOBILE LIT FUNCTION` stubs (including dotted targets and zero-arg calls). It also adjusts Occam file wrapping so call stubs/preamble can be emitted at the top level.
> 
> Hardens Elm golden-file checks by centralizing `elm make` execution into `run_elm_make()` with retries for Elm’s transient cache lock error, and updates both `check_elm_syntax.py` and `run_elm.py` to use it.
> 
> Adds a large set of new Occam golden fixtures covering call rendering cases (comments, dotted calls, transforms, refs, dict args, and parameter variations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2dfd61efbbb6fcfb833e11df9c35189e8e5b917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->