### PR TITLE
Mojo: emit bare zero-parameter call stubs

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -101,15 +101,16 @@ def _mojo_typed_param_list(
     """Return ``("name: Type", ...)`` for a typed Mojo signature.
 
     Returns ``None`` to signal the caller should fall back to the
-    generic ``[*Ts: AnyType](*args: *Ts)`` form.  Falls back when the
-    parameter list is empty, when any per-call value at a parameter
-    slot is non-scalar (a ref-marker dict, a collection, ``None``,
-    etc.), when any slot has no values (e.g. transform-stub callers
-    pass an empty ``arg_values``), or when scalar Python types
-    disagree across calls at the same slot.
+    generic ``[*Ts: AnyType](*args: *Ts)`` form.  Falls back when any
+    per-call value at a parameter slot is non-scalar (a ref-marker
+    dict, a collection, ``None``, etc.), when any slot has no values
+    (e.g. transform-stub callers pass an empty ``arg_values``), or
+    when scalar Python types disagree across calls at the same slot.
+    A zero-parameter call returns ``()`` (typed, empty) so the caller
+    emits a bare ``fn name():`` form rather than the generic stub.
     """
     if not params:
-        return None
+        return ()
     slots: list[list[Value]] = []
     for element in arg_values:
         per_arg = element if isinstance(element, list) else [element]

--- a/tests/integration/cases/call_no_params/Mojo_call.mojo
+++ b/tests/integration/cases/call_no_params/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process():
     pass
 def main():
     process()

--- a/tests/integration/cases/call_no_params_transform/Mojo_call.mojo
+++ b/tests/integration/cases/call_no_params_transform/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process():
     pass
 fn emit[*Ts: AnyType](*args: *Ts):
     pass


### PR DESCRIPTION
## Summary
- `_mojo_typed_param_list` now returns `()` instead of `None` when `params` is empty, so zero-parameter calls render as `fn process():` (and `fn method(self):` for dotted methods) instead of the generic `[*Ts: AnyType](*args: *Ts)` form.
- Regenerates the two affected goldens: `call_no_params/Mojo_call.mojo` and `call_no_params_transform/Mojo_call.mojo`.

Refs #1972.

## Test plan
- [x] `pytest tests/integration/test_calls.py -k Mojo` (24 passed, 4 skipped)
- [x] `mojo build` on both regenerated goldens compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes stub-signature formatting for zero-parameter Mojo calls and updates expected integration outputs.
> 
> **Overview**
> Mojo call-stub generation now treats an empty parameter list as a typed empty signature (`()`) instead of falling back to the generic `[*Ts: AnyType](*args: *Ts)` form, so zero-arg calls render as `fn name():` (and methods as `fn method(self):`).
> 
> Updates the affected integration golden files (`call_no_params` and `call_no_params_transform`) to expect the bare zero-parameter stub output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e1a4d49375d3e07ae03c6de4db852dc48ade6ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->