### PR TITLE
Remove direct test of format_call_preamble_stub

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -13,9 +13,6 @@ from literalizer import (
     NewVariable,
     literalize,
 )
-from literalizer._language import (
-    StubReturn,
-)
 from literalizer.exceptions import (
     NullInCollectionError,
     UnrepresentableSpecialFloatError,
@@ -440,53 +437,6 @@ def test_java_list_rejects_null_elements() -> None:
             include_delimiters=True,
             variable_form=None,
         )
-
-
-def test_gleam_call_preamble_stub_many_parameters() -> None:
-    """Gleam call stubs handle more than 26 parameters.
-
-    ``_gleam_type_var`` falls back to numeric suffixes past the 26-letter
-    alphabet, so a 27-parameter call must emit a ``z`` for the last
-    single-letter slot and an ``a1`` for the next one.
-    """
-    params = [f"p{i}" for i in range(27)]
-    (line,) = Gleam().format_call_preamble_stub(
-        ("target",),
-        params,
-        StubReturn.VOID,
-        [],
-    )
-    assert line == (
-        "pub fn target("
-        "_p0: a, "
-        "_p1: b, "
-        "_p2: c, "
-        "_p3: d, "
-        "_p4: e, "
-        "_p5: f, "
-        "_p6: g, "
-        "_p7: h, "
-        "_p8: i, "
-        "_p9: j, "
-        "_p10: k, "
-        "_p11: l, "
-        "_p12: m, "
-        "_p13: n, "
-        "_p14: o, "
-        "_p15: p, "
-        "_p16: q, "
-        "_p17: r, "
-        "_p18: s, "
-        "_p19: t, "
-        "_p20: u, "
-        "_p21: v, "
-        "_p22: w, "
-        "_p23: x, "
-        "_p24: y, "
-        "_p25: z, "
-        "_p26: a1"
-        ") -> Nil { Nil }"
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -12,6 +12,7 @@ from literalizer import (
     InputFormat,
     NewVariable,
     literalize,
+    literalize_call,
 )
 from literalizer.exceptions import (
     NullInCollectionError,
@@ -437,6 +438,35 @@ def test_java_list_rejects_null_elements() -> None:
             include_delimiters=True,
             variable_form=None,
         )
+
+
+def test_gleam_call_stub_more_than_26_parameters() -> None:
+    """Gleam type-var generation falls back to numeric suffixes past
+    the 26-letter alphabet.
+
+    Calls with 27 parameters exercise ``_gleam_type_var``'s numeric
+    suffix branch, emitting ``z`` for the last single-letter slot and
+    ``a1`` for the next one in the generated stub signature.
+    """
+    parameter_names = [f"p{i}" for i in range(27)]
+    yaml_row = "\n".join(f"  - {i}" for i in range(27))
+    source = f"---\n-\n{yaml_row}\n"
+    result = literalize_call(
+        source=source,
+        input_format=InputFormat.YAML,
+        language=Gleam(),
+        target_function="process",
+        parameter_names=parameter_names,
+        wrap_in_file=True,
+    )
+    assert (
+        "pub fn process("
+        "_p0: a, _p1: b, _p2: c, _p3: d, _p4: e, _p5: f, _p6: g, "
+        "_p7: h, _p8: i, _p9: j, _p10: k, _p11: l, _p12: m, _p13: n, "
+        "_p14: o, _p15: p, _p16: q, _p17: r, _p18: s, _p19: t, "
+        "_p20: u, _p21: v, _p22: w, _p23: x, _p24: y, _p25: z, "
+        "_p26: a1) -> Nil { Nil }"
+    ) in result.code
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1969.

Removes ``test_gleam_call_preamble_stub_many_parameters``, the only test that called ``format_call_preamble_stub`` directly. The integration suite already exercises this method via the public ``literalize_call`` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that replaces a direct call-stub unit test with an integration-style `literalize_call` assertion, without altering production logic.
> 
> **Overview**
> Switches the Gleam “more than 26 parameters” test to generate a YAML input and validate the emitted stub signature via `literalize_call`, removing the last direct test dependency on `format_call_preamble_stub`/`StubReturn`.
> 
> This keeps coverage of the `_gleam_type_var` numeric-suffix behavior (e.g., `z` then `a1`) while asserting it through the public API output (`result.code`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6588ae421cef516b9e05e3ad87b048893343f159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->