### PR TITLE
Raise UnsupportedCallShapeError for multi-key dict call args

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1303,6 +1303,16 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def supports_inline_multiline_dict_args(self) -> bool:
+        """Whether the language can render a call argument as an inline
+        dict literal that spans multiple lines.  When ``False``,
+        :func:`~literalizer.literalize_call` rejects inputs that would
+        produce a multi-key dict argument with
+        :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def supports_standalone_comments_in_wrapped_calls(self) -> bool:
         """Whether manually wrapped call output can contain standalone
         comment lines between call statements.

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2719,12 +2719,47 @@ def _render_call_whole(
 
 
 @beartype
+def _has_inline_multiline_dict_arg(
+    *,
+    data: Value,
+    per_element: bool,
+    ref_key: str,
+) -> bool:
+    """Return ``True`` when *data* would render at least one call
+    argument as a dict literal with two or more entries.
+    """
+    if per_element:
+        if not isinstance(data, list):
+            return False
+        return any(
+            _value_is_multikey_non_ref_dict(value=element, ref_key=ref_key)
+            for element in data
+        )
+    return _value_is_multikey_non_ref_dict(value=data, ref_key=ref_key)
+
+
+@beartype
+def _value_is_multikey_non_ref_dict(*, value: Value, ref_key: str) -> bool:
+    """Return ``True`` if *value* is a dict with multiple keys that is
+    not a single-key ``$ref`` marker.
+    """
+    if not isinstance(value, dict):
+        return False
+    if len(value) == 1 and isinstance(value.get(ref_key), str):
+        return False
+    return len(value) > 1
+
+
+@beartype
 def _validate_call_preconditions(
     *,
     language: Language,
     target_function: str,
     target_function_parts: tuple[str, ...],
     parameter_names: Sequence[str],
+    data: Value,
+    per_element: bool,
+    ref_key: str,
     ref_case: IdentifierCase | None,
     call_transform: Callable[[str], str] | None,
 ) -> None:
@@ -2737,6 +2772,19 @@ def _validate_call_preconditions(
             language_name=type(language).__name__,
             reason=(
                 "zero-parameter calls have no representation in this language"
+            ),
+        )
+    if (
+        not language.supports_inline_multiline_dict_args
+        and _has_inline_multiline_dict_arg(
+            data=data, per_element=per_element, ref_key=ref_key
+        )
+    ):
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                "multi-key dict call arguments have no inline multiline "
+                "representation in this language"
             ),
         )
     if len(target_function_parts) > 1 and not language.supports_dotted_calls:
@@ -2897,6 +2945,9 @@ def literalize_call(
         target_function=target_function,
         target_function_parts=target_function_parts,
         parameter_names=parameter_names,
+        data=data,
+        per_element=per_element,
+        ref_key=ref_key,
         ref_case=ref_case,
         call_transform=call_transform,
     )

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2182,7 +2182,7 @@ def _compute_call_arg_ref_single_use_names(
 def _strip_call_arg_refs_for_preamble(
     *,
     data: Value,
-    per_element: bool,
+    per_element_data: list[Value] | None,
     ref_key: str,
     ref_values: Mapping[str, Value],
 ) -> Value:
@@ -2212,11 +2212,9 @@ def _strip_call_arg_refs_for_preamble(
             ref_key=ref_key,
         )
         return resolved.value if resolved.include else []
-    if per_element:
-        if not isinstance(data, list):
-            return data
+    if per_element_data is not None:
         result: list[Value] = []
-        for element in data:
+        for element in per_element_data:
             if isinstance(element, list):
                 result.append(
                     [
@@ -2721,21 +2719,16 @@ def _render_call_whole(
 @beartype
 def _has_inline_multiline_dict_arg(
     *,
-    data: Value,
-    per_element: bool,
+    arg_values: Sequence[Value],
     ref_key: str,
 ) -> bool:
-    """Return ``True`` when *data* would render at least one call
-    argument as a dict literal with two or more entries.
+    """Return ``True`` when *arg_values* contains a dict with two or
+    more entries that is not a ``$ref`` marker.
     """
-    if per_element:
-        if not isinstance(data, list):
-            return False
-        return any(
-            _value_is_multikey_non_ref_dict(value=element, ref_key=ref_key)
-            for element in data
-        )
-    return _value_is_multikey_non_ref_dict(value=data, ref_key=ref_key)
+    return any(
+        _value_is_multikey_non_ref_dict(value=value, ref_key=ref_key)
+        for value in arg_values
+    )
 
 
 @beartype
@@ -2757,8 +2750,7 @@ def _validate_call_preconditions(
     target_function: str,
     target_function_parts: tuple[str, ...],
     parameter_names: Sequence[str],
-    data: Value,
-    per_element: bool,
+    arg_values: Sequence[Value],
     ref_key: str,
     ref_case: IdentifierCase | None,
     call_transform: Callable[[str], str] | None,
@@ -2777,7 +2769,7 @@ def _validate_call_preconditions(
     if (
         not language.supports_inline_multiline_dict_args
         and _has_inline_multiline_dict_arg(
-            data=data, per_element=per_element, ref_key=ref_key
+            arg_values=arg_values, ref_key=ref_key
         )
     ):
         raise UnsupportedCallShapeError(
@@ -2939,14 +2931,26 @@ def literalize_call(
         case _ as style:
             pass
 
+    per_element_data: list[Value] | None = None
+    if per_element:
+        if not isinstance(data, list):
+            msg = (
+                "per_element=True requires a top-level list, "
+                f"got {type(data).__name__}"
+            )
+            raise PerElementNotListError(msg)
+        per_element_data = data
+    arg_values: Sequence[Value] = (
+        per_element_data if per_element_data is not None else [data]
+    )
+
     target_function_parts = tuple(target_function.split(sep="."))
     _validate_call_preconditions(
         language=language,
         target_function=target_function,
         target_function_parts=target_function_parts,
         parameter_names=parameter_names,
-        data=data,
-        per_element=per_element,
+        arg_values=arg_values,
         ref_key=ref_key,
         ref_case=ref_case,
         call_transform=call_transform,
@@ -2955,18 +2959,12 @@ def literalize_call(
 
     data_for_preamble = _strip_call_arg_refs_for_preamble(
         data=data,
-        per_element=per_element,
+        per_element_data=per_element_data,
         ref_key=ref_key,
         ref_values=ref_values or {},
     )
 
-    if per_element:
-        if not isinstance(data, list):
-            msg = (
-                "per_element=True requires a top-level list, "
-                f"got {type(data).__name__}"
-            )
-            raise PerElementNotListError(msg)
+    if per_element_data is not None:
         collection_comments: CollectionComments | None = None
         if (
             input_format is InputFormat.YAML
@@ -2977,7 +2975,7 @@ def literalize_call(
                 ruamel_data=parsed.raw_data,
             )
         result = _render_call_per_element(
-            data=data,
+            data=per_element_data,
             language=language,
             style=style,
             target_function=target_function,

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -629,6 +629,11 @@ def _expected_call_shape_exception(
         and not lang_cls.supports_zero_parameter_calls
     ):
         return UnsupportedCallShapeError
+    if (
+        config.requires_inline_multiline_dict_args
+        and not lang_cls.supports_inline_multiline_dict_args
+    ):
+        return UnsupportedCallShapeError
     return None
 
 
@@ -733,11 +738,6 @@ def _lang_satisfies_call_shape_constraints(
     shape.
     """
     if (
-        config.requires_inline_multiline_dict_args
-        and not lang_cls.supports_inline_multiline_dict_args
-    ):
-        return False
-    if (
         case_uses_ref_inside_dict_literal(
             case_dir_name=config.case_dir_name,
             ref_key="$ref",
@@ -752,6 +752,7 @@ def _lang_satisfies_call_shape_constraints(
         return False
     return not (
         config.case_dir_name in _CASES_REQUIRING_COMMENTED_DICT_CALL_ARGS
+        and lang_cls.supports_inline_multiline_dict_args
         and not lang_cls.supports_commented_dict_call_args
     )
 

--- a/tests/test_class_enum_access.py
+++ b/tests/test_class_enum_access.py
@@ -33,3 +33,4 @@ def test_format_enums_populated(*, language_cls: LanguageCls) -> None:
     assert len(language_cls.CallStyles) >= 0
     assert len(language_cls.identifier_cases) >= 1
     assert isinstance(language_cls.supports_zero_parameter_calls, bool)
+    assert isinstance(language_cls.supports_inline_multiline_dict_args, bool)


### PR DESCRIPTION
Closes #1955.

Moves the `supports_inline_multiline_dict_args` constraint from a test-discovery filter into a render-time guard in `literalize_call`: Cobol now raises `UnsupportedCallShapeError` when an input would render a multi-key dict argument (per-element list element or per_element=False top-level), instead of silently emitting invalid syntax. The integration tests assert the raise via `expected_exception`, and the `supports_commented_dict_call_args` filter is tightened so Mojo/Dhall stay filtered out (they remain out of scope per the parent issue).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `literalize_call` validation to raise earlier for certain inputs based on language capabilities; this can turn previously generated (but invalid) output into an exception, affecting callers relying on the old behavior.
> 
> **Overview**
> `literalize_call` now enforces a new render-time precondition: if a language sets `supports_inline_multiline_dict_args=False`, passing a multi-key dict as a call argument (either as the whole argument when `per_element=False` or within any per-element row) raises `UnsupportedCallShapeError` instead of emitting invalid syntax.
> 
> This adds the `supports_inline_multiline_dict_args` capability to the `Language` protocol, introduces helpers to detect multi-key non-`$ref` dict arguments, refactors preamble ref-stripping to use `per_element_data` instead of a boolean, and updates integration/unit tests to assert the new exception behavior while tightening one test-case filter around commented dict args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057a88684351afc4f1d84c52356479e0ae4c8dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->