### PR TITLE
Remove Mapping[str, object] cast in _to_source TOML branch

### DIFF
--- a/tests/test_coercion_errors.py
+++ b/tests/test_coercion_errors.py
@@ -9,9 +9,8 @@ remain in :mod:`tests.test_yaml`.
 
 import json
 import re
-from collections.abc import Mapping, Sequence
 from io import StringIO
-from typing import assert_never, cast
+from typing import TYPE_CHECKING, assert_never
 
 import pytest
 import tomlkit
@@ -28,9 +27,12 @@ from literalizer.exceptions import (
 )
 from literalizer.languages import Dhall, Mojo, Python
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 type _SourceData = (
-    Mapping[str, _SourceData]
-    | Sequence[_SourceData]
+    dict[str, _SourceData]
+    | list[_SourceData]
     | str
     | int
     | float
@@ -82,10 +84,8 @@ def _to_source(
             yaml.dump(data=data, stream=stream)  # pyright: ignore[reportUnknownMemberType]
             return stream.getvalue()
         case InputFormat.TOML:
-            toml_data: Mapping[str, object] = (
-                cast("Mapping[str, object]", data)
-                if isinstance(data, dict)
-                else {"_": data}
+            toml_data: Mapping[str, _SourceData] = (
+                data if isinstance(data, dict) else {"_": data}
             )
             return tomlkit.dumps(data=toml_data)
         case _ as unreachable:


### PR DESCRIPTION
## Summary
- Closes #2036.
- Tightens the test-only `_SourceData` recursive alias to use `dict`/`list` instead of `Mapping`/`Sequence`, so the `isinstance(data, dict)` narrow in the TOML branch of `_to_source` produces a type compatible with `Mapping[str, _SourceData]` directly — no `cast` needed.
- Moves the now type-only `Mapping` import under `TYPE_CHECKING`.

## Test plan
- [x] `uv run pytest tests/test_coercion_errors.py`
- [x] `uv run mypy`, `uv run pyright`, `uv run ty check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only typing/narrowing adjustments with no production logic changes; main risk is catching any latent type-checker/runtime mismatch in TOML test serialization.
> 
> **Overview**
> Simplifies TOML serialization in `tests/test_coercion_errors.py` by removing an explicit `cast` and relying on `isinstance(data, dict)` narrowing to produce a `Mapping[str, _SourceData]` directly.
> 
> Tightens the recursive `_SourceData` alias to `dict`/`list` (instead of `Mapping`/`Sequence`) and moves `Mapping` to a `TYPE_CHECKING`-only import to keep runtime imports minimal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d874e6e010dddd765545187927b8ad5597b8618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->