### PR TITLE
Mojo: emit typed free-function call stubs from inferred arg types

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -79,6 +79,44 @@ from literalizer._language import (
 from literalizer._types import Scalar, Value
 from literalizer.exceptions import NullInCollectionError
 
+_PYTHON_TO_MOJO_SCALAR: dict[type, str] = {
+    str: "String",
+    int: "Int",
+}
+
+
+def _mojo_typed_param_list(
+    params: Sequence[str],
+    arg_values: Sequence[Value],
+) -> tuple[str, ...] | None:
+    """Return ``("name: Type", ...)`` for a typed Mojo signature.
+
+    Returns ``None`` to signal the caller should fall back to the
+    generic ``[*Ts: AnyType](*args: *Ts)`` form.  Falls back when the
+    parameter list is empty, when any per-call value at a parameter
+    slot is non-scalar (a ref-marker dict, a collection, ``None``,
+    etc.), when any slot has no values (e.g. transform-stub callers
+    pass an empty ``arg_values``), or when scalar Python types
+    disagree across calls at the same slot.
+    """
+    if not params:
+        return None
+    slots: list[list[Value]] = [[] for _ in params]
+    for element in arg_values:
+        if len(params) == 1:
+            slots[0].append(element)
+        else:
+            for index in range(len(params)):
+                slots[index].append(cast("Sequence[Value]", element)[index])
+    typed: list[str] = []
+    for name, slot_values in zip(params, slots, strict=True):
+        types = {_PYTHON_TO_MOJO_SCALAR.get(type(v)) for v in slot_values}
+        if None in types or len(types) != 1:
+            return None
+        (mojo_type,) = types
+        typed.append(f"{name}: {mojo_type}")
+    return tuple(typed)
+
 
 def _mojo_init_expr(parts: Sequence[str]) -> str:
     """Return the constructor expression for a multi-part call target.
@@ -127,21 +165,31 @@ def _mojo_call_stub(
 @beartype
 def _mojo_call_preamble_stub(
     parts: Sequence[str],
-    _params: Sequence[str],
+    params: Sequence[str],
     _stub_return: StubReturn,
-    _args: Sequence[Value],
+    args: Sequence[Value],
     /,
     *,
     indent: str,
 ) -> tuple[str, ...]:
     """Return Mojo file-scope stubs for a call name.
 
-    1-part names become a module-level generic ``fn``.  Multi-part
-    names become ``@fieldwise_init`` struct types: the innermost type
-    holds the method, and each enclosing type holds a field of the
-    next inner type.
+    1-part names become a module-level ``fn``: typed per-parameter
+    when every call's argument values at each slot share a scalar
+    Python type that maps to a Mojo scalar, and the generic
+    ``[*Ts: AnyType](*args: *Ts)`` form otherwise.  Multi-part names
+    become ``@fieldwise_init`` struct types: the innermost type holds
+    the method, and each enclosing type holds a field of the next
+    inner type.
     """
     if len(parts) == 1:
+        typed_params = _mojo_typed_param_list(
+            params=params,
+            arg_values=args,
+        )
+        if typed_params is not None:
+            param_list = ", ".join(typed_params)
+            return (f"fn {parts[0]}({param_list}):\n{indent}pass",)
         return (f"fn {parts[0]}[*Ts: AnyType](*args: *Ts):\n{indent}pass",)
     root = parts[0]
     method = parts[-1]

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -101,13 +101,15 @@ def _mojo_typed_param_list(
     """
     if not params:
         return None
-    slots: list[list[Value]] = [[] for _ in params]
+    slots: list[list[Value]] = []
     for element in arg_values:
-        if len(params) == 1:
-            slots[0].append(element)
-        else:
-            for index in range(len(params)):
-                slots[index].append(cast("Sequence[Value]", element)[index])
+        per_arg = element if isinstance(element, list) else [element]
+        for slot_index, arg_value in enumerate(iterable=per_arg):
+            if slot_index >= len(slots):
+                slots.append([])
+            slots[slot_index].append(arg_value)
+    if len(slots) != len(params):
+        return None
     typed: list[str] = []
     for name, slot_values in zip(params, slots, strict=True):
         types = {_PYTHON_TO_MOJO_SCALAR.get(type(v)) for v in slot_values}

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -79,11 +79,6 @@ from literalizer._language import (
 from literalizer._types import Scalar, Value
 from literalizer.exceptions import NullInCollectionError
 
-_PYTHON_TO_MOJO_SCALAR: dict[type, str] = {
-    str: "String",
-    int: "Int",
-}
-
 
 def _mojo_typed_param_list(
     params: Sequence[str],
@@ -99,6 +94,10 @@ def _mojo_typed_param_list(
     pass an empty ``arg_values``), or when scalar Python types
     disagree across calls at the same slot.
     """
+    python_to_mojo_scalar: dict[type, str] = {
+        str: "String",
+        int: "Int",
+    }
     if not params:
         return None
     slots: list[list[Value]] = []
@@ -112,7 +111,7 @@ def _mojo_typed_param_list(
         return None
     typed: list[str] = []
     for name, slot_values in zip(params, slots, strict=True):
-        types = {_PYTHON_TO_MOJO_SCALAR.get(type(v)) for v in slot_values}
+        types = {python_to_mojo_scalar.get(type(v)) for v in slot_values}
         if None in types or len(types) != 1:
             return None
         (mojo_type,) = types

--- a/tests/integration/cases/call_comments/Mojo_call.mojo
+++ b/tests/integration/cases/call_comments/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(value: String):
     pass
 def main():
     # Test cases

--- a/tests/integration/cases/call_existing_ref_arg/Mojo_call.mojo
+++ b/tests/integration/cases/call_existing_ref_arg/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(value: Int):
     pass
 def main():
     var existing = 42

--- a/tests/integration/cases/call_multi_args/Mojo_call.mojo
+++ b/tests/integration/cases/call_multi_args/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(value: Int, count: Int):
     pass
 def main():
     process(1, 42)

--- a/tests/integration/cases/call_negative_int/Mojo_call.mojo
+++ b/tests/integration/cases/call_negative_int/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(value: Int):
     pass
 def main():
     process(-1)

--- a/tests/integration/cases/call_per_element_false/Mojo_call.mojo
+++ b/tests/integration/cases/call_per_element_false/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(data: Int):
     pass
 def main():
     process(1)

--- a/tests/integration/cases/call_ref_args_escaped_quote/Mojo_call.mojo
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(v: String):
     pass
 def main():
     var my_str = "a\"b"

--- a/tests/integration/cases/call_reserved_target/Mojo_call.mojo
+++ b/tests/integration/cases/call_reserved_target/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn op[*Ts: AnyType](*args: *Ts):
+fn op(value: String):
     pass
 def main():
     op("hello")

--- a/tests/integration/cases/call_wrap_in_file/Mojo_call.mojo
+++ b/tests/integration/cases/call_wrap_in_file/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(a: Int, b: Int):
     pass
 def main():
     process(1, 2)

--- a/tests/integration/cases/call_wrap_in_file_escaped_quote/Mojo_call.mojo
+++ b/tests/integration/cases/call_wrap_in_file_escaped_quote/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(v: String):
     pass
 def main():
     process("a\"b")


### PR DESCRIPTION
First slice of #1972. Replaces Mojo's generic ``fn name[*Ts: AnyType](*args: *Ts):`` stub with a typed signature ``fn name(p0: T0, ...):`` for 1-part call targets when every call's argument values at each slot share a scalar Python type that maps to a Mojo scalar (currently ``str → String``, ``int → Int``); falls back to the generic form otherwise. Dotted-method stubs, ``StubReturn.VALUE`` return-type inference, heterogeneous_strategy/VARIANT handling, and additional scalar mappings (float/bytes/date/datetime) are deferred to follow-up slices on #1972. Regenerated 7 Mojo call goldens; full test suite passes with 100% line + branch coverage on ``mojo.py``. Mojo-compiler verification was not run locally — recommend a spot-check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mojo call stub codegen to sometimes emit typed parameter signatures instead of always using a generic variadic stub, which may affect downstream expectations of generated output. Scope is limited to 1-part call targets and falls back to the previous generic form when inference is unsafe.
> 
> **Overview**
> Mojo call stub generation now attempts to infer a *typed* module-level `fn` signature for 1-part call targets by examining all observed call arguments and mapping consistent scalar Python types (`str`, `int`) to Mojo scalars (`String`, `Int`); it falls back to the existing generic `[*Ts: AnyType](*args: *Ts)` stub when inference is ambiguous, missing, or non-scalar.
> 
> Integration “golden” Mojo call fixtures are updated to expect typed stubs (e.g. `fn process(value: Int)` / `fn process(value: String)` and multi-arg typed signatures) where inference succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb44eb385e2589101d803e983260e6c861270e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->