### PR TITLE
Guard wrap path for standalone comments in unsupported languages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Changelog
 Next
 ----
 
+- :func:`~literalizer.literalize_call` now raises a typed
+  :class:`~literalizer.exceptions.UnsupportedCallShapeError`
+  when ``wrap_in_file=True`` and the YAML source carries standalone
+  comments but the target language sets
+  ``supports_standalone_comments_in_wrapped_calls = False`` (currently
+  ``Elm``, ``Erlang``, ``Haskell``, ``Jsonnet``, ``PureScript``, and
+  ``Roc``).  :class:`~literalizer.LiteralizeResult` now exposes
+  :attr:`~literalizer.LiteralizeResult.contains_standalone_comments`
+  so callers that wrap manually via
+  :meth:`~literalizer.Language.wrap_calls_with_declarations` can apply
+  the same guard.
+
 - :func:`~literalizer.literalize` now raises a typed
   :class:`~literalizer.exceptions.VariableNameNotSupportedError`
   when ``variable_form`` is supplied but the target language sets

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2777,6 +2777,30 @@ def _yaml_has_standalone_comments(
 
 
 @beartype
+def _validate_wrap_in_file_supports_standalone_comments(
+    *,
+    language: Language,
+    wrap_in_file: bool,
+    contains_standalone_comments: bool,
+) -> None:
+    """Raise when wrapping calls would drop required standalone
+    comments.
+    """
+    if (
+        wrap_in_file
+        and contains_standalone_comments
+        and not language.supports_standalone_comments_in_wrapped_calls
+    ):
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                "standalone comments cannot be preserved when wrapping "
+                "calls in this language"
+            ),
+        )
+
+
+@beartype
 def _validate_call_preconditions(
     *,
     language: Language,
@@ -2992,18 +3016,11 @@ def literalize_call(
         ref_case=ref_case,
         call_transform=call_transform,
     )
-    if (
-        wrap_in_file
-        and contains_standalone_comments
-        and not language.supports_standalone_comments_in_wrapped_calls
-    ):
-        raise UnsupportedCallShapeError(
-            language_name=type(language).__name__,
-            reason=(
-                "standalone comments cannot be preserved when wrapping "
-                "calls in this language"
-            ),
-        )
+    _validate_wrap_in_file_supports_standalone_comments(
+        language=language,
+        wrap_in_file=wrap_in_file,
+        contains_standalone_comments=contains_standalone_comments,
+    )
     target_function = language.format_call_target(target_function_parts)
 
     data_for_preamble = _strip_call_arg_refs_for_preamble(

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2755,19 +2755,16 @@ def _value_is_multikey_non_ref_dict(*, value: Value, ref_key: str) -> bool:
 
 
 @beartype
-def _yaml_has_standalone_comments(
-    *,
-    raw_data: object,
-    yaml_needs_comment_resolve: bool,
-) -> bool:
+def _yaml_has_standalone_comments(*, raw_data: object) -> bool:
     """Return ``True`` when the YAML source carries standalone comments.
 
     Standalone comments are comments that appear on their own line —
     either before a top-level element or after the last element.  Inline
     comments (those that follow a value on the same line) do not count.
+    Returns ``False`` for non-YAML input or for YAML that parses to a
+    scalar; ``ruamel.yaml`` only attaches collection-comment metadata
+    to :class:`CommentedSeq` / :class:`CommentedMap` / :class:`CommentedSet`.
     """
-    if not yaml_needs_comment_resolve:
-        return False
     if not isinstance(raw_data, CommentedSeq | CommentedMap | CommentedSet):
         return False
     collection_comments = extract_yaml_comments(ruamel_data=raw_data)
@@ -2978,7 +2975,6 @@ def literalize_call(
     data = parsed.data
     contains_standalone_comments = _yaml_has_standalone_comments(
         raw_data=parsed.raw_data,
-        yaml_needs_comment_resolve=parsed.yaml_needs_comment_resolve,
     )
     match language.call_style_config:
         case CallSupport.NOT_IN_LANGUAGE:

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import assert_never
 
 from beartype import BeartypeConf, beartype
-from ruamel.yaml.comments import CommentedSeq
+from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 from ruamel.yaml.compat import ordereddict
 
 from literalizer._checks import check_data
@@ -106,6 +106,17 @@ class LiteralizeResult:
     these and re-invoke :attr:`Language.compute_body_preamble` to
     derive a single body preamble that covers every type referenced
     across the combined output.
+    """
+
+    contains_standalone_comments: bool = False
+    """Whether the rendered source carried standalone comments (lines
+    whose only content is a comment, distinct from inline trailing
+    comments).  Set when ``literalize_call`` parses YAML input that
+    contains top-level before-element or trailing comments.  Callers
+    that wrap the result via :meth:`Language.wrap_calls_with_declarations`
+    can consult this together with
+    :attr:`Language.supports_standalone_comments_in_wrapped_calls`
+    to decide whether wrapping is safe.
     """
 
     source_data: Value = None
@@ -2744,6 +2755,28 @@ def _value_is_multikey_non_ref_dict(*, value: Value, ref_key: str) -> bool:
 
 
 @beartype
+def _yaml_has_standalone_comments(
+    *,
+    raw_data: object,
+    yaml_needs_comment_resolve: bool,
+) -> bool:
+    """Return ``True`` when the YAML source carries standalone comments.
+
+    Standalone comments are comments that appear on their own line —
+    either before a top-level element or after the last element.  Inline
+    comments (those that follow a value on the same line) do not count.
+    """
+    if not yaml_needs_comment_resolve:
+        return False
+    if not isinstance(raw_data, CommentedSeq | CommentedMap | CommentedSet):
+        return False
+    collection_comments = extract_yaml_comments(ruamel_data=raw_data)
+    if collection_comments.trailing:
+        return True
+    return any(element.before for element in collection_comments.elements)
+
+
+@beartype
 def _validate_call_preconditions(
     *,
     language: Language,
@@ -2919,6 +2952,10 @@ def literalize_call(
     """
     parsed = parse_input(source=source, input_format=input_format)
     data = parsed.data
+    contains_standalone_comments = _yaml_has_standalone_comments(
+        raw_data=parsed.raw_data,
+        yaml_needs_comment_resolve=parsed.yaml_needs_comment_resolve,
+    )
     match language.call_style_config:
         case CallSupport.NOT_IN_LANGUAGE:
             raise CallsNotSupportedByLanguageError(
@@ -2955,6 +2992,18 @@ def literalize_call(
         ref_case=ref_case,
         call_transform=call_transform,
     )
+    if (
+        wrap_in_file
+        and contains_standalone_comments
+        and not language.supports_standalone_comments_in_wrapped_calls
+    ):
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                "standalone comments cannot be preserved when wrapping "
+                "calls in this language"
+            ),
+        )
     target_function = language.format_call_target(target_function_parts)
 
     data_for_preamble = _strip_call_arg_refs_for_preamble(
@@ -3042,6 +3091,7 @@ def literalize_call(
             preamble=(),
             body_preamble=(),
             types_present=computed.types_present,
+            contains_standalone_comments=contains_standalone_comments,
             source_data=data_for_preamble,
         )
 
@@ -3050,5 +3100,6 @@ def literalize_call(
         preamble=preamble,
         body_preamble=computed.body,
         types_present=computed.types_present,
+        contains_standalone_comments=contains_standalone_comments,
         source_data=data_for_preamble,
     )

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -634,6 +634,11 @@ def _expected_call_shape_exception(
         and not lang_cls.supports_inline_multiline_dict_args
     ):
         return UnsupportedCallShapeError
+    if (
+        config.case_dir_name in _CASES_REQUIRING_STANDALONE_WRAPPED_COMMENTS
+        and not lang_cls.supports_standalone_comments_in_wrapped_calls
+    ):
+        return UnsupportedCallShapeError
     return None
 
 
@@ -743,11 +748,6 @@ def _lang_satisfies_call_shape_constraints(
             ref_key="$ref",
         )
         and not lang_cls.supports_call_refs_in_dict_literals
-    ):
-        return False
-    if (
-        config.case_dir_name in _CASES_REQUIRING_STANDALONE_WRAPPED_COMMENTS
-        and not lang_cls.supports_standalone_comments_in_wrapped_calls
     ):
         return False
     return not (
@@ -1064,6 +1064,17 @@ def run_call_golden_case(
         union_types, combined_source_data
     )
     call_body_preamble = unified_body_preamble + tuple(body_stubs)
+    if (
+        result.contains_standalone_comments
+        and not spec.supports_standalone_comments_in_wrapped_calls
+    ):
+        raise UnsupportedCallShapeError(
+            language_name=lang_cls.__name__,
+            reason=(
+                "standalone comments cannot be preserved when wrapping "
+                "calls in this language"
+            ),
+        )
     declarations_bare_codes = tuple(d.bare_code for d in decl_results)
     wrapped = spec.wrap_calls_with_declarations(
         declarations=declarations_bare_codes,

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -21,6 +21,7 @@ from literalizer.exceptions import (
     FreeFunctionCallNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
+    UnsupportedCallShapeError,
     UnsupportedIdentifierCaseError,
     VariableNameNotSupportedError,
 )
@@ -379,6 +380,44 @@ def test_literalize_call_arg_ref_parameter_count_still_validated() -> None:
             target_function="f",
             parameter_names=["only"],
         )
+
+
+def test_literalize_call_wrap_in_file_standalone_comments_raises() -> None:
+    """``wrap_in_file=True`` rejects standalone comments when the target
+    language cannot represent them in wrapped output.
+    """
+    source = "# header\n- 1\n- 2\n"
+    with pytest.raises(
+        expected_exception=UnsupportedCallShapeError,
+        match=(
+            r"^Haskell cannot represent this call shape: standalone "
+            r"comments cannot be preserved when wrapping calls in this "
+            r"language$"
+        ),
+    ):
+        literalize_call(
+            source=source,
+            input_format=InputFormat.YAML,
+            language=Haskell(),
+            target_function="process",
+            parameter_names=["value"],
+            wrap_in_file=True,
+        )
+
+
+def test_literalize_call_yaml_scalar_with_comment_no_standalone() -> None:
+    """A scalar YAML source with only an inline comment has no
+    standalone comments and ``literalize_call`` proceeds normally.
+    """
+    result = literalize_call(
+        source="42  # inline\n",
+        input_format=InputFormat.YAML,
+        language=Python(),
+        target_function="process",
+        parameter_names=["value"],
+        per_element=False,
+    )
+    assert result.contains_standalone_comments is False
 
 
 def test_literalize_call_ref_case_unsupported_raises() -> None:

--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -405,21 +405,6 @@ def test_literalize_call_wrap_in_file_standalone_comments_raises() -> None:
         )
 
 
-def test_literalize_call_yaml_scalar_with_comment_no_standalone() -> None:
-    """A scalar YAML source with only an inline comment has no
-    standalone comments and ``literalize_call`` proceeds normally.
-    """
-    result = literalize_call(
-        source="42  # inline\n",
-        input_format=InputFormat.YAML,
-        language=Python(),
-        target_function="process",
-        parameter_names=["value"],
-        per_element=False,
-    )
-    assert result.contains_standalone_comments is False
-
-
 def test_literalize_call_ref_case_unsupported_raises() -> None:
     """``ref_case`` outside the language's ``supported_ref_cases``
     raises.


### PR DESCRIPTION
## Summary
- Closes #1963. Adds standalone-comment detection during ``literalize_call`` YAML parsing and surfaces it on ``LiteralizeResult.contains_standalone_comments``.
- ``literalize_call(wrap_in_file=True)`` now raises ``UnsupportedCallShapeError`` when standalone comments appear and ``language.supports_standalone_comments_in_wrapped_calls`` is False (Elm, Erlang, Haskell, Jsonnet, PureScript, Roc).
- Test harness applies the same guard before ``wrap_calls_with_declarations``; ``_expected_call_shape_exception`` now expects the raise and the corresponding test-discovery filter is removed so the 12 previously-skipped cases assert the error.

## Test plan
- [x] ``pytest tests/`` (2844 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `literalize_call` behavior for YAML inputs by adding a new precondition that can raise `UnsupportedCallShapeError` in previously-accepted `wrap_in_file=True` cases, potentially impacting callers relying on wrapped output.
> 
> **Overview**
> `literalize_call` now detects *standalone YAML comment lines* (top-level before-element or trailing comments) and, when `wrap_in_file=True`, raises a typed `UnsupportedCallShapeError` if the target language can’t preserve those comments during wrapping (via `supports_standalone_comments_in_wrapped_calls`).
> 
> The call result now exposes `LiteralizeResult.contains_standalone_comments` so downstream wrappers (including the integration harness’ manual `wrap_calls_with_declarations` path) can apply the same guard; integration tests and the changelog are updated accordingly, including a new negative test asserting the error for Haskell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288a35442a97ad0eb9cf2bff24078710effd97f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->