### PR TITLE
Remove dead wrap_calls_with_declarations branches in Jsonnet/Fortran

### DIFF
--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -823,8 +823,6 @@ class Fortran(metaclass=LanguageCls):
         exec_stmts: list[str] = []
         for bare_code in declarations:
             lines = bare_code.splitlines()
-            if not lines:
-                continue
             type_decls.append(lines[0])
             exec_stmts.extend(lines[1:])
         body_parts: list[str] = [*type_decls, *exec_stmts, calls]

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
@@ -384,29 +385,7 @@ class Jsonnet(metaclass=LanguageCls):
         """Return call-statement formatting for this language."""
         return identity_call_statement
 
-    def wrap_calls_with_declarations(
-        self,
-        declarations: tuple[str, ...],
-        calls: str,
-        body_preamble: tuple[str, ...],
-    ) -> str:
-        """Emit ref declarations as top-level ``local`` bindings before
-        the call expressions, which :meth:`wrap_in_file` wraps in a
-        Jsonnet array.
-
-        The default ``wrap_calls_with_declarations`` would splice
-        declarations *into* the array, where ``local`` bindings are
-        invalid; placing them before keeps the file a single chained
-        let-binding ending in an array expression.
-        """
-        wrapped_calls = self.wrap_in_file(
-            content=calls,
-            variable_name="",
-            body_preamble=body_preamble,
-        )
-        if not declarations:
-            return wrapped_calls
-        return "\n".join(declarations) + "\n" + wrapped_calls
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
     @staticmethod
     def wrap_in_file(

--- a/tests/integration/test_fortran_call_stubs.py
+++ b/tests/integration/test_fortran_call_stubs.py
@@ -1,7 +1,7 @@
 """Targeted Fortran call-stub tests.
 
-Covers no-parameter single-function stubs and empty-preamble paths in
-``Fortran.wrap_calls_with_declarations`` and ``Fortran.wrap_in_file``.
+Covers no-parameter single-function stubs and the empty-preamble path
+in ``Fortran.wrap_in_file``.
 """
 
 from literalizer._language import StubReturn
@@ -42,23 +42,6 @@ def test_wrap_in_file_call_mode_empty_preamble() -> None:
     result = fortran.wrap_in_file(
         content="call process()",
         variable_name="",
-        body_preamble=(),
-    )
-    assert result == (
-        "program main\n"
-        "    use fval_m\n"
-        "    implicit none\n"
-        "    call process()\n"
-        "end program main"
-    )
-
-
-def test_wrap_calls_with_declarations_empty_bare_code() -> None:
-    """Empty bare_code strings in declarations are skipped silently."""
-    fortran = Fortran(module_name="main")
-    result = fortran.wrap_calls_with_declarations(
-        declarations=("",),
-        calls="call process()",
         body_preamble=(),
     )
     assert result == (

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -25,7 +25,6 @@ from literalizer.languages import (
     Gleam,
     Haskell,
     Java,
-    Jsonnet,
     Matlab,
     Python,
     R,
@@ -470,20 +469,3 @@ def test_gleam_special_floats_raise(yaml_value: str) -> None:
             input_format=InputFormat.YAML,
             language=Gleam(),
         )
-
-
-def test_jsonnet_wrap_calls_with_declarations_prepends_bindings() -> None:
-    """Non-empty declarations are placed before the wrapped call
-    expression.
-
-    Jsonnet ``local`` bindings are invalid inside an array literal, so
-    ``wrap_calls_with_declarations`` emits them before the
-    ``wrap_in_file`` output rather than splicing them inside the array.
-    """
-    spec = Jsonnet()
-    result = spec.wrap_calls_with_declarations(
-        declarations=("local x = 1;",),
-        calls="[x]",
-        body_preamble=(),
-    )
-    assert result == "local x = 1;\n[x]"


### PR DESCRIPTION
## Summary

Closes #2025.

The Jsonnet override of `wrap_calls_with_declarations` and the empty-`bare_code` skip in Fortran's version both handled inputs that `literalize_call` cannot produce: Jsonnet has `supports_variable_names = False` (so ref declarations never reach `wrap_calls_with_declarations`), and `literalize` always emits a non-empty `bare_code` for Fortran. Jsonnet now inherits `default_wrap_calls_with_declarations`, the Fortran guard is gone, and the two orphan unit tests (`test_jsonnet_wrap_calls_with_declarations_prepends_bindings`, `test_wrap_calls_with_declarations_empty_bare_code`) are deleted.

## Test plan

- [x] `pytest` — 3007 passed, 691 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that removes unreachable branches and associated tests; behavior should be unchanged for valid inputs produced by the literalizer.
> 
> **Overview**
> Removes dead call-wrapping logic in `Jsonnet` and `Fortran`.
> 
> `Jsonnet` now uses the shared `default_wrap_calls_with_declarations` instead of a custom implementation, and `Fortran.wrap_calls_with_declarations` drops the guard that skipped empty declaration strings.
> 
> Deletes the two orphan tests that exercised these unreachable paths and updates the Fortran call-stub integration test description accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95818e570707971b0055c75f071911f6069cd14d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->