### PR TITLE
Add compose helper for literalize results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- Add :func:`~literalizer.compose` for combining multiple
+  :class:`~literalizer.LiteralizeResult` values into one result.  It
+  concatenates declarations, merges preamble and body-preamble entries
+  in first-seen order, preserves pre-declaration comments, and can wrap
+  the merged output as a complete file.
+
 2026.05.01.1
 ------------
 

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -162,60 +162,51 @@ declarations; D rejects duplicate ``import`` lines) and a linter flags
 it (``ruff`` and ``pylint`` warn about repeated ``from typing import
 Any`` lines).
 
-Remove the duplicate preamble lines in first-seen order before
-emitting the file:
+Use :func:`~literalizer.compose` to remove duplicate preamble lines in
+first-seen order before emitting the file:
 
 .. code-block:: python
 
-   """Compose a declaration and a call into one Haskell source file."""
+   """Compose a declaration and a call into one Python source file."""
 
-   from literalizer import InputFormat, NewVariable, literalize, literalize_call
-   from literalizer.languages import Haskell
+   from literalizer import (
+       InputFormat,
+       NewVariable,
+       compose,
+       literalize,
+       literalize_call,
+   )
+   from literalizer.languages import Python
 
-   language = Haskell()
+   language = Python(date_format=Python.date_formats.PYTHON)
 
    declaration = literalize(
-       source="[1, 2, 3]",
-       input_format=InputFormat.JSON,
+       source="2026-01-01",
+       input_format=InputFormat.YAML,
        language=language,
-       variable_form=NewVariable(name="myList"),
+       variable_form=NewVariable(name="my_date"),
    )
    call = literalize_call(
-       source='[[{"$ref": "myList"}, 42]]',
-       input_format=InputFormat.JSON,
+       source='[[{"$ref": "my_date"}, 2026-01-02]]',
+       input_format=InputFormat.YAML,
        language=language,
        target_function="process",
-       parameter_names=["data", "count"],
+       parameter_names=["first", "second"],
    )
 
-   seen: set[str] = set()
-   merged_body_preamble: list[str] = []
-   for block in (*declaration.body_preamble, *call.body_preamble):
-       if block in seen:
-           continue
-       seen.add(block)
-       merged_body_preamble.append(block)
-
-   # ``declaration_code`` is the bare text without ``body_preamble``
-   # prepended; ``code`` includes the body_preamble, which would
-   # reintroduce duplicates.
-   composed = "\n".join(
-       [
-           *merged_body_preamble,
-           declaration.declaration_code,
-           call.declaration_code,
-       ],
+   composed = compose(
+       results=(declaration, call),
+       language=language,
+       wrap_in_file=True,
    )
 
-   assert composed.count("data Val = HInt Integer | HList [Val]") == 1
+   assert composed.code.count("import datetime") == 1
 
-The same pattern applies to :attr:`~literalizer.LiteralizeResult.preamble`
-when ``wrap_in_file=False`` and the caller is assembling the file
-manually: concatenate the preamble tuples from both results, drop
-duplicates while preserving order, and prepend the result.
-
-A first-class composition helper is tracked separately; until then,
-this duplicate-removal step is a required part of the workflow.
+Pass ``wrap_in_file=True`` to :func:`~literalizer.compose` when the
+language should assemble the merged result as a complete file.  Body
+preamble entries are deduplicated by exact string; if separate results
+emit different definitions for the same generated type name, resolve
+that name collision before composing.
 
 Snake case is the recommended authoring convention for ``$ref`` names:
 ``pyhumps`` converts ``snake_case`` to every other case without loss.

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -31,6 +31,7 @@ from literalizer._literalize import (
     LiteralizeResult,
     NewVariable,
     VariableForm,
+    compose,
     literalize,
     literalize_call,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "SetFormatConfig",
     "TrailingCommaConfig",
     "VariableForm",
+    "compose",
     "fixed_open",
     "literalize",
     "literalize_call",

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1980,6 +1980,115 @@ def literalize(
 
 
 @beartype
+def _merge_preamble_entries(*, entries: tuple[str, ...]) -> tuple[str, ...]:
+    """Merge preamble entries preserving first-seen order.
+
+    Single-line entries are deduplicated by exact string. Multi-line blocks
+    that share the same first and last line are treated as variants of the
+    same generated declaration: the first block fixes the output position,
+    and middle lines from later variants are appended if they have not
+    appeared yet.
+    """
+    key_to_middle: dict[tuple[str, str], list[str]] = {}
+    order: list[tuple[str, str]] = []
+    for entry in entries:
+        lines = entry.splitlines()
+        if not lines:  # pragma: no cover
+            continue
+        header = lines[0]
+        footer = lines[-1] if len(lines) > 1 else ""
+        key = (header, footer)
+        middle = lines[1:-1]
+        if key not in key_to_middle:
+            key_to_middle[key] = list(middle)
+            order.append(key)
+            continue
+        existing = set(key_to_middle[key])
+        for line in middle:
+            if line in existing:
+                continue
+            key_to_middle[key].append(line)
+            existing.add(line)
+
+    result: list[str] = []
+    for header, footer in order:
+        middle = key_to_middle[(header, footer)]
+        parts = [header, *middle]
+        if footer and footer != header:
+            parts.append(footer)
+        result.append("\n".join(parts))
+    return tuple(result)
+
+
+@beartype
+def compose(
+    *,
+    results: Sequence[LiteralizeResult],
+    language: Language,
+    wrap_in_file: bool = False,
+) -> LiteralizeResult:
+    """Compose multiple literalization results into one result.
+
+    ``declaration_code`` is concatenated in input order. ``preamble`` and
+    ``body_preamble`` are merged in first-seen order. ``body_preamble``
+    entries are deduplicated by exact string; ``preamble`` entries also
+    merge multi-line blocks that share the same first and last line, so
+    generated type-union variants can contribute missing middle lines.
+    ``pre_declaration_comments`` are preserved in input order.
+
+    The helper trusts the caller to pass results generated for the same
+    language. :class:`LiteralizeResult` does not record the producing
+    language, so there is no reliable consistency check to perform here.
+    Divergent type-definition variants with different strings are also left
+    for callers to resolve before composing.
+    """
+    declaration_code = "\n".join(result.declaration_code for result in results)
+    preamble = _merge_preamble_entries(
+        entries=tuple(line for result in results for line in result.preamble),
+    )
+    body_preamble = deduplicate_preamble_entries(
+        entries=tuple(
+            line for result in results for line in result.body_preamble
+        ),
+    )
+    pre_declaration_comments = tuple(
+        line for result in results for line in result.pre_declaration_comments
+    )
+    types_present = frozenset[type]().union(
+        *(result.types_present for result in results),
+    )
+    source_data: list[Value] = [result.source_data for result in results]
+
+    if wrap_in_file:
+        content = declaration_code
+        if pre_declaration_comments:
+            content = "\n".join(pre_declaration_comments) + "\n" + content
+        wrapped = language.wrap_in_file(
+            content=content,
+            variable_name="",
+            body_preamble=body_preamble,
+        )
+        if preamble:
+            wrapped = "\n".join(preamble) + "\n" + wrapped
+        return LiteralizeResult(
+            declaration_code=wrapped,
+            preamble=(),
+            body_preamble=(),
+            types_present=types_present,
+            source_data=source_data,
+        )
+
+    return LiteralizeResult(
+        declaration_code=declaration_code,
+        preamble=preamble,
+        body_preamble=body_preamble,
+        pre_declaration_comments=pre_declaration_comments,
+        types_present=types_present,
+        source_data=source_data,
+    )
+
+
+@beartype
 def _extract_call_arg_ref_name(*, value: Value, ref_key: str) -> str | None:
     """Return the identifier name for a ``{ref_key: "name"}`` marker.
 
@@ -2663,16 +2772,10 @@ def literalize_call(
         When composing the output of this function with
         :func:`literalize` — for example, declaring a variable with
         :func:`literalize` and then referencing it via a ref marker in
-        the call — the two halves each
-        compute :attr:`~LiteralizeResult.preamble` and
-        :attr:`~LiteralizeResult.body_preamble` independently from the
-        data they see.  Concatenating the results into a single file
-        can produce duplicate import lines or duplicate type
-        declarations, which strict compilers (Haskell, D, …) reject
-        and a linter (``ruff``, ``pylint``, …) flags.  Remove the
-        duplicate preamble entries (preserving first-seen order) before
-        emitting the file.  The "Composing declarations and calls"
-        section of :doc:`/function-call-use-case` shows a worked example.
+        the call — use :func:`compose` so duplicate preamble entries are
+        removed in first-seen order.  The "Composing declarations and
+        calls" section of :doc:`/function-call-use-case` shows a worked
+        example.
     """
     parsed = parse_input(source=source, input_format=input_format)
     data = parsed.data

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -8,7 +8,7 @@ driven through :func:`literalizer.literalize_call`.  The runner
 
 import dataclasses
 import functools
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -27,62 +27,6 @@ from literalizer.exceptions import (
 
 from .check_golden import check_golden
 from .language_specs import sorted_languages, with_per_fixture_module_name
-
-
-@beartype
-def _prepend_preamble(
-    wrapped: str,
-    preamble: tuple[str, ...],
-) -> str:
-    """Prepend *preamble* lines before *wrapped*."""
-    if not preamble:
-        return wrapped
-    return "\n".join(preamble) + "\n" + wrapped
-
-
-@beartype
-def _dedupe_preamble_blocks(*, blocks: Iterable[str]) -> tuple[str, ...]:
-    """Return preamble *blocks* with duplicates merged.
-
-    Some languages emit multi-line preamble blocks whose first line is a
-    stable header (for example, ``pub type GVal {`` in Gleam). When the
-    call-test harness combines declaration preambles with call
-    preambles, the same header can appear multiple times with different
-    bodies. Blocks sharing the same header *and* footer are merged: the
-    first block's middle lines are kept as-is, and any additional middle
-    lines from subsequent blocks that are not yet present are appended.
-    Blocks that share only the header but differ in their footer (e.g.
-    two distinct type definitions sharing a common attribute decorator)
-    are kept as separate blocks.
-    """
-    key_to_middle: dict[tuple[str, str], list[str]] = {}
-    order: list[tuple[str, str]] = []
-    for block in blocks:
-        lines = block.splitlines()
-        if not lines:  # pragma: no cover
-            continue
-        header = lines[0]
-        footer = lines[-1] if len(lines) > 1 else ""
-        key = (header, footer)
-        middle = lines[1:-1]
-        if key not in key_to_middle:
-            key_to_middle[key] = list(middle)
-            order.append(key)
-        else:
-            existing = set(key_to_middle[key])
-            for line in middle:
-                if line not in existing:
-                    key_to_middle[key].append(line)
-                    existing.add(line)
-    result: list[str] = []
-    for key in order:
-        header, footer = key
-        middle = key_to_middle[key]
-        parts: list[str] = [header, *middle]
-        if footer and footer != header:
-            parts.append(footer)
-        result.append("\n".join(parts))
-    return tuple(result)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -425,11 +369,8 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         per_element=True,
         call_style_type=None,
         # ``single_var`` is declared first so its preamble (which sees
-        # both ``int`` and ``list``) wins ``_dedupe_preamble_blocks``
-        # against the ``int``-only preamble emitted for
-        # ``repeated_var``.  Without this ordering, languages that emit
-        # a header-keyed type union (e.g. Gleam's ``pub type GVal``)
-        # end up missing the ``GList`` constructor.
+        # both ``int`` and ``list``) wins ordered composition against the
+        # ``int``-only preamble emitted for ``repeated_var``.
         ref_declarations={
             "single_var": "[4, 5, 6]",
             "repeated_var": "1",
@@ -982,38 +923,35 @@ def run_call_golden_case(
                 StubReturn.VOID,
             ),
         )
-    decl_preambles = tuple(line for d in decl_results for line in d.preamble)
-    # Recompute the body preamble across the union of types observed in
-    # every declaration *and* the call.  Concatenating each piece's
-    # already-rendered body preamble would emit overlapping
-    # type-definition strings (e.g. Haskell's ``data Val = ...`` with
-    # different constructor sets) that no string-level duplicate
-    # filter can reconcile.  Combine ``source_data`` from every piece
-    # so ``compute_body_preamble`` can inspect actual values when it
-    # needs to (e.g. Haskell's datetime microsecond-precision check).
-    empty_types: frozenset[type] = frozenset()
-    union_types = empty_types.union(
-        *(d.types_present for d in decl_results),
-        result.types_present,
+    composed = literalizer.compose(
+        results=(*decl_results, result),
+        language=spec,
     )
-    combined_source_data: list[Value] = [
-        *(d.source_data for d in decl_results),
-        result.source_data,
-    ]
+    # Some golden cases intentionally combine declarations whose generated
+    # type definitions have the same name but different variants. ``compose``
+    # exposes the combined metadata; the harness recomputes this preamble as
+    # the caller-owned conflict resolution step for those language specs.
     unified_body_preamble = spec.compute_body_preamble(
-        union_types, combined_source_data
+        composed.types_present,
+        composed.source_data,
     )
-    call_body_preamble = unified_body_preamble + tuple(body_stubs)
+    stub_result = literalizer.LiteralizeResult(
+        declaration_code="",
+        preamble=tuple(preamble_stubs),
+        body_preamble=tuple(body_stubs),
+    )
+    composed_with_stubs = literalizer.compose(
+        results=(composed, stub_result),
+        language=spec,
+    )
     declarations_bare_codes = tuple(d.bare_code for d in decl_results)
     wrapped = spec.wrap_calls_with_declarations(
         declarations=declarations_bare_codes,
         calls=result.bare_code,
-        body_preamble=call_body_preamble,
+        body_preamble=unified_body_preamble + tuple(body_stubs),
     )
-    all_preamble = _dedupe_preamble_blocks(
-        blocks=decl_preambles + result.preamble + tuple(preamble_stubs)
-    )
-    wrapped = _prepend_preamble(wrapped=wrapped, preamble=all_preamble)
+    if composed_with_stubs.preamble:
+        wrapped = "\n".join(composed_with_stubs.preamble) + "\n" + wrapped
     check_golden(
         file_regression=file_regression,
         contents=wrapped + "\n",

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,146 @@
+"""Tests for composing literalization results."""
+
+from literalizer import (
+    InputFormat,
+    LiteralizeResult,
+    NewVariable,
+    compose,
+    literalize,
+    literalize_call,
+)
+from literalizer.languages import Python
+
+PYTHON = Python()
+
+
+def test_compose_merges_result_parts_in_order() -> None:
+    """``compose`` preserves result order and deduplicates preambles."""
+    first = LiteralizeResult(
+        declaration_code="first = 1",
+        preamble=("import a", "import b"),
+        body_preamble=("class A: ...", "class B: ..."),
+        pre_declaration_comments=("# first",),
+        types_present=frozenset({int}),
+        source_data=1,
+    )
+    second = LiteralizeResult(
+        declaration_code="second = 2",
+        preamble=("import b", "import c"),
+        body_preamble=("class B: ...", "class C: ..."),
+        pre_declaration_comments=("# second",),
+        types_present=frozenset({str}),
+        source_data="two",
+    )
+
+    result = compose(results=(first, second), language=PYTHON)
+
+    assert result.declaration_code == "first = 1\nsecond = 2"
+    assert result.preamble == ("import a", "import b", "import c")
+    assert result.body_preamble == (
+        "class A: ...",
+        "class B: ...",
+        "class C: ...",
+    )
+    assert result.pre_declaration_comments == ("# first", "# second")
+    assert result.types_present == frozenset({int, str})
+    assert result.source_data == [1, "two"]
+    assert result.code == (
+        "class A: ...\n"
+        "class B: ...\n"
+        "class C: ...\n"
+        "# first\n"
+        "# second\n"
+        "first = 1\n"
+        "second = 2"
+    )
+
+
+def test_compose_wrap_in_file_folds_preambles_into_code() -> None:
+    """``wrap_in_file=True`` returns a self-contained code result."""
+    first = LiteralizeResult(
+        declaration_code="first = 1",
+        preamble=("import a", "import b"),
+        body_preamble=("class A: ...", "class B: ..."),
+        pre_declaration_comments=("# first",),
+    )
+    second = LiteralizeResult(
+        declaration_code="second = 2",
+        preamble=("import b", "import c"),
+        body_preamble=("class B: ...", "class C: ..."),
+        pre_declaration_comments=("# second",),
+    )
+
+    result = compose(
+        results=(first, second),
+        language=PYTHON,
+        wrap_in_file=True,
+    )
+
+    assert result.preamble == ()
+    assert result.body_preamble == ()
+    assert result.pre_declaration_comments == ()
+    assert result.declaration_code == (
+        "import a\n"
+        "import b\n"
+        "import c\n"
+        "class A: ...\n"
+        "class B: ...\n"
+        "class C: ...\n"
+        "# first\n"
+        "# second\n"
+        "first = 1\n"
+        "second = 2"
+    )
+
+
+def test_compose_literalize_and_call_deduplicates_preamble() -> None:
+    """``compose`` supports the declaration-plus-ref-call workflow."""
+    python = Python(date_format=Python.date_formats.PYTHON)
+    declaration = literalize(
+        source="2026-01-01",
+        input_format=InputFormat.YAML,
+        language=python,
+        variable_form=NewVariable(name="my_date"),
+    )
+    call = literalize_call(
+        source='[[{"$ref": "my_date"}, 2026-01-02]]',
+        input_format=InputFormat.YAML,
+        language=python,
+        target_function="process",
+        parameter_names=["first", "second"],
+    )
+
+    result = compose(
+        results=(declaration, call),
+        language=python,
+        wrap_in_file=True,
+    )
+
+    assert result.code == (
+        "import datetime\n"
+        "my_date = datetime.date(year=2026, month=1, day=1)\n"
+        "process("
+        "first=my_date, "
+        "second=datetime.date(year=2026, month=1, day=2)"
+        ")"
+    )
+
+
+def test_compose_merges_multiline_preamble_blocks() -> None:
+    """Generated preamble variants with the same wrapper are merged."""
+    first = LiteralizeResult(
+        declaration_code="first",
+        preamble=("pub type GVal {\n  GInt(Int)\n}",),
+        body_preamble=(),
+    )
+    second = LiteralizeResult(
+        declaration_code="second",
+        preamble=("pub type GVal {\n  GList(List(GVal))\n}",),
+        body_preamble=(),
+    )
+
+    result = compose(results=(first, second), language=PYTHON)
+
+    assert result.preamble == (
+        "pub type GVal {\n  GInt(Int)\n  GList(List(GVal))\n}",
+    )


### PR DESCRIPTION
Closes #1500.

Adds a public `compose` helper for combining multiple `LiteralizeResult` values, including ordered declaration concatenation, merged preambles, preserved pre-declaration comments, and optional file wrapping.

Updates the function-call docs and changelog to point users at the new API, and replaces the integration harness workaround with `compose` while keeping caller-owned body-preamble recomputation for divergent generated type definitions.

Validated with ruff, ty, focused compose tests, and focused call golden tests for Python, Haskell, and Gleam.