### PR TITLE
Clarify literalize ref casing docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,8 +41,9 @@ Next
   now accept a ``ref_key`` parameter (``str``, default ``"$ref"``).  The
   marker key used to identify variable-reference mappings in the input data
   is now user-configurable: a single-key dict whose key equals *ref_key*
-  and whose value is a string is treated as a ref marker when *ref_case* is
-  set.
+  and whose value is a string is treated as a ref marker.  Pass
+  ``ref_case`` only when the identifier name should be converted before
+  rendering.
 - Every built-in language class now exposes a ``VersionFormats`` enum and a
   configurable ``language_version`` constructor parameter that selects which
   version of the target language the generated code is written for.  For

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -232,9 +232,9 @@ References inside plain data structures
 is useful when you want to emit a data structure where some values are
 references to variables declared elsewhere rather than inline literals.
 
-Pass ``ref_case`` to :func:`~literalizer.literalize` to activate ref
-resolution; without it, ``{"$ref": ...}`` is treated as an ordinary
-literal dict, preserving backwards compatibility.
+By default, ref identifiers are emitted verbatim.  Pass ``ref_case`` to
+:func:`~literalizer.literalize` when the identifier should be converted
+before rendering.
 
 For example, suppose you have a configuration dict where ``timeout`` and
 ``host`` are already declared as named constants and you want to reference


### PR DESCRIPTION
Updates the changelog and function-call guide to state that literalize ref markers are recognized by default. Clarifies that ref_case only converts the identifier before rendering rather than enabling ref resolution. This keeps the public docs aligned with the implemented behavior and regression coverage for issue #1755. Validation: focused pytest coverage for escaped refs, literalize ref defaults, unsupported ref cases, and literalize ref golden files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify existing `literalize`/`literalize_call` behavior; no runtime logic is modified.
> 
> **Overview**
> Clarifies in the changelog and function-call guide that `{"$ref": "name"}` markers are recognized by default, and that `ref_case` is **only** used to case-convert the reference identifier before rendering (not to enable ref resolution).
> 
> Updates the “References inside plain data structures” section to reflect the default verbatim behavior and when to supply `ref_case`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0e5d191dc724a0df6cffda34b06ce5d94930af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->