### PR TITLE
Separate syntactic and stylistic ref_case support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 Next
 ----
 
+- Separated syntactic ``ref_case`` validity from stylistic preference.
+  :class:`~literalizer.Language` now exposes
+  :attr:`~literalizer.Language.supported_ref_cases` -- a frozenset of
+  cases that produce a syntactically legal identifier -- alongside the
+  existing :attr:`~literalizer.Language.identifier_cases`, which now
+  documents stylistic preference only.  ``literalize`` and
+  ``literalize_call`` validate ``ref_case`` against
+  ``supported_ref_cases``, so cases that are syntactically legal but
+  non-idiomatic (e.g. ``IdentifierCase.CAMEL`` in Python) are now
+  accepted.  Two shared constants,
+  :data:`~literalizer.NON_KEBAB_REF_CASES` and
+  :data:`~literalizer.ALL_REF_CASES`, cover the common settings.
+
 - :func:`~literalizer.literalize_call` now raises a typed
   :class:`~literalizer.exceptions.DottedCallTargetNotSupportedError`
   when ``target_function`` contains a dot but the target language sets

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -159,10 +159,22 @@ Case conversion
 
 The ``ref_case`` parameter accepts a :class:`~literalizer.IdentifierCase`
 value (``SNAKE``, ``CAMEL``, ``PASCAL``, ``UPPER_SNAKE``, or ``KEBAB``).
-Each :class:`Language` exposes the subset it understands via its nested
-``IdentifierCases`` enum; passing a case that the language does not
-expose raises
-:class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`.
+Each :class:`Language` exposes two related but independent attributes:
+
+* :attr:`~literalizer.Language.supported_ref_cases` -- the cases that
+  produce a syntactically legal identifier in the target language.
+  Passing a case outside this set raises
+  :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`.
+  Most C-family languages set this to
+  :data:`~literalizer.NON_KEBAB_REF_CASES`, since ``my-var`` is not a
+  legal identifier; Lisp-family languages and other kebab-friendly
+  grammars use :data:`~literalizer.ALL_REF_CASES`.
+* :attr:`~literalizer.Language.identifier_cases` -- the cases that are
+  *idiomatic* for the language, ordered by stylistic preference (the
+  first element is the default).  This list is documentation of style
+  only; it is not used to reject explicit ``ref_case`` choices.  A
+  language may prefer only ``SNAKE`` while still syntactically
+  supporting ``CAMEL``, ``PASCAL``, and ``UPPER_SNAKE``.
 
 The same YAML source can drive idiomatic identifiers across multiple
 languages.  For example, the JSON source ``[[{"$ref": "user_obj"}, 42]]``

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -4,6 +4,8 @@ from literalizer._formatters.collection_openers import (
     fixed_open,
 )
 from literalizer._language import (
+    ALL_REF_CASES,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CollectionLayout,
     CommandCallStyle,
@@ -37,6 +39,8 @@ from literalizer._literalize import (
 from literalizer._parsing import InputFormat
 
 __all__ = [
+    "ALL_REF_CASES",
+    "NON_KEBAB_REF_CASES",
     "BothVariableForms",
     "CallStyle",
     "CollectionLayout",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -367,6 +367,28 @@ class IdentifierCase(enum.Enum):
         return _convert_identifier_case(case=self, name=name)
 
 
+ALL_REF_CASES: frozenset[IdentifierCase] = frozenset(IdentifierCase)
+"""Every :class:`IdentifierCase` member.
+
+Use as :attr:`Language.supported_ref_cases` for languages whose
+identifier grammar admits every case in :class:`IdentifierCase`,
+including ``KEBAB`` (e.g. Lisp-family languages where ``my-var`` is a
+single legal symbol).
+"""
+
+
+NON_KEBAB_REF_CASES: frozenset[IdentifierCase] = ALL_REF_CASES - {
+    IdentifierCase.KEBAB,
+}
+"""Every :class:`IdentifierCase` member except ``KEBAB``.
+
+Use as :attr:`Language.supported_ref_cases` for languages whose
+identifier grammar rejects ``-`` in identifiers (the common C-family
+case, where ``my-var`` would parse as subtraction or fail outright)
+while still accepting the four non-kebab cases as legal identifiers.
+"""
+
+
 def _convert_identifier_case(*, case: IdentifierCase, name: str) -> str:
     """Convert *name* to *case* with snake_case normalization.
 
@@ -530,6 +552,7 @@ class LanguageCls(type):
     Modifiers: type[enum.Enum]
     HeterogeneousStrategies: type[enum.Enum]
     identifier_cases: tuple[IdentifierCase, ...]
+    supported_ref_cases: frozenset[IdentifierCase]
     modifier_combinations: tuple[ModifierCombination, ...]
     module_name_case: IdentifierCase
     extension: str
@@ -747,15 +770,31 @@ class Language(Protocol):
 
     @property
     def identifier_cases(self) -> tuple[IdentifierCase, ...]:
-        """Identifier case conventions this language supports for
-        ``$ref`` conversion.
+        """Identifier case conventions idiomatic for this language.
 
-        Ordered by idiomatic preference — the first element is the
-        language's default case.  Passing a :class:`IdentifierCase`
-        to :func:`~literalizer.literalize_call` via ``ref_case`` is
+        Ordered by stylistic preference -- the first element is the
+        language's default/idiomatic case for generated defaults and
+        golden fixtures.  This list is *not* used to validate user
+        ``ref_case`` choices; that role belongs to
+        :attr:`supported_ref_cases`.  A language may prefer only
+        ``SNAKE`` while still syntactically supporting ``CAMEL``,
+        ``PASCAL``, and ``UPPER_SNAKE``.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def supported_ref_cases(self) -> frozenset[IdentifierCase]:
+        """Identifier cases that produce a syntactically legal
+        identifier in this language.
+
+        Used solely for correctness validation: passing a
+        :class:`IdentifierCase` not in this set to
+        :func:`~literalizer.literalize` or
+        :func:`~literalizer.literalize_call` via ``ref_case`` is
         rejected with
-        :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`
-        unless it is in this tuple.
+        :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`.
+        Independent of :attr:`identifier_cases`, which records
+        stylistic preference rather than syntactic validity.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1949,10 +1949,10 @@ def literalize(
             and *wrap_in_file* is ``False``, or if the language's
             ``declaration_style`` does not support redefinition.
         UnsupportedIdentifierCaseError: If *ref_case* is not in
-            :attr:`~literalizer._language.Language.identifier_cases`
+            :attr:`~literalizer._language.Language.supported_ref_cases`
             for the target language.
     """
-    if ref_case is not None and ref_case not in language.identifier_cases:
+    if ref_case is not None and ref_case not in language.supported_ref_cases:
         raise UnsupportedIdentifierCaseError(
             language_name=type(language).__name__,
             case_name=ref_case.name,
@@ -2719,7 +2719,7 @@ def _validate_call_preconditions(
             language_name=type(language).__name__,
             target_function=target_function,
         )
-    if ref_case is not None and ref_case not in language.identifier_cases:
+    if ref_case is not None and ref_case not in language.supported_ref_cases:
         raise UnsupportedIdentifierCaseError(
             language_name=type(language).__name__,
             case_name=ref_case.name,
@@ -2783,7 +2783,7 @@ def literalize_call(
             set, each ref identifier is normalized to ``snake_case``
             and then converted to the requested case via ``pyhumps``,
             so the same source can drive idiomatic identifiers across
-            multiple languages.  When *language*'s ``identifier_cases``
+            multiple languages.  When *language*'s ``supported_ref_cases``
             does not expose the requested case,
             :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`
             is raised.

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -177,8 +177,10 @@ class UnrepresentableSpecialFloatError(Exception):
 
 
 class UnsupportedIdentifierCaseError(Exception):
-    """Raised when ``literalize_call`` is passed a ``ref_case`` that the
-    target language's ``IdentifierCases`` enum does not expose.
+    """Raised when ``literalize`` or ``literalize_call`` is passed a
+    ``ref_case`` that is not in the target language's
+    ``supported_ref_cases`` -- i.e. one that would not produce a
+    syntactically legal identifier in the target language.
     """
 
     def __init__(self, *, language_name: str, case_name: str) -> None:

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_concat_control
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -433,6 +434,9 @@ class Ada(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommandCallStyle,
     CommentConfig,
@@ -419,6 +420,9 @@ class Bash(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = _bash_validate_spec_for_data

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -40,6 +40,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -455,6 +456,9 @@ class C(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -33,6 +33,7 @@ from literalizer._formatters.format_floats import (
 )
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
+    ALL_REF_CASES,
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
     CommentConfig,
@@ -334,6 +335,7 @@ class Clojure(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.KEBAB,
     )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
 
     validate_spec_for_data = no_validate_spec_for_data
 

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -35,8 +35,8 @@ from literalizer._formatters.format_integers import (
     raise_for_unrepresentable_int,
 )
 from literalizer._language import (
+    ALL_REF_CASES,
     NO_HETEROGENEOUS_BEHAVIOR,
-    NON_KEBAB_REF_CASES,
     CallStyle,
     CommandCallStyle,
     CommentConfig,
@@ -549,9 +549,7 @@ class Cobol(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.UPPER_SNAKE,
     )
-    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
-        NON_KEBAB_REF_CASES
-    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
 
     validate_spec_for_data = no_validate_spec_for_data
 

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_integers import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommandCallStyle,
     CommentConfig,
@@ -547,6 +548,9 @@ class Cobol(metaclass=LanguageCls):
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -32,6 +32,7 @@ from literalizer._formatters.format_floats import (
 )
 from literalizer._formatters.format_strings import format_string_double_minimal
 from literalizer._language import (
+    ALL_REF_CASES,
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
     CommentConfig,
@@ -351,6 +352,7 @@ class CommonLisp(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.KEBAB,
     )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
 
     validate_spec_for_data = no_validate_spec_for_data
 

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -49,6 +49,7 @@ from literalizer._formatters.type_inference import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -1203,6 +1204,9 @@ class Cpp(metaclass=LanguageCls):
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = (

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash_hash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -464,6 +465,9 @@ class Crystal(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -57,6 +57,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -654,6 +655,9 @@ class CSharp(metaclass=LanguageCls):
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = (

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -38,6 +38,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -420,6 +421,9 @@ class D(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -49,6 +49,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -630,6 +631,9 @@ class Dart(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     def wrap_in_file(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -42,6 +42,7 @@ from literalizer._heterogeneous import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -771,6 +772,9 @@ class Dhall(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -44,6 +44,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash_hash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -483,6 +484,9 @@ class Elixir(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -39,6 +39,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -747,6 +748,9 @@ class Elm(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -38,6 +38,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -444,6 +445,9 @@ class Erlang(metaclass=LanguageCls):
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -23,6 +23,7 @@ from literalizer._formatters.format_entries import (
 from literalizer._formatters.format_floats import format_float_scientific
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CallSupport,
     CommentConfig,
@@ -432,6 +433,9 @@ class Forth(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_concat_control
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -545,6 +546,9 @@ class Fortran(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -46,6 +46,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -552,6 +553,9 @@ class FSharp(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -43,6 +43,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -838,6 +839,9 @@ class Gleam(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -50,6 +50,7 @@ from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -548,6 +549,9 @@ class Go(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -377,6 +378,9 @@ class Groovy(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -44,6 +44,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -1226,6 +1227,9 @@ class Haskell(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash_hcl
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -371,6 +372,9 @@ class Hcl(metaclass=LanguageCls):
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -49,6 +49,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -908,6 +909,9 @@ class Java(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = (

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -47,6 +47,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -459,6 +460,9 @@ class JavaScript(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CallSupport,
     CommentConfig,
@@ -340,6 +341,9 @@ class Json5(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -364,6 +365,9 @@ class Jsonnet(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -470,6 +471,9 @@ class Julia(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -58,6 +58,7 @@ from literalizer._formatters.type_inference import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -829,6 +830,9 @@ class Kotlin(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -383,6 +384,9 @@ class Lua(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -35,6 +35,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_concat_control
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -460,6 +461,9 @@ class Matlab(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -46,6 +46,7 @@ from literalizer._heterogeneous import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -697,6 +698,9 @@ class Mojo(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -48,6 +48,7 @@ from literalizer._heterogeneous import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -878,6 +879,9 @@ class Nim(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -37,8 +37,8 @@ from literalizer._formatters.format_strings import (
     format_string_backslash_dollar,
 )
 from literalizer._language import (
+    ALL_REF_CASES,
     NO_HETEROGENEOUS_BEHAVIOR,
-    NON_KEBAB_REF_CASES,
     CallStyle,
     CallSupport,
     CommentConfig,
@@ -411,9 +411,7 @@ class Nix(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
     )
-    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
-        NON_KEBAB_REF_CASES
-    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
 
     validate_spec_for_data = no_validate_spec_for_data
 

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -38,6 +38,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CallSupport,
     CommentConfig,
@@ -409,6 +410,9 @@ class Nix(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -34,6 +34,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CallSupport,
     CommentConfig,
@@ -313,6 +314,9 @@ class Norg(metaclass=LanguageCls):
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_integers import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -514,6 +515,9 @@ class ObjectiveC(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -537,6 +538,9 @@ class OCaml(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -34,6 +34,7 @@ from literalizer._formatters.format_floats import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -356,6 +357,9 @@ class Occam(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -43,6 +43,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -482,6 +483,9 @@ class Odin(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -426,6 +427,9 @@ class Perl(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -47,6 +47,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -435,6 +436,9 @@ class Php(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -33,6 +33,7 @@ from literalizer._formatters.format_floats import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -394,6 +395,9 @@ class PowerShell(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -42,6 +42,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommandCallStyle,
     CommentConfig,
@@ -899,6 +900,9 @@ class PureScript(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -49,6 +49,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -938,6 +939,9 @@ class Python(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -37,6 +37,7 @@ from literalizer._formatters.format_integers import format_integer_hex
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -429,6 +430,9 @@ class R(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -33,6 +33,7 @@ from literalizer._formatters.format_floats import (
 )
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
+    ALL_REF_CASES,
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
     CommentConfig,
@@ -340,6 +341,7 @@ class Racket(metaclass=LanguageCls):
         IdentifierCase.KEBAB,
         IdentifierCase.SNAKE,
     )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
 
     validate_spec_for_data = no_validate_spec_for_data
 

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -44,6 +44,7 @@ from literalizer._formatters.format_strings import (
     format_string_backslash_single_minimal,
 )
 from literalizer._language import (
+    ALL_REF_CASES,
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
     CommentConfig,
@@ -461,6 +462,7 @@ class Raku(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.KEBAB,
     )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
 
     validate_spec_for_data = no_validate_spec_for_data
 

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -42,6 +42,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommandCallStyle,
     CommentConfig,
@@ -757,6 +758,9 @@ class Roc(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -46,6 +46,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -476,6 +477,9 @@ class Ruby(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -52,6 +52,7 @@ from literalizer._heterogeneous import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -1242,6 +1243,9 @@ class Rust(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     def wrap_in_file(

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -47,6 +47,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -567,6 +568,9 @@ class Scala(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -33,6 +33,7 @@ from literalizer._formatters.format_floats import (
 )
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
+    ALL_REF_CASES,
     NO_HETEROGENEOUS_BEHAVIOR,
     CallStyle,
     CommentConfig,
@@ -335,6 +336,7 @@ class Scheme(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.KEBAB,
     )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
 
     validate_spec_for_data = no_validate_spec_for_data
 

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -44,6 +44,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -567,6 +568,9 @@ class Sml(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -49,6 +49,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -701,6 +702,9 @@ class Swift(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -462,6 +463,9 @@ class SystemVerilog(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -33,6 +33,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommandCallStyle,
     CommentConfig,
@@ -378,6 +379,9 @@ class Tcl(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -39,6 +39,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CallSupport,
     CommentConfig,
@@ -347,6 +348,9 @@ class Toml(metaclass=LanguageCls):
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -50,6 +50,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -638,6 +639,9 @@ class TypeScript(metaclass=LanguageCls):
         IdentifierCase.CAMEL,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -46,6 +46,7 @@ from literalizer._formatters.format_strings import (
 from literalizer._heterogeneous import collect_heterogeneous_container_ids
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -617,6 +618,9 @@ class V(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -45,6 +45,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -509,6 +510,9 @@ class VisualBasic(metaclass=LanguageCls):
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -36,6 +36,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -407,6 +408,9 @@ class Wren(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
         IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -38,6 +38,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CallSupport,
     CommentConfig,
@@ -321,6 +322,9 @@ class Yaml(metaclass=LanguageCls):
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -44,6 +44,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
     CallStyle,
     CommentConfig,
     DateFormatConfig,
@@ -492,6 +493,9 @@ class Zig(metaclass=LanguageCls):
         IdentifierCase.SNAKE,
         IdentifierCase.PASCAL,
         IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
     )
 
     validate_spec_for_data = no_validate_spec_for_data

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -30,6 +30,7 @@ from literalizer.languages import (
     Nix,
     Python,
     Racket,
+    Raku,
     Yaml,
 )
 
@@ -320,10 +321,12 @@ def test_literalize_call_arg_ref_parameter_count_still_validated() -> None:
 
 
 def test_literalize_call_ref_case_unsupported_raises() -> None:
-    """``ref_case`` outside the language's ``IdentifierCases`` raises."""
+    """``ref_case`` outside the language's ``supported_ref_cases``
+    raises.
+    """
     with pytest.raises(
         expected_exception=UnsupportedIdentifierCaseError,
-        match=r"^Python does not support identifier case 'CAMEL'$",
+        match=r"^Python does not support identifier case 'KEBAB'$",
     ):
         literalize_call(
             source='[[{"$ref": "user_obj"}, 42]]',
@@ -331,12 +334,14 @@ def test_literalize_call_ref_case_unsupported_raises() -> None:
             language=Python(),
             target_function="process",
             parameter_names=["data", "count"],
-            ref_case=IdentifierCase.CAMEL,
+            ref_case=IdentifierCase.KEBAB,
         )
 
 
 def test_literalize_ref_case_unsupported_raises() -> None:
-    """``ref_case`` outside the language's ``identifier_cases`` raises."""
+    """``ref_case`` outside the language's ``supported_ref_cases``
+    raises.
+    """
     with pytest.raises(
         expected_exception=UnsupportedIdentifierCaseError,
         match=r"^Python does not support identifier case 'KEBAB'$",
@@ -347,6 +352,59 @@ def test_literalize_ref_case_unsupported_raises() -> None:
             language=Python(),
             ref_case=IdentifierCase.KEBAB,
         )
+
+
+def test_literalize_accepts_syntactic_non_idiomatic_ref_case() -> None:
+    """Cases legal in the language but absent from the idiomatic
+    preference list are accepted and rendered.
+
+    Python's ``identifier_cases`` lists only ``SNAKE``, ``UPPER_SNAKE``,
+    and ``PASCAL``; ``CAMEL`` is non-idiomatic but still a syntactically
+    legal Python identifier.  Validation uses ``supported_ref_cases``,
+    which exposes ``CAMEL``.
+    """
+    assert IdentifierCase.CAMEL not in Python().identifier_cases
+    assert IdentifierCase.CAMEL in Python().supported_ref_cases
+
+    result = literalize(
+        source='{"$ref": "user_obj"}',
+        input_format=InputFormat.JSON,
+        language=Python(),
+        ref_case=IdentifierCase.CAMEL,
+    )
+
+    assert "userObj" in result.declaration_code
+
+
+def test_literalize_kebab_friendly_language_accepts_kebab_ref_case() -> None:
+    """Kebab-friendly languages render kebab-form refs as legal
+    symbols.
+    """
+    assert IdentifierCase.KEBAB in Raku().supported_ref_cases
+
+    result = literalize(
+        source='{"$ref": "user_obj"}',
+        input_format=InputFormat.JSON,
+        language=Raku(),
+        ref_case=IdentifierCase.KEBAB,
+    )
+
+    assert "user-obj" in result.declaration_code
+
+
+def test_supported_ref_cases_independent_of_identifier_cases() -> None:
+    """``supported_ref_cases`` is not derived from ``identifier_cases``.
+
+    The two attributes answer different questions -- syntactic validity
+    vs. stylistic preference -- and one is not a function of the other.
+    """
+    python = Python()
+    assert frozenset(python.identifier_cases) != python.supported_ref_cases
+    assert frozenset(python.identifier_cases) <= python.supported_ref_cases
+
+    raku = Raku()
+    assert frozenset(raku.identifier_cases) != raku.supported_ref_cases
+    assert frozenset(raku.identifier_cases) <= raku.supported_ref_cases
 
 
 def test_literalize_call_unknown_ref_values_keep_strip_behavior() -> None:


### PR DESCRIPTION
Adds `Language.supported_ref_cases: frozenset[IdentifierCase]` for syntactic validity, decoupled from `identifier_cases`, which now documents stylistic preference only. `literalize` and `literalize_call` validate `ref_case` against `supported_ref_cases`, so cases that are syntactically legal but non-idiomatic (e.g. `IdentifierCase.CAMEL` in Python) are now accepted; `KEBAB` is still rejected for C-family languages and accepted for Lisp-family ones. Two shared constants, `ALL_REF_CASES` and `NON_KEBAB_REF_CASES`, cover the common settings.

Closes #1627

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public API and validation semantics for `ref_case`, affecting how `literalize`/`literalize_call` accept or reject identifier casing across many languages; risk is mainly behavioral/backward-compatibility around previously rejected or accepted cases.
> 
> **Overview**
> **Ref-case validation is now based on syntactic legality, not style.** Adds `Language.supported_ref_cases` (plus exported constants `ALL_REF_CASES` and `NON_KEBAB_REF_CASES`) and updates `literalize`/`literalize_call` to validate `ref_case` against this set instead of `identifier_cases`.
> 
> **Language definitions and docs/tests are updated accordingly.** Each built-in language now declares `supported_ref_cases` (typically `NON_KEBAB_REF_CASES`, while kebab-friendly languages use `ALL_REF_CASES`), docs clarify the distinction, and integration tests now cover accepting non-idiomatic-but-legal cases (e.g. Python `CAMEL`) and kebab support in kebab-friendly languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22863d5e35e3bc3decd539126a73d7205f789424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->