### PR TITLE
Split lint-beam into lint-elixir and lint-erlang

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -589,16 +589,13 @@ jobs:
           find tests/integration/cases -name '*.wren' -print0 > /tmp/files-wren
           xargs -0 -P "$(nproc)" -n1 wren_cli < /tmp/files-wren
 
-  # Erlang + Elixir share the BEAM runtime via setup-beam. Gleam has its
-  # own sibling job (`lint-gleam`) that runs check and run passes in
-  # sequence.
-  lint-beam:
+  lint-elixir:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Install Erlang and Elixir
+      - name: Install Elixir
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.18'
@@ -607,13 +604,24 @@ jobs:
       # Fixtures only declare `defmodule Check` with a `def x` body, so
       # `elixir` compiles the module but never invokes it. The script
       # compiles each fixture, calls `Check.x()` to force the body to
-      # execute, and purges the module between fixtures — all inside a
+      # execute, and purges the module between fixtures, all inside a
       # single BEAM VM, paying the cold-start cost once instead of twice
       # per fixture (serial `elixirc` + `elixir` loops).
       - name: Lint Elixir
         run: |-
           find tests/integration/cases -name '*.ex' -print0 > /tmp/files-elixir
           elixir .github/scripts/lint-elixir.exs < /tmp/files-elixir
+
+  lint-erlang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27'
 
       # Compile every fixture in a single erlc invocation to pay the
       # BEAM VM startup cost once. Each fixture already carries a unique
@@ -1563,7 +1571,8 @@ jobs:
       - lint-uv-scripts
       - lint-dotnet
       - lint-curl-tarballs
-      - lint-beam
+      - lint-elixir
+      - lint-erlang
       - lint-gleam
       - lint-jvm-mini
       - lint-haskell-family


### PR DESCRIPTION
## Summary
- Splits the combined `lint-beam` job in `.github/workflows/lint.yml` into independent `lint-elixir` and `lint-erlang` jobs so each language's pass/fail status is reported separately and can be retried in isolation.
- Updates the `completion-lint` needs list accordingly. Each job runs its own `erlef/setup-beam@v1` (~6s install cost on top of an ~16s combined job).

## Test plan
- [ ] CI: confirm both `lint-elixir` and `lint-erlang` jobs run and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that reorganizes GitHub Actions jobs; main risk is accidental misconfiguration causing one of the BEAM lint steps to stop running or the completion gate to misreport status.
> 
> **Overview**
> Splits the combined BEAM lint job into two independent GitHub Actions jobs: `lint-elixir` and `lint-erlang`, so each language reports status separately and can be retried in isolation.
> 
> Updates `completion-lint` to depend on the new jobs, and adjusts setup so Elixir installs Elixir+OTP while Erlang installs OTP only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb044b439fa630e6abbb4c3177d5258ac05f029e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->