### PR TITLE
Replace R named-dict-entry unit test with golden case (closes #2019)

### DIFF
--- a/tests/integration/cases/simple_dict/R_empty_dict_key_error.R
+++ b/tests/integration/cases/simple_dict/R_empty_dict_key_error.R
@@ -1,0 +1,6 @@
+my_data <- list(
+    "name" = "Alice",
+    "age" = 30,
+    "active" = TRUE,
+    "score" = NULL
+)

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -10,7 +10,7 @@ import enum
 import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from beartype import beartype
 
@@ -364,6 +364,54 @@ def build_default_sequence_element_type_variants() -> Iterable[Variant]:
         )
         for lang_cls, type_name in DEFAULT_SEQUENCE_ELEMENT_TYPES.items()
     ]
+
+
+@runtime_checkable
+class _HasEmptyDictKey(Protocol):
+    """Structural type for languages that expose an ``empty_dict_key``
+    constructor field.
+
+    Used by :func:`build_empty_dict_key_variants` to narrow a generic
+    :class:`literalizer.Language` to one with the field, without
+    introspecting ``__dataclass_fields__`` or casting to ``Any``.
+    """
+
+    empty_dict_key: enum.Enum
+    empty_dict_keys: type[enum.Enum]
+
+
+@beartype
+def build_empty_dict_key_variants() -> Iterable[Variant]:
+    """Build empty-dict-key variants for every language whose spec
+    exposes the field with more than one policy.
+
+    Languages whose ``EmptyDictKey`` enum has a single member (the common
+    case today) produce no variants; languages that don't expose
+    ``empty_dict_key`` at all are skipped via the protocol check.
+    """
+    variants: list[Variant] = []
+    for lang_cls in sorted_languages():
+        spec = make_spec(lang_cls=lang_cls)
+        if not isinstance(spec, _HasEmptyDictKey):
+            continue
+        default = spec.empty_dict_key
+        for fmt in spec.empty_dict_keys:
+            if fmt is default:
+                continue
+            variants.append(
+                Variant(
+                    name=(
+                        f"{lang_cls.__name__}"
+                        f"_empty_dict_key_{fmt.name.lower()}"
+                    ),
+                    spec=make_spec(
+                        lang_cls=lang_cls,
+                        empty_dict_key=fmt,
+                    ),
+                    lang_cls=lang_cls,
+                )
+            )
+    return variants
 
 
 @beartype
@@ -1145,6 +1193,7 @@ _COMPLEX_BUILDERS: dict[str, Callable[[], Iterable[Variant]]] = {
         build_default_sequence_element_type_variants
     ),
     "default_dict_value_type": build_default_dict_value_type_variants,
+    "empty_dict_key": build_empty_dict_key_variants,
     "default_dict_key_type": build_default_dict_key_type_variants,
     "default_ordered_map_value_type": (
         build_default_ordered_map_value_type_variants
@@ -1297,6 +1346,7 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     ),
     "default_dict_value_type": DEFAULT_DICT_INPUTS,
     "default_dict_key_type": DEFAULT_DICT_INPUTS,
+    "empty_dict_key": (_ci(case_dir_name="simple_dict"),),
     "default_ordered_map_value_type": (_ci(case_dir_name="ordered_map"),),
     "comment": (_ci(case_dir_name="comments"),),
     "type_hints": tuple(

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -28,7 +28,6 @@ from literalizer.languages import (
     Jsonnet,
     Matlab,
     Python,
-    R,
     Rust,
     Sml,
 )
@@ -76,18 +75,6 @@ def test_python_datetime_whole_hour_offset_omits_minutes() -> None:
         ")"
         ")"
     )
-
-
-def test_r_formats_named_dict_entries() -> None:
-    """R dict entries with names are formatted without raising."""
-    result = literalize(
-        source="{name: value}",
-        input_format=InputFormat.YAML,
-        language=R(empty_dict_key=R.empty_dict_keys.ERROR),
-        variable_form=None,
-    )
-
-    assert result.code == 'list(\n    "name" = "value"\n)'
 
 
 def test_haskell_explicit_epoch_datetime_uses_int_constructor() -> None:


### PR DESCRIPTION
## Summary

- Moves `test_r_formats_named_dict_entries` coverage from `tests/test_languages.py` into the per-language variant-golden matrix as `R_empty_dict_key_error` against `simple_dict`.
- Adds an auto-discovered `empty_dict_key` axis: any language whose spec exposes the field with more than one `EmptyDictKey` member generates a variant per non-default policy. Today only R qualifies; future additions are picked up without editing the test framework.
- The new builder uses a `runtime_checkable` Protocol to narrow the generic `Language` spec, avoiding `cast` and `__dataclass_fields__` introspection.

## Test plan

- [x] `pytest tests/integration/test_literalize_golden.py::test_format_variant_golden_file tests/integration/test_orphan_golden_files.py tests/test_languages.py` passes
- [x] New golden `tests/integration/cases/simple_dict/R_empty_dict_key_error.R` recognized by orphan detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that expand the integration golden/variant matrix and move existing R coverage from a unit test to a golden file; main risk is increased test matrix/maintenance if more languages add `empty_dict_key` options.
> 
> **Overview**
> Moves coverage for R named dict entries from a dedicated unit test into the integration golden suite by adding a new `R_empty_dict_key_error.R` golden under `simple_dict`.
> 
> Adds an auto-discovered `empty_dict_key` variant axis in `tests/integration/variant_cases.py` (via a runtime-checkable `Protocol`) so any language exposing multiple `empty_dict_key` policies generates non-default variants and runs them against `simple_dict` inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a0b1dfe3ca95c4f3ef48aa54edf608771d2e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->