### PR TITLE
Use match statements for elm and haskell formatter dispatch

### DIFF
--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -389,31 +389,40 @@ def _elm_call_stub(
     flat_name = _elm_flatten_dotted(parts=parts)
     n = len(params)
     _max_elm_tuple_size = len(("a", "b", "c"))
-    if n == 0:  # pragma: no cover
-        type_sig = f"{flat_name} : ()"
-        impl = f"{flat_name} = ()"
-    elif n == 1:
-        type_sig = f"{flat_name} : a -> ()"
-        impl = f"{flat_name} _ = ()"
-    elif n <= _max_elm_tuple_size:
-        _alphabet_size = len(string.ascii_lowercase)
-        type_vars = ", ".join(
-            chr(ord("a") + (i % _alphabet_size))
-            + (str(object=i // _alphabet_size) if i >= _alphabet_size else "")
-            for i in range(n)
-        )
-        type_sig = f"{flat_name} : ( {type_vars} ) -> ()"
-        impl = f"{flat_name} _ = ()"
-    else:  # pragma: no cover
-        _alphabet_size = len(string.ascii_lowercase)
-        type_vars = " -> ".join(
-            chr(ord("a") + (i % _alphabet_size))
-            + (str(object=i // _alphabet_size) if i >= _alphabet_size else "")
-            for i in range(n)
-        )
-        wildcards = " ".join("_" for _ in range(n))
-        type_sig = f"{flat_name} : {type_vars} -> ()"
-        impl = f"{flat_name} {wildcards} = ()"
+    match n:
+        case 0:  # pragma: no cover
+            type_sig = f"{flat_name} : ()"
+            impl = f"{flat_name} = ()"
+        case 1:
+            type_sig = f"{flat_name} : a -> ()"
+            impl = f"{flat_name} _ = ()"
+        case _ if n <= _max_elm_tuple_size:
+            _alphabet_size = len(string.ascii_lowercase)
+            type_vars = ", ".join(
+                chr(ord("a") + (i % _alphabet_size))
+                + (
+                    str(object=i // _alphabet_size)
+                    if i >= _alphabet_size
+                    else ""
+                )
+                for i in range(n)
+            )
+            type_sig = f"{flat_name} : ( {type_vars} ) -> ()"
+            impl = f"{flat_name} _ = ()"
+        case _:  # pragma: no cover
+            _alphabet_size = len(string.ascii_lowercase)
+            type_vars = " -> ".join(
+                chr(ord("a") + (i % _alphabet_size))
+                + (
+                    str(object=i // _alphabet_size)
+                    if i >= _alphabet_size
+                    else ""
+                )
+                for i in range(n)
+            )
+            wildcards = " ".join("_" for _ in range(n))
+            type_sig = f"{flat_name} : {type_vars} -> ()"
+            impl = f"{flat_name} {wildcards} = ()"
     return (type_sig, impl)
 
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -286,26 +286,27 @@ def _build_date_formatters(
     else:
         fmt_date = date_formatter
 
-    if datetime_format_name == "HASKELL":
-        fmt_datetime: Callable[[datetime.datetime], str] = (
-            _build_haskell_datetime_formatter(prefix=constructor_prefix)
-        )
-    elif datetime_format_name == "EPOCH":
-        fmt_datetime = datetime_formatter
-    elif is_explicit:
-        _str_pfx_dt = f"{constructor_prefix}Str "
-
-        def _explicit_datetime(value: datetime.datetime) -> str:
-            """Delegate to module-level implementation."""
-            return _wrap_with_str_constructor_datetime(
-                value=value,
-                str_prefix=_str_pfx_dt,
-                formatter=datetime_formatter,
+    match datetime_format_name:
+        case "HASKELL":
+            fmt_datetime: Callable[[datetime.datetime], str] = (
+                _build_haskell_datetime_formatter(prefix=constructor_prefix)
             )
+        case "EPOCH":
+            fmt_datetime = datetime_formatter
+        case _ if is_explicit:
+            _str_pfx_dt = f"{constructor_prefix}Str "
 
-        fmt_datetime = _explicit_datetime
-    else:
-        fmt_datetime = datetime_formatter
+            def _explicit_datetime(value: datetime.datetime) -> str:
+                """Delegate to module-level implementation."""
+                return _wrap_with_str_constructor_datetime(
+                    value=value,
+                    str_prefix=_str_pfx_dt,
+                    formatter=datetime_formatter,
+                )
+
+            fmt_datetime = _explicit_datetime
+        case _:
+            fmt_datetime = datetime_formatter
 
     return _DateTimeFormatters(
         format_date=fmt_date,


### PR DESCRIPTION
## Summary
- Convert the arity-based if/elif chain in `_elm_call_stub` to a `match` on `n`.
- Convert the `datetime_format_name` if/elif chain in the Haskell datetime formatter builder to a `match`.

## Test plan
- [x] `uv run pyright` (clean)
- [x] `uv run pytest` for elm/haskell unit and integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change that preserves existing branching behavior for Elm call stubs and Haskell datetime formatter selection. Low risk aside from potential edge-case differences in pattern guard ordering.
> 
> **Overview**
> Replaces two `if/elif` dispatch chains with Python `match` statements.
> 
> In `elm.py`, `_elm_call_stub` now uses `match n` to select the stub type signature/implementation by arity (0, 1, tuple up to 3, or curried fallback). In `haskell.py`, `_build_date_formatters` now uses `match datetime_format_name` to pick the datetime formatter, including the explicit `HStr`-wrapping path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6166eebf9be1793b62bcbc5101b7e4e29549317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->