### PR TITLE
Raise DottedCallStubNotSupportedError for dotted call_transform wrappers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,13 @@ Next
   ``supports_dotted_calls = False`` (currently only ``Hcl``).  The
   capability flag is now enforced rather than declarative.
 
+- :func:`~literalizer.literalize_call` now raises a typed
+  :class:`~literalizer.exceptions.DottedCallStubNotSupportedError`
+  when ``call_transform`` produces a dotted wrapper name (e.g.
+  ``tracer.emit``) but the target language sets
+  ``supports_dotted_call_stub = False``.  The capability flag is now
+  enforced rather than declarative.
+
 - Removed the redundant ``supports_default_set_element_type``,
   ``supports_default_sequence_element_type``,
   ``supports_default_dict_value_type``, ``supports_default_dict_key_type``,

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -809,6 +809,14 @@ class Language(Protocol):
     :class:`~literalizer.exceptions.DottedCallTargetNotSupportedError`.
     """
 
+    supports_dotted_call_stub: bool
+    """Whether the language can declare a stub for a dotted call wrapper
+    name (e.g. ``tracer.emit``) produced by ``call_transform``.  When
+    ``False``, a dotted ``call_transform`` wrapper is rejected by
+    :func:`~literalizer.literalize_call` with
+    :class:`~literalizer.exceptions.DottedCallStubNotSupportedError`.
+    """
+
     supports_variable_names: bool
     """Whether the language supports wrapping output in a named variable
     via the ``variable_form`` argument to

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -49,6 +49,7 @@ from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
+    DottedCallStubNotSupportedError,
     DottedCallTargetNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
@@ -2722,6 +2723,7 @@ def _validate_call_preconditions(
     target_function: str,
     target_function_parts: tuple[str, ...],
     ref_case: IdentifierCase | None,
+    call_transform: Callable[[str], str] | None,
 ) -> None:
     """Raise typed errors for unsupported ``literalize_call`` inputs."""
     if len(target_function_parts) > 1 and not language.supports_dotted_calls:
@@ -2729,6 +2731,15 @@ def _validate_call_preconditions(
             language_name=type(language).__name__,
             target_function=target_function,
         )
+    if call_transform is not None and not language.supports_dotted_call_stub:
+        wrapper = _extract_call_transform_wrapper(
+            call_transform=call_transform,
+        )
+        if "." in wrapper:
+            raise DottedCallStubNotSupportedError(
+                language_name=type(language).__name__,
+                transform_stub_name=wrapper,
+            )
     if ref_case is not None and ref_case not in language.supported_ref_cases:
         raise UnsupportedIdentifierCaseError(
             language_name=type(language).__name__,
@@ -2861,6 +2872,7 @@ def literalize_call(
         target_function=target_function,
         target_function_parts=target_function_parts,
         ref_case=ref_case,
+        call_transform=call_transform,
     )
     target_function = language.format_call_target(target_function_parts)
 

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -208,6 +208,27 @@ class DottedCallTargetNotSupportedError(Exception):
         self.target_function = target_function
 
 
+class DottedCallStubNotSupportedError(Exception):
+    """Raised when ``literalize_call`` is given a ``call_transform``
+    whose wrapper is dotted (e.g. ``tracer.emit``) but the target
+    language does not support dotted call stub names.
+    """
+
+    def __init__(
+        self,
+        *,
+        language_name: str,
+        transform_stub_name: str,
+    ) -> None:
+        """Create a ``DottedCallStubNotSupportedError``."""
+        super().__init__(
+            f"{language_name} does not support dotted call stubs: "
+            f"{transform_stub_name!r}"
+        )
+        self.language_name = language_name
+        self.transform_stub_name = transform_stub_name
+
+
 class VariableNamesNotSupportedError(Exception):
     """Raised when ``literalize`` is given a ``variable_form`` but the
     target language does not support variable-name wrapping.

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -22,6 +22,7 @@ from literalizer._language import StubReturn
 from literalizer._types import Value
 from literalizer.exceptions import (
     CallArgNotSupportedError,
+    DottedCallStubNotSupportedError,
     DottedCallTargetNotSupportedError,
     HeterogeneousCollectionError,
 )
@@ -728,11 +729,6 @@ def _lang_supports_case(
     lang_cls: literalizer.LanguageCls,
 ) -> bool:
     """Return True if *lang_cls* can produce valid output for *config*."""
-    if (
-        any("." in name for name in config.transform_stub_names)
-        and not lang_cls.supports_dotted_call_stub
-    ):
-        return False
     return lang_cls.has_free_function_calls or not any(
         "." not in name for name in config.transform_stub_names
     )
@@ -982,6 +978,9 @@ def _run_call_with_declarations(
     except DottedCallTargetNotSupportedError:
         golden_path.unlink(missing_ok=True)
         pytest.skip(f"{lang_name} does not support dotted call targets")
+    except DottedCallStubNotSupportedError:
+        golden_path.unlink(missing_ok=True)
+        pytest.skip(f"{lang_name} does not support dotted call stubs")
     except CallArgNotSupportedError as exc:
         golden_path.unlink(missing_ok=True)
         pytest.skip(f"{lang_name} rejected call arg: {exc.reason}")

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -16,6 +16,7 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
+    DottedCallStubNotSupportedError,
     DottedCallTargetNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
@@ -319,6 +320,27 @@ def test_literalize_call_dotted_target_supported_language() -> None:
         parameter_names=["a"],
     )
     assert "module.fn(a=1)" in result.code
+
+
+def test_literalize_call_dotted_stub_unsupported_raises() -> None:
+    """Dotted ``call_transform`` wrapper raises for languages without
+    support.
+    """
+    with pytest.raises(
+        expected_exception=DottedCallStubNotSupportedError,
+        match=(
+            r"^Haskell does not support dotted call stubs: "
+            r"'tracer\.emit'$"
+        ),
+    ):
+        literalize_call(
+            source="[[1]]",
+            input_format=InputFormat.JSON,
+            language=Haskell(),
+            target_function="process",
+            parameter_names=["value"],
+            call_transform=lambda c: f"tracer.emit({c})",
+        )
 
 
 def test_literalize_call_arg_ref_parameter_count_still_validated() -> None:


### PR DESCRIPTION
## Summary
- Adds `DottedCallStubNotSupportedError`, raised by `literalize_call` before rendering when `call_transform` produces a dotted wrapper name (e.g. `tracer.emit`) but the language sets `supports_dotted_call_stub = False`.
- Drops the `supports_dotted_call_stub` pre-filter in the integration test setup; case selection now relies on the typed exception.
- Adds focused coverage for one unsupported language (Haskell).

Closes #1936.

## Test plan
- [x] `pytest tests/integration/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new precondition checks in `literalize_call` that can raise a new exception for previously-accepted inputs, potentially breaking callers that use dotted `call_transform` wrappers with languages that can’t stub them.
> 
> **Overview**
> `literalize_call` now enforces a new language capability, rejecting dotted wrapper names produced by `call_transform` (e.g. `tracer.emit(...)`) when the language sets `supports_dotted_call_stub = False`, via a new typed `DottedCallStubNotSupportedError`.
> 
> Integration tests are updated to rely on the typed exception (removing pre-filtering of incompatible languages) and add explicit coverage that `Haskell` raises and is skipped appropriately in golden runs; the changelog documents the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31cae13fa6aac8006df68450477073b558c556dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->