### PR TITLE
Raise FreeFunctionCallNotSupportedError for undotted call_transform wrappers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,13 @@ Next
   ``supports_dotted_call_stub = False``.  The capability flag is now
   enforced rather than declarative.
 
+- :func:`~literalizer.literalize_call` now raises a typed
+  :class:`~literalizer.exceptions.FreeFunctionCallNotSupportedError`
+  when ``call_transform`` produces an undotted wrapper name (e.g.
+  ``emit``) but the target language sets
+  ``has_free_function_calls = False`` (currently only ``Wren``).  The
+  capability flag is now enforced rather than declarative.
+
 - Removed the redundant ``supports_default_set_element_type``,
   ``supports_default_sequence_element_type``,
   ``supports_default_dict_value_type``, ``supports_default_dict_key_type``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,8 +45,8 @@ Next
 
 - :func:`~literalizer.literalize_call` now raises a typed
   :class:`~literalizer.exceptions.FreeFunctionCallNotSupportedError`
-  when ``call_transform`` produces an undotted wrapper name (e.g.
-  ``emit``) but the target language sets
+  when ``call_transform`` produces a bare wrapper name with no dot
+  (e.g. ``emit``) but the target language sets
   ``has_free_function_calls = False`` (currently only ``Wren``).  The
   capability flag is now enforced rather than declarative.
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -819,9 +819,9 @@ class Language(Protocol):
 
     has_free_function_calls: bool
     """Whether the language has a free function call syntax (i.e. the
-    ability to call a function by an undotted name).  When ``False``,
-    a ``call_transform`` whose wrapper is an undotted name is rejected
-    by :func:`~literalizer.literalize_call` with
+    ability to call a function by a bare name with no dot).  When
+    ``False``, a ``call_transform`` whose wrapper is a bare name with
+    no dot is rejected by :func:`~literalizer.literalize_call` with
     :class:`~literalizer.exceptions.FreeFunctionCallNotSupportedError`.
     """
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -817,6 +817,14 @@ class Language(Protocol):
     :class:`~literalizer.exceptions.DottedCallStubNotSupportedError`.
     """
 
+    has_free_function_calls: bool
+    """Whether the language has a free function call syntax (i.e. the
+    ability to call a function by an undotted name).  When ``False``,
+    a ``call_transform`` whose wrapper is an undotted name is rejected
+    by :func:`~literalizer.literalize_call` with
+    :class:`~literalizer.exceptions.FreeFunctionCallNotSupportedError`.
+    """
+
     supports_variable_names: bool
     """Whether the language supports wrapping output in a named variable
     via the ``variable_form`` argument to

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -51,6 +51,7 @@ from literalizer.exceptions import (
     CallsNotSupportedByToolError,
     DottedCallStubNotSupportedError,
     DottedCallTargetNotSupportedError,
+    FreeFunctionCallNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
     UnsupportedIdentifierCaseError,
@@ -2731,12 +2732,24 @@ def _validate_call_preconditions(
             language_name=type(language).__name__,
             target_function=target_function,
         )
-    if call_transform is not None and not language.supports_dotted_call_stub:
+    if call_transform is not None and (
+        not language.supports_dotted_call_stub
+        or not language.has_free_function_calls
+    ):
         wrapper = _extract_call_transform_wrapper(
             call_transform=call_transform,
         )
-        if "." in wrapper:
+        if "." in wrapper and not language.supports_dotted_call_stub:
             raise DottedCallStubNotSupportedError(
+                language_name=type(language).__name__,
+                transform_stub_name=wrapper,
+            )
+        if (
+            wrapper
+            and "." not in wrapper
+            and not language.has_free_function_calls
+        ):
+            raise FreeFunctionCallNotSupportedError(
                 language_name=type(language).__name__,
                 transform_stub_name=wrapper,
             )

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -229,6 +229,27 @@ class DottedCallStubNotSupportedError(Exception):
         self.transform_stub_name = transform_stub_name
 
 
+class FreeFunctionCallNotSupportedError(Exception):
+    """Raised when ``literalize_call`` is given a ``call_transform``
+    whose wrapper is an undotted name (e.g. ``emit``) but the target
+    language has no free function call syntax.
+    """
+
+    def __init__(
+        self,
+        *,
+        language_name: str,
+        transform_stub_name: str,
+    ) -> None:
+        """Create a ``FreeFunctionCallNotSupportedError``."""
+        super().__init__(
+            f"{language_name} has no free function call syntax for "
+            f"call stub: {transform_stub_name!r}"
+        )
+        self.language_name = language_name
+        self.transform_stub_name = transform_stub_name
+
+
 class VariableNamesNotSupportedError(Exception):
     """Raised when ``literalize`` is given a ``variable_form`` but the
     target language does not support variable-name wrapping.

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -231,8 +231,8 @@ class DottedCallStubNotSupportedError(Exception):
 
 class FreeFunctionCallNotSupportedError(Exception):
     """Raised when ``literalize_call`` is given a ``call_transform``
-    whose wrapper is an undotted name (e.g. ``emit``) but the target
-    language has no free function call syntax.
+    whose wrapper is a bare name with no dot (e.g. ``emit``) but the
+    target language has no free function call syntax.
     """
 
     def __init__(

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -24,6 +24,7 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     DottedCallStubNotSupportedError,
     DottedCallTargetNotSupportedError,
+    FreeFunctionCallNotSupportedError,
     HeterogeneousCollectionError,
 )
 
@@ -724,17 +725,6 @@ def case_uses_ref_inside_dict_literal(
 
 
 @beartype
-def _lang_supports_case(
-    config: CallCaseConfig,
-    lang_cls: literalizer.LanguageCls,
-) -> bool:
-    """Return True if *lang_cls* can produce valid output for *config*."""
-    return lang_cls.has_free_function_calls or not any(
-        "." not in name for name in config.transform_stub_names
-    )
-
-
-@beartype
 def _lang_satisfies_config_constraints(
     lang_cls: literalizer.LanguageCls,
     config: CallCaseConfig,
@@ -809,8 +799,6 @@ def discover_call_cases() -> list[CallCase]:
     for config in CALL_CASE_CONFIGS:
         for lang_cls in sorted_languages():
             if len(lang_cls.CallStyles) == 0:
-                continue
-            if not _lang_supports_case(config=config, lang_cls=lang_cls):
                 continue
             if not _lang_satisfies_config_constraints(
                 lang_cls=lang_cls, config=config
@@ -981,6 +969,9 @@ def _run_call_with_declarations(
     except DottedCallStubNotSupportedError:
         golden_path.unlink(missing_ok=True)
         pytest.skip(f"{lang_name} does not support dotted call stubs")
+    except FreeFunctionCallNotSupportedError:
+        golden_path.unlink(missing_ok=True)
+        pytest.skip(f"{lang_name} has no free function call syntax")
     except CallArgNotSupportedError as exc:
         golden_path.unlink(missing_ok=True)
         pytest.skip(f"{lang_name} rejected call arg: {exc.reason}")

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -346,8 +346,8 @@ def test_literalize_call_dotted_stub_unsupported_raises() -> None:
 
 
 def test_literalize_call_free_function_unsupported_raises() -> None:
-    """Undotted ``call_transform`` wrapper raises for languages without
-    free function call syntax.
+    """A bare ``call_transform`` wrapper name with no dot raises for
+    languages without free function call syntax.
     """
     with pytest.raises(
         expected_exception=FreeFunctionCallNotSupportedError,

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -18,6 +18,7 @@ from literalizer.exceptions import (
     CallsNotSupportedByToolError,
     DottedCallStubNotSupportedError,
     DottedCallTargetNotSupportedError,
+    FreeFunctionCallNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
     UnsupportedIdentifierCaseError,
@@ -34,6 +35,7 @@ from literalizer.languages import (
     Python,
     Racket,
     Raku,
+    Wren,
     Yaml,
 )
 
@@ -340,6 +342,27 @@ def test_literalize_call_dotted_stub_unsupported_raises() -> None:
             target_function="process",
             parameter_names=["value"],
             call_transform=lambda c: f"tracer.emit({c})",
+        )
+
+
+def test_literalize_call_free_function_unsupported_raises() -> None:
+    """Undotted ``call_transform`` wrapper raises for languages without
+    free function call syntax.
+    """
+    with pytest.raises(
+        expected_exception=FreeFunctionCallNotSupportedError,
+        match=(
+            r"^Wren has no free function call syntax for call stub: "
+            r"'emit'$"
+        ),
+    ):
+        literalize_call(
+            source="[[1]]",
+            input_format=InputFormat.JSON,
+            language=Wren(),
+            target_function="Throttler.process",
+            parameter_names=["value"],
+            call_transform=lambda c: f"emit({c})",
         )
 
 


### PR DESCRIPTION
## Summary

- Add `has_free_function_calls` capability flag to the `Language` protocol and enforce it in `literalize_call`: an undotted `call_transform` wrapper now raises the new typed `FreeFunctionCallNotSupportedError` for languages (currently only `Wren`) without free function call syntax.
- Replace the ad-hoc `_lang_supports_case` skip in `call_cases.py` with a `pytest.skip` on the new exception, so the capability flag drives both production and golden-test behaviour.

## Test plan

- [x] `test_literalize_call_free_function_unsupported_raises`
- [x] Existing call golden suite still passes (Wren cases skip via the new exception)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `Language` capability (`has_free_function_calls`) and changes `literalize_call` to raise a new typed exception for certain `call_transform` wrappers, which may break existing custom language implementations and call-transform usage (notably for `Wren`).
> 
> **Overview**
> `literalize_call` now enforces whether a target language supports **bare (undotted) wrapper calls** produced by `call_transform` by adding a new `Language`/`LanguageCls` flag, `has_free_function_calls`.
> 
> When a `call_transform` yields a wrapper like `emit(...)` (no dot) and the language sets `has_free_function_calls = False` (currently `Wren`), `literalize_call` now raises the new typed `FreeFunctionCallNotSupportedError` (documented in `CHANGELOG.rst`). Integration tests are updated to expect/skip on this exception instead of pre-filtering cases, and a new regression test asserts the `Wren` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f5d0c7daa1baeb7f09e43e2c7553f153106fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->