### PR TITLE
Raise VariableNameNotSupportedError for unsupported variable forms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Next
 ----
 
 - :func:`~literalizer.literalize` now raises a typed
-  :class:`~literalizer.exceptions.VariableNamesNotSupportedError`
+  :class:`~literalizer.exceptions.VariableNameNotSupportedError`
   when ``variable_form`` is supplied but the target language sets
   ``supports_variable_names = False`` (currently ``Json5``,
   ``Jsonnet``, and ``Yaml``).  The capability flag is now enforced

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -832,7 +832,7 @@ class Language(Protocol):
     :class:`~literalizer.NewVariable`,
     :class:`~literalizer.ExistingVariable`,
     or :class:`~literalizer.BothVariableForms` is rejected with
-    :class:`~literalizer.exceptions.VariableNamesNotSupportedError`.
+    :class:`~literalizer.exceptions.VariableNameNotSupportedError`.
     """
 
     @property

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -55,7 +55,7 @@ from literalizer.exceptions import (
     ParameterCountMismatchError,
     PerElementNotListError,
     UnsupportedIdentifierCaseError,
-    VariableNamesNotSupportedError,
+    VariableNameNotSupportedError,
 )
 
 _DISABLED_REF_KEY = ""
@@ -1954,7 +1954,7 @@ def literalize(
         UnsupportedIdentifierCaseError: If *ref_case* is not in
             :attr:`~literalizer._language.Language.supported_ref_cases`
             for the target language.
-        VariableNamesNotSupportedError: If *variable_form* is supplied
+        VariableNameNotSupportedError: If *variable_form* is supplied
             but the target language sets
             :attr:`~literalizer._language.Language.supports_variable_names`
             to ``False``.
@@ -1965,7 +1965,7 @@ def literalize(
             case_name=ref_case.name,
         )
     if variable_form is not None and not language.supports_variable_names:
-        raise VariableNamesNotSupportedError(
+        raise VariableNameNotSupportedError(
             language_name=type(language).__name__,
             variable_name=variable_form.name,
         )

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -250,13 +250,13 @@ class FreeFunctionCallNotSupportedError(Exception):
         self.transform_stub_name = transform_stub_name
 
 
-class VariableNamesNotSupportedError(Exception):
+class VariableNameNotSupportedError(Exception):
     """Raised when ``literalize`` is given a ``variable_form`` but the
     target language does not support variable-name wrapping.
     """
 
     def __init__(self, *, language_name: str, variable_name: str) -> None:
-        """Create a ``VariableNamesNotSupportedError``."""
+        """Create a ``VariableNameNotSupportedError``."""
         super().__init__(
             f"{language_name} does not support variable names: "
             f"{variable_name!r}"

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -23,6 +23,7 @@ import literalizer
 from literalizer.exceptions import (
     CallArgNotSupportedError,
     HeterogeneousCollectionError,
+    VariableNameNotSupportedError,
 )
 
 from .case_discovery import (
@@ -313,12 +314,23 @@ def run_literalize_ref_golden_case(
     yaml_string = input_path.read_text()
     golden_path = input_path.parent / (golden_name + lang_cls.extension)
     spec = with_per_fixture_module_name(spec=spec, golden_path=golden_path)
+    variable_form_obj: literalizer.NewVariable | None = wrap_variable_form()
+    try:
+        literalizer.literalize(
+            source='{"_": "_"}',
+            input_format=literalizer.InputFormat.JSON,
+            language=spec,
+            variable_form=variable_form_obj,
+            wrap_in_file=True,
+        )
+    except VariableNameNotSupportedError:
+        variable_form_obj = None
     try:
         result = literalizer.literalize(
             source=yaml_string,
             input_format=literalizer.InputFormat.YAML,
             language=spec,
-            variable_form=wrap_variable_form(lang_cls=lang_cls),
+            variable_form=variable_form_obj,
             wrap_in_file=True,
             ref_case=ref_case,
             ref_key=config.ref_key,
@@ -334,7 +346,7 @@ def run_literalize_ref_golden_case(
             f"{lang_cls.__name__} rejected ref identifier: {exc.reason}"
         )
     final_code = result.code
-    if wrap_variable_form(lang_cls=lang_cls) is not None:
+    if variable_form_obj is not None:
         ruamel_yaml = _YAML()
         raw_data: object = ruamel_yaml.load(  # pyright: ignore[reportUnknownMemberType]
             stream=yaml_string,
@@ -359,10 +371,9 @@ def run_literalize_ref_golden_case(
                 wrap_in_file=False,
             )
             stub_entries.append((converted_name, stub.declaration_code))
-        variable_form_obj = wrap_variable_form(lang_cls=lang_cls)
         final_code = _inject_stubs_before_variable(
             code=result.code,
-            variable_name=variable_form_obj.name if variable_form_obj else "",
+            variable_name=variable_form_obj.name,
             stub_entries=stub_entries,
         )
     check_golden(

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -22,7 +22,7 @@ from literalizer.exceptions import (
     ParameterCountMismatchError,
     PerElementNotListError,
     UnsupportedIdentifierCaseError,
-    VariableNamesNotSupportedError,
+    VariableNameNotSupportedError,
 )
 from literalizer.languages import (
     Bash,
@@ -599,7 +599,7 @@ def test_literalize_variable_names_not_supported_raises() -> None:
     support.
     """
     with pytest.raises(
-        expected_exception=VariableNamesNotSupportedError,
+        expected_exception=VariableNameNotSupportedError,
         match=r"^Yaml does not support variable names: 'x'$",
     ):
         literalize(
@@ -609,3 +609,17 @@ def test_literalize_variable_names_not_supported_raises() -> None:
             variable_form=BothVariableForms(name="x"),
             wrap_in_file=True,
         )
+
+
+def test_literalize_variable_names_supported_renders() -> None:
+    """``variable_form`` succeeds for languages with variable-name
+    support.
+    """
+    result = literalize(
+        source="42",
+        input_format=InputFormat.JSON,
+        language=Python(),
+        variable_form=BothVariableForms(name="x"),
+        wrap_in_file=True,
+    )
+    assert "x = 42" in result.code

--- a/tests/integration/test_literalize_golden.py
+++ b/tests/integration/test_literalize_golden.py
@@ -18,6 +18,7 @@ from literalizer.exceptions import (
     IncompatibleFormatsError,
     NullInCollectionError,
     UnrepresentableIntegerError,
+    VariableNameNotSupportedError,
 )
 
 from .case_discovery import (
@@ -75,7 +76,17 @@ def test_golden_file(
                     language=spec,
                     pre_indent_level=0,
                     include_delimiters=True,
-                    variable_form=wrap_variable_form(lang_cls=lang_cls),
+                    variable_form=wrap_variable_form(),
+                    wrap_in_file=True,
+                )
+            except VariableNameNotSupportedError:
+                result = literalizer.literalize(
+                    source=yaml_string,
+                    input_format=literalizer.InputFormat.YAML,
+                    language=spec,
+                    pre_indent_level=0,
+                    include_delimiters=True,
+                    variable_form=None,
                     wrap_in_file=True,
                 )
             except UnrepresentableIntegerError:
@@ -213,6 +224,17 @@ def test_format_variant_golden_file(
                     pre_indent_level=0,
                     include_delimiters=True,
                     variable_form=variant_case.variable_form,
+                    wrap_in_file=True,
+                    collection_layout=variant.collection_layout,
+                )
+            except VariableNameNotSupportedError:
+                result = literalizer.literalize(
+                    source=yaml_string,
+                    input_format=literalizer.InputFormat.YAML,
+                    language=spec,
+                    pre_indent_level=0,
+                    include_delimiters=True,
+                    variable_form=None,
                     wrap_in_file=True,
                     collection_layout=variant.collection_layout,
                 )

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -49,22 +49,16 @@ _CASES_DIR = Path(__file__).parent / "cases"
 
 
 @beartype
-def _wrap_variable_name(lang_cls: literalizer.LanguageCls) -> str | None:
-    """Return the wrap variable name for a language class."""
-    return "my_data" if lang_cls.supports_variable_names else None
+def wrap_variable_form() -> literalizer.NewVariable:
+    """Return the canonical :class:`NewVariable` form used by the
+    variable-form integration tests.
 
-
-@beartype
-def wrap_variable_form(
-    lang_cls: literalizer.LanguageCls,
-) -> literalizer.NewVariable | None:
-    """Return a :class:`NewVariable` form for a language class, or
-    None.
+    Callers that pass the result to ``literalize`` should treat
+    :class:`~literalizer.exceptions.VariableNameNotSupportedError` as
+    the signal that the language cannot wrap output in a named
+    variable, rather than pre-filtering on ``supports_variable_names``.
     """
-    name = _wrap_variable_name(lang_cls=lang_cls)
-    if name is None:
-        return None
-    return literalizer.NewVariable(name=name)
+    return literalizer.NewVariable(name="my_data")
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +267,7 @@ class VariantCase:
     variant_name: str
     variant: Variant
     case_dir_name: str
-    variable_form: literalizer.NewVariable | None
+    variable_form: literalizer.NewVariable
 
 
 @beartype
@@ -1406,9 +1400,7 @@ def build_variant_cases() -> list[VariantCase]:
                     variant_name=f"{variant.name}{ci.suffix}",
                     variant=variant,
                     case_dir_name=ci.case_dir_name,
-                    variable_form=wrap_variable_form(
-                        lang_cls=variant.lang_cls
-                    ),
+                    variable_form=wrap_variable_form(),
                 )
                 for ci in inputs
                 if not (


### PR DESCRIPTION
Closes #1914.

## Summary

- Rename `VariableNamesNotSupportedError` to `VariableNameNotSupportedError` (singular) in `src/literalizer/exceptions.py` and all references.
- Drop the `supports_variable_names` pre-filter in the variable-form integration test setup. `wrap_variable_form()` now always returns a `NewVariable`; callers attempt named output and treat `VariableNameNotSupportedError` as the unsupported signal.
- Add a focused supported-language render test alongside the existing unsupported-language raise test.

## Test plan

- [x] `uv run pytest tests/`
- [x] `uv run prek run --files <touched files>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this renames a public exception type and updates call sites/tests, which can break downstream imports or exception handling despite no behavioral change beyond error naming.
> 
> **Overview**
> Renames the `literalize` variable-wrapping unsupported error from `VariableNamesNotSupportedError` to `VariableNameNotSupportedError` and updates references/docs accordingly.
> 
> Integration tests were adjusted to stop pre-filtering on `supports_variable_names`; they now always attempt a `NewVariable` wrapper and treat `VariableNameNotSupportedError` as the runtime signal to fall back to unwrapped output. Adds a small integration assertion that a supported language (Python) successfully renders `variable_form` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40b29844e139ccb4c148e83cdd4b91d4de95db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->