### PR TITLE
Emit Nim object-variant type declaration in call context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- ``Nim`` :func:`~literalizer.literalize_call` now emits the
+  object-variant ``type`` declaration when the ``OBJECT_VARIANT``
+  heterogeneous strategy is active, so the rendered call references a
+  defined wrapping type.
+
 - ``Mojo`` typed call stubs now cover ``bool``, ``float``, ``bytes``,
   ``date``, and ``datetime`` argument values (mapped to ``Bool``,
   ``Float64``, and ``String`` respectively), and apply to dotted-method

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1155,7 +1155,7 @@ class Nim(metaclass=LanguageCls):
                 :attr:`dict_format_config` so that ``{...}.toTable``
                 renders correctly, but the call stub uses
                 ``varargs[untyped]`` and never evaluates its arguments,
-                leaving the import "unused" from Nim's point of view.
+                so the Nim compiler treats the import as unused.
                 """
                 return (
                     "{.warning[UnusedImport]:off.}",

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1128,13 +1128,22 @@ class Nim(metaclass=LanguageCls):
     def call_data_dependent_preamble(
         self,
     ) -> Callable[[Value], tuple[str, ...]]:
-        """No data-dependent preamble for call context.
+        """Return data-dependent preamble lines for a call context.
 
-        The ``data_dependent_preamble`` method of Nim adds
-        ``import json`` for variable declarations that use ``%*``.
-        Call arguments are formatted as inline literals and never use
+        For ``HeterogeneousStrategies.OBJECT_VARIANT`` emits the Nim
+        ``type`` block declaring the object variant used to wrap
+        heterogeneous scalars; the call rendering references that type
+        by name, so the declaration must be present.  For other
+        strategies, call arguments are inline literals that never use
         ``%*``, so ``import json`` is never needed in a call context.
         """
+        if self._uses_object_variant:
+            return self.heterogeneous_strategy.value.build_preamble(
+                self.heterogeneous_value_variant_name,
+                self._heterogeneous_variant_date_type,
+                self._heterogeneous_variant_datetime_type,
+                self.indent,
+            )
         return no_data_preamble
 
     @cached_property

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1138,12 +1138,31 @@ class Nim(metaclass=LanguageCls):
         ``%*``, so ``import json`` is never needed in a call context.
         """
         if self._uses_object_variant:
-            return self.heterogeneous_strategy.value.build_preamble(
-                self.heterogeneous_value_variant_name,
-                self._heterogeneous_variant_date_type,
-                self._heterogeneous_variant_datetime_type,
-                self.indent,
+            strategy_preamble = (
+                self.heterogeneous_strategy.value.build_preamble(
+                    self.heterogeneous_value_variant_name,
+                    self._heterogeneous_variant_date_type,
+                    self._heterogeneous_variant_datetime_type,
+                    self.indent,
+                )
             )
+
+            def _preamble(data: Value, /) -> tuple[str, ...]:
+                """Suppress UnusedImport for ``tables`` and emit the
+                object-variant type block.
+
+                The ``import tables`` line is contributed by
+                :attr:`dict_format_config` so that ``{...}.toTable``
+                renders correctly, but the call stub uses
+                ``varargs[untyped]`` and never evaluates its arguments,
+                leaving the import "unused" from Nim's point of view.
+                """
+                return (
+                    "{.warning[UnusedImport]:off.}",
+                    *strategy_preamble(data),
+                )
+
+            return _preamble
         return no_data_preamble
 
     @cached_property

--- a/tests/integration/call_variant_cases.py
+++ b/tests/integration/call_variant_cases.py
@@ -11,8 +11,6 @@ from collections.abc import Callable, Iterable
 
 from beartype import beartype
 
-from literalizer._language import no_data_preamble
-
 from .call_cases import CALL_CASE_CONFIGS, CallCaseConfig
 from .language_specs import make_spec, sorted_languages
 from .variant_cases import (
@@ -64,35 +62,12 @@ def build_statement_terminator_style_call_variants() -> list[Variant]:
     return variants
 
 
-@functools.cache
-@beartype
-def _build_call_arg_heterogeneous_value_variant_name_variants() -> list[
-    Variant
-]:
-    """Variant-name variants whose call rendering declares the variant
-    type.
-
-    Filters
-    :func:`build_heterogeneous_value_variant_name_variants` to languages
-    whose ``call_data_dependent_preamble`` actually emits the wrapping
-    type's declaration in the call context.  Languages that share the
-    no-op default produce a call golden referring to an undefined
-    variant type, so they are excluded until their call path emits the
-    declaration.
-    """
-    return [
-        variant
-        for variant in build_heterogeneous_value_variant_name_variants()
-        if variant.spec.call_data_dependent_preamble is not no_data_preamble
-    ]
-
-
 CALL_VARIANT_SOURCES: list[tuple[str, Callable[[], Iterable[Variant]]]] = [
     ("call_scalar_args", build_statement_terminator_style_call_variants),
     ("call_mixed_type_dicts", build_heterogeneous_value_name_variants),
     (
         "call_mixed_type_dicts",
-        _build_call_arg_heterogeneous_value_variant_name_variants,
+        build_heterogeneous_value_variant_name_variants,
     ),
 ]
 

--- a/tests/integration/cases/call_mixed_type_dicts/Nim_heterogeneous_value_variant_name_JsonValue_call.nim
+++ b/tests/integration/cases/call_mixed_type_dicts/Nim_heterogeneous_value_variant_name_JsonValue_call.nim
@@ -1,4 +1,5 @@
 import tables
+{.warning[UnusedImport]:off.}
 type
   JsonValueKind = enum
     vkStr, vkBool

--- a/tests/integration/cases/call_mixed_type_dicts/Nim_heterogeneous_value_variant_name_JsonValue_call.nim
+++ b/tests/integration/cases/call_mixed_type_dicts/Nim_heterogeneous_value_variant_name_JsonValue_call.nim
@@ -1,0 +1,15 @@
+import tables
+type
+  JsonValueKind = enum
+    vkStr, vkBool
+  JsonValue = object
+    case kind: JsonValueKind
+    of vkStr: strVal: string
+    of vkBool: boolVal: bool
+type MgrType = object
+type AppType = object
+    mgr: MgrType
+template run(self: MgrType; args: varargs[untyped]) = discard
+var app: AppType
+app.mgr.run({"type": JsonValue(kind: vkStr, strVal: "create"), "pr_id": JsonValue(kind: vkStr, strVal: "pr_1"), "draft": JsonValue(kind: vkBool, boolVal: true)}.toTable)
+app.mgr.run({"type": JsonValue(kind: vkStr, strVal: "create"), "pr_id": JsonValue(kind: vkStr, strVal: "pr_2")}.toTable)


### PR DESCRIPTION
Closes #1992.

## Summary
- Nim's `call_data_dependent_preamble` now emits the OBJECT_VARIANT strategy's `type` block when that strategy is active, so call goldens reference a defined wrapping type instead of an undefined identifier.
- Removed the `_build_call_arg_heterogeneous_value_variant_name_variants` filter in `tests/integration/call_variant_cases.py` — its sole purpose was hiding the Nim gap. `CALL_VARIANT_SOURCES` now uses `build_heterogeneous_value_variant_name_variants` directly.
- New golden: `tests/integration/cases/call_mixed_type_dicts/Nim_heterogeneous_value_variant_name_JsonValue_call.nim`.

## Test plan
- [x] `pytest tests/integration/` (2717 passed, 690 skipped, 16924 subtests passed)
- [x] `pytest tests/integration/test_calls.py::test_call_variant_golden_file` covers the new Nim case alongside the existing Mojo/Rust variants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Nim call codegen preamble emission and corresponding integration test coverage, with no impact on security-sensitive or core data-handling logic beyond generated output correctness.
> 
> **Overview**
> Fixes Nim `literalize_call` output when `HeterogeneousStrategies.OBJECT_VARIANT` is used by emitting the required object-variant `type` declaration in the call preamble (and suppressing the resulting `UnusedImport` warning for `tables`).
> 
> Updates integration variants to stop filtering out languages lacking this preamble behavior, and adds a new Nim golden file covering the mixed-type-dict call case with the variant wrapper type defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff08488f38eeb17866d0fed235cc03c4dd9c300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->