### PR TITLE
Type _coerce_yaml_keys data as a recursive YAML-like alias

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -29,8 +29,8 @@ from literalizer.exceptions import (
 
 type YamlCoercible = (
     Scalar
-    | list[object]
-    | dict[object, object]
+    | list[YamlCoercible]
+    | dict[object, YamlCoercible]
     | CommentedOrderedMap
     | CommentedSet
 )
@@ -111,7 +111,7 @@ def _unwrap_yaml_scalar(*, value: Scalar) -> Scalar:  # noqa: PLR0911
 
 
 @beartype
-def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:  # noqa: PLR0911
+def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:
     """Recursively convert non-string dict keys to their string form.
 
     YAML allows non-string mapping keys (e.g. integers); ``Value``
@@ -143,26 +143,23 @@ def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:  # noqa: PLR0911
             )
             return cast("Value", omap)
         case dict():
-            return {
-                f"{k}": _coerce_yaml_keys(data=cast("YamlCoercible", v))
-                for k, v in data.items()
-            }
+            return {f"{k}": _coerce_yaml_keys(data=v) for k, v in data.items()}
         case list():
-            return [
-                _coerce_yaml_keys(data=cast("YamlCoercible", item))
-                for item in data
-            ]
+            return [_coerce_yaml_keys(data=item) for item in data]
         case CommentedSet():
             members = cast("set[Scalar]", set(data))
             return {_unwrap_yaml_scalar(value=item) for item in members}
-        case bool() | int() | float() | str() | datetime.datetime():
-            return cast("Value", _unwrap_yaml_scalar(value=data))
-        case datetime.date():
-            return cast("Value", _unwrap_yaml_scalar(value=data))
-        case bytes():
-            return cast("Value", _unwrap_yaml_scalar(value=data))
-        case None:
-            return cast("Value", _unwrap_yaml_scalar(value=data))
+        case (
+            bool()
+            | int()
+            | float()
+            | str()
+            | datetime.datetime()
+            | datetime.date()
+            | bytes()
+            | None
+        ):
+            return _unwrap_yaml_scalar(value=data)
         case _ as unreachable:
             assert_never(unreachable)
 


### PR DESCRIPTION
## Summary

Makes `YamlCoercible` recursive so the `dict()`/`list()` arms in `_coerce_yaml_keys` narrow to typed containers, eliminating the per-value `cast(\"YamlCoercible\", ...)` calls. Also drops the four `cast(\"Value\", ...)` calls at the scalar leaves (Scalar is a subset of Value) and collapses the four identical scalar arms into one. The `CommentedOrderedMap` and `CommentedSet` arms keep their casts since those ruamel classes are untyped. Mirrors the pattern from #2034 and #2032.

Closes #2035

## Test plan

- [x] `pytest tests/ -k yaml` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type/refactor change localized to YAML coercion; behavior should be unchanged aside from improved type narrowing, but it touches recursive normalization logic used in YAML parsing.
> 
> **Overview**
> Updates YAML parsing’s key-coercion typing by making `YamlCoercible` a recursive alias so `_coerce_yaml_keys` can recurse through `dict`/`list` values without per-element casts.
> 
> Simplifies `_coerce_yaml_keys` by collapsing scalar match arms into a single branch and removing redundant `Value` casts at scalar leaves, while keeping necessary casts for untyped `ruamel` containers like `CommentedOrderedMap`/`CommentedSet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f892da3fa576607c5adb9ab439bb4fe9a3671d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->