### PR TITLE
Validate default set element type support

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -237,5 +237,6 @@ unicode
 unterminated
 uv
 val_t
+validators
 whitespace
 yaml

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -13,6 +13,9 @@ from beartype import beartype
 from literalizer._formatters.collection_openers import typed_collection_open
 from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._types import Value
+from literalizer.exceptions import DefaultSetElementTypeNotSupportedError
+
+type LanguageValidator = Callable[..., None]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -559,6 +562,7 @@ class LanguageCls(type):
     validate_call_arg: Callable[[Value], None]
     format_call_statement: Callable[[str], str]
     call_data_dependent_preamble: Callable[[Value], tuple[str, ...]]
+    validators: tuple[LanguageValidator, ...]
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""
@@ -1007,6 +1011,11 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def default_set_element_type(self) -> str | None:
+        """The default element type used for empty set output."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def comment_format(self) -> enum.Enum:
         """The comment format chosen for this language instance."""
         ...  # pylint: disable=unnecessary-ellipsis
@@ -1442,6 +1451,58 @@ class Language(Protocol):
         :func:`no_validate_spec_for_data` as a no-op.
         """
         ...  # pylint: disable=unnecessary-ellipsis
+
+
+@runtime_checkable
+class DefaultSetElementTypeSupport(Protocol):
+    """Protocol for language options used by default set type
+    validation.
+    """
+
+    @property
+    def default_set_element_type(self) -> str | None:
+        """The default element type used for empty set output."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def supports_default_set_element_type(self) -> bool:
+        """Whether this language supports a default set element type."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+@runtime_checkable
+class LanguageValidationTarget(Protocol):
+    """Protocol for language instances with constructor validators."""
+
+    @property
+    def validators(self) -> tuple[LanguageValidator, ...]:
+        """Constructor validators to run after initialization."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+@beartype
+def run_language_validators(
+    *,
+    language: LanguageValidationTarget,
+) -> None:
+    """Run constructor validators for *language*."""
+    for validator in language.validators:
+        validator(language=language)
+
+
+@beartype
+def validate_default_set_element_type_support(
+    *,
+    language: DefaultSetElementTypeSupport,
+) -> None:
+    """Raise if *language* cannot support its default set element type."""
+    if (
+        language.default_set_element_type is not None
+        and not language.supports_default_set_element_type
+    ):
+        raise DefaultSetElementTypeNotSupportedError(
+            language_name=type(language).__name__,
+        )
 
 
 def _no_call_stub(

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -154,6 +154,17 @@ class IncompatibleFormatsError(Exception):
     """
 
 
+class DefaultSetElementTypeNotSupportedError(Exception):
+    """Raised when ``default_set_element_type`` is not supported."""
+
+    def __init__(self, *, language_name: str) -> None:
+        """Create a ``DefaultSetElementTypeNotSupportedError``."""
+        super().__init__(
+            f"{language_name} does not support default_set_element_type"
+        )
+        self.language_name = language_name
+
+
 class UnrepresentableIntegerError(Exception):
     """Raised when an integer value exceeds the range the target
     language can represent natively.

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -62,6 +63,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -230,6 +233,17 @@ class Ada(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""
@@ -549,6 +563,7 @@ class Ada(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_DASH
     declaration_style: DeclarationStyles = DeclarationStyles.DECLARE

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -205,6 +208,17 @@ class Bash(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -490,6 +504,7 @@ class Bash(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.DECLARE

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -67,6 +68,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -235,6 +238,17 @@ class C(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for C."""
@@ -518,6 +532,7 @@ class C(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.TYPED

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -44,6 +44,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PrefixCallStyle,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -120,6 +123,17 @@ class Clojure(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -387,6 +401,7 @@ class Clojure(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.VECTOR
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.SEMICOLON
     declaration_style: DeclarationStyles = DeclarationStyles.DEF

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import CallArgNotSupportedError
@@ -346,6 +349,17 @@ class Cobol(metaclass=LanguageCls):
     supports_commented_dict_call_args = False
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""
@@ -637,6 +651,7 @@ class Cobol(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.SEQUENCE
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.STAR_ANGLE
     declaration_style: DeclarationStyles = DeclarationStyles.TYPED

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -43,6 +43,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PrefixCallStyle,
@@ -60,6 +61,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -129,6 +132,17 @@ class CommonLisp(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -404,6 +418,7 @@ class CommonLisp(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.SEMICOLON
     declaration_style: DeclarationStyles = DeclarationStyles.DEFPARAMETER

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -78,6 +79,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value, ValueKind
 
@@ -887,6 +890,17 @@ class Cpp(metaclass=LanguageCls):
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
             identity_call_arg,
@@ -1306,6 +1320,7 @@ class Cpp(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.INITIALIZER_LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.AUTO

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -75,6 +76,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
 )
 from literalizer._types import Value
 
@@ -190,6 +192,17 @@ class Crystal(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -68,6 +68,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -88,6 +89,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -372,6 +374,17 @@ class CSharp(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -67,6 +68,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -176,6 +179,17 @@ class D(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -474,6 +488,7 @@ class D(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.AUTO

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -76,6 +77,7 @@ from literalizer._language import (
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
+    run_language_validators,
     value_contains,
     wrap_in_file_noop,
 )
@@ -298,6 +300,17 @@ class Dart(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -52,6 +52,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -64,6 +65,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Scalar, Value
@@ -539,6 +542,17 @@ class Dhall(metaclass=LanguageCls):
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     class DateFormats(enum.Enum):
         """Date format options for Dhall."""
 
@@ -829,6 +843,7 @@ class Dhall(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.LINE
     declaration_style: DeclarationStyles = DeclarationStyles.LET

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -72,6 +73,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -217,6 +220,17 @@ class Elixir(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -565,6 +579,7 @@ class Elixir(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.MAP_SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -64,6 +65,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -524,6 +527,17 @@ class Elm(metaclass=LanguageCls):
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
             identity_call_arg,
@@ -840,6 +854,7 @@ class Elm(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_DASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -65,6 +66,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -211,6 +214,17 @@ class Erlang(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -522,6 +536,7 @@ class Erlang(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.BINARY
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.PERCENT
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -34,6 +34,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PostfixCallStyle,
@@ -52,6 +53,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -214,6 +217,17 @@ class Forth(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -486,6 +500,7 @@ class Forth(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.BACKSLASH
     declaration_style: DeclarationStyles = DeclarationStyles.COLON

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -336,6 +339,17 @@ class Fortran(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""
@@ -650,6 +664,7 @@ class Fortran(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.EXCLAMATION
     declaration_style: DeclarationStyles = DeclarationStyles.TYPED

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -75,6 +76,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -296,6 +299,17 @@ class FSharp(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -618,6 +632,7 @@ class FSharp(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.LET

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -70,6 +71,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import UnrepresentableSpecialFloatError
@@ -539,6 +542,17 @@ class Gleam(metaclass=LanguageCls):
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
             identity_call_arg,
@@ -895,6 +909,7 @@ class Gleam(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.LET

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -80,6 +81,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
 )
 from literalizer._types import Value
 
@@ -273,6 +275,17 @@ class Go(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -66,6 +67,7 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -153,6 +155,17 @@ class Groovy(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -70,6 +71,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -964,6 +967,17 @@ class Haskell(metaclass=LanguageCls):
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
             identity_call_arg,
@@ -1330,6 +1344,7 @@ class Haskell(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_DASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -45,6 +45,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -64,6 +65,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Value
@@ -157,6 +160,17 @@ class Hcl(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -450,6 +464,7 @@ class Hcl(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -78,6 +79,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import NullInCollectionError
@@ -589,6 +592,17 @@ class Java(metaclass=LanguageCls):
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
             identity_call_arg,
@@ -1097,6 +1111,7 @@ class Java(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.VAR

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     ObjectCallStyle,
     OrderedMapFormatConfig,
@@ -76,6 +77,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -140,6 +143,17 @@ class JavaScript(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -513,6 +527,7 @@ class JavaScript(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.CONST

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -64,6 +65,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Value
@@ -133,6 +136,17 @@ class Json5(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -392,6 +406,7 @@ class Json5(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -62,6 +63,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Value
@@ -149,6 +152,17 @@ class Jsonnet(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -447,6 +461,7 @@ class Jsonnet(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -74,6 +75,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -168,6 +171,17 @@ class Julia(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -524,6 +538,7 @@ class Julia(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -87,6 +88,7 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -444,6 +446,17 @@ class Kotlin(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -47,6 +47,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -65,6 +66,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -154,6 +157,17 @@ class Lua(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -437,6 +451,7 @@ class Lua(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.TABLE
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_DASH
     declaration_style: DeclarationStyles = DeclarationStyles.LOCAL

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -44,6 +44,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -62,6 +63,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -221,6 +224,17 @@ class Matlab(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -514,6 +528,7 @@ class Matlab(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.CELL_ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.PERCENT
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -74,6 +75,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
 )
 from literalizer._types import Scalar, Value
 from literalizer.exceptions import NullInCollectionError
@@ -436,6 +438,17 @@ class Mojo(metaclass=LanguageCls):
     supports_commented_dict_call_args = False
     supports_module_name = False
     supports_call_refs_in_dict_literals = False
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -76,6 +77,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -501,6 +504,24 @@ def _nim_call_stub(
     root_type = f"{root.title()}Type"
     lines.append(f"var {root}: {root_type}")
     return tuple(lines)
+
+
+def validate_nim_constructor_formats(*, language: object) -> None:
+    """Validate that incompatible Nim formats are not combined."""
+    language = cast("Nim", language)
+    _decl_cls = type(language.declaration_style)
+    _strategy_cls = type(language.heterogeneous_strategy)
+    if (
+        language.declaration_style is _decl_cls.CONST
+        and language.heterogeneous_strategy is _strategy_cls.OBJECT_VARIANT
+    ):
+        msg = (
+            "Nim CONST requires a constant-expression initializer, "
+            "but OBJECT_VARIANT produces runtime .toTable / @[] "
+            "calls which are not constant expressions. "
+            "Use VAR or LET instead."
+        )
+        raise IncompatibleFormatsError(msg)
 
 
 @beartype
@@ -932,6 +953,7 @@ class Nim(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.SEQ
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.VAR
@@ -957,27 +979,19 @@ class Nim(metaclass=LanguageCls):
     language_version: VersionFormats = VersionFormats.V2
     indent: str = "    "
 
-    def __post_init__(self) -> None:
-        """Validate that incompatible formats are not combined.
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(
+            validate_default_set_element_type_support,
+            validate_nim_constructor_formats,
+        ),
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
-        ``OBJECT_VARIANT`` replaces the JSON-based rendering for Nim
-        with runtime ``.toTable`` / ``@[]`` constructors, so ``CONST``
-        (which requires a compile-time-expressible initializer)
-        cannot be combined with it.
-        """
-        _decl_cls = type(self.declaration_style)
-        _strategy_cls = type(self.heterogeneous_strategy)
-        if (
-            self.declaration_style is _decl_cls.CONST
-            and self.heterogeneous_strategy is _strategy_cls.OBJECT_VARIANT
-        ):
-            msg = (
-                "Nim CONST requires a constant-expression initializer, "
-                "but OBJECT_VARIANT produces runtime .toTable / @[] "
-                "calls which are not constant expressions. "
-                "Use VAR or LET instead."
-            )
-            raise IncompatibleFormatsError(msg)
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     null_literal: ClassVar[str] = "nil"
     true_literal: ClassVar[str] = "true"

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -66,6 +67,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Value
@@ -201,6 +204,17 @@ class Nix(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -461,6 +475,7 @@ class Nix(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.LET

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -45,6 +45,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -62,6 +63,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Value
@@ -105,6 +108,17 @@ class Norg(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -365,6 +379,7 @@ class Norg(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.PERCENT
     declaration_style: DeclarationStyles = DeclarationStyles.BLOCK

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -45,6 +45,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -62,6 +63,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -290,6 +293,17 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""
@@ -578,6 +592,7 @@ class ObjectiveC(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.TYPED

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -72,6 +73,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -266,6 +269,17 @@ class OCaml(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -585,6 +599,7 @@ class OCaml(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.PAREN_STAR
     declaration_style: DeclarationStyles = DeclarationStyles.LET

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -44,6 +44,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -147,6 +150,17 @@ class Occam(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""
@@ -416,6 +430,7 @@ class Occam(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_DASH
     declaration_style: DeclarationStyles = DeclarationStyles.VAL

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -71,6 +72,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -225,6 +227,17 @@ class Odin(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -73,6 +74,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -164,6 +167,17 @@ class Perl(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -480,6 +494,7 @@ class Perl(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.MY

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -74,6 +75,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -163,6 +166,17 @@ class Php(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -489,6 +503,7 @@ class Php(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -43,6 +43,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -59,6 +60,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -179,6 +182,17 @@ class PowerShell(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -448,6 +462,7 @@ class PowerShell(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -67,6 +68,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import (
@@ -680,6 +683,17 @@ class PureScript(metaclass=LanguageCls):
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     class DateFormats(enum.Enum):
         """Date format options for PureScript."""
 
@@ -975,6 +989,7 @@ class PureScript(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_DASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -78,6 +79,7 @@ from literalizer._language import (
     no_data_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -546,6 +548,17 @@ class Python(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -66,6 +67,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -178,6 +181,17 @@ class R(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -484,6 +498,7 @@ class R(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -44,6 +44,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PrefixCallStyle,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -121,6 +124,17 @@ class Racket(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -393,6 +407,7 @@ class Racket(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.SEMICOLON
     declaration_style: DeclarationStyles = DeclarationStyles.DEFINE

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -73,6 +74,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -197,6 +200,17 @@ class Raku(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -514,6 +528,7 @@ class Raku(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.MY

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -53,6 +53,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -66,6 +67,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -537,6 +540,18 @@ class Roc(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
+
     supports_special_floats = True
 
     class DateFormats(enum.Enum):
@@ -879,6 +894,7 @@ class Roc(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -76,6 +77,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -200,6 +203,17 @@ class Ruby(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -530,6 +544,7 @@ class Ruby(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -81,6 +82,7 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     prepend_body_preamble,
+    run_language_validators,
     value_contains,
 )
 from literalizer._types import Scalar, Value
@@ -642,6 +644,25 @@ def _rust_call_stub(
     construction = f"{root_type} {{ {fields[0]}: {construction} }}"
     lines.append(f"let {root} = {construction};")
     return tuple(lines)
+
+
+def validate_rust_constructor_formats(*, language: object) -> None:
+    """Validate that incompatible Rust formats are not combined."""
+    language = cast("Rust", language)
+    _decl_cls = type(language.declaration_style)
+    _seq_cls = type(language.sequence_format)
+    if (
+        language.declaration_style in {_decl_cls.CONST, _decl_cls.STATIC}
+        and language.sequence_format is _seq_cls.VEC
+    ):
+        msg = (
+            f"Rust {language.declaration_style.name} requires a "
+            f"constant-expression initializer, but the "
+            f"VEC sequence format produces vec![…] which "
+            f"is not a constant expression. "
+            f"Use ARRAY or TUPLE instead."
+        )
+        raise IncompatibleFormatsError(msg)
 
 
 @beartype
@@ -1464,22 +1485,16 @@ class Rust(metaclass=LanguageCls):
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_rust_constructor_formats,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
     def __post_init__(self) -> None:
-        """Validate that incompatible formats are not combined."""
-        _decl_cls = type(self.declaration_style)
-        _seq_cls = type(self.sequence_format)
-        if (
-            self.declaration_style in {_decl_cls.CONST, _decl_cls.STATIC}
-            and self.sequence_format is _seq_cls.VEC
-        ):
-            msg = (
-                f"Rust {self.declaration_style.name} requires a "
-                f"constant-expression initializer, but the "
-                f"VEC sequence format produces vec![…] which "
-                f"is not a constant expression. "
-                f"Use ARRAY or TUPLE instead."
-            )
-            raise IncompatibleFormatsError(msg)
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -78,6 +79,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import NullInCollectionError
@@ -240,6 +243,17 @@ class Scala(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -621,6 +635,7 @@ class Scala(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.VAL

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -44,6 +44,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PrefixCallStyle,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -117,6 +120,17 @@ class Scheme(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -388,6 +402,7 @@ class Scheme(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.SEMICOLON
     declaration_style: DeclarationStyles = DeclarationStyles.DEFINE

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -72,6 +73,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
@@ -321,6 +324,17 @@ class Sml(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -615,6 +629,7 @@ class Sml(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.PAREN_STAR
     declaration_style: DeclarationStyles = DeclarationStyles.VAL

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -78,6 +79,7 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -341,6 +343,17 @@ class Swift(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -64,6 +65,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -249,6 +252,17 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = True
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""
@@ -529,6 +543,7 @@ class SystemVerilog(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.TYPED

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -44,6 +44,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -61,6 +62,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -162,6 +165,17 @@ class Tcl(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -432,6 +446,7 @@ class Tcl(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.DICT
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.SET

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -50,6 +50,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -66,6 +67,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Value
@@ -133,6 +136,17 @@ class Toml(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -399,6 +413,7 @@ class Toml(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     ObjectCallStyle,
     OrderedMapFormatConfig,
@@ -80,6 +81,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -260,6 +263,17 @@ class TypeScript(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -692,6 +706,7 @@ class TypeScript(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.CONST

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -74,6 +75,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 
@@ -350,6 +353,17 @@ class V(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -674,6 +688,7 @@ class V(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.ARRAY
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     IdentifierCase,
     KeywordCallStyle,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -75,6 +76,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
 )
 from literalizer._types import Value
 
@@ -281,6 +283,17 @@ class VisualBasic(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -46,6 +46,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -63,6 +64,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -180,6 +183,17 @@ class Wren(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -461,6 +475,7 @@ class Wren(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.LIST
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.VAR

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -49,6 +49,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     SequenceFormatConfig,
@@ -66,6 +67,8 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    run_language_validators,
+    validate_default_set_element_type_support,
     wrap_in_file_noop,
 )
 from literalizer._types import Value
@@ -107,6 +110,17 @@ class Yaml(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
@@ -373,6 +387,7 @@ class Yaml(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.SEQUENCE
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.HASH
     declaration_style: DeclarationStyles = DeclarationStyles.ASSIGN

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -54,6 +54,7 @@ from literalizer._language import (
     HeterogeneousBehavior,
     IdentifierCase,
     LanguageCls,
+    LanguageValidator,
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
@@ -72,6 +73,8 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
     prepend_body_preamble,
+    run_language_validators,
+    validate_default_set_element_type_support,
 )
 from literalizer._types import Value
 from literalizer.exceptions import UnrepresentableIntegerError
@@ -248,6 +251,17 @@ class Zig(metaclass=LanguageCls):
     supports_commented_dict_call_args = True
     supports_module_name = False
     supports_call_refs_in_dict_literals = True
+
+    validators: tuple[LanguageValidator, ...] = dataclasses.field(
+        default=(validate_default_set_element_type_support,),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Run constructor validators."""
+        run_language_validators(language=self)
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""
@@ -552,6 +566,7 @@ class Zig(metaclass=LanguageCls):
     bytes_format: BytesFormats = BytesFormats.HEX
     sequence_format: SequenceFormats = SequenceFormats.ARRAY
     set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.AUTO
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.CONST

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from beartype import beartype
 
 import literalizer
+from literalizer.exceptions import DefaultSetElementTypeNotSupportedError
 from literalizer.languages import (
     C,
     Cobol,
@@ -267,21 +268,25 @@ def build_non_default_variants(
 
 @beartype
 def build_default_set_element_type_variants() -> Iterable[Variant]:
-    """Build default-set-type variants for languages that support it."""
+    """Build default-set-type variants, using the typed unsupported
+    signal for languages that reject the option.
+    """
     variants: list[Variant] = []
     for lang_cls in sorted_languages():
-        if not lang_cls.supports_default_set_element_type:
-            continue
         type_name = DEFAULT_SET_ELEMENT_TYPE_OVERRIDES.get(
             lang_cls,
             DEFAULT_TYPE_OVERRIDE_FALLBACK,
         )
+        try:
+            spec = make_spec(
+                lang_cls=lang_cls, default_set_element_type=type_name
+            )
+        except DefaultSetElementTypeNotSupportedError:
+            continue
         variants.append(
             Variant(
                 name=f"{lang_cls.__name__}_default_set_element_type_string",
-                spec=make_spec(
-                    lang_cls=lang_cls, default_set_element_type=type_name
-                ),
+                spec=spec,
                 lang_cls=lang_cls,
             )
         )

--- a/tests/test_default_set_element_type.py
+++ b/tests/test_default_set_element_type.py
@@ -1,0 +1,18 @@
+"""Tests for default set element type support."""
+
+import pytest
+
+from literalizer.exceptions import DefaultSetElementTypeNotSupportedError
+from literalizer.languages import Scala
+
+
+def test_unsupported_default_set_element_type_raises_typed_error() -> None:
+    """Unsupported languages reject ``default_set_element_type`` by
+    name.
+    """
+    with pytest.raises(
+        expected_exception=DefaultSetElementTypeNotSupportedError,
+    ) as exc_info:
+        Scala(default_set_element_type="String")
+
+    assert exc_info.value.language_name == "Scala"


### PR DESCRIPTION
Adds DefaultSetElementTypeNotSupportedError and a shared constructor-validator runner that every language calls from __post_init__. Each language now declares an explicit validators tuple: unsupported default_set_element_type languages include the typed default-set validator, supported languages use an empty tuple unless they already have constructor format checks. The default-set-element-type integration variants now attempt construction and skip only on that typed exception instead of pre-filtering by support metadata. Validated with unit, golden variant, formatting, commit-hook, and pre-push type checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches nearly every language spec by adding a shared `__post_init__` validation hook, which could change instantiation behavior and surface new errors at construction time. Core formatting logic is mostly unchanged, but widespread constructor changes increase regression risk.
> 
> **Overview**
> Adds a shared constructor-validation mechanism for language specs: `LanguageCls` now exposes a `validators` tuple and all languages call `run_language_validators()` from `__post_init__`.
> 
> Introduces `DefaultSetElementTypeNotSupportedError` plus `validate_default_set_element_type_support`, so setting `default_set_element_type` on unsupported languages fails fast with a typed exception. Updates integration variant generation to attempt construction and skip only when that typed exception is raised, and adds a unit test asserting the new error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30d922f52fa0f26036dc7e08f66e9581d2b2c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->