### PR TITLE
Discover ref-declaration variable support via typed exception

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -26,6 +26,7 @@ from literalizer.exceptions import (
     DottedCallTargetNotSupportedError,
     FreeFunctionCallNotSupportedError,
     HeterogeneousCollectionError,
+    VariableNameNotSupportedError,
 )
 
 from .check_golden import check_golden
@@ -885,28 +886,6 @@ def _check_call_result_includes_ref_declaration_types(
     )
 
 
-@beartype
-def _skip_if_ref_declarations_unsupported(
-    *,
-    config: CallCaseConfig,
-    spec: literalizer.Language,
-    golden_path: Path,
-) -> None:
-    """Skip the test when the language cannot wrap ref declarations in
-    a named variable.
-    """
-    if not config.ref_declarations:
-        return
-    lang_cls = cast("literalizer.LanguageCls", type(spec))
-    if lang_cls.supports_variable_names:
-        return
-    golden_path.unlink(missing_ok=True)
-    pytest.skip(
-        f"{lang_cls.__name__} does not support variable-name wrapping "
-        f"for ref declarations",
-    )
-
-
 @dataclasses.dataclass(frozen=True)
 class _CallWithDeclarations:
     """Result of literalizing ref declarations and a call together."""
@@ -957,6 +936,12 @@ def _run_call_with_declarations(
             ref_case=effective_ref_case,
             consumable_refs=config.consumable_refs,
             ref_values=ref_values or None,
+        )
+    except VariableNameNotSupportedError:
+        golden_path.unlink(missing_ok=True)
+        pytest.skip(
+            f"{lang_name} does not support variable-name wrapping "
+            f"for ref declarations",
         )
     except HeterogeneousCollectionError:
         golden_path.unlink(missing_ok=True)
@@ -1027,9 +1012,6 @@ def run_call_golden_case(
             file_regression=file_regression,
         )
         return
-    _skip_if_ref_declarations_unsupported(
-        config=config, spec=spec, golden_path=golden_path
-    )
     call_outcome = _run_call_with_declarations(
         config=config,
         spec=spec,


### PR DESCRIPTION
## Summary
Closes #1916. Replaces the `supports_variable_names` pre-check in the `literalize_call` ref-declaration golden runner with a `try/except VariableNameNotSupportedError` branch in `_run_call_with_declarations`, removing the now-unused `_skip_if_ref_declarations_unsupported` helper. This is the last `supports_*` flag in integration test selection covered by a #1909-#1915 typed exception; remaining `supports_*` flags describe language capabilities not in scope.

## Test plan
- [x] `pytest tests/integration` (2588 passed, 680 skipped, 16924 subtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test harness change only, switching from a capability flag pre-check to a typed exception-based skip for languages that can’t wrap ref declarations in variable names.
> 
> **Overview**
> Refactors the `literalize_call` golden runner to **skip ref-declaration cases by catching `VariableNameNotSupportedError`** from `_run_call_with_declarations`, deleting the prior `supports_variable_names` pre-check helper and centralizing the skip/unlink behavior with the other typed “unsupported” exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e353d1e192826ba2cccfe7d470e15472c47d2f48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->