### PR TITLE
Make language modules the source of truth for lint version flags

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -717,12 +717,17 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
         run: uv tool install clang-tidy
-      # ``-std=c99`` matches ``C.language_version`` in
-      # ``src/literalizer/languages/c.py``; keep them in sync.
+      - name: Resolve C language-version flag
+        id: c_std
+        run: |-
+          flag=$(uv run python -c "from literalizer.languages.c import C; print(C().lint_std_flag())")
+          echo "flag=$flag" >> "$GITHUB_OUTPUT"
       - name: Run clang-tidy on C files
+        env:
+          STD_FLAG: ${{ steps.c_std.outputs.flag }}
         run: |-
           find tests/integration/cases -name '*.c' -print0 > /tmp/files-c-tidy
-          xargs -0 -P "$(nproc)" -n1 -I{} clang-tidy {} -- -std=c99 < /tmp/files-c-tidy
+          xargs -0 -P "$(nproc)" -n1 -I{} clang-tidy {} -- "$STD_FLAG" < /tmp/files-c-tidy
 
   lint-cpp-tidy:
     runs-on: ubuntu-latest
@@ -737,12 +742,17 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
         run: uv tool install clang-tidy
-      # ``-std=c++20`` matches ``Cpp.language_version`` in
-      # ``src/literalizer/languages/cpp.py``; keep them in sync.
+      - name: Resolve C++ language-version flag
+        id: cpp_std
+        run: |-
+          flag=$(uv run python -c "from literalizer.languages.cpp import Cpp; print(Cpp().lint_std_flag())")
+          echo "flag=$flag" >> "$GITHUB_OUTPUT"
       - name: Run clang-tidy on C++ files
+        env:
+          STD_FLAG: ${{ steps.cpp_std.outputs.flag }}
         run: |-
           find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-cpp-tidy
-          xargs -0 -P "$(nproc)" -n1 -I{} clang-tidy {} -- -std=c++20 < /tmp/files-cpp-tidy
+          xargs -0 -P "$(nproc)" -n1 -I{} clang-tidy {} -- "$STD_FLAG" < /tmp/files-cpp-tidy
 
   lint-cobol:
     runs-on: ubuntu-latest
@@ -773,21 +783,31 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Resolve C language-version flag
+        id: c_std
+        run: |-
+          flag=$(uv run python -c "from literalizer.languages.c import C; print(C().lint_std_flag())")
+          echo "flag=$flag" >> "$GITHUB_OUTPUT"
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name '*.c' -print0 > /tmp/files-to-lint
       # Each fixture defines its own main, so compile and run directly.
       # The build-and-run step also surfaces any syntax errors, so a
       # separate `-fsyntax-only` pass would be redundant.
-      # ``-std=c99`` matches ``C.language_version`` in
-      # ``src/literalizer/languages/c.py``; keep them in sync.
       - name: Run C files
+        env:
+          STD_FLAG: ${{ steps.c_std.outputs.flag }}
         run: |-
-          cat > /tmp/run-c.sh <<'SCRIPT'
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          clang -std=c99 "$1" -o "$tmpdir/run" || exit 1
-          "$tmpdir/run" || exit 1
+          cat > /tmp/run-c.sh <<SCRIPT
+          tmpdir=\$(mktemp -d)
+          trap 'rm -rf "\$tmpdir"' EXIT
+          clang "$STD_FLAG" "\$1" -o "\$tmpdir/run" || exit 1
+          "\$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-c.sh < /tmp/files-to-lint
 
@@ -797,6 +817,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Resolve C++ language-version flag
+        id: cpp_std
+        run: |-
+          flag=$(uv run python -c "from literalizer.languages.cpp import Cpp; print(Cpp().lint_std_flag())")
+          echo "flag=$flag" >> "$GITHUB_OUTPUT"
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name '*.cpp' -print0 > /tmp/files-to-lint
@@ -805,22 +835,24 @@ jobs:
       # covering every header any fixture includes, then preload it in
       # each compile invocation so the parsed AST is reused instead of
       # re-parsed per file.
-      # ``-std=c++20`` matches ``Cpp.language_version`` in
-      # ``src/literalizer/languages/cpp.py``; keep them in sync.
       - name: Build precompiled header
-        run: clang++ -std=c++20 -x c++-header .github/scripts/lint-cpp-pch.hpp -o
+        env:
+          STD_FLAG: ${{ steps.cpp_std.outputs.flag }}
+        run: clang++ "$STD_FLAG" -x c++-header .github/scripts/lint-cpp-pch.hpp -o
           /tmp/pch.hpp.pch
       # Each fixture defines its own main, so compile and run directly.
       # The build-and-run step also surfaces any syntax errors, so a
       # separate `-fsyntax-only` pass would be redundant.
       - name: Run C++ files
+        env:
+          STD_FLAG: ${{ steps.cpp_std.outputs.flag }}
         run: |-
-          cat > /tmp/run-cpp.sh <<'SCRIPT'
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          clang++ -std=c++20 -include-pch /tmp/pch.hpp.pch "$1" \
-            -o "$tmpdir/run" || exit 1
-          "$tmpdir/run" || exit 1
+          cat > /tmp/run-cpp.sh <<SCRIPT
+          tmpdir=\$(mktemp -d)
+          trap 'rm -rf "\$tmpdir"' EXIT
+          clang++ "$STD_FLAG" -include-pch /tmp/pch.hpp.pch "\$1" \\
+            -o "\$tmpdir/run" || exit 1
+          "\$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-cpp.sh < /tmp/files-to-lint
 
@@ -1046,10 +1078,22 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - name: Resolve Rust language-version flag
+        id: rust_std
+        run: |-
+          flag=$(uv run python -c "from literalizer.languages.rust import Rust; print(Rust().lint_std_flag())")
+          echo "flag=$flag" >> "$GITHUB_OUTPUT"
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name '*.rs' -print0 > /tmp/files-to-lint
       - name: Check Rust syntax and run binaries
+        env:
+          STD_FLAG: ${{ steps.rust_std.outputs.flag }}
         run: |-
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
@@ -1058,10 +1102,8 @@ jobs:
           cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
           deps="$tmpdir/chrono-check/target/debug/deps"
           chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
-          # ``--edition 2021`` matches ``Rust.language_version`` in
-          # ``src/literalizer/languages/rust.py``; keep them in sync.
           while IFS= read -r -d '' f; do
-            rustc --edition 2021 \
+            rustc "$STD_FLAG" \
               -L "dependency=$deps" \
               --extern "chrono=$chrono_rlib" \
               "$f" -o "$tmpdir/out" 2>&1 || exit 1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- ``C``, ``Cpp``, and ``Rust`` now expose a ``lint_std_flag()`` method
+  that returns the toolchain version flag (e.g. ``-std=c99``) for the
+  spec's ``language_version``.  ``.github/workflows/lint.yml`` reads
+  these methods rather than hardcoding the flags, making the language
+  module the single source of truth.
+
 - ``Mojo`` typed call stubs now cover ``bool``, ``float``, ``bytes``,
   ``date``, and ``datetime`` argument values (mapped to ``Bool``,
   ``Float64``, and ``String`` respectively), and apply to dotted-method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -433,6 +433,8 @@ ignore_names = [
     "BTREE_SET",
     "call_styles",
     "heterogeneous_strategies",
+    # Called from .github/workflows/lint.yml via ``python -c``
+    "lint_std_flag",
     "OBJECT_VARIANT",
     "TAGGED_ENUM",
     "UNION_TYPE",

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -4,7 +4,7 @@ import collections.abc
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from typing import ClassVar
 
@@ -451,6 +451,19 @@ class C(metaclass=LanguageCls):
 
     version_formats = VersionFormats
 
+    _LINT_STD_FLAGS: ClassVar[Mapping[VersionFormats, str]] = {
+        VersionFormats.C99: "-std=c99",
+    }
+
+    def lint_std_flag(self) -> str:
+        """Compiler flag for this spec's :attr:`language_version`.
+
+        Read by ``.github/workflows/lint.yml`` so the flag passed to
+        ``clang`` and ``clang-tidy`` cannot drift from the dataclass
+        default.
+        """
+        return self._LINT_STD_FLAGS[self.language_version]
+
     module_name_case: ClassVar[IdentifierCase] = IdentifierCase.SNAKE
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
@@ -538,8 +551,6 @@ class C(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the ``-std=`` flag passed to clang and clang-tidy
-    # in ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.C99
     indent: str = "    "
     bool_field: str = "b"

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar, assert_never
@@ -1202,6 +1202,18 @@ class Cpp(metaclass=LanguageCls):
 
     version_formats = VersionFormats
 
+    _LINT_STD_FLAGS: ClassVar[Mapping[VersionFormats, str]] = {
+        VersionFormats.CPP20: "-std=c++20",
+    }
+
+    def lint_std_flag(self) -> str:
+        """Compiler flag for this spec's :attr:`language_version`.
+
+        Read by ``.github/workflows/lint.yml`` so the flag passed to
+        ``clang++`` cannot drift from the dataclass default.
+        """
+        return self._LINT_STD_FLAGS[self.language_version]
+
     module_name_case: ClassVar[IdentifierCase] = IdentifierCase.SNAKE
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
@@ -1330,8 +1342,6 @@ class Cpp(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the ``-std=`` flag passed to clang++ in
-    # ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.CPP20
     indent: str = "    "
 

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 import textwrap
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar, assert_never, cast
@@ -1239,6 +1239,18 @@ class Rust(metaclass=LanguageCls):
 
     version_formats = VersionFormats
 
+    _LINT_STD_FLAGS: ClassVar[Mapping[VersionFormats, str]] = {
+        VersionFormats.EDITION_2021: "--edition=2021",
+    }
+
+    def lint_std_flag(self) -> str:
+        """Compiler flag for this spec's :attr:`language_version`.
+
+        Read by ``.github/workflows/lint.yml`` so the flag passed to
+        ``rustc`` cannot drift from the dataclass default.
+        """
+        return self._LINT_STD_FLAGS[self.language_version]
+
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
         IdentifierCase.SNAKE,
@@ -1311,8 +1323,6 @@ class Rust(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     heterogeneous_value_enum_name: str = "Value"
-    # Keep in sync with the ``--edition`` flag in
-    # ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.EDITION_2021
     indent: str = "    "
 


### PR DESCRIPTION
## Summary

- `C`, `Cpp`, and `Rust` gain a `lint_std_flag()` method derived from `language_version` (kept in a local `_LINT_STD_FLAGS` mapping so adding a new variant is a hard error if the flag isn't supplied).
- `.github/workflows/lint.yml` resolves the flag at job start via `uv run python -c "...lint_std_flag()"` and threads it through `STD_FLAG` env vars (avoiding template injection per zizmor).
- The bidirectional "keep in sync" comments in `c.py` / `cpp.py` / `rust.py` and the workflow are removed; drift is now structurally impossible.

Picks **Option B** from #1930. Unblocks #1932 (more languages) and #1933 (toolchain pins): both can now extend the same per-language method pattern instead of growing more sync comments.

## Test plan

- [ ] CI: `lint-c`, `lint-cpp`, `lint-rust`, `lint-c-tidy`, `lint-cpp-tidy` jobs pass.
- [x] `pytest tests/` (2845 passed).
- [x] `actionlint` and `zizmor` clean on `lint.yml`.
- [x] `pyright` clean on changed modules.

Closes #1930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates CI lint jobs to dynamically resolve compiler/edition flags at runtime, which could break linting if the Python invocation or flag plumbing is wrong. Code changes are small and localized to lint configuration and language spec helpers.
> 
> **Overview**
> Makes the language modules the single source of truth for C/C++/Rust toolchain version flags used in CI.
> 
> `C`, `Cpp`, and `Rust` add `lint_std_flag()` (backed by a per-version mapping) and `.github/workflows/lint.yml` now resolves these flags via `uv run python -c ...` and threads them into `clang`, `clang++`, `clang-tidy`, and `rustc` invocations instead of hardcoding `-std=...`/`--edition ...`. The changelog is updated and `pyproject.toml`’s vulture ignore list is extended to allow the new method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67286fe7458d0acd6b2806633199703c97db2cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->