### PR TITLE
[codex] Add wrap combined file capability

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1239,6 +1239,13 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        declaration style.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def statement_terminator(self) -> str:
         """String appended to each call expression to form a complete
         statement.

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1927,8 +1927,9 @@ def literalize(
             (e.g. heterogeneous scalar types in a language that requires
             homogeneous collections).
         ValueError: If *variable_form* is :class:`BothVariableForms`
-            and *wrap_in_file* is ``False``, or if the language's
-            ``declaration_style`` does not support redefinition.
+            and *wrap_in_file* is ``False``, or if the language does not
+            support ``wrap_combined_in_file`` for its selected
+            ``declaration_style``.
         UnsupportedIdentifierCaseError: If *ref_case* is not in
             :attr:`~literalizer._language.Language.identifier_cases`
             for the target language.
@@ -1942,11 +1943,11 @@ def literalize(
         if not wrap_in_file:
             msg = "BothVariableForms requires wrap_in_file=True"
             raise ValueError(msg)
-        if not language.declaration_style.value.supports_redefinition:
+        if not language.supports_wrap_combined_in_file:
             msg = (
-                "BothVariableForms requires a declaration_style that "
-                "supports redefinition; "
-                f"{language.declaration_style.name!r} does not."
+                "BothVariableForms requires supports_wrap_combined_in_file; "
+                f"{type(language).__name__} with declaration_style "
+                f"{language.declaration_style.name!r} does not support it."
             )
             raise ValueError(msg)
         return _literalize_both_forms(

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -544,6 +544,13 @@ class Ada(metaclass=LanguageCls):
             f"end {self.module_name};"
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -485,6 +485,13 @@ class Bash(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -513,6 +513,13 @@ class C(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -382,6 +382,13 @@ class Clojure(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -632,6 +632,13 @@ class Cobol(metaclass=LanguageCls):
             + "    STOP RUN."
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -399,6 +399,13 @@ class CommonLisp(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1299,6 +1299,13 @@ class Cpp(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.CPP
     datetime_format: DatetimeFormats = DatetimeFormats.CPP
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -514,6 +514,14 @@ class Crystal(metaclass=LanguageCls):
         )
 
     module_name: str = "Check"
+
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -810,6 +810,13 @@ class CSharp(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.CSHARP
     datetime_format: DatetimeFormats = DatetimeFormats.CSHARP
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -469,6 +469,13 @@ class D(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -681,6 +681,13 @@ class Dart(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.DART
     datetime_format: DatetimeFormats = DatetimeFormats.DART
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -824,6 +824,13 @@ class Dhall(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -560,6 +560,13 @@ class Elixir(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -835,6 +835,13 @@ class Elm(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -517,6 +517,13 @@ class Erlang(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.BINARY

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -481,6 +481,13 @@ class Forth(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -645,6 +645,13 @@ class Fortran(metaclass=LanguageCls):
             "end program main"
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -613,6 +613,13 @@ class FSharp(metaclass=LanguageCls):
         )
         return body
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.FSHARP
     datetime_format: DatetimeFormats = DatetimeFormats.FSHARP
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -890,6 +890,13 @@ class Gleam(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -597,6 +597,13 @@ class Go(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.GO
     datetime_format: DatetimeFormats = DatetimeFormats.GO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -426,6 +426,13 @@ class Groovy(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1325,6 +1325,13 @@ class Haskell(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.HASKELL
     datetime_format: DatetimeFormats = DatetimeFormats.HASKELL
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -445,6 +445,13 @@ class Hcl(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1092,6 +1092,13 @@ class Java(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.JAVA
     datetime_format: DatetimeFormats = DatetimeFormats.INSTANT
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -508,6 +508,13 @@ class JavaScript(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.JS
     datetime_format: DatetimeFormats = DatetimeFormats.JS
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -387,6 +387,13 @@ class Json5(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -442,6 +442,13 @@ class Jsonnet(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -519,6 +519,13 @@ class Julia(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.JULIA
     datetime_format: DatetimeFormats = DatetimeFormats.JULIA
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -878,6 +878,13 @@ class Kotlin(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.KOTLIN
     datetime_format: DatetimeFormats = DatetimeFormats.KOTLIN
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -432,6 +432,13 @@ class Lua(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.LUA
     datetime_format: DatetimeFormats = DatetimeFormats.LUA
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -509,6 +509,13 @@ class Matlab(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.MATLAB
     datetime_format: DatetimeFormats = DatetimeFormats.MATLAB
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -753,6 +753,13 @@ class Mojo(metaclass=LanguageCls):
             body_preamble=(),
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -927,6 +927,13 @@ class Nim(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.NIM
     datetime_format: DatetimeFormats = DatetimeFormats.NIM
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -456,6 +456,13 @@ class Nix(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -360,6 +360,13 @@ class Norg(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -573,6 +573,13 @@ class ObjectiveC(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.OBJC
     datetime_format: DatetimeFormats = DatetimeFormats.OBJC
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -580,6 +580,13 @@ class OCaml(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.OCAML
     datetime_format: DatetimeFormats = DatetimeFormats.OCAML
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -387,6 +387,13 @@ class Occam(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -530,6 +530,13 @@ class Odin(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -475,6 +475,13 @@ class Perl(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.PERL
     datetime_format: DatetimeFormats = DatetimeFormats.PERL
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -484,6 +484,13 @@ class Php(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.PHP
     datetime_format: DatetimeFormats = DatetimeFormats.PHP
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -443,6 +443,13 @@ class PowerShell(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -970,6 +970,13 @@ class PureScript(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -987,6 +987,13 @@ class Python(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.PYTHON
     datetime_format: DatetimeFormats = DatetimeFormats.PYTHON
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -478,6 +478,13 @@ class R(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.R
     datetime_format: DatetimeFormats = DatetimeFormats.R
     empty_dict_key: EmptyDictKey = EmptyDictKey.POSITIONAL

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -388,6 +388,13 @@ class Racket(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -509,6 +509,13 @@ class Raku(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.RAKU
     datetime_format: DatetimeFormats = DatetimeFormats.RAKU
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -874,6 +874,13 @@ class Roc(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -525,6 +525,13 @@ class Ruby(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.RUBY
     datetime_format: DatetimeFormats = DatetimeFormats.RUBY
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1280,6 +1280,13 @@ class Rust(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.RUST
     datetime_format: DatetimeFormats = DatetimeFormats.RUST
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -616,6 +616,13 @@ class Scala(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.SCALA
     datetime_format: DatetimeFormats = DatetimeFormats.SCALA
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -383,6 +383,13 @@ class Scheme(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -610,6 +610,13 @@ class Sml(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.SML
     datetime_format: DatetimeFormats = DatetimeFormats.SML
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -750,6 +750,13 @@ class Swift(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.SWIFT
     datetime_format: DatetimeFormats = DatetimeFormats.SWIFT
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -524,6 +524,13 @@ class SystemVerilog(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -427,6 +427,13 @@ class Tcl(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -394,6 +394,13 @@ class Toml(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.TOML
     datetime_format: DatetimeFormats = DatetimeFormats.TOML
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -687,6 +687,13 @@ class TypeScript(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.JS
     datetime_format: DatetimeFormats = DatetimeFormats.JS
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -669,6 +669,13 @@ class V(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -604,6 +604,13 @@ class VisualBasic(metaclass=LanguageCls):
             "End Module"
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -456,6 +456,13 @@ class Wren(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -368,6 +368,13 @@ class Yaml(metaclass=LanguageCls):
         del declaration, assignment, variable_name, body_preamble
         raise WrapCombinedInFileNotSupportedError
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.YAML
     datetime_format: DatetimeFormats = DatetimeFormats.YAML
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -547,6 +547,13 @@ class Zig(metaclass=LanguageCls):
             body_preamble=body_preamble,
         )
 
+    @property
+    def supports_wrap_combined_in_file(self) -> bool:
+        """Whether ``wrap_combined_in_file`` supports the selected
+        style.
+        """
+        return bool(self.declaration_style.value.supports_redefinition)
+
     date_format: DateFormats = DateFormats.ZIG
     datetime_format: DatetimeFormats = DatetimeFormats.ZIG
     bytes_format: BytesFormats = BytesFormats.HEX

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -321,10 +321,10 @@ def test_both_variable_forms_without_wrap_in_file_raises() -> None:
 
 
 def test_both_variable_forms_without_redefinition_support_raises() -> None:
-    """BothVariableForms raises when declaration_style cannot redefine."""
+    """BothVariableForms raises when combined file wrapping is unsupported."""
     expected = (
-        "BothVariableForms requires a declaration_style that supports "
-        "redefinition; 'ASSIGN' does not."
+        "BothVariableForms requires supports_wrap_combined_in_file; "
+        "Yaml with declaration_style 'ASSIGN' does not support it."
     )
     with pytest.raises(
         expected_exception=ValueError,

--- a/tests/integration/test_language_metadata.py
+++ b/tests/integration/test_language_metadata.py
@@ -8,6 +8,7 @@ from pygments.lexers import find_lexer_class_by_name
 import literalizer.languages
 from literalizer._language import LanguageCls
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
+from literalizer.languages import Dhall, Norg
 
 _SORTED_LANGUAGES: list[LanguageCls] = sorted(
     literalizer.languages.ALL_LANGUAGES,
@@ -78,6 +79,7 @@ def test_protocol_properties_accessible(
     assert isinstance(spec.scalar_body_preamble, dict)
     assert isinstance(spec.supports_standalone_comments_in_wrapped_calls, bool)
     assert isinstance(spec.supports_commented_dict_call_args, bool)
+    assert isinstance(spec.supports_wrap_combined_in_file, bool)
 
 
 @pytest.mark.parametrize(
@@ -127,6 +129,25 @@ def test_format_enumeration_properties(
 
 @pytest.mark.parametrize(
     argnames="language_cls",
+    argvalues=_SORTED_LANGUAGES,
+    ids=[c.__name__ for c in _SORTED_LANGUAGES],
+)
+def test_wrap_combined_in_file_capability_matches_declaration_style(
+    *,
+    language_cls: LanguageCls,
+) -> None:
+    """Check the declared wrap capability for the default declaration
+    style.
+    """
+    spec = language_cls()
+    assert (
+        spec.supports_wrap_combined_in_file
+        is spec.declaration_style.value.supports_redefinition
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="language_cls",
     argvalues=_UNSUPPORTED_COMBINED_LANGUAGES,
     ids=[c.__name__ for c in _UNSUPPORTED_COMBINED_LANGUAGES],
 )
@@ -135,6 +156,27 @@ def test_wrap_combined_in_file_unsupported_raises(
     language_cls: LanguageCls,
 ) -> None:
     """Check wrap_combined_in_file raises when redefinition is unsupported."""
+    with pytest.raises(expected_exception=WrapCombinedInFileNotSupportedError):
+        language_cls().wrap_combined_in_file(
+            declaration="x = 1",
+            assignment="x = 2",
+            variable_name="x",
+            body_preamble=(),
+        )
+
+
+@pytest.mark.parametrize(
+    argnames="language_cls",
+    argvalues=[Norg, Dhall],
+    ids=["Norg", "Dhall"],
+)
+def test_issue_1776_wrap_combined_in_file_raises_typed_error(
+    *,
+    language_cls: LanguageCls,
+) -> None:
+    """Check issue #1776 languages do not raise bare
+    NotImplementedError.
+    """
     with pytest.raises(expected_exception=WrapCombinedInFileNotSupportedError):
         language_cls().wrap_combined_in_file(
             declaration="x = 1",


### PR DESCRIPTION
Adds a declared supports_wrap_combined_in_file capability across language specs so callers can pre-check combined declaration/assignment wrapping instead of probing wrap_combined_in_file. literalize() now uses that capability before BothVariableForms, while unsupported implementations such as Norg and Dhall continue to raise WrapCombinedInFileNotSupportedError as a typed safety net. This fixes #1776 and keeps the capability derived from each selected declaration_style's supports_redefinition metadata. Validated with ruff, mypy, pyright, ty, pyrefly, pyright-verifytypes, and focused pytest coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the cross-language protocol and updates many language specs, so any mistake in the new capability flag could incorrectly reject or allow `BothVariableForms` output. Logic is straightforward and covered by focused tests, but it affects behavior across all targets.
> 
> **Overview**
> Adds a new per-language capability flag, `supports_wrap_combined_in_file`, so callers can check whether `wrap_combined_in_file` is supported for the *currently selected* `declaration_style`.
> 
> Updates `literalize()` to require this capability when using `BothVariableForms`, replacing the previous check that only looked at `supports_redefinition`, and improves the resulting `ValueError` message.
> 
> Implements the capability across all language specs (derived from `declaration_style.value.supports_redefinition`) and extends integration tests to assert the flag matches the declaration style and that unsupported languages like `Dhall`/`Norg` raise `WrapCombinedInFileNotSupportedError` (fixing the reported issue).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba9544f3ef8afb9246832100829d30e73cdffe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->