### PR TITLE
Type literalize_ref_cases data as a recursive YAML-like alias

### DIFF
--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -70,6 +70,7 @@ type _RefData = (
 )
 
 
+@beartype
 def _collect_ref_names(data: _RefData, *, ref_key: str) -> list[str]:
     """Recursively collect all ref name values from parsed data."""
     match data:

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -12,7 +12,6 @@ import dataclasses
 import functools
 import re
 from pathlib import Path
-from typing import cast
 
 import pytest
 from beartype import beartype
@@ -66,24 +65,27 @@ def discover_literalize_default_ref_cases() -> list[LiteralizeRefCase]:
     ]
 
 
-def _collect_ref_names(data: object, *, ref_key: str) -> list[str]:
+type _RefData = (
+    dict[str, _RefData] | list[_RefData] | str | int | float | bool | None
+)
+
+
+def _collect_ref_names(data: _RefData, *, ref_key: str) -> list[str]:
     """Recursively collect all ref name values from parsed data."""
     match data:
         case dict():
-            typed_data = cast("dict[object, object]", data)
-            if len(typed_data) == 1 and ref_key in typed_data:
-                name = typed_data[ref_key]
+            if len(data) == 1 and ref_key in data:
+                name = data[ref_key]
                 return [name] if isinstance(name, str) else []
             return [
                 n
-                for v in typed_data.values()
+                for v in data.values()
                 for n in _collect_ref_names(data=v, ref_key=ref_key)
             ]
         case list():
-            typed_list = cast("list[object]", data)
             return [
                 n
-                for item in typed_list
+                for item in data
                 for n in _collect_ref_names(data=item, ref_key=ref_key)
             ]
         case _:
@@ -348,7 +350,7 @@ def run_literalize_ref_golden_case(
     final_code = result.code
     if variable_form_obj is not None:
         ruamel_yaml = _YAML()
-        raw_data: object = ruamel_yaml.load(  # pyright: ignore[reportUnknownMemberType]
+        raw_data: _RefData = ruamel_yaml.load(  # pyright: ignore[reportUnknownMemberType]
             stream=yaml_string,
         )
         stub_entries: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary
- Replaces two `dict[object, object]` / `list[object]` casts in `_collect_ref_names` with a `_RefData` recursive type alias so `match` narrowing produces typed containers without needing the casts.
- Mirrors the pattern recently introduced for `_SourceData` in `tests/test_coercion_errors.py`.

## Test plan
- [x] mypy, pyright, ty all clean
- [x] `pytest -k literalize_ref` passes (473 passed, 95 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only typing refactor that removes `cast()` usage without changing runtime logic or production code paths.
> 
> **Overview**
> Refactors `tests/integration/literalize_ref_cases.py` to introduce a recursive `_RefData` type alias for YAML-parsed data and uses it throughout `_collect_ref_names` and the `ruamel_yaml.load()` result.
> 
> This removes explicit `cast()` calls and relies on `match`-based narrowing for `dict`/`list` traversal while keeping the test behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee3f0076696c2d185ab1b59673d1a3176cb138d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->