### PR TITLE
Beartype test helpers and fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,9 +3,11 @@
 from pathlib import Path
 
 import pytest
+from beartype import beartype
 
 
 @pytest.fixture(name="cases_dir")
+@beartype
 def fixture_cases_dir(request: pytest.FixtureRequest) -> Path:
     """Return the absolute path to the integration test cases
     directory.

--- a/tests/integration/test_orphan_golden_files.py
+++ b/tests/integration/test_orphan_golden_files.py
@@ -3,6 +3,8 @@
 import os
 from pathlib import Path
 
+from beartype import beartype
+
 from .call_cases import discover_call_cases
 from .call_variant_cases import build_call_variant_cases
 from .case_discovery import (
@@ -20,6 +22,7 @@ from .literalize_ref_cases import (
 from .variant_cases import build_variant_cases
 
 
+@beartype
 def _expected_variant_golden_files(cases_dir: Path) -> set[Path]:
     """Return expected paths for variant, statement-terminator, strategy,
     and
@@ -65,6 +68,7 @@ def _expected_variant_golden_files(cases_dir: Path) -> set[Path]:
     return expected
 
 
+@beartype
 def _expected_golden_files(cases_dir: Path) -> set[Path]:
     """Return the set of all golden files that parameterized tests
     cover.

--- a/tests/test_coercion_errors.py
+++ b/tests/test_coercion_errors.py
@@ -15,6 +15,7 @@ from typing import assert_never, cast
 
 import pytest
 import tomlkit
+from beartype import beartype
 from ruamel.yaml import YAML
 
 from literalizer import InputFormat, literalize
@@ -58,6 +59,7 @@ ALL_FORMATS = list(InputFormat)
 FORMATS_WITH_NULL = [f for f in ALL_FORMATS if f != InputFormat.TOML]
 
 
+@beartype
 def _to_source(
     data: _SourceData,
     input_format: InputFormat,

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,12 +3,14 @@
 from typing import Any, cast
 
 import pytest
+from beartype import beartype
 from ruamel.yaml import YAML
 
 from literalizer.languages import ALL_LANGUAGES
 
 
 @pytest.fixture(scope="session", name="lint_workflow")
+@beartype
 def fixture_lint_workflow(
     pytestconfig: pytest.Config,
 ) -> dict[str, Any]:


### PR DESCRIPTION
Adds `@beartype` to typed helpers and fixtures across `tests/` that were not yet decorated, matching the existing convention in `tests/integration/`. `test_*` functions are auto-decorated by `pytest-beartype-tests`, so this targets only helpers and fixtures: `_to_source` in `test_coercion_errors.py`, `fixture_lint_workflow` in `test_meta.py`, `fixture_cases_dir` in `tests/integration/conftest.py`, and `_expected_variant_golden_files` / `_expected_golden_files` in `test_orphan_golden_files.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds runtime type checking to fixtures/helpers without altering production code paths. Potential failures are limited to surfacing incorrect test helper usage during test runs.
> 
> **Overview**
> Adds `@beartype` coverage across several typed test fixtures and helper functions (including `fixture_cases_dir`, `fixture_lint_workflow`, `_to_source`, and golden-file expectation builders) to enforce runtime type validation consistently in `tests/`.
> 
> No production logic changes; this primarily tightens test-time contracts and may cause new test failures if existing calls violate the annotated types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1959e2c50eb4db2ade8dac2fb46846ffdc45d9f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->