### PR TITLE
Remove F# bigint suffix unit test covered by golden case

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -22,7 +22,6 @@ from literalizer.languages import (
     Cobol,
     Dart,
     Fortran,
-    FSharp,
     Gleam,
     Haskell,
     Java,
@@ -47,7 +46,6 @@ FORTRAN = Fortran(
     sequence_format=Fortran.sequence_formats.LIST,
     module_name="check",
 )
-FSHARP = FSharp(module_name="check")
 
 
 def test_python_datetime_whole_hour_offset_omits_minutes() -> None:
@@ -378,22 +376,6 @@ def test_fortran_continuation_with_escaped_quote_and_comment() -> None:
         "    fentry('host', fstr('it''s here')), &  ! a comment\n"
         "    fentry('port', fint(80_int64)) &  ! another\n"
         "])"
-    )
-
-
-def test_fsharp_scalar_very_large_int_uses_bigint_suffix() -> None:
-    """Bare F# scalar integers above i64 range use the ``I`` suffix."""
-    result = literalize(
-        source="9223372036854775808",
-        input_format=InputFormat.JSON,
-        language=FSHARP,
-        pre_indent_level=0,
-        include_delimiters=False,
-        variable_form=None,
-    )
-
-    assert result.code == (
-        "type Val =\n    | FInt of bigint\n9223372036854775808I"
     )
 
 


### PR DESCRIPTION
## Summary
- Removes the redundant `test_fsharp_scalar_very_large_int_uses_bigint_suffix` unit test from `tests/test_languages.py`.
- The F# `I` bigint suffix for integers above the i64 range is already exercised by the `scalar_int_very_large` golden case (`tests/integration/cases/scalar_int_very_large/FSharp.fs`).
- Also drops the now-unused `FSharp` import and `FSHARP` module-level constant.

Closes #2020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes a redundant F#-specific unit test and associated unused imports/constants without changing production code paths.
> 
> **Overview**
> Removes the standalone F# unit test that asserted very-large integer literals use the `I` bigint suffix, relying instead on the existing golden integration case for coverage.
> 
> Cleans up `tests/test_languages.py` by dropping the now-unused `FSharp` import and `FSHARP` test constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9447cee9269f95b1e8ed2ae46d839d1a167b0ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->