### PR TITLE
Unpin uv version in setup-uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -54,9 +51,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -317,9 +314,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -370,9 +364,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -546,9 +537,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       # Populate a shared primed project once up front so each parallel
@@ -669,9 +657,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
@@ -728,9 +713,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
@@ -751,9 +733,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
@@ -1191,9 +1170,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install Mojo
@@ -1407,9 +1383,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       - name: Check V syntax

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Pin uv because otherwise setup-uv looks up the latest
-          # version, and that lookup sometimes fails.
-          version: 0.11.7
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 


### PR DESCRIPTION
## Summary
- Remove the `version: 0.11.7` pin (and its 2-line explanatory comment) from every `astral-sh/setup-uv@v7` invocation across `ci.yml`, `lint.yml`, and `release.yml` so workflows install the latest uv.

## Test plan
- [ ] CI passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/lint/release workflows will now install the latest `uv`, which can introduce unexpected breakages if a new `uv` release changes behavior or has a transient issue.
> 
> **Overview**
> Removes the hard-pinned `uv` version (and its explanatory comment) from all `astral-sh/setup-uv@v7` steps in `ci.yml`, `lint.yml`, and `release.yml`, so GitHub Actions always installs the latest available `uv` while keeping caching configuration unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26bb4607dfc726d7f4f0c1dd31da185d875fb6fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->