### PR TITLE
Type _coerce_toml_values data as a recursive TOML-like alias

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -296,7 +296,8 @@ def _parse_toml(*, source: str) -> _ParsedInput:
     except TOMLKitError as exc:
         message = f"Invalid TOML: {exc}"
         raise TOMLParseError(message) from exc
-    toml_data = _coerce_toml_values(data=toml_doc.unwrap())
+    unwrapped: _TomlData = toml_doc.unwrap()
+    toml_data = _coerce_toml_values(data=unwrapped)
     return _ParsedInput(
         data=toml_data,
         raw_data=toml_doc,
@@ -320,8 +321,13 @@ def parse_input(*, source: str, input_format: InputFormat) -> _ParsedInput:
             assert_never(unreachable)
 
 
+type _TomlData = (
+    dict[str, _TomlData] | list[_TomlData] | datetime.time | Scalar
+)
+
+
 @beartype
-def _coerce_toml_values(*, data: object) -> Value:
+def _coerce_toml_values(*, data: _TomlData) -> Value:
     """Recursively convert TOML-specific types to ``Value`` types.
 
     ``tomlkit`` produces ``datetime.time`` values which cannot be
@@ -330,16 +336,10 @@ def _coerce_toml_values(*, data: object) -> Value:
     """
     match data:
         case dict():
-            return {
-                k: _coerce_toml_values(data=v)
-                for k, v in cast("dict[str, object]", data).items()
-            }
+            return {k: _coerce_toml_values(data=v) for k, v in data.items()}
         case list():
-            return [
-                _coerce_toml_values(data=item)
-                for item in cast("list[object]", data)
-            ]
+            return [_coerce_toml_values(data=item) for item in data]
         case datetime.time():
             return data.isoformat()
         case _:
-            return cast("Value", data)
+            return data


### PR DESCRIPTION
## Summary
- Replaces three `dict[str, object]` / `list[object]` / `Value` casts in `_coerce_toml_values` with a `_TomlData` recursive type alias so `match` narrowing produces typed containers without needing the casts.
- Mirrors the pattern from `_RefData` (#2032) and `_SourceData` (#2028).

Closes #2034

## Test plan
- [x] mypy, pyright, ty all clean
- [x] `pytest -k toml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a typing/clarity refactor around TOML value coercion with no intended behavior change, aside from relying on narrower types instead of runtime casts.
> 
> **Overview**
> Improves TOML parsing typing by introducing a recursive `_TomlData` alias and threading it through `_parse_toml`/`_coerce_toml_values`.
> 
> This removes several `cast(...)` calls in the TOML coercion logic (dict/list branches) and returns the already-narrowed value directly in the default match case, keeping the conversion behavior (notably `datetime.time` to ISO strings) the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbaf303fd45e6b5c4b9b75c3914ca973b6aa045d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->