### PR TITLE
Fix C++ dotted stub return

### DIFF
--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -808,7 +808,9 @@ def _cpp_call_stub(
         if stub_return is StubReturn.VOID:
             method_decl = f"void {method}(auto...) const {{}}"
         else:
-            method_decl = f"auto {method}(auto...) const {{ return 0; }}"
+            method_decl = (
+                f"[[nodiscard]] auto {method}(auto...) const {{ return 0; }}"
+            )
         return (
             f"struct {type_name} {{ {method_decl} }};",
             f"const {type_name} {root};",

--- a/tests/integration/cases/call_keyword_args/Cpp_call.cpp
+++ b/tests/integration/cases/call_keyword_args/Cpp_call.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include <variant>
-struct throttlerType_ { auto check(auto...) const { return 0; } };
+struct throttlerType_ { [[nodiscard]] auto check(auto...) const { return 0; } };
 const throttlerType_ throttler;
 auto emit(auto...) { return 0; }
 int main() {


### PR DESCRIPTION
Fixes #1788.\n\nC++ two-part dotted call stubs now respect StubReturn.VALUE by emitting a [[nodiscard]] value-returning method, while the existing VOID path remains void. The call_keyword_args C++ golden fixture covers the value-returning dotted target case.\n\nValidated with targeted integration tests and the repository pre-push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to C++ call-stub codegen and its integration golden output; main risk is snapshot/test churn if other fixtures depend on the prior stub signature.
> 
> **Overview**
> Fixes C++ dotted call stub generation for the 2-part `root.method` case so that `StubReturn.VALUE` emits a value-returning `[[nodiscard]] auto ... { return 0; }` method (while `StubReturn.VOID` remains `void`).
> 
> Updates the `call_keyword_args` C++ integration golden (`Cpp_call.cpp`) to reflect the new `[[nodiscard]]` method signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2caa075ea272291ed1c49c6de5b5c3b76b0a5b22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->