### PR TITLE
Remove unnecessary pyright ignore in test_coercion_errors

### DIFF
--- a/tests/test_coercion_errors.py
+++ b/tests/test_coercion_errors.py
@@ -77,7 +77,7 @@ def _to_source(
                 if isinstance(data, dict)
                 else {"_": data}
             )
-            return tomlkit.dumps(data=toml_data)  # pyright: ignore[reportUnknownMemberType]
+            return tomlkit.dumps(data=toml_data)
         case _ as unreachable:
             assert_never(unreachable)
 


### PR DESCRIPTION
Removes a `# pyright: ignore[reportUnknownMemberType]` comment that pyright now flags as unnecessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a test helper by removing a now-unneeded `pyright` suppression, with no runtime logic changes.
> 
> **Overview**
> Removes an unnecessary `# pyright: ignore[reportUnknownMemberType]` suppression from the TOML serialization path in `tests/test_coercion_errors.py` (the `tomlkit.dumps` call), keeping the tests unchanged while satisfying stricter `pyright` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2e963a9ea436ba491af66617c5d1f23d8e57b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->