### PR TITLE
Try Mojo lint on ubuntu-latest runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1258,11 +1258,11 @@ jobs:
         run: |-
           mapfile -d '' -t files < <(find tests/integration/cases -name '*.mojo' -print0 | sort -z)
           n=${#files[@]}
+          : > /tmp/shard-files
           for (( i=${{ matrix.shard }}; i<n; i+=4 )); do
-            src="${files[i]}"
-            printf 'Checking %s\n' "$src"
-            mojo run --Werror "$src"
+            printf '%s\0' "${files[i]}" >> /tmp/shard-files
           done
+          xargs -0 -P "$(nproc)" -n1 mojo run --Werror < /tmp/shard-files
 
   lint-nim:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1234,14 +1234,8 @@ jobs:
           done < /tmp/files-to-lint
           crystal run "$driver"
 
-  # Mojo reserves ~3.6 GB of virtual address space per invocation
-  # (upstream: modular/modular#6433), so ubuntu-latest's 7 GB runner
-  # crashes in libKGENCompilerRTShared.so before producing any output —
-  # and even with overcommit + swap workarounds it could only run
-  # serially. Ubicloud's 16 GB runner comfortably fits `$(nproc)`
-  # parallel invocations without the workarounds.
   lint-mojo:
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1234,15 +1234,19 @@ jobs:
           done < /tmp/files-to-lint
           crystal run "$driver"
 
+  # Mojo reserves ~3.6 GB of virtual address space per invocation
+  # (upstream: modular/modular#6433), so parallel invocations on
+  # ubuntu-latest's 7 GB runner crash in libKGENCompilerRTShared.so.
+  # Shard across runners and build serially within each shard.
   lint-mojo:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Find files to lint
-        shell: bash
-        run: find tests/integration/cases -name '*.mojo' -print0 > /tmp/files-to-lint
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -1251,7 +1255,14 @@ jobs:
       - name: Install Mojo
         run: uv tool install --prerelease=allow 'mojo-compiler==1.0.0b1'
       - name: Check Mojo syntax
-        run: xargs -0 -P "$(nproc)" -n1 mojo run --Werror < /tmp/files-to-lint
+        run: |-
+          mapfile -d '' -t files < <(find tests/integration/cases -name '*.mojo' -print0 | sort -z)
+          n=${#files[@]}
+          for (( i=${{ matrix.shard }}; i<n; i+=4 )); do
+            src="${files[i]}"
+            printf 'Checking %s\n' "$src"
+            mojo run --Werror "$src"
+          done
 
   lint-nim:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Mojo 1.0.0b1 may no longer need the 16 GB Ubicloud runner that the previous Mojo releases required. Switch `lint-mojo` to `ubuntu-latest` and drop the runner-sizing comment to see whether CI still passes.

Closes #1993.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI execution model for Mojo linting (runner type + parallelization/sharding), which could impact lint coverage, execution time, or reintroduce Mojo compiler memory-related failures.
> 
> **Overview**
> Moves the `lint-mojo` GitHub Actions job off the custom `ubicloud-standard-4` runner onto `ubuntu-latest`.
> 
> To avoid Mojo’s per-invocation memory pressure on smaller runners, the job now **shards `.mojo` fixtures across a 4-way matrix** by deterministically sorting the file list and assigning every 4th file to each shard before running `mojo run --Werror`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c581049238301c339ea253cd0c8f1f077da474c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->