### PR TITLE
Replace cast with annotated assignment in call_cases yaml load

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -778,11 +778,8 @@ def case_uses_ref_inside_dict_literal(
     literals.
     """
     yaml = YAML(typ="safe", pure=False)
-    loaded = cast(
-        "Value",
-        yaml.load(  # pyright: ignore[reportUnknownMemberType]
-            stream=(CALL_CASES_DIR / case_dir_name / "input.yaml").read_text(),
-        ),
+    loaded: Value = yaml.load(  # pyright: ignore[reportUnknownMemberType]
+        stream=(CALL_CASES_DIR / case_dir_name / "input.yaml").read_text(),
     )
     return _has_ref_inside_dict_literal(
         value=loaded,


### PR DESCRIPTION
## Summary
- Drop a `typing.cast` in `tests/integration/call_cases.py` by annotating the `yaml.load(...)` result directly as `Value`.

## Test plan
- [x] pre-commit hooks (mypy, pyright, ty, pyrefly, ruff) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-harness change that only adjusts typing around `ruamel.yaml.YAML.load` without altering runtime behavior.
> 
> **Overview**
> Simplifies `case_uses_ref_inside_dict_literal` by replacing a `typing.cast` wrapper around `yaml.load(...)` with an explicit annotated assignment (`loaded: Value = ...`).
> 
> This is a small typing/readability change in the integration test harness only; call-case parsing and ref-detection logic are otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e95f567963ef1a16a78878236abdf5bc4a05bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->