### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,6 +175,7 @@ repos:
         stages: [pre-push]
         priority: 520
         entry: uv run --extra=dev -m mypy
+        args: [--num-workers=4]
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -186,6 +187,7 @@ repos:
         stages: [pre-push]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        args: [--command=mypy --num-workers=4]
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -174,8 +174,7 @@ repos:
         name: mypy
         stages: [pre-push]
         priority: 520
-        entry: uv run --extra=dev -m mypy
-        args: [--num-workers=4]
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -186,8 +185,8 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         priority: 540
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
-        args: [--command=mypy --num-workers=4]
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]


### PR DESCRIPTION
## Summary
- add `--num-workers=4` to the `mypy` pre-commit hook args
- add `--num-workers=4` to the `mypy-docs` command args via hook args

## Test plan
- [x] run pre-commit hooks during commit
- [x] push branch (pre-push hooks run)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-push hook command-line flags to run `mypy` in parallel; no runtime or production code is touched.
> 
> **Overview**
> Speeds up pre-push type checking by enabling `mypy` parallelism (`--num-workers=4`) in the `mypy` hook.
> 
> Applies the same worker setting to the docs type-checking hook (`mypy-docs`) by updating the embedded `mypy` command passed to `doccmd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69ba2e366227a75ab87a342c5435861fb700a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->