### PR TITLE
Mojo: type list-arg slots in call stubs from inferred element types

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -98,19 +98,17 @@ _mojo_element_to_type = make_element_to_type(
 def _value_to_mojo_type(value: Value, /) -> str | None:
     """Map one call-argument value to its Mojo type string.
 
-    Homogeneous list values (e.g. ``[1, 2, 3]``) resolve via
-    :func:`infer_element_type` to a recursive ``List[...]`` type so a
-    typed stub can declare ``data: List[Int]`` for a list-typed slot.
-    Any value whose Python type does not appear in the scalar map (or
-    whose list inference fails) returns ``None`` so the caller falls
-    back to the generic ``[*Ts: AnyType](*args: *Ts)`` form.
+    Routes every value through :func:`infer_element_type` so a list
+    slot resolves to a recursive ``List[...]`` type (e.g.
+    ``[1, 2, 3]`` -> ``List[Int]``) and scalar slots resolve via the
+    same Python-type lookup that the collection-opener machinery
+    uses.  Returns ``None`` when inference fails (empty or
+    inhomogeneous list) or when the resulting Python type has no
+    Mojo mapping, so the caller falls back to the generic
+    ``[*Ts: AnyType](*args: *Ts)`` form.
     """
-    if isinstance(value, list):
-        inferred = infer_element_type(items=[value])
-        if inferred is None:
-            return None
-        return _mojo_element_to_type(inferred)
-    return _mojo_element_to_type(type(value))
+    inferred = infer_element_type(items=[value])
+    return None if inferred is None else _mojo_element_to_type(inferred)
 
 
 def _mojo_typed_param_list(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -40,6 +40,7 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._formatters.type_inference import infer_element_type
 from literalizer._heterogeneous import (
     collect_heterogeneous_container_ids,
     iter_wrapped_scalars,
@@ -94,6 +95,24 @@ _mojo_element_to_type = make_element_to_type(
 )
 
 
+def _value_to_mojo_type(value: Value, /) -> str | None:
+    """Map one call-argument value to its Mojo type string.
+
+    Homogeneous list values (e.g. ``[1, 2, 3]``) resolve via
+    :func:`infer_element_type` to a recursive ``List[...]`` type so a
+    typed stub can declare ``data: List[Int]`` for a list-typed slot.
+    Any value whose Python type does not appear in the scalar map (or
+    whose list inference fails) returns ``None`` so the caller falls
+    back to the generic ``[*Ts: AnyType](*args: *Ts)`` form.
+    """
+    if isinstance(value, list):
+        inferred = infer_element_type(items=[value])
+        if inferred is None:
+            return None
+        return _mojo_element_to_type(inferred)
+    return _mojo_element_to_type(type(value))
+
+
 def _mojo_typed_param_list(
     params: Sequence[str],
     arg_values: Sequence[Value],
@@ -102,12 +121,13 @@ def _mojo_typed_param_list(
 
     Returns ``None`` to signal the caller should fall back to the
     generic ``[*Ts: AnyType](*args: *Ts)`` form.  Falls back when any
-    per-call value at a parameter slot is non-scalar (a ref-marker
-    dict, a collection, ``None``, etc.), when any slot has no values
-    (e.g. transform-stub callers pass an empty ``arg_values``), or
-    when scalar Python types disagree across calls at the same slot.
-    A zero-parameter call returns ``()`` (typed, empty) so the caller
-    emits a bare ``fn name():`` form rather than the generic stub.
+    per-call value at a parameter slot has no Mojo type (a ref-marker
+    dict, ``None``, an inhomogeneous list, etc.), when any slot has
+    no values (e.g. transform-stub callers pass an empty
+    ``arg_values``), or when types disagree across calls at the same
+    slot.  A zero-parameter call returns ``()`` (typed, empty) so the
+    caller emits a bare ``fn name():`` form rather than the generic
+    stub.
     """
     if not params:
         return ()
@@ -122,7 +142,7 @@ def _mojo_typed_param_list(
         return None
     typed: list[str] = []
     for name, slot_values in zip(params, slots, strict=True):
-        types = {_mojo_element_to_type(type(v)) for v in slot_values}
+        types = {_value_to_mojo_type(v) for v in slot_values}
         if None in types or len(types) != 1:
             return None
         (mojo_type,) = types

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -98,17 +98,20 @@ _mojo_element_to_type = make_element_to_type(
 def _value_to_mojo_type(value: Value, /) -> str | None:
     """Map one call-argument value to its Mojo type string.
 
-    Routes every value through :func:`infer_element_type` so a list
+    Routes list values through :func:`infer_element_type` so a list
     slot resolves to a recursive ``List[...]`` type (e.g.
-    ``[1, 2, 3]`` -> ``List[Int]``) and scalar slots resolve via the
-    same Python-type lookup that the collection-opener machinery
-    uses.  Returns ``None`` when inference fails (empty or
-    inhomogeneous list) or when the resulting Python type has no
-    Mojo mapping, so the caller falls back to the generic
-    ``[*Ts: AnyType](*args: *Ts)`` form.
+    ``[1, 2, 3]`` -> ``List[Int]``).  Non-list values, including
+    dicts (ref-marker dicts on the ``wrap_in_file=True`` production
+    path that bypasses ref substitution, ordered maps, real dicts),
+    look up their Python ``type`` directly so only the scalar Mojo
+    mappings are typed and any other shape falls back to the generic
+    ``[*Ts: AnyType](*args: *Ts)`` form.  An empty or inhomogeneous
+    list short-circuits via ``or list`` to the bare ``list`` type,
+    which has no Mojo mapping and so also triggers the fallback.
     """
-    inferred = infer_element_type(items=[value])
-    return None if inferred is None else _mojo_element_to_type(inferred)
+    if isinstance(value, list):
+        return _mojo_element_to_type(infer_element_type(items=[value]) or list)
+    return _mojo_element_to_type(type(value))
 
 
 def _mojo_typed_param_list(

--- a/tests/integration/cases/call_ref_args/Mojo_call.mojo
+++ b/tests/integration/cases/call_ref_args/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(data: List[Int], count: Int):
     pass
 def main():
     var my_var = [

--- a/tests/integration/cases/call_ref_args_converted/Mojo_call.mojo
+++ b/tests/integration/cases/call_ref_args_converted/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(data: List[Int], count: Int):
     pass
 def main():
     var my_var = [

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Mojo_call.mojo
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Mojo_call.mojo
@@ -1,4 +1,4 @@
-fn process[*Ts: AnyType](*args: *Ts):
+fn process(data: List[Int], count: Int):
     pass
 def main():
     var my_var = [


### PR DESCRIPTION
## Summary
- Extends `_mojo_typed_param_list` (via a new `_value_to_mojo_type` helper) to map list values through `infer_element_type` so a parameter slot that always holds a homogeneous list types as `List[Int]` (etc.) instead of falling back to `[*Ts: AnyType](*args: *Ts)`.
- Regenerates the three affected goldens: `call_ref_args`, `call_ref_args_converted`, `call_ref_args_converted_nonsnake`.

Refs #1972.

## Test plan
- [x] `pytest tests/integration/test_calls.py -k Mojo` (24 passed, 4 skipped)
- [x] Full `pytest tests/` suite passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Mojo call-stub signature typing and update corresponding golden integration fixtures; no runtime data handling or security-sensitive paths are affected.
> 
> **Overview**
> Mojo call-stub generation now infers typed parameter signatures for *homogeneous list arguments*, emitting `List[...]` (e.g. `List[Int]`) instead of falling back to the generic `[*Ts: AnyType](*args: *Ts)` form.
> 
> Integration goldens for the affected call-ref-args cases are regenerated to expect the new typed `fn process(data: List[Int], count: Int):` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa91e1951ef0ec3f61a1aa1fc79e059959ccca5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->