### PR TITLE
Refactor _collection_open_for_multiline_value to use match

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1149,14 +1149,14 @@ def _collection_open_for_multiline_value(
     Used for a nested multiline collection.
     """
     del expand_refs
-    if isinstance(data, dict):
-        if is_ordered_map:
+    match data:
+        case dict() if is_ordered_map:
             opener = spec.ordered_map_format_config.ordered_map_open(data)
-        elif dict_open_override is not None:
+        case dict() if dict_open_override is not None:
             opener = dict_open_override
-        elif not ref_key:
+        case dict() if not ref_key:
             opener = spec.dict_format_config.dict_open(data)
-        else:
+        case dict():
             dict_open_items = {
                 k: v
                 for k, v in data.items()
@@ -1164,24 +1164,24 @@ def _collection_open_for_multiline_value(
                 or _extract_call_arg_ref_name(value=v, ref_key=ref_key) is None
             }
             opener = spec.dict_format_config.dict_open(dict_open_items or data)
-    elif isinstance(data, set):
-        sorted_set: list[Value] = sorted(
-            data,
-            key=lambda v: (type(v).__name__, repr(v)),
-        )
-        opener = spec.set_format_config.set_open(sorted_set)
-    elif sequence_open_override is not None:
-        opener = sequence_open_override
-    elif not ref_key:
-        opener = spec.sequence_open(data)
-    else:
-        sequence_open_items = [
-            v
-            for v in data
-            if not isinstance(v, dict)
-            or _extract_call_arg_ref_name(value=v, ref_key=ref_key) is None
-        ]
-        opener = spec.sequence_open(sequence_open_items or data)
+        case set():
+            sorted_set: list[Value] = sorted(
+                data,
+                key=lambda v: (type(v).__name__, repr(v)),
+            )
+            opener = spec.set_format_config.set_open(sorted_set)
+        case _ if sequence_open_override is not None:
+            opener = sequence_open_override
+        case _ if not ref_key:
+            opener = spec.sequence_open(data)
+        case _:
+            sequence_open_items = [
+                v
+                for v in data
+                if not isinstance(v, dict)
+                or _extract_call_arg_ref_name(value=v, ref_key=ref_key) is None
+            ]
+            opener = spec.sequence_open(sequence_open_items or data)
     return opener
 
 


### PR DESCRIPTION
## Summary
- Replaces the nested `isinstance(data, ...)` if/elif chain in `_collection_open_for_multiline_value` with a `match` statement using `dict()` / `set()` type patterns and guards.

## Test plan
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that reorganizes type/guard branching in `_collection_open_for_multiline_value` without changing inputs/outputs; main risk is subtle behavior drift in opener selection order.
> 
> **Overview**
> Refactors `_collection_open_for_multiline_value` to replace the `isinstance`/`elif` chain with a `match` statement using `dict()`/`set()` patterns and guard clauses.
> 
> Logic for choosing collection openers is preserved (ordered-map vs dict overrides, ref-aware opener inference, set sorting, and sequence override handling), but expressed via pattern matching for readability and maintainability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2457bd2a367738c70c47d84f8efcb4f877cfed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->