### PR TITLE
Enforce supports_dotted_calls in literalize_call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- :func:`~literalizer.literalize_call` now raises a typed
+  :class:`~literalizer.exceptions.DottedCallTargetNotSupportedError`
+  when ``target_function`` contains a dot but the target language sets
+  ``supports_dotted_calls = False`` (currently only ``Hcl``).  The
+  capability flag is now enforced rather than declarative.
+
 - Removed the redundant ``supports_default_set_element_type``,
   ``supports_default_sequence_element_type``,
   ``supports_default_dict_value_type``, ``supports_default_dict_key_type``,

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -762,6 +762,14 @@ class Language(Protocol):
     extension: str
     """The file extension for this language, including the leading dot."""
 
+    supports_dotted_calls: bool
+    """Whether the language accepts dotted ``target_function`` values
+    (e.g. ``"module.fn"``) in
+    :func:`~literalizer.literalize_call`.  When ``False``, dotted
+    targets are rejected with
+    :class:`~literalizer.exceptions.DottedCallTargetNotSupportedError`.
+    """
+
     @property
     def language_version(self) -> enum.Enum:
         """The selected version of the target language."""

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2706,6 +2706,27 @@ def _render_call_whole(
 
 
 @beartype
+def _validate_call_preconditions(
+    *,
+    language: Language,
+    target_function: str,
+    target_function_parts: tuple[str, ...],
+    ref_case: IdentifierCase | None,
+) -> None:
+    """Raise typed errors for unsupported ``literalize_call`` inputs."""
+    if len(target_function_parts) > 1 and not language.supports_dotted_calls:
+        raise DottedCallTargetNotSupportedError(
+            language_name=type(language).__name__,
+            target_function=target_function,
+        )
+    if ref_case is not None and ref_case not in language.identifier_cases:
+        raise UnsupportedIdentifierCaseError(
+            language_name=type(language).__name__,
+            case_name=ref_case.name,
+        )
+
+
+@beartype
 def literalize_call(
     *,
     source: str,
@@ -2825,16 +2846,12 @@ def literalize_call(
             pass
 
     target_function_parts = tuple(target_function.split(sep="."))
-    if len(target_function_parts) > 1 and not language.supports_dotted_calls:
-        raise DottedCallTargetNotSupportedError(
-            language_name=type(language).__name__,
-            target_function=target_function,
-        )
-    if ref_case is not None and ref_case not in language.identifier_cases:
-        raise UnsupportedIdentifierCaseError(
-            language_name=type(language).__name__,
-            case_name=ref_case.name,
-        )
+    _validate_call_preconditions(
+        language=language,
+        target_function=target_function,
+        target_function_parts=target_function_parts,
+        ref_case=ref_case,
+    )
     target_function = language.format_call_target(target_function_parts)
 
     data_for_preamble = _strip_call_arg_refs_for_preamble(

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -49,6 +49,7 @@ from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
+    DottedCallTargetNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
     UnsupportedIdentifierCaseError,
@@ -2824,6 +2825,11 @@ def literalize_call(
             pass
 
     target_function_parts = tuple(target_function.split(sep="."))
+    if len(target_function_parts) > 1 and not language.supports_dotted_calls:
+        raise DottedCallTargetNotSupportedError(
+            language_name=type(language).__name__,
+            target_function=target_function,
+        )
     if ref_case is not None and ref_case not in language.identifier_cases:
         raise UnsupportedIdentifierCaseError(
             language_name=type(language).__name__,

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -190,6 +190,22 @@ class UnsupportedIdentifierCaseError(Exception):
         self.case_name = case_name
 
 
+class DottedCallTargetNotSupportedError(Exception):
+    """Raised when ``literalize_call`` is given a dotted
+    ``target_function``
+    but the target language does not support dotted call expressions.
+    """
+
+    def __init__(self, *, language_name: str, target_function: str) -> None:
+        """Create a ``DottedCallTargetNotSupportedError``."""
+        super().__init__(
+            f"{language_name} does not support dotted call targets: "
+            f"{target_function!r}"
+        )
+        self.language_name = language_name
+        self.target_function = target_function
+
+
 class WrapCombinedInFileNotSupportedError(Exception):
     """Raised when a language does not support ``wrap_combined_in_file``.
 

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -16,6 +16,7 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
+    DottedCallTargetNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
     UnsupportedIdentifierCaseError,
@@ -24,6 +25,7 @@ from literalizer.languages import (
     Bash,
     Dhall,
     Haskell,
+    Hcl,
     JavaScript,
     Nix,
     Python,
@@ -261,6 +263,43 @@ def test_literalize_call_bash_rejects_list_arg_per_element_false() -> None:
             language=Bash(),
             target_function="cmd",
             parameter_names=["items"],
+            per_element=False,
+        )
+
+
+def test_literalize_call_dotted_target_unsupported_raises() -> None:
+    """Dotted ``target_function`` raises for languages without support."""
+    with pytest.raises(
+        expected_exception=DottedCallTargetNotSupportedError,
+        match=(
+            r"^Hcl does not support dotted call targets: "
+            r"'module\.fn'$"
+        ),
+    ):
+        literalize_call(
+            source="[[1]]",
+            input_format=InputFormat.JSON,
+            language=Hcl(),
+            target_function="module.fn",
+            parameter_names=["a"],
+        )
+
+
+def test_literalize_call_dotted_target_unsupported_per_element_false() -> None:
+    """Dotted ``target_function`` raises on the per_element=False path."""
+    with pytest.raises(
+        expected_exception=DottedCallTargetNotSupportedError,
+        match=(
+            r"^Hcl does not support dotted call targets: "
+            r"'module\.fn'$"
+        ),
+    ):
+        literalize_call(
+            source="[1, 2]",
+            input_format=InputFormat.JSON,
+            language=Hcl(),
+            target_function="module.fn",
+            parameter_names=["data"],
             per_element=False,
         )
 


### PR DESCRIPTION
Resolves #1925 by enforcing the `supports_dotted_calls` capability flag instead of leaving it declarative. `literalize_call` now raises a typed `DottedCallTargetNotSupportedError` when `target_function` contains a `.` but the language sets `supports_dotted_calls = False` (currently only `Hcl`). The flag is also added to the `Language` Protocol so the runtime check is statically typed without a cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enforces a previously-declarative capability flag in `literalize_call`, which changes runtime behavior for dotted `target_function` inputs and can break custom `Language` implementations missing the new protocol attribute.
> 
> **Overview**
> `literalize_call` now **actively rejects** dotted `target_function` values when the selected language sets `supports_dotted_calls = False`, raising a new typed `DottedCallTargetNotSupportedError` (notably for `Hcl`).
> 
> This adds `supports_dotted_calls` to the `Language` protocol for static typing, centralizes call-input validation in a new `_validate_call_preconditions` helper, updates the changelog, and extends integration tests to cover both `per_element=True` and `per_element=False` error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156d63613a6fda7787b483980ec755b9a194fc47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->