### PR TITLE
Wire ref-arg fixtures into Mojo VARIANT call-variant sources (#2030)

### DIFF
--- a/tests/integration/call_variant_cases.py
+++ b/tests/integration/call_variant_cases.py
@@ -117,6 +117,14 @@ CALL_VARIANT_SOURCES: list[tuple[str, Callable[[], Iterable[Variant]]]] = [
         "call_scalar_args_with_null",
         build_heterogeneous_strategy_call_variants,
     ),
+    (
+        "call_ref_args_heterogeneous_list",
+        build_heterogeneous_strategy_call_variants,
+    ),
+    (
+        "call_ref_args_reused",
+        build_heterogeneous_strategy_call_variants,
+    ),
 ]
 
 

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Mojo_heterogeneous_strategy_variant_call.mojo
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Mojo_heterogeneous_strategy_variant_call.mojo
@@ -1,0 +1,14 @@
+def process[*Ts: AnyType](*args: *Ts):
+    pass
+def main():
+    var my_ints = [
+        1,
+        2,
+        3,
+    ]
+    var my_strings = [
+        "a",
+        "b",
+    ]
+    process(my_ints^, 42)
+    process(my_strings^, 7)

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Nim_heterogeneous_strategy_object_variant_call.nim
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Nim_heterogeneous_strategy_object_variant_call.nim
@@ -1,0 +1,13 @@
+{.warning[UnusedImport]:off.}
+template process(args: varargs[untyped]) = discard
+var my_ints = @[
+    1,
+    2,
+    3
+]
+var my_strings = @[
+    "a",
+    "b"
+]
+process(my_ints, 42)
+process(my_strings, 7)

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Rust_heterogeneous_strategy_tagged_enum_call.rs
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Rust_heterogeneous_strategy_tagged_enum_call.rs
@@ -1,0 +1,14 @@
+fn main() {
+    fn process<A, B>(_data: A, _count: B) {}
+    let my_ints = vec![
+        1,
+        2,
+        3,
+    ];
+    let my_strings = vec![
+        "a",
+        "b",
+    ];
+    process(my_ints, 42);
+    process(my_strings, 7);
+}

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/V_heterogeneous_strategy_error_call.v
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/V_heterogeneous_strategy_error_call.v
@@ -1,0 +1,16 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	my_ints := [
+		1,
+		2,
+		3,
+	]
+	my_strings := [
+		'a',
+		'b',
+	]
+	process(my_ints, 42);
+	process(my_strings, 7);
+}

--- a/tests/integration/cases/call_ref_args_reused/Mojo_heterogeneous_strategy_variant_call.mojo
+++ b/tests/integration/cases/call_ref_args_reused/Mojo_heterogeneous_strategy_variant_call.mojo
@@ -1,0 +1,12 @@
+def process[*Ts: AnyType](*args: *Ts):
+    pass
+def main():
+    var single_var = [
+        4,
+        5,
+        6,
+    ]
+    var repeated_var = 1
+    process(repeated_var, 1)
+    process(single_var^, 0)
+    process(repeated_var, 8)

--- a/tests/integration/cases/call_ref_args_reused/Nim_heterogeneous_strategy_object_variant_call.nim
+++ b/tests/integration/cases/call_ref_args_reused/Nim_heterogeneous_strategy_object_variant_call.nim
@@ -1,0 +1,11 @@
+{.warning[UnusedImport]:off.}
+template process(args: varargs[untyped]) = discard
+var single_var = @[
+    4,
+    5,
+    6
+]
+var repeated_var = 1
+process(repeated_var, 1)
+process(single_var, 0)
+process(repeated_var, 8)

--- a/tests/integration/cases/call_ref_args_reused/Rust_heterogeneous_strategy_tagged_enum_call.rs
+++ b/tests/integration/cases/call_ref_args_reused/Rust_heterogeneous_strategy_tagged_enum_call.rs
@@ -1,0 +1,12 @@
+fn main() {
+    fn process<A, B>(_data: A, _count: B) {}
+    let single_var = vec![
+        4,
+        5,
+        6,
+    ];
+    let repeated_var = 1;
+    process(repeated_var, 1);
+    process(single_var, 0);
+    process(repeated_var, 8);
+}

--- a/tests/integration/cases/call_ref_args_reused/V_heterogeneous_strategy_error_call.v
+++ b/tests/integration/cases/call_ref_args_reused/V_heterogeneous_strategy_error_call.v
@@ -1,0 +1,14 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	single_var := [
+		4,
+		5,
+		6,
+	]
+	repeated_var := 1
+	process(repeated_var, 1);
+	process(single_var, 0);
+	process(repeated_var, 8);
+}


### PR DESCRIPTION
## Summary

Adds `call_ref_args_heterogeneous_list` and `call_ref_args_reused` to `CALL_VARIANT_SOURCES` and regenerates their Mojo VARIANT goldens. Both fixtures currently fall back to the generic `def process[*Ts: AnyType](*args: *Ts)` stub because `_mojo_typed_param_list` returns `None` for slots whose values are all-list-with-divergent-element-types or that mix scalars and lists. The typed `Variant[...]` / `List[Variant[...]]` signature + `Value(...)` wrap path for ref args is left for a follow-up under #2030.

## Test plan

- [ ] `uv run pytest tests/integration/test_calls.py -k 'Mojo_heterogeneous_strategy_variant and (call_ref_args_heterogeneous_list or call_ref_args_reused)'`
- [ ] Verify generated `.mojo` goldens compile (or document expected failure) under the Mojo compiler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test case wiring and new golden fixtures, with no production/runtime logic modifications.
> 
> **Overview**
> Extends `CALL_VARIANT_SOURCES` to run non-default heterogeneous-strategy variants for two additional ref-arg fixtures: `call_ref_args_heterogeneous_list` and `call_ref_args_reused`.
> 
> Adds corresponding new golden outputs for Mojo/Nim/Rust/V under the heterogeneous-strategy variants, including Mojo `VARIANT` fixtures that currently fall back to a generic `process[*Ts: AnyType](*args: *Ts)` stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42f2371224fa05351d270fc6b103190c23cbd6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->