### PR TITLE
Mojo: typed call stubs for dotted methods and more scalar types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- ``Mojo`` typed call stubs now cover ``bool``, ``float``, ``bytes``,
+  ``date``, and ``datetime`` argument values (mapped to ``Bool``,
+  ``Float64``, and ``String`` respectively), and apply to dotted-method
+  stubs as well as free-function stubs.  The generic
+  ``[*Ts: AnyType](*args: *Ts)`` form is still emitted when scalar
+  types disagree across calls or any argument is non-scalar.
+
 - :func:`~literalizer.literalize_call` now raises a typed
   :class:`~literalizer.exceptions.UnsupportedCallShapeError`
   when ``wrap_in_file=True`` and the YAML source carries standalone

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -79,6 +79,20 @@ from literalizer._language import (
 from literalizer._types import Scalar, Value
 from literalizer.exceptions import NullInCollectionError
 
+_mojo_element_to_type = make_element_to_type(
+    str_type="String",
+    bool_type="Bool",
+    int_type="Int",
+    float_type="Float64",
+    mixed_numeric_type="String",
+    bytes_type="String",
+    date_type="String",
+    datetime_type="String",
+    list_template="List[{inner}]",
+    dict_type_template="Dict[String, {inner}]",
+    fallback_value_type="String",
+)
+
 
 def _mojo_typed_param_list(
     params: Sequence[str],
@@ -94,10 +108,6 @@ def _mojo_typed_param_list(
     pass an empty ``arg_values``), or when scalar Python types
     disagree across calls at the same slot.
     """
-    python_to_mojo_scalar: dict[type, str] = {
-        str: "String",
-        int: "Int",
-    }
     if not params:
         return None
     slots: list[list[Value]] = []
@@ -111,7 +121,7 @@ def _mojo_typed_param_list(
         return None
     typed: list[str] = []
     for name, slot_values in zip(params, slots, strict=True):
-        types = {python_to_mojo_scalar.get(type(v)) for v in slot_values}
+        types = {_mojo_element_to_type(type(v)) for v in slot_values}
         if None in types or len(types) != 1:
             return None
         (mojo_type,) = types
@@ -175,19 +185,18 @@ def _mojo_call_preamble_stub(
 ) -> tuple[str, ...]:
     """Return Mojo file-scope stubs for a call name.
 
-    1-part names become a module-level ``fn``: typed per-parameter
-    when every call's argument values at each slot share a scalar
-    Python type that maps to a Mojo scalar, and the generic
-    ``[*Ts: AnyType](*args: *Ts)`` form otherwise.  Multi-part names
-    become ``@fieldwise_init`` struct types: the innermost type holds
-    the method, and each enclosing type holds a field of the next
-    inner type.
+    1-part names become a module-level ``fn``; multi-part names become
+    ``@fieldwise_init`` struct types whose innermost type holds the
+    method.  Both stub kinds emit typed per-parameter signatures when
+    every call's argument values at each slot share a scalar Python
+    type that maps to a Mojo scalar, and the generic
+    ``[*Ts: AnyType](*args: *Ts)`` form otherwise.
     """
+    typed_params = _mojo_typed_param_list(
+        params=params,
+        arg_values=args,
+    )
     if len(parts) == 1:
-        typed_params = _mojo_typed_param_list(
-            params=params,
-            arg_values=args,
-        )
         if typed_params is not None:
             param_list = ", ".join(typed_params)
             return (f"fn {parts[0]}({param_list}):\n{indent}pass",)
@@ -196,10 +205,16 @@ def _mojo_call_preamble_stub(
     method = parts[-1]
     fields = parts[1:-1]
     struct_header = "(Copyable, Movable)"
-    method_stub = (
-        f"{indent}fn {method}[*Ts: AnyType](self, *args: *Ts):\n"
-        f"{indent}{indent}pass"
-    )
+    if typed_params is not None:
+        method_param_list = ", ".join(("self", *typed_params))
+        method_stub = (
+            f"{indent}fn {method}({method_param_list}):\n{indent}{indent}pass"
+        )
+    else:
+        method_stub = (
+            f"{indent}fn {method}[*Ts: AnyType](self, *args: *Ts):\n"
+            f"{indent}{indent}pass"
+        )
     if not fields:
         type_name = f"_{root.capitalize()}Type"
         return (
@@ -232,19 +247,7 @@ def _mojo_call_preamble_stub(
 
 
 _mojo_narrowed_empty_form = make_narrowed_empty_form(
-    element_to_type=make_element_to_type(
-        str_type="String",
-        bool_type="Bool",
-        int_type="Int",
-        float_type="Float64",
-        mixed_numeric_type="String",
-        bytes_type="String",
-        date_type="String",
-        datetime_type="String",
-        list_template="List[{inner}]",
-        dict_type_template="Dict[String, {inner}]",
-        fallback_value_type="String",
-    ),
+    element_to_type=_mojo_element_to_type,
     template="List[{type}]()",
     fallback_type="String",
 )

--- a/tests/integration/cases/call_keyword_args/Mojo_call.mojo
+++ b/tests/integration/cases/call_keyword_args/Mojo_call.mojo
@@ -1,6 +1,6 @@
 @fieldwise_init
 struct _ThrottlerType(Copyable, Movable):
-    fn check[*Ts: AnyType](self, *args: *Ts):
+    fn check(self, user_id: String, ts: Float64):
         pass
 fn emit[*Ts: AnyType](*args: *Ts):
     pass


### PR DESCRIPTION
Second slice of #1972 (follows #1975).

## Summary

- Extracts the shared ``make_element_to_type`` Mojo mapping (already used by ``_mojo_narrowed_empty_form``) into a module-level ``_mojo_element_to_type`` and routes ``_mojo_typed_param_list`` through it. Typed call stubs now also cover ``bool → Bool``, ``float → Float64``, and ``bytes`` / ``date`` / ``datetime → String``.
- Applies the same typed-vs-generic stub selection to dotted-method stubs (``@fieldwise_init struct ... { fn method(self, ...): }``). The generic ``[*Ts: AnyType](self, *args: *Ts)`` form still appears when scalar types disagree across calls or any argument is non-scalar.

## Goldens

- ``tests/integration/cases/call_keyword_args/Mojo_call.mojo``: ``throttler.check`` flips from the generic stub to ``fn check(self, user_id: String, ts: Float64):``. All other 23 Mojo call goldens are unchanged (the remaining dotted cases use heterogeneous ``str``/``int``/``bool`` arg sets and continue to fall back).

## Deferred

- ``StubReturn.VALUE`` return-type inference.
- ``heterogeneous_strategy = VARIANT`` typed stubs.
- Mojo-compiler verification of the regenerated golden — recommend a spot-check before merge.

## Test plan
- [x] ``uv run pytest tests/`` — 2845 passed
- [x] 100% line + branch coverage on ``src/literalizer/languages/mojo.py``
- [x] ``uv run mypy``, ``uv run pyright``, ``uv run pylint`` — all clean on ``mojo.py``
- [ ] Spot-check ``call_keyword_args/Mojo_call.mojo`` against a Mojo compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Mojo codegen for call stubs and could alter generated signatures across fixtures; fallback behavior remains when types are ambiguous or non-scalar.
> 
> **Overview**
> **Mojo call stub generation now emits more precise typed signatures.** Type inference for stub parameters is centralized via a shared `_mojo_element_to_type` mapping and extended to cover `bool`, `float`, `bytes`, `date`, and `datetime` (mapping to `Bool`, `Float64`, and `String`).
> 
> **Typed-vs-generic stub selection is now applied to dotted targets as well.** `@fieldwise_init` method stubs will emit `fn method(self, name: Type, ...)` when scalar types are consistent across calls, otherwise they still fall back to the generic `[*Ts: AnyType]` form; integration goldens update accordingly (e.g. `throttler.check`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6673644a0f9b7686df88282b1d25ec0a9885a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->