### PR TITLE
Mojo: type homogeneous dict call args as Dict[String, T]

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -40,7 +40,7 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_strings import format_string_backslash
-from literalizer._formatters.type_inference import infer_element_type
+from literalizer._formatters.type_inference import DictType, infer_element_type
 from literalizer._heterogeneous import (
     collect_heterogeneous_container_ids,
     iter_wrapped_scalars,
@@ -78,10 +78,7 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import Scalar, Value
-from literalizer.exceptions import (
-    CallArgNotSupportedError,
-    NullInCollectionError,
-)
+from literalizer.exceptions import NullInCollectionError
 
 _mojo_element_to_type = make_element_to_type(
     str_type="String",
@@ -103,17 +100,23 @@ def _value_to_mojo_type(value: Value, /) -> str | None:
 
     Routes list values through :func:`infer_element_type` so a list
     slot resolves to a recursive ``List[...]`` type (e.g.
-    ``[1, 2, 3]`` -> ``List[Int]``).  Non-list values, including
-    dicts (ref-marker dicts on the ``wrap_in_file=True`` production
-    path that bypasses ref substitution, ordered maps, real dicts),
-    look up their Python ``type`` directly so only the scalar Mojo
-    mappings are typed and any other shape falls back to the generic
-    ``[*Ts: AnyType](*args: *Ts)`` form.  An empty or inhomogeneous
-    list short-circuits via ``or list`` to the bare ``list`` type,
-    which has no Mojo mapping and so also triggers the fallback.
+    ``[1, 2, 3]`` -> ``List[Int]``).  Dicts route the same way so a
+    homogeneous-value dict slot resolves to ``Dict[String, ...]``
+    (e.g. ``{"a": 1}`` -> ``Dict[String, Int]``); ordered maps, empty
+    dicts, and dicts with heterogeneous values return ``None`` so the
+    slot falls back to the generic ``[*Ts: AnyType](*args: *Ts)`` form
+    rather than lying about the value type via the dict resolver's
+    fallback.  Other values look up their Python ``type`` directly so
+    only the scalar Mojo mappings are typed and any other shape also
+    triggers the fallback.
     """
     if isinstance(value, list):
         return _mojo_element_to_type(infer_element_type(items=[value]) or list)
+    if isinstance(value, dict):
+        inferred = infer_element_type(items=[value])
+        if isinstance(inferred, DictType) and inferred.value_type is not None:
+            return _mojo_element_to_type(inferred)
+        return None
     return _mojo_element_to_type(type(value))
 
 
@@ -199,24 +202,6 @@ def _mojo_call_stub(
 
 
 @beartype
-def _args_contain_dict(args: Sequence[Value]) -> bool:
-    """Return ``True`` if any per-call slot value is a plain dict.
-
-    Ref-marker dicts are stripped before this point, so any ``dict``
-    seen here is a real dict-literal argument.
-    """
-    for element in args:
-        per_arg = element if isinstance(element, list) else [element]
-        for slot_value in per_arg:
-            match slot_value:
-                case dict():
-                    return True
-                case _:
-                    continue
-    return False
-
-
-@beartype
 def _mojo_call_preamble_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -231,24 +216,15 @@ def _mojo_call_preamble_stub(
     1-part names become a module-level ``fn``; multi-part names become
     ``@fieldwise_init`` struct types whose innermost type holds the
     method.  Both stub kinds emit typed per-parameter signatures when
-    every call's argument values at each slot share a scalar Python
-    type that maps to a Mojo scalar, and the generic
+    every call's argument values at each slot resolve to the same
+    Mojo type (a scalar, a recursive ``List[...]``, or a homogeneous
+    ``Dict[String, ...]``), and the generic
     ``[*Ts: AnyType](*args: *Ts)`` form otherwise.
     """
     typed_params = _mojo_typed_param_list(
         params=params,
         arg_values=args,
     )
-    if typed_params is None and _args_contain_dict(args=args):
-        raise CallArgNotSupportedError(
-            language_name="Mojo",
-            reason=(
-                "Mojo's generic ``[*Ts: AnyType](*args: *Ts)`` stub "
-                "cannot infer the type of a dict literal argument; "
-                "typed dict-value call stubs are not yet implemented "
-                "(see #1966)"
-            ),
-        )
     if len(parts) == 1:
         if typed_params is not None:
             param_list = ", ".join(typed_params)

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -123,7 +123,7 @@ def _value_to_mojo_type(value: Value, /) -> str | None:
     ``[1, 2, 3]`` -> ``List[Int]``).  Dicts route the same way so a
     homogeneous-value dict slot resolves to ``Dict[String, ...]``
     (e.g. ``{"a": 1}`` -> ``Dict[String, Int]``).  Uses the strict
-    call-arg resolver so a dict whose values cannot be unified to a
+    resolver so a dict whose values cannot be unified to a
     concrete Mojo type (an empty dict, or a nested heterogeneous dict
     that survives upstream checks under the ``VARIANT`` strategy)
     returns ``None`` and the slot falls back to the generic

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -40,7 +40,7 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_strings import format_string_backslash
-from literalizer._formatters.type_inference import DictType, infer_element_type
+from literalizer._formatters.type_inference import infer_element_type
 from literalizer._heterogeneous import (
     collect_heterogeneous_container_ids,
     iter_wrapped_scalars,
@@ -102,21 +102,19 @@ def _value_to_mojo_type(value: Value, /) -> str | None:
     slot resolves to a recursive ``List[...]`` type (e.g.
     ``[1, 2, 3]`` -> ``List[Int]``).  Dicts route the same way so a
     homogeneous-value dict slot resolves to ``Dict[String, ...]``
-    (e.g. ``{"a": 1}`` -> ``Dict[String, Int]``); ordered maps, empty
-    dicts, and dicts with heterogeneous values return ``None`` so the
-    slot falls back to the generic ``[*Ts: AnyType](*args: *Ts)`` form
-    rather than lying about the value type via the dict resolver's
-    fallback.  Other values look up their Python ``type`` directly so
-    only the scalar Mojo mappings are typed and any other shape also
-    triggers the fallback.
+    (e.g. ``{"a": 1}`` -> ``Dict[String, Int]``); the dict-value
+    resolver's ``String`` fallback covers empty dicts, and dicts with
+    heterogeneous values cannot reach this point because
+    :func:`check_data` rejects them upstream as
+    :exc:`HeterogeneousScalarCollectionError`.  Other values look up
+    their Python ``type`` directly so only the scalar Mojo mappings
+    are typed and any other shape (ordered maps, etc.) falls back to
+    the generic ``[*Ts: AnyType](*args: *Ts)`` form.
     """
     if isinstance(value, list):
         return _mojo_element_to_type(infer_element_type(items=[value]) or list)
     if isinstance(value, dict):
-        inferred = infer_element_type(items=[value])
-        if isinstance(inferred, DictType) and inferred.value_type is not None:
-            return _mojo_element_to_type(inferred)
-        return None
+        return _mojo_element_to_type(infer_element_type(items=[value]) or dict)
     return _mojo_element_to_type(type(value))
 
 

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -115,6 +115,7 @@ _mojo_call_arg_element_to_type = make_element_to_type(
 )
 
 
+@beartype
 def _value_to_mojo_type(value: Value, /) -> str | None:
     """Map one call-argument value to its Mojo type string.
 
@@ -132,15 +133,17 @@ def _value_to_mojo_type(value: Value, /) -> str | None:
     directly so only the scalar Mojo mappings are typed and any other
     shape (ordered maps, etc.) falls back to the same generic form.
     """
-    if isinstance(value, list):
-        return _mojo_call_arg_element_to_type(
-            infer_element_type(items=[value]) or list,
-        )
-    if isinstance(value, dict):
-        return _mojo_call_arg_element_to_type(
-            infer_element_type(items=[value]) or dict,
-        )
-    return _mojo_call_arg_element_to_type(type(value))
+    match value:
+        case list():
+            return _mojo_call_arg_element_to_type(
+                infer_element_type(items=[value]) or list,
+            )
+        case dict():
+            return _mojo_call_arg_element_to_type(
+                infer_element_type(items=[value]) or dict,
+            )
+        case _:
+            return _mojo_call_arg_element_to_type(type(value))
 
 
 def _mojo_typed_param_list(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -94,6 +94,26 @@ _mojo_element_to_type = make_element_to_type(
     fallback_value_type="String",
 )
 
+# Strict resolver for call-argument typing: omits ``fallback_value_type``
+# so an unresolvable dict-value type (e.g. a nested
+# ``DictType(value_type=None)`` produced when the ``VARIANT``
+# heterogeneous strategy lets a mixed-value dict reach the typed-stub
+# helper) returns ``None`` instead of silently lying with
+# ``Dict[String, String]``.
+_mojo_call_arg_element_to_type = make_element_to_type(
+    str_type="String",
+    bool_type="Bool",
+    int_type="Int",
+    float_type="Float64",
+    mixed_numeric_type="String",
+    bytes_type="String",
+    date_type="String",
+    datetime_type="String",
+    list_template="List[{inner}]",
+    dict_type_template="Dict[String, {inner}]",
+    fallback_value_type=None,
+)
+
 
 def _value_to_mojo_type(value: Value, /) -> str | None:
     """Map one call-argument value to its Mojo type string.
@@ -102,20 +122,25 @@ def _value_to_mojo_type(value: Value, /) -> str | None:
     slot resolves to a recursive ``List[...]`` type (e.g.
     ``[1, 2, 3]`` -> ``List[Int]``).  Dicts route the same way so a
     homogeneous-value dict slot resolves to ``Dict[String, ...]``
-    (e.g. ``{"a": 1}`` -> ``Dict[String, Int]``); the dict-value
-    resolver's ``String`` fallback covers empty dicts, and dicts with
-    heterogeneous values cannot reach this point because
-    :func:`check_data` rejects them upstream as
-    :exc:`HeterogeneousScalarCollectionError`.  Other values look up
-    their Python ``type`` directly so only the scalar Mojo mappings
-    are typed and any other shape (ordered maps, etc.) falls back to
-    the generic ``[*Ts: AnyType](*args: *Ts)`` form.
+    (e.g. ``{"a": 1}`` -> ``Dict[String, Int]``).  Uses the strict
+    call-arg resolver so a dict whose values cannot be unified to a
+    concrete Mojo type (an empty dict, or a nested heterogeneous dict
+    that survives upstream checks under the ``VARIANT`` strategy)
+    returns ``None`` and the slot falls back to the generic
+    ``[*Ts: AnyType](*args: *Ts)`` form rather than fabricating a
+    ``String`` value type.  Other values look up their Python ``type``
+    directly so only the scalar Mojo mappings are typed and any other
+    shape (ordered maps, etc.) falls back to the same generic form.
     """
     if isinstance(value, list):
-        return _mojo_element_to_type(infer_element_type(items=[value]) or list)
+        return _mojo_call_arg_element_to_type(
+            infer_element_type(items=[value]) or list,
+        )
     if isinstance(value, dict):
-        return _mojo_element_to_type(infer_element_type(items=[value]) or dict)
-    return _mojo_element_to_type(type(value))
+        return _mojo_call_arg_element_to_type(
+            infer_element_type(items=[value]) or dict,
+        )
+    return _mojo_call_arg_element_to_type(type(value))
 
 
 def _mojo_typed_param_list(

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -1071,26 +1071,22 @@ def run_call_golden_case(
         source_data=result.source_data,
         per_element=config.per_element,
     )
-    try:
-        body_stubs.extend(
-            spec.format_call_stub(
-                target_function_parts,
-                config.parameter_names,
-                stub_return,
-                call_arg_values,
-            ),
-        )
-        preamble_stubs.extend(
-            spec.format_call_preamble_stub(
-                target_function_parts,
-                config.parameter_names,
-                stub_return,
-                call_arg_values,
-            ),
-        )
-    except CallArgNotSupportedError as exc:
-        golden_path.unlink(missing_ok=True)
-        pytest.skip(f"{lang_cls.__name__} rejected call stub: {exc.reason}")
+    body_stubs.extend(
+        spec.format_call_stub(
+            target_function_parts,
+            config.parameter_names,
+            stub_return,
+            call_arg_values,
+        ),
+    )
+    preamble_stubs.extend(
+        spec.format_call_preamble_stub(
+            target_function_parts,
+            config.parameter_names,
+            stub_return,
+            call_arg_values,
+        ),
+    )
     # Stubs for transform function names (single argument).
     for wrapper_name in config.transform_stub_names:
         wrapper_name_parts = tuple(wrapper_name.split(sep="."))

--- a/tests/integration/cases/call_homogeneous_value_dict_arg/Mojo_call.mojo
+++ b/tests/integration/cases/call_homogeneous_value_dict_arg/Mojo_call.mojo
@@ -1,0 +1,4 @@
+fn process(value: Dict[String, Int]):
+    pass
+def main():
+    process({"a": 1, "b": 2})


### PR DESCRIPTION
Closes #1966.

Routes dict call args through `infer_element_type` so a homogeneous-value dict slot resolves to a typed receiver (e.g. `Dict[String, Int]`) instead of the generic `[*Ts: AnyType](*args: *Ts)` stub the Mojo compiler cannot infer for dict literals. Removes the interim `_args_contain_dict` guard and `CallArgNotSupportedError` raise added in #1986; the new `call_homogeneous_value_dict_arg` fixture now produces a `Mojo_call.mojo` golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mojo call-stub type inference to produce typed `Dict[String, T]` parameters for homogeneous dict literals and removes the prior hard error/skip path for dict call args, which could affect generated Mojo call stubs across existing call cases.
> 
> **Overview**
> Mojo call-stub generation now infers types for **dict literal arguments** and emits typed parameters like `Dict[String, Int]` when dict values are homogeneous, instead of always falling back to the generic `[*Ts: AnyType](*args: *Ts)` signature.
> 
> This removes the previous guard that raised `CallArgNotSupportedError` for dict args, updates the integration harness to no longer skip on that stub-generation error path, and adds a new golden case covering a homogeneous dict argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7406d6e63e2e6917b4ab3f19928687f58633421c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->