### PR TITLE
Raise UnsupportedCallShapeError for zero-parameter calls

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1293,6 +1293,16 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def supports_zero_parameter_calls(self) -> bool:
+        """Whether the language can render a function call with no
+        parameters.  When ``False``,
+        :func:`~literalizer.literalize_call` rejects empty
+        ``parameter_names`` with
+        :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def supports_standalone_comments_in_wrapped_calls(self) -> bool:
         """Whether manually wrapped call output can contain standalone
         comment lines between call statements.

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -54,6 +54,7 @@ from literalizer.exceptions import (
     FreeFunctionCallNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
+    UnsupportedCallShapeError,
     UnsupportedIdentifierCaseError,
     VariableNameNotSupportedError,
 )
@@ -2723,10 +2724,21 @@ def _validate_call_preconditions(
     language: Language,
     target_function: str,
     target_function_parts: tuple[str, ...],
+    parameter_names: Sequence[str],
     ref_case: IdentifierCase | None,
     call_transform: Callable[[str], str] | None,
 ) -> None:
     """Raise typed errors for unsupported ``literalize_call`` inputs."""
+    if (
+        len(parameter_names) == 0
+        and not language.supports_zero_parameter_calls
+    ):
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                "zero-parameter calls have no representation in this language"
+            ),
+        )
     if len(target_function_parts) > 1 and not language.supports_dotted_calls:
         raise DottedCallTargetNotSupportedError(
             language_name=type(language).__name__,
@@ -2884,6 +2896,7 @@ def literalize_call(
         language=language,
         target_function=target_function,
         target_function_parts=target_function_parts,
+        parameter_names=parameter_names,
         ref_case=ref_case,
         call_transform=call_transform,
     )

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -265,6 +265,25 @@ class VariableNameNotSupportedError(Exception):
         self.variable_name = variable_name
 
 
+class UnsupportedCallShapeError(Exception):
+    """Raised when ``literalize_call`` is given a call shape the target
+    language cannot represent.
+
+    Distinct from :class:`CallArgNotSupportedError` (which concerns
+    individual argument values): this covers structural properties of
+    the call itself, e.g. zero-parameter calls in languages whose
+    syntax requires at least one operand.
+    """
+
+    def __init__(self, *, language_name: str, reason: str) -> None:
+        """Create an ``UnsupportedCallShapeError``."""
+        super().__init__(
+            f"{language_name} cannot represent this call shape: {reason}"
+        )
+        self.language_name = language_name
+        self.reason = reason
+
+
 class WrapCombinedInFileNotSupportedError(Exception):
     """Raised when a language does not support ``wrap_combined_in_file``.
 

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -27,6 +27,7 @@ from literalizer.exceptions import (
     DottedCallTargetNotSupportedError,
     FreeFunctionCallNotSupportedError,
     HeterogeneousCollectionError,
+    UnsupportedCallShapeError,
     VariableNameNotSupportedError,
 )
 
@@ -611,6 +612,24 @@ class CallCase:
 
     config: CallCaseConfig
     lang_cls: literalizer.LanguageCls
+    expected_exception: type[Exception] | None = None
+
+
+@beartype
+def _expected_call_shape_exception(
+    *,
+    lang_cls: literalizer.LanguageCls,
+    config: CallCaseConfig,
+) -> type[Exception] | None:
+    """Return the exception ``literalize_call`` is expected to raise for
+    this (lang, config) pair, or ``None`` if it should produce output.
+    """
+    if (
+        len(config.parameter_names) == 0
+        and not lang_cls.supports_zero_parameter_calls
+    ):
+        return UnsupportedCallShapeError
+    return None
 
 
 CALL_CASES_DIR = Path(__file__).parent / "cases"
@@ -714,11 +733,6 @@ def _lang_satisfies_call_shape_constraints(
     shape.
     """
     if (
-        len(config.parameter_names) == 0
-        and not lang_cls.supports_zero_parameter_calls
-    ):
-        return False
-    if (
         config.requires_inline_multiline_dict_args
         and not lang_cls.supports_inline_multiline_dict_args
     ):
@@ -769,7 +783,17 @@ def discover_call_cases() -> list[CallCase]:
                 default_style = styles[0]
                 if isinstance(default_style.value, config.call_style_type):
                     continue
-            cases.append(CallCase(config=config, lang_cls=lang_cls))
+            expected_exception = _expected_call_shape_exception(
+                lang_cls=lang_cls,
+                config=config,
+            )
+            cases.append(
+                CallCase(
+                    config=config,
+                    lang_cls=lang_cls,
+                    expected_exception=expected_exception,
+                )
+            )
     return cases
 
 

--- a/tests/integration/test_calls.py
+++ b/tests/integration/test_calls.py
@@ -45,6 +45,16 @@ def test_call_golden_file(
         )
         kwargs["call_style"] = style
     spec = make_spec(lang_cls=lang_cls, **kwargs)
+    if call_case.expected_exception is not None:
+        with pytest.raises(expected_exception=call_case.expected_exception):
+            run_call_golden_case(
+                config=config,
+                spec=spec,
+                golden_name=f"{lang_cls.__name__}_call",
+                cases_dir=cases_dir,
+                file_regression=file_regression,
+            )
+        return
     run_call_golden_case(
         config=config,
         spec=spec,

--- a/tests/integration/test_orphan_golden_files.py
+++ b/tests/integration/test_orphan_golden_files.py
@@ -89,6 +89,8 @@ def _expected_golden_files(cases_dir: Path) -> set[Path]:
     expected.update(_expected_variant_golden_files(cases_dir=cases_dir))
 
     for call_case in discover_call_cases():
+        if call_case.expected_exception is not None:
+            continue
         ext = call_case.lang_cls.extension
         golden_name = f"{call_case.lang_cls.__name__}_call"
         expected.add(


### PR DESCRIPTION
Closes #1954.

## Summary

- Adds `UnsupportedCallShapeError` and raises it from `literalize_call` when `parameter_names` is empty for a language with `supports_zero_parameter_calls=False` (Cobol, Dhall, Elm), instead of silently emitting invalid syntax.
- Lifts the constraint out of the test-discovery filter in `tests/integration/call_cases.py`; `CallCase` gains an `expected_exception` field and the integration test asserts the raise via `pytest.raises`.
- First slice of #1952 — the same pattern can be extended to the remaining call-shape flags incrementally (#1955, #1956 remain open).

## Test plan

- [x] `uv run pytest tests/integration/test_calls.py tests/integration/test_orphan_golden_files.py` — 1605 passed, 127 skipped.
- [x] Verified Cobol/Dhall/Elm × `call_no_params` (and Dhall/Elm × `call_no_params_transform`) now appear in the parametrization and pass via `pytest.raises`.