### PR TITLE
Add ref_values to literalize_call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- :func:`~literalizer.literalize_call` accepts a new ``ref_values``
+  mapping from ``{"$ref": "name"}`` identifiers to the source values
+  declared elsewhere.  Supplied ref values now participate in
+  data-driven preamble inference, so generated body declarations such
+  as Haskell's ``data Val = ...`` include types reachable only through
+  refs while the rendered call still emits the bare identifier.
+
 2026.05.01.1
 ------------
 

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -117,6 +117,39 @@ This composes with
 by :func:`~literalizer.literalize_call`, without repeating the literal
 value at the call site.
 
+When the referenced value contains types that affect generated
+declarations or imports, pass those source values via ``ref_values``.
+The call still renders only the identifier, but the referenced value
+participates in preamble inference:
+
+.. code-block:: python
+
+   """Render a call whose ref contributes to preamble inference."""
+
+   from literalizer import InputFormat, NewVariable, literalize, literalize_call
+   from literalizer.languages import Haskell
+
+   language = Haskell()
+   declaration = literalize(
+       source="[1, 2, 3]",
+       input_format=InputFormat.JSON,
+       language=language,
+       variable_form=NewVariable(name="myList"),
+   )
+   call = literalize_call(
+       source='[[{"$ref": "myList"}, 42]]',
+       input_format=InputFormat.JSON,
+       language=language,
+       target_function="process",
+       parameter_names=["data", "count"],
+       ref_values={"myList": declaration.source_data},
+   )
+   assert call.declaration_code == "process(myList, 42)"
+
+If a ref name is omitted from ``ref_values``, its marker is ignored for
+preamble inference as before.  ``ref_values`` keys are the names from
+the input data before any ``ref_case`` conversion.
+
 By default the identifier is emitted verbatim.  Pass ``ref_case`` to
 :func:`~literalizer.literalize_call` to convert the name to the target
 language's idiomatic case.
@@ -186,6 +219,7 @@ emitting the file:
        language=language,
        target_function="process",
        parameter_names=["data", "count"],
+       ref_values={"myList": declaration.source_data},
    )
 
    seen: set[str] = set()

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import assert_never
 
 from beartype import BeartypeConf, beartype
@@ -2079,6 +2079,61 @@ def _strip_refs_from_value(*, value: Value, ref_key: str) -> Value:
     return value
 
 
+@dataclasses.dataclass(frozen=True)
+class _PreambleRefResolution:
+    """Ref-marker resolution result for preamble inference."""
+
+    include: bool
+    value: Value
+
+
+@beartype
+def _resolve_ref_for_preamble(
+    *,
+    value: Value,
+    ref_values: Mapping[str, Value],
+    ref_key: str,
+) -> _PreambleRefResolution:
+    """Resolve ref markers for preamble inference.
+
+    Returns ``include=False`` when *value* is a ref marker whose source
+    value was not supplied.  Callers use that flag to drop the
+    marker, preserving the historical "strip refs" behavior for
+    unknown ref names.
+    """
+    ref_name = _extract_call_arg_ref_name(value=value, ref_key=ref_key)
+    if ref_name is not None:
+        if ref_name not in ref_values:
+            return _PreambleRefResolution(include=False, value=None)
+        return _PreambleRefResolution(
+            include=True,
+            value=ref_values[ref_name],
+        )
+    if isinstance(value, list):
+        resolved_list: list[Value] = []
+        for item in value:
+            resolved = _resolve_ref_for_preamble(
+                value=item,
+                ref_values=ref_values,
+                ref_key=ref_key,
+            )
+            if resolved.include:
+                resolved_list.append(resolved.value)
+        return _PreambleRefResolution(include=True, value=resolved_list)
+    if isinstance(value, dict):
+        resolved_dict: dict[str, Value] = {}
+        for key, item in value.items():
+            resolved = _resolve_ref_for_preamble(
+                value=item,
+                ref_values=ref_values,
+                ref_key=ref_key,
+            )
+            if resolved.include:
+                resolved_dict[key] = resolved.value
+        return _PreambleRefResolution(include=True, value=resolved_dict)
+    return _PreambleRefResolution(include=True, value=value)
+
+
 @beartype
 def _compute_call_arg_ref_single_use_names(
     *,
@@ -2115,14 +2170,20 @@ def _strip_call_arg_refs_for_preamble(
     data: Value,
     per_element: bool,
     ref_key: str,
+    ref_values: Mapping[str, Value],
 ) -> Value:
-    """Return *data* with call-argument ref markers removed.
+    """Return *data* with call-argument ref markers resolved or removed.
 
     Ref markers represent a variable declared elsewhere, not real data,
     so they would pollute data-driven preamble inference (e.g. dragging
     in ``Data.Map`` imports for Haskell just because the marker happens
-    to be a ``{str: str}`` dict).  Drop them before computing the
-    preamble while leaving :func:`_format_call_args` to render them.
+    to be a ``{str: str}`` dict).  Drop refs whose values are unknown
+    before computing the preamble while leaving :func:`_format_call_args`
+    to render them.
+
+    When *ref_values* supplies the value behind a marker, substitute
+    that value into the preamble input so the referenced variable's
+    types participate in body-preamble computation.
 
     When *per_element* is ``True``, *data* is a list of argument lists
     and refs are stripped from each inner list.  Otherwise a
@@ -2130,6 +2191,13 @@ def _strip_call_arg_refs_for_preamble(
     Refs nested inside list or dict argument values are also stripped
     recursively.
     """
+    if ref_values:
+        resolved = _resolve_ref_for_preamble(
+            value=data,
+            ref_values=ref_values,
+            ref_key=ref_key,
+        )
+        return resolved.value if resolved.include else []
     if per_element:
         if not isinstance(data, list):
             return data
@@ -2649,6 +2717,7 @@ def literalize_call(
     wrap_in_file: bool = False,
     ref_case: IdentifierCase | None = None,
     consumable_refs: frozenset[str] = frozenset(),
+    ref_values: Mapping[str, Value] | None = None,
     ref_key: str = "$ref",
     collection_layout: CollectionLayout = CollectionLayout.COMPACT,
 ) -> LiteralizeResult:
@@ -2705,6 +2774,15 @@ def literalize_call(
             Names should match the identifiers used in *source* before
             any *ref_case* conversion.  Defaults to an empty set (no
             refs are consumed).
+        ref_values: Optional mapping from ref identifier to the source
+            value declared elsewhere.  When supplied, values for refs
+            used in *source* are included in data-driven preamble
+            inference, so languages with generated body types (for
+            example Haskell's ``data Val = ...``) declare constructors
+            for types reachable only through refs.  Missing ref names
+            keep the historical behavior: their markers are omitted
+            from preamble inference.  Keys should match the identifiers
+            used in *source* before any *ref_case* conversion.
         ref_key: The dict key used to identify variable-reference
             markers in the input data.  A single-key dict whose key
             equals *ref_key* and whose value is a string is treated as
@@ -2757,6 +2835,7 @@ def literalize_call(
         data=data,
         per_element=per_element,
         ref_key=ref_key,
+        ref_values=ref_values or {},
     )
 
     if per_element:

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -879,6 +879,30 @@ def _run_wrap_in_file_case(
 
 
 @beartype
+def _check_call_result_includes_ref_declaration_types(
+    *,
+    result: literalizer.LiteralizeResult,
+    decl_results: list[literalizer.LiteralizeResult],
+) -> None:
+    """Check refs supplied via ``ref_values`` feed call type
+    collection.
+    """
+    if not decl_results:
+        return
+    empty_types: frozenset[type] = frozenset()
+    declaration_types = empty_types.union(
+        *(d.types_present for d in decl_results),
+    )
+    missing_types = declaration_types - result.types_present
+    if missing_types == empty_types:
+        return
+    pytest.fail(  # pragma: no cover
+        "literalize_call result types do not include ref declaration "
+        f"types: missing {missing_types!r}",
+    )
+
+
+@beartype
 def run_call_golden_case(
     *,
     config: CallCaseConfig,
@@ -906,13 +930,15 @@ def run_call_golden_case(
         # ref-site and declaration-site spellings agree.
         default_case = spec.identifier_cases[0]
         effective_ref_case = default_case
-        declarations = {
-            default_case.convert(name=ref_name): ref_source
-            for ref_name, ref_source in config.ref_declarations.items()
+        declaration_names = {
+            ref_name: default_case.convert(name=ref_name)
+            for ref_name in config.ref_declarations
         }
     else:
         effective_ref_case = None
-        declarations = config.ref_declarations
+        declaration_names = {
+            ref_name: ref_name for ref_name in config.ref_declarations
+        }
     if config.wrap_in_file:
         _run_wrap_in_file_case(
             config=config,
@@ -929,15 +955,22 @@ def run_call_golden_case(
         # Literalize each ``{"$ref": "name"}`` target into a variable
         # declaration so the generated file is self-contained and the
         # golden file can lint cleanly.
-        decl_results: list[literalizer.LiteralizeResult] = [
-            literalizer.literalize(
+        decl_results_by_ref_name: dict[str, literalizer.LiteralizeResult] = {
+            ref_name: literalizer.literalize(
                 source=ref_source,
                 input_format=literalizer.InputFormat.JSON,
                 language=spec,
-                variable_form=literalizer.NewVariable(name=ref_name),
+                variable_form=literalizer.NewVariable(
+                    name=declaration_names[ref_name],
+                ),
             )
-            for ref_name, ref_source in declarations.items()
-        ]
+            for ref_name, ref_source in config.ref_declarations.items()
+        }
+        decl_results = list(decl_results_by_ref_name.values())
+        ref_values = {
+            ref_name: declaration.source_data
+            for ref_name, declaration in decl_results_by_ref_name.items()
+        }
         result = literalizer.literalize_call(
             source=yaml_string,
             input_format=literalizer.InputFormat.YAML,
@@ -948,6 +981,7 @@ def run_call_golden_case(
             per_element=config.per_element,
             ref_case=effective_ref_case,
             consumable_refs=config.consumable_refs,
+            ref_values=ref_values or None,
         )
     except HeterogeneousCollectionError:
         golden_path.unlink(missing_ok=True)
@@ -959,6 +993,10 @@ def run_call_golden_case(
         pytest.skip(
             f"{lang_cls.__name__} rejected call arg: {exc.reason}",
         )
+    _check_call_result_includes_ref_declaration_types(
+        result=result,
+        decl_results=decl_results,
+    )
     # Build stub declarations for undefined names.
     body_stubs: list[str] = []
     preamble_stubs: list[str] = []

--- a/tests/integration/cases/call_existing_ref_arg/Cpp_call.cpp
+++ b/tests/integration/cases/call_existing_ref_arg/Cpp_call.cpp
@@ -1,6 +1,5 @@
 #include <initializer_list>
 #include <vector>
-#include <cstddef>
 auto process(auto...) { return 0; }
 int main() {
 auto existing = 42;

--- a/tests/integration/cases/call_existing_ref_arg/V_call.v
+++ b/tests/integration/cases/call_existing_ref_arg/V_call.v
@@ -1,4 +1,3 @@
-interface IVal {}
 interface ICallArg_ {}
 fn process(args ...ICallArg_) {}
 

--- a/tests/integration/cases/call_ref_args/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args/Cpp_call.cpp
@@ -1,5 +1,6 @@
 #include <initializer_list>
 #include <vector>
+#include <variant>
 auto process(auto...) { return 0; }
 int main() {
 auto my_var = std::vector<int>{

--- a/tests/integration/cases/call_ref_args/V_call.v
+++ b/tests/integration/cases/call_ref_args/V_call.v
@@ -1,3 +1,4 @@
+interface IVal {}
 interface ICallArg_ {}
 fn process(args ...ICallArg_) {}
 

--- a/tests/integration/cases/call_ref_args_converted/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args_converted/Cpp_call.cpp
@@ -1,5 +1,6 @@
 #include <initializer_list>
 #include <vector>
+#include <variant>
 auto process(auto...) { return 0; }
 int main() {
 auto my_var = std::vector<int>{

--- a/tests/integration/cases/call_ref_args_converted/V_call.v
+++ b/tests/integration/cases/call_ref_args_converted/V_call.v
@@ -1,3 +1,4 @@
+interface IVal {}
 interface ICallArg_ {}
 fn process(args ...ICallArg_) {}
 

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Cpp_call.cpp
@@ -1,5 +1,6 @@
 #include <initializer_list>
 #include <vector>
+#include <variant>
 auto process(auto...) { return 0; }
 int main() {
 auto my_var = std::vector<int>{

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/V_call.v
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/V_call.v
@@ -1,3 +1,4 @@
+interface IVal {}
 interface ICallArg_ {}
 fn process(args ...ICallArg_) {}
 

--- a/tests/integration/cases/call_ref_args_converted_whole/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args_converted_whole/Cpp_call.cpp
@@ -1,6 +1,5 @@
 #include <initializer_list>
 #include <vector>
-#include <cstddef>
 auto process(auto...) { return 0; }
 int main() {
 auto my_var = std::vector<int>{

--- a/tests/integration/cases/call_ref_args_converted_whole/V_call.v
+++ b/tests/integration/cases/call_ref_args_converted_whole/V_call.v
@@ -1,4 +1,3 @@
-interface IVal {}
 interface ICallArg_ {}
 fn process(args ...ICallArg_) {}
 

--- a/tests/integration/cases/call_ref_args_escaped_quote/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Cpp_call.cpp
@@ -1,8 +1,6 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
-#include <cstddef>
-#include <variant>
 auto process(auto...) { return 0; }
 int main() {
 const auto* my_str = "a\"b";

--- a/tests/integration/cases/call_ref_args_escaped_quote/V_call.v
+++ b/tests/integration/cases/call_ref_args_escaped_quote/V_call.v
@@ -1,4 +1,3 @@
-interface IVal {}
 interface ICallArg_ {}
 fn process(args ...ICallArg_) {}
 

--- a/tests/integration/cases/call_ref_args_reused/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args_reused/Cpp_call.cpp
@@ -1,5 +1,6 @@
 #include <initializer_list>
 #include <vector>
+#include <variant>
 auto process(auto...) { return 0; }
 int main() {
 auto single_var = std::vector<int>{

--- a/tests/integration/cases/call_ref_args_reused/V_call.v
+++ b/tests/integration/cases/call_ref_args_reused/V_call.v
@@ -1,3 +1,4 @@
+interface IVal {}
 interface ICallArg_ {}
 fn process(args ...ICallArg_) {}
 

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -1,6 +1,7 @@
 """Negative-path checks for ``literalize_call``."""
 
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -22,12 +23,16 @@ from literalizer.exceptions import (
 from literalizer.languages import (
     Bash,
     Dhall,
+    Haskell,
     JavaScript,
     Nix,
     Python,
     Racket,
     Yaml,
 )
+
+if TYPE_CHECKING:
+    from literalizer._types import Value
 
 
 def test_dhall_literalize_call_rejects_non_scalar_arg() -> None:
@@ -303,6 +308,98 @@ def test_literalize_ref_case_unsupported_raises() -> None:
             language=Python(),
             ref_case=IdentifierCase.KEBAB,
         )
+
+
+def test_literalize_call_unknown_ref_values_keep_strip_behavior() -> None:
+    """Unknown refs still do not contribute marker dict types."""
+    result = literalize_call(
+        source='[[{"$ref": "myList"}]]',
+        input_format=InputFormat.JSON,
+        language=Haskell(),
+        target_function="process",
+        parameter_names=["data"],
+        ref_values={},
+    )
+
+    assert result.types_present == frozenset({list})
+    assert result.body_preamble == ("data Val = HList [Val]",)
+
+
+def test_literalize_call_unknown_ref_values_strip_top_level_ref() -> None:
+    """Unknown refs are stripped even when other ref values are
+    supplied.
+    """
+    result = literalize_call(
+        source='{"$ref": "myList"}',
+        input_format=InputFormat.JSON,
+        language=Haskell(),
+        target_function="process",
+        parameter_names=["data"],
+        per_element=False,
+        ref_values={"other": 1},
+    )
+
+    assert result.types_present == frozenset({list})
+    assert result.body_preamble == ("data Val = HList [Val]",)
+
+
+def test_literalize_call_unknown_refs_strip_from_nested_preamble() -> None:
+    """Unknown nested refs do not shape preamble type inference."""
+    known_value: list[Value] = [1, 2]
+    ref_values: dict[str, Value] = {"known": known_value}
+    result = literalize_call(
+        source=(
+            '[[{"$ref": "known"}, {"$ref": "missing"}, '
+            '{"inner": {"$ref": "missing"}}]]'
+        ),
+        input_format=InputFormat.JSON,
+        language=Haskell(),
+        target_function="process",
+        parameter_names=["a", "b", "c"],
+        ref_values=ref_values,
+    )
+
+    assert result.body_preamble == (
+        "data Val = HInt Integer | HStr String | HList [Val] | HMap "
+        "[(String, Val)]",
+        "instance Num Val where\n"
+        "    fromInteger = HInt\n"
+        '    _ + _ = error "not implemented"\n'
+        '    _ * _ = error "not implemented"\n'
+        '    abs _ = error "not implemented"\n'
+        '    signum _ = error "not implemented"\n'
+        "    negate (HInt n) = HInt (negate n)\n"
+        '    negate _ = error "not implemented"',
+    )
+
+
+def test_literalize_call_without_ref_values_strips_top_level_ref() -> None:
+    """The historical top-level ref strip behavior is retained."""
+    result = literalize_call(
+        source='{"$ref": "myList"}',
+        input_format=InputFormat.JSON,
+        language=Haskell(),
+        target_function="process",
+        parameter_names=["data"],
+        per_element=False,
+    )
+
+    assert result.types_present == frozenset({list})
+    assert result.body_preamble == ("data Val = HList [Val]",)
+
+
+def test_literalize_call_without_ref_values_strips_per_element_ref() -> None:
+    """Per-element preamble inference skips ref marker elements."""
+    result = literalize_call(
+        source='[{"$ref": "myList"}]',
+        input_format=InputFormat.JSON,
+        language=Haskell(),
+        target_function="process",
+        parameter_names=["data"],
+    )
+
+    assert result.types_present == frozenset({list})
+    assert result.body_preamble == ("data Val = HList [Val]",)
 
 
 def test_both_variable_forms_without_wrap_in_file_raises() -> None:


### PR DESCRIPTION
Adds a `ref_values` mapping to `literalize_call` so `$ref` markers can contribute their source values to preamble type collection while still rendering as identifiers.
This fixes under-declared generated body types for production callers using refs, while preserving the old stripped-marker behavior for refs omitted from the mapping.
The integration call harness now feeds ref declarations into `literalize_call`, and affected C++/V ref-case goldens were regenerated.
Validated with the integration call/error suites plus pre-commit and pre-push checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `literalize_call` preamble/type inference by substituting referenced values, which can change generated imports/type declarations across languages. Behavior for unknown refs is preserved and covered by new tests, reducing regression risk.
> 
> **Overview**
> `literalize_call` now accepts optional `ref_values` to resolve `{"$ref": "name"}` markers during **preamble/type inference** (including nested markers), so generated imports/body type declarations include types only reachable through referenced variables while the call site still emits the bare identifier.
> 
> The call integration harness now passes declaration `source_data` into `ref_values` and asserts the call result’s `types_present` includes types from ref declarations; related C++/V golden fixtures were regenerated to reflect updated inferred preambles. Docs and changelog were updated, and new error-path tests verify unknown/missing ref names keep the historical “strip refs from preamble inference” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dec90c4300440f743a03f3b8e444995b76bd4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->