### PR TITLE
Apply @beartype, kw-only, and match to new Mojo call helpers

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -161,13 +161,19 @@ def _value_to_mojo_type(
             return _mojo_call_arg_element_to_type(type(value))
 
 
+@beartype
 def _gather_mojo_call_slots(
+    *,
     arg_values: Sequence[Value],
 ) -> list[list[Value]]:
     """Group per-call argument values by positional slot."""
     slots: list[list[Value]] = []
     for element in arg_values:
-        per_arg = element if isinstance(element, list) else [element]
+        match element:
+            case list():
+                per_arg: Sequence[Value] = element
+            case _:
+                per_arg = [element]
         for slot_index, arg_value in enumerate(iterable=per_arg):
             if slot_index >= len(slots):
                 slots.append([])
@@ -175,7 +181,8 @@ def _gather_mojo_call_slots(
     return slots
 
 
-def _slot_is_all_scalars(slot_values: Sequence[Value]) -> bool:
+@beartype
+def _slot_is_all_scalars(*, slot_values: Sequence[Value]) -> bool:
     """Return ``True`` when every value at this slot is a scalar."""
     return all(not isinstance(v, list | dict) for v in slot_values)
 


### PR DESCRIPTION
## Summary
- Adds `@beartype`, keyword-only params, and a `match` statement to `_gather_mojo_call_slots` and `_slot_is_all_scalars` (new helpers added in #2038 / issue #2029), matching the style applied to the Swift helpers in 70b82f839.

## Test plan
- [x] `uv run pytest tests/integration/test_calls.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small refactor adding runtime type checks and keyword-only parameters to internal Mojo call-typing helpers without changing broader call formatting logic.
> 
> **Overview**
> Adds `@beartype` to the new Mojo call helper functions and makes their inputs keyword-only (including changing `_slot_is_all_scalars` to require `slot_values=`).
> 
> Refactors `_gather_mojo_call_slots` to use a `match` statement for list-vs-scalar normalization instead of an `isinstance` check, keeping the slot-grouping behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5f6c679e392a721b175618c57b0fa52ccfb241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->