### PR TITLE
Beartype remaining keyword-arg helpers in _parsing and _language

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -389,6 +389,7 @@ while still accepting the four non-kebab cases as legal identifiers.
 """
 
 
+@beartype
 def _convert_identifier_case(*, case: IdentifierCase, name: str) -> str:
     """Convert *name* to *case* with snake_case normalization.
 

--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -200,6 +200,7 @@ def _parse_json5(*, source: str) -> _ParsedInput:
 
 
 @functools.cache
+@beartype
 def get_yaml() -> YAML:
     """Return the cached round-trip ``YAML`` instance.
 
@@ -214,6 +215,7 @@ def get_yaml() -> YAML:
 
 
 @functools.cache
+@beartype
 def _get_safe_yaml() -> YAML:
     """Return the cached safe (C-backed when available) ``YAML`` instance.
 
@@ -227,7 +229,8 @@ def _get_safe_yaml() -> YAML:
     return YAML(typ="safe", pure=False)
 
 
-def _yaml_needs_roundtrip(source: str) -> bool:
+@beartype
+def _yaml_needs_roundtrip(*, source: str) -> bool:
     """Return True when *source* needs the comment-preserving loader.
 
     The fast path is only safe when the source has none of the


### PR DESCRIPTION
## Summary
- Add `@beartype` to `get_yaml`, `_get_safe_yaml`, and `_yaml_needs_roundtrip` in `_parsing.py` (making `source` keyword-only on the last).
- Add `@beartype` to `_convert_identifier_case` in `_language.py`.

## Test plan
- [x] Pre-commit hooks (mypy, pyright, ty, pyrefly, ruff) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds runtime type validation and a minor signature tightening (`source` now keyword-only) in internal helper functions without changing core parsing/formatting logic.
> 
> **Overview**
> Adds `@beartype` to `_convert_identifier_case` plus YAML helper functions `get_yaml`, `_get_safe_yaml`, and `_yaml_needs_roundtrip` to enforce runtime type checks.
> 
> Tightens `_yaml_needs_roundtrip` to require `source` as a keyword-only argument, aligning it with other parsing helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d971482b65e61c79c6999a9fe377cc84d55691b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->