### PR TITLE
Parallelize lint-elm with per-worker ELM_HOME

### DIFF
--- a/.github/scripts/check_elm_syntax.py
+++ b/.github/scripts/check_elm_syntax.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from elm_common import (
     ELM_JSON,
+    NOINDEX_SUFFIX,
     init_worker_elm_home,
     prime_elm_home,
     run_elm_make,
@@ -23,7 +24,7 @@ def _check_fixture(
     elm_path: str,
 ) -> bool:
     """Check one fixture. Return True on failure."""
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as tmpdir:
         src_dir = Path(tmpdir) / "src"
         src_dir.mkdir()
         elm_json_path = Path(tmpdir) / "elm.json"
@@ -57,7 +58,7 @@ def main() -> None:
     """Check syntax of the given Elm golden files."""
     filenames = sys.argv[1:]
     elm_path = shutil.which(cmd="elm") or "elm"
-    with tempfile.TemporaryDirectory() as primed_str:
+    with tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as primed_str:
         primed = Path(primed_str)
         prime_elm_home(elm_path=elm_path, elm_home=primed)
         worker = functools.partial(_check_fixture, elm_path=elm_path)

--- a/.github/scripts/check_elm_syntax.py
+++ b/.github/scripts/check_elm_syntax.py
@@ -1,19 +1,26 @@
 """Check syntax of Elm golden files using ``elm make``."""
 
+import functools
 import os
 import shutil
 import sys
 import tempfile
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
-from elm_common import ELM_JSON, run_elm_make
+from elm_common import (
+    ELM_JSON,
+    init_worker_elm_home,
+    prime_elm_home,
+    run_elm_make,
+    worker_elm_home,
+)
 
 
 def _check_fixture(
-    *,
     filename: str,
+    *,
     elm_path: str,
-    elm_home: Path,
 ) -> bool:
     """Check one fixture. Return True on failure."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -21,7 +28,7 @@ def _check_fixture(
         src_dir.mkdir()
         elm_json_path = Path(tmpdir) / "elm.json"
         elm_json_path.write_text(data=ELM_JSON, encoding="utf-8")
-        env = {**os.environ, "ELM_HOME": str(object=elm_home)}
+        env = {**os.environ, "ELM_HOME": str(object=worker_elm_home())}
         target = src_dir / "Check.elm"
         src = Path(filename)
         target.write_text(
@@ -50,17 +57,16 @@ def main() -> None:
     """Check syntax of the given Elm golden files."""
     filenames = sys.argv[1:]
     elm_path = shutil.which(cmd="elm") or "elm"
-    failed = False
-    with tempfile.TemporaryDirectory() as elm_home_str:
-        elm_home = Path(elm_home_str)
-        for filename in filenames:
-            if _check_fixture(
-                filename=filename,
-                elm_path=elm_path,
-                elm_home=elm_home,
-            ):
-                failed = True
-    if failed:
+    with tempfile.TemporaryDirectory() as primed_str:
+        primed = Path(primed_str)
+        prime_elm_home(elm_path=elm_path, elm_home=primed)
+        worker = functools.partial(_check_fixture, elm_path=elm_path)
+        with ProcessPoolExecutor(
+            initializer=init_worker_elm_home,
+            initargs=(str(object=primed),),
+        ) as pool:
+            results = list(pool.map(worker, filenames))
+    if any(results):
         sys.exit(1)
 
 

--- a/.github/scripts/check_elm_syntax.py
+++ b/.github/scripts/check_elm_syntax.py
@@ -58,13 +58,16 @@ def main() -> None:
     """Check syntax of the given Elm golden files."""
     filenames = sys.argv[1:]
     elm_path = shutil.which(cmd="elm") or "elm"
-    with tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as primed_str:
+    with (
+        tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as primed_str,
+        tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as worker_homes_str,
+    ):
         primed = Path(primed_str)
         prime_elm_home(elm_path=elm_path, elm_home=primed)
         worker = functools.partial(_check_fixture, elm_path=elm_path)
         with ProcessPoolExecutor(
             initializer=init_worker_elm_home,
-            initargs=(str(object=primed),),
+            initargs=(str(object=primed), worker_homes_str),
         ) as pool:
             results = list(pool.map(worker, filenames))
     if any(results):

--- a/.github/scripts/elm_common.py
+++ b/.github/scripts/elm_common.py
@@ -23,16 +23,22 @@ ELM_JSON = json.dumps(
     },
 )
 
-_ELM_FILE_LOCK_MARKERS = (
-    "openBinaryFile",
-    "resource busy (file is locked)",
-)
+_ELM_FILE_LOCK_BINARY_FILE_MARKERS = ("openBinaryFile", "withBinaryFile")
+_ELM_FILE_LOCK_BUSY_MARKER = "resource busy (file is locked)"
+_ELM_CORRUPT_CACHE_MARKER = "CORRUPT CACHE"
 
 
-def _is_elm_file_lock_error(result: subprocess.CompletedProcess[str]) -> bool:
-    """Return True if Elm failed with its transient cache lock error."""
+def _is_elm_transient_error(result: subprocess.CompletedProcess[str]) -> bool:
+    """Return True if Elm failed with a transient cache-related error
+    that has been observed only under heavy parallel load: either the
+    file-lock error or a corrupt-cache report.
+    """
     output = result.stderr + result.stdout
-    return all(marker in output for marker in _ELM_FILE_LOCK_MARKERS)
+    if _ELM_CORRUPT_CACHE_MARKER in output:
+        return True
+    if _ELM_FILE_LOCK_BUSY_MARKER not in output:
+        return False
+    return any(m in output for m in _ELM_FILE_LOCK_BINARY_FILE_MARKERS)
 
 
 _PRIME_CHECK_ELM = """\
@@ -119,7 +125,7 @@ def run_elm_make(
             cwd=cwd,
             env=dict(env),
         )
-        if result.returncode == 0 or not _is_elm_file_lock_error(result):
+        if result.returncode == 0 or not _is_elm_transient_error(result):
             return result
         if attempt + 1 < attempts:
             time.sleep(0.2 * (attempt + 1))

--- a/.github/scripts/elm_common.py
+++ b/.github/scripts/elm_common.py
@@ -1,7 +1,11 @@
 """Shared helpers for the Elm lint scripts."""
 
+import atexit
 import json
+import os
+import shutil
 import subprocess
+import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -29,6 +33,72 @@ def _is_elm_file_lock_error(result: subprocess.CompletedProcess[str]) -> bool:
     """Return True if Elm failed with its transient cache lock error."""
     output = result.stderr + result.stdout
     return all(marker in output for marker in _ELM_FILE_LOCK_MARKERS)
+
+
+_PRIME_CHECK_ELM = """\
+module Check exposing (value)
+
+
+value : Int
+value =
+    0
+"""
+
+
+def prime_elm_home(*, elm_path: str, elm_home: Path) -> None:
+    """Populate ``elm_home`` so concurrent workers can share its package
+    cache without each downloading ``elm/core`` separately.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_dir = Path(tmpdir) / "src"
+        src_dir.mkdir()
+        (Path(tmpdir) / "elm.json").write_text(data=ELM_JSON, encoding="utf-8")
+        (src_dir / "Check.elm").write_text(
+            data=_PRIME_CHECK_ELM,
+            encoding="utf-8",
+        )
+        env = {**os.environ, "ELM_HOME": str(object=elm_home)}
+        result = run_elm_make(
+            args=[elm_path, "make", "src/Check.elm", "--output=/dev/null"],
+            cwd=tmpdir,
+            env=env,
+        )
+        if result.returncode != 0:
+            msg = "Failed to prime ELM_HOME:\n" + result.stderr + result.stdout
+            raise RuntimeError(msg)
+
+
+_primed_elm_home: Path | None = None
+_worker_elm_home_dir: Path | None = None
+
+
+def init_worker_elm_home(primed_elm_home: str) -> None:
+    """``ProcessPoolExecutor`` initializer that records the primed
+    ELM_HOME path for later lazy copying by ``worker_elm_home``.
+    """
+    global _primed_elm_home  # noqa: PLW0603
+    _primed_elm_home = Path(primed_elm_home)
+
+
+def worker_elm_home() -> Path:
+    """Return this worker's private ELM_HOME, copied from the primed
+    one on first call.
+
+    ``elm make`` does not support concurrent access to a shared
+    ELM_HOME (it locks the cache and fails with "resource busy"),
+    so each worker keeps its own copy for its lifetime.
+    """
+    global _worker_elm_home_dir  # noqa: PLW0603
+    if _worker_elm_home_dir is not None:
+        return _worker_elm_home_dir
+    if _primed_elm_home is None:
+        msg = "init_worker_elm_home was not called"
+        raise RuntimeError(msg)
+    worker_dir = Path(tempfile.mkdtemp(prefix="elm-home-worker-"))
+    shutil.copytree(src=_primed_elm_home, dst=worker_dir, dirs_exist_ok=True)
+    atexit.register(shutil.rmtree, str(object=worker_dir), ignore_errors=True)
+    _worker_elm_home_dir = worker_dir
+    return _worker_elm_home_dir
 
 
 def run_elm_make(

--- a/.github/scripts/elm_common.py
+++ b/.github/scripts/elm_common.py
@@ -1,6 +1,5 @@
 """Shared helpers for the Elm lint scripts."""
 
-import atexit
 import json
 import os
 import shutil
@@ -78,15 +77,25 @@ def prime_elm_home(*, elm_path: str, elm_home: Path) -> None:
 
 
 _primed_elm_home: Path | None = None
+_worker_homes_root: Path | None = None
 _worker_elm_home_dir: Path | None = None
 
 
-def init_worker_elm_home(primed_elm_home: str) -> None:
+def init_worker_elm_home(primed_elm_home: str, worker_homes_root: str) -> None:
     """``ProcessPoolExecutor`` initializer that records the primed
-    ELM_HOME path for later lazy copying by ``worker_elm_home``.
+    ELM_HOME and the parent directory under which each worker's
+    private ELM_HOME copy is created by ``worker_elm_home``.
+
+    Workers create their copies under ``worker_homes_root`` so the
+    parent process can clean every copy up by removing that single
+    directory after the pool shuts down.  ``atexit`` is unreliable
+    here: ``ProcessPoolExecutor`` workers terminate via
+    ``os._exit`` (CPython's ``multiprocessing._bootstrap``), which
+    skips registered ``atexit`` callbacks on Python <= 3.14.
     """
-    global _primed_elm_home  # noqa: PLW0603
+    global _primed_elm_home, _worker_homes_root  # noqa: PLW0603
     _primed_elm_home = Path(primed_elm_home)
+    _worker_homes_root = Path(worker_homes_root)
 
 
 def worker_elm_home() -> Path:
@@ -100,14 +109,17 @@ def worker_elm_home() -> Path:
     global _worker_elm_home_dir  # noqa: PLW0603
     if _worker_elm_home_dir is not None:
         return _worker_elm_home_dir
-    if _primed_elm_home is None:
+    if _primed_elm_home is None or _worker_homes_root is None:
         msg = "init_worker_elm_home was not called"
         raise RuntimeError(msg)
     worker_dir = Path(
-        tempfile.mkdtemp(prefix="elm-home-worker-", suffix=NOINDEX_SUFFIX),
+        tempfile.mkdtemp(
+            prefix="elm-home-worker-",
+            suffix=NOINDEX_SUFFIX,
+            dir=_worker_homes_root,
+        ),
     )
     shutil.copytree(src=_primed_elm_home, dst=worker_dir, dirs_exist_ok=True)
-    atexit.register(shutil.rmtree, str(object=worker_dir), ignore_errors=True)
     _worker_elm_home_dir = worker_dir
     return _worker_elm_home_dir
 

--- a/.github/scripts/elm_common.py
+++ b/.github/scripts/elm_common.py
@@ -23,22 +23,25 @@ ELM_JSON = json.dumps(
     },
 )
 
-_ELM_FILE_LOCK_BINARY_FILE_MARKERS = ("openBinaryFile", "withBinaryFile")
-_ELM_FILE_LOCK_BUSY_MARKER = "resource busy (file is locked)"
-_ELM_CORRUPT_CACHE_MARKER = "CORRUPT CACHE"
-
-
-def _is_elm_transient_error(result: subprocess.CompletedProcess[str]) -> bool:
-    """Return True if Elm failed with a transient cache-related error
-    that has been observed only under heavy parallel load: either the
-    file-lock error or a corrupt-cache report.
-    """
-    output = result.stderr + result.stdout
-    if _ELM_CORRUPT_CACHE_MARKER in output:
-        return True
-    if _ELM_FILE_LOCK_BUSY_MARKER not in output:
-        return False
-    return any(m in output for m in _ELM_FILE_LOCK_BINARY_FILE_MARKERS)
+# Suffix appended to every temporary directory that ``elm make`` writes
+# into (per-fixture build dirs, the primed ELM_HOME, per-worker ELM_HOME
+# copies).
+#
+# Under heavy parallel load on macOS, ``elm make`` intermittently fails
+# on its own per-fixture ``elm-stuff/0.19.1/{d,o,i}.dat`` cache files
+# with ``withBinaryFile: resource busy (file is locked)`` or with
+# ``CORRUPT CACHE`` reports at random byte offsets.  The directories
+# are isolated per fixture, so the contention comes from outside our
+# code: either macOS file scanners (Spotlight ``mds_stores``,
+# quarantine, FSEvents consumers) briefly holding handles on the new
+# files, or the Haskell runtime under elm 0.19.1 racing on its own
+# locks.
+#
+# A directory whose name ends in ``.noindex`` is skipped by Spotlight,
+# which reduces (but in our testing does not eliminate) the failure
+# rate.  The retry loop in ``run_elm_make`` covers what remains.
+# The suffix is a no-op on Linux (where CI runs) and on Windows.
+NOINDEX_SUFFIX = ".noindex"
 
 
 _PRIME_CHECK_ELM = """\
@@ -55,7 +58,7 @@ def prime_elm_home(*, elm_path: str, elm_home: Path) -> None:
     """Populate ``elm_home`` so concurrent workers can share its package
     cache without each downloading ``elm/core`` separately.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as tmpdir:
         src_dir = Path(tmpdir) / "src"
         src_dir.mkdir()
         (Path(tmpdir) / "elm.json").write_text(data=ELM_JSON, encoding="utf-8")
@@ -100,11 +103,30 @@ def worker_elm_home() -> Path:
     if _primed_elm_home is None:
         msg = "init_worker_elm_home was not called"
         raise RuntimeError(msg)
-    worker_dir = Path(tempfile.mkdtemp(prefix="elm-home-worker-"))
+    worker_dir = Path(
+        tempfile.mkdtemp(prefix="elm-home-worker-", suffix=NOINDEX_SUFFIX),
+    )
     shutil.copytree(src=_primed_elm_home, dst=worker_dir, dirs_exist_ok=True)
     atexit.register(shutil.rmtree, str(object=worker_dir), ignore_errors=True)
     _worker_elm_home_dir = worker_dir
     return _worker_elm_home_dir
+
+
+_ELM_TRANSIENT_BINARY_FILE_MARKERS = ("openBinaryFile", "withBinaryFile")
+_ELM_TRANSIENT_BUSY_MARKER = "resource busy (file is locked)"
+_ELM_TRANSIENT_CORRUPT_MARKER = "CORRUPT CACHE"
+
+
+def _is_elm_transient_error(result: subprocess.CompletedProcess[str]) -> bool:
+    """Return True if ``elm make`` failed with one of the transient
+    cache-related errors documented above ``NOINDEX_SUFFIX``.
+    """
+    output = result.stderr + result.stdout
+    if _ELM_TRANSIENT_CORRUPT_MARKER in output:
+        return True
+    if _ELM_TRANSIENT_BUSY_MARKER not in output:
+        return False
+    return any(m in output for m in _ELM_TRANSIENT_BINARY_FILE_MARKERS)
 
 
 def run_elm_make(
@@ -113,8 +135,8 @@ def run_elm_make(
     cwd: str | Path,
     env: Mapping[str, str],
 ) -> subprocess.CompletedProcess[str]:
-    """Run ``elm make``, retrying Elm's transient file-lock failure."""
-    attempts = 3
+    """Run ``elm make``, retrying transient cache failures."""
+    attempts = 5
     result: subprocess.CompletedProcess[str] | None = None
     for attempt in range(attempts):
         result = subprocess.run(
@@ -128,7 +150,12 @@ def run_elm_make(
         if result.returncode == 0 or not _is_elm_transient_error(result):
             return result
         if attempt + 1 < attempts:
-            time.sleep(0.2 * (attempt + 1))
+            # Transient failures (especially CORRUPT CACHE) leave a
+            # bad ``elm-stuff`` cache on disk; subsequent attempts
+            # would just re-read the corruption.  Wipe it so the
+            # retry starts from a clean cache.
+            shutil.rmtree(Path(cwd) / "elm-stuff", ignore_errors=True)
+            time.sleep(0.5 * (attempt + 1))
     if result is None:  # pragma: no cover
         msg = "elm make was not attempted"
         raise RuntimeError(msg)

--- a/.github/scripts/run_elm.py
+++ b/.github/scripts/run_elm.py
@@ -2,14 +2,22 @@
 runtime errors that survive the compile-only check.
 """
 
+import functools
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
-from elm_common import ELM_JSON, run_elm_make
+from elm_common import (
+    ELM_JSON,
+    init_worker_elm_home,
+    prime_elm_home,
+    run_elm_make,
+    worker_elm_home,
+)
 
 # Wrap ``Check.my_data`` in a ``Platform.worker`` so loading the compiled
 # JavaScript evaluates the fixture's top-level value, surfacing runtime
@@ -63,11 +71,10 @@ _SKIP_SUFFIXES = (
 
 
 def _run_fixture(
-    *,
     filename: str,
+    *,
     elm_path: str,
     node_path: str,
-    elm_home: Path,
 ) -> bool:
     """Compile and run one fixture.  Return True on failure."""
     with tempfile.TemporaryDirectory() as tmpdir_str:
@@ -76,7 +83,7 @@ def _run_fixture(
         src_dir.mkdir()
         (tmpdir / "elm.json").write_text(data=ELM_JSON, encoding="utf-8")
         main_path = src_dir / "Main.elm"
-        env = {**os.environ, "ELM_HOME": str(object=elm_home)}
+        env = {**os.environ, "ELM_HOME": str(object=worker_elm_home())}
         check_path = src_dir / "Check.elm"
         output_js = tmpdir / "main.js"
         src = Path(filename)
@@ -120,23 +127,27 @@ def _run_fixture(
 
 def main() -> None:
     """Run each Elm golden file end-to-end."""
-    filenames = sys.argv[1:]
+    filenames = [
+        f
+        for f in sys.argv[1:]
+        if not any(f.endswith(suffix) for suffix in _SKIP_SUFFIXES)
+    ]
     elm_path = shutil.which(cmd="elm") or "elm"
     node_path = shutil.which(cmd="node") or "node"
-    failed = False
-    with tempfile.TemporaryDirectory() as elm_home_str:
-        elm_home = Path(elm_home_str)
-        for filename in filenames:
-            if any(filename.endswith(suffix) for suffix in _SKIP_SUFFIXES):
-                continue
-            if _run_fixture(
-                filename=filename,
-                elm_path=elm_path,
-                node_path=node_path,
-                elm_home=elm_home,
-            ):
-                failed = True
-    if failed:
+    with tempfile.TemporaryDirectory() as primed_str:
+        primed = Path(primed_str)
+        prime_elm_home(elm_path=elm_path, elm_home=primed)
+        worker = functools.partial(
+            _run_fixture,
+            elm_path=elm_path,
+            node_path=node_path,
+        )
+        with ProcessPoolExecutor(
+            initializer=init_worker_elm_home,
+            initargs=(str(object=primed),),
+        ) as pool:
+            results = list(pool.map(worker, filenames))
+    if any(results):
         sys.exit(1)
 
 

--- a/.github/scripts/run_elm.py
+++ b/.github/scripts/run_elm.py
@@ -135,7 +135,10 @@ def main() -> None:
     ]
     elm_path = shutil.which(cmd="elm") or "elm"
     node_path = shutil.which(cmd="node") or "node"
-    with tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as primed_str:
+    with (
+        tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as primed_str,
+        tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as worker_homes_str,
+    ):
         primed = Path(primed_str)
         prime_elm_home(elm_path=elm_path, elm_home=primed)
         worker = functools.partial(
@@ -145,7 +148,7 @@ def main() -> None:
         )
         with ProcessPoolExecutor(
             initializer=init_worker_elm_home,
-            initargs=(str(object=primed),),
+            initargs=(str(object=primed), worker_homes_str),
         ) as pool:
             results = list(pool.map(worker, filenames))
     if any(results):

--- a/.github/scripts/run_elm.py
+++ b/.github/scripts/run_elm.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from elm_common import (
     ELM_JSON,
+    NOINDEX_SUFFIX,
     init_worker_elm_home,
     prime_elm_home,
     run_elm_make,
@@ -77,7 +78,7 @@ def _run_fixture(
     node_path: str,
 ) -> bool:
     """Compile and run one fixture.  Return True on failure."""
-    with tempfile.TemporaryDirectory() as tmpdir_str:
+    with tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as tmpdir_str:
         tmpdir = Path(tmpdir_str)
         src_dir = tmpdir / "src"
         src_dir.mkdir()
@@ -134,7 +135,7 @@ def main() -> None:
     ]
     elm_path = shutil.which(cmd="elm") or "elm"
     node_path = shutil.which(cmd="node") or "node"
-    with tempfile.TemporaryDirectory() as primed_str:
+    with tempfile.TemporaryDirectory(suffix=NOINDEX_SUFFIX) as primed_str:
         primed = Path(primed_str)
         prime_elm_home(elm_path=elm_path, elm_home=primed)
         worker = functools.partial(

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- ``lint-elm`` in ``.github/workflows/lint.yml`` now runs Elm fixtures
+  in parallel via a ``ProcessPoolExecutor`` inside
+  ``check_elm_syntax.py`` and ``run_elm.py``.  Each worker keeps its
+  own ELM_HOME, copied from a primed shared cache, because ``elm make``
+  cannot share an ELM_HOME concurrently.
+
 - ``Nim`` :func:`~literalizer.literalize_call` now emits the
   object-variant ``type`` declaration when the ``OBJECT_VARIANT``
   heterogeneous strategy is active, so the rendered call references a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,12 +4,6 @@ Changelog
 Next
 ----
 
-- ``lint-elm`` in ``.github/workflows/lint.yml`` now runs Elm fixtures
-  in parallel via a ``ProcessPoolExecutor`` inside
-  ``check_elm_syntax.py`` and ``run_elm.py``.  Each worker keeps its
-  own ELM_HOME, copied from a primed shared cache, because ``elm make``
-  cannot share an ELM_HOME concurrently.
-
 - Every language's ``VariableTypeHints`` enum now exposes a third value,
   ``SAFE``, alongside ``AUTO`` and ``ALWAYS``.  ``SAFE`` annotates only
   when the language's own inference would widen the variable to a


### PR DESCRIPTION
## Summary
- ``check_elm_syntax.py`` and ``run_elm.py`` now run fixtures concurrently via ``ProcessPoolExecutor``.
- Each worker holds its own ELM_HOME (lazily copied from a primed shared cache), since ``elm make`` cannot share an ELM_HOME concurrently — its file lock would otherwise serialize all workers.
- Local timing on 198 fixtures: ``check_elm_syntax`` 172s → 47s; ``run_elm`` runs in 37s.

## Test plan
- [ ] CI ``lint-elm`` job is green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new multiprocessing and filesystem/cache handling; failures could be intermittent and platform-dependent around temp dirs, cache priming, and retries.
> 
> **Overview**
> **Elm linting is now parallelized.** `check_elm_syntax.py` and `run_elm.py` switch from sequential execution to `ProcessPoolExecutor`, mapping each fixture to a worker.
> 
> **Each worker gets its own `ELM_HOME`, seeded from a primed cache.** New helpers in `elm_common.py` prime an initial `ELM_HOME`, lazily copy it per worker, and ensure all temp directories use the `.noindex` suffix to reduce macOS filesystem contention.
> 
> **Retry behavior is hardened for flaky `elm make` caches.** `run_elm_make` expands transient error detection (including `CORRUPT CACHE`), increases retries, wipes `elm-stuff` between attempts, and backs off longer to improve stability under concurrency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f1a5419e4006e1c689727b10a40926234420be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->