### PR TITLE
Suppress Mojo ^ transfer for register-trivial scalar refs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Changelog
 Next
 ----
 
+- ``Mojo`` :func:`~literalizer.literalize_call` no longer appends the
+  ``^`` transfer operator to a consumable ``$ref`` whose underlying
+  value is a register-trivial scalar (``Int``, ``Bool``, ``Float64``).
+  Mojo 0.26.1.0+ rejects ``^`` on those types under ``--Werror``
+  ("transfer from a value of trivial register type ... has no effect
+  and can be removed"); the ref is now emitted bare instead.
+  Non-trivial refs (e.g. ``List[Int]``, ``Dict[...]``) keep the ``^``
+  consume form.  ``Language`` exposes a new
+  :attr:`~literalizer._language.Language.consumable_ref_value_inhibits_consuming_form`
+  predicate that languages can override to opt into the same
+  per-value routing; the default
+  (:data:`~literalizer._language.never_inhibits_consuming_form`)
+  preserves the existing behavior.
+
 - Renamed ``VariableTypeHints.AUTO`` to ``VariableTypeHints.NEVER`` for
   every language.  The behavior is unchanged; the new name describes
   the option (no annotation, defer to the language's inference) rather

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,18 +4,22 @@ Changelog
 Next
 ----
 
-- ``Mojo`` :func:`~literalizer.literalize_call` no longer appends the
-  ``^`` transfer operator to a consumable ``$ref`` whose underlying
-  value is a register-trivial scalar (``Int``, ``Bool``, ``Float64``).
-  Mojo 0.26.1.0+ rejects ``^`` on those types under ``--Werror``
-  ("transfer from a value of trivial register type ... has no effect
-  and can be removed"); the ref is now emitted bare instead.
-  Non-trivial refs (e.g. ``List[Int]``, ``Dict[...]``) keep the ``^``
-  consume form.  ``Language`` exposes a new
+- ``Mojo`` and ``C++`` :func:`~literalizer.literalize_call` no longer
+  wrap a consumable ``$ref`` in the language's consume form when the
+  underlying value's type would make the wrapping a hard error or a
+  ``clang-tidy`` lint failure.  In Mojo, ``^`` is dropped for
+  register-trivial scalars (``Int``, ``Bool``, ``Float64``) because
+  Mojo 0.26.1.0+ rejects "transfer from a value of trivial register
+  type" under ``--Werror``.  In C++, ``std::move`` is dropped for
+  trivially-copyable types (``bool``, integer, ``double``,
+  ``std::chrono::year_month_day``,
+  ``std::chrono::system_clock::time_point``) which
+  ``performance-move-const-arg`` / ``hicpp-move-const-arg`` reject.
+  Non-trivial refs (e.g. ``List[...]``, ``Dict[...]``, strings, bytes)
+  keep their consume form.  ``Language`` exposes a new
   :attr:`~literalizer._language.Language.consumable_ref_value_inhibits_consuming_form`
-  predicate that languages can override to opt into the same
-  per-value routing; the default
-  (:data:`~literalizer._language.never_inhibits_consuming_form`)
+  predicate that languages override to opt into per-value routing; the
+  default (:data:`~literalizer._language.never_inhibits_consuming_form`)
   preserves the existing behavior.
 
 - Renamed ``VariableTypeHints.AUTO`` to ``VariableTypeHints.NEVER`` for

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Next
   register-trivial scalars (``Int``, ``Bool``, ``Float64``) because
   Mojo 0.26.1.0+ rejects "transfer from a value of trivial register
   type" under ``--Werror``.  In C++, ``std::move`` is dropped for
-  trivially-copyable types (``bool``, integer, ``double``,
+  register-trivial types (``bool``, integer, ``double``,
   ``std::chrono::year_month_day``,
   ``std::chrono::system_clock::time_point``) which
   ``performance-move-const-arg`` / ``hicpp-move-const-arg`` reject.

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1528,6 +1528,25 @@ class Language(Protocol):
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
+    @property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        makes the language's consume form illegal.
+
+        Returns ``True`` when the consume operator (e.g. Mojo ``^``)
+        would be rejected for *value*, in which case the call site
+        routes the ref through :attr:`format_call_arg_ref_identifier`
+        instead of :attr:`format_call_arg_ref_identifier_consumable`.
+
+        Most languages set this to :data:`never_inhibits_consuming_form`.
+        Mojo overrides it: applying ``^`` to a register-trivial scalar
+        (``Int``, ``Bool``, ``Float64``) is a hard error under
+        ``--Werror``, so those value types inhibit the consume form.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
     def wrap_in_file(
         self,
         content: str,
@@ -1620,6 +1639,26 @@ identity_call_ref_identifier: Callable[[str], str] = (
 rewriting.  Languages that decorate ref identifiers (e.g. PHP's
 ``$name`` or Perl's ``$name``) override
 :attr:`Language.format_call_ref_identifier` instead.
+"""
+
+
+@beartype
+def _never_inhibits_consuming_form(_value: Value, /) -> bool:
+    """Return ``False`` — the language's consuming form accepts every
+    value type.
+    """
+    return False
+
+
+never_inhibits_consuming_form: Callable[[Value], bool] = (
+    _never_inhibits_consuming_form
+)
+"""Shared callable for languages whose consume form (e.g. C++
+``std::move``) is valid for every value type.  Languages whose consume
+operator rejects certain value types (notably Mojo's ``^``, which is a
+hard error on register-trivial scalars under ``--Werror``) override
+:attr:`Language.consumable_ref_value_inhibits_consuming_form` to a
+predicate that returns ``True`` for those values.
 """
 
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1655,7 +1655,7 @@ never_inhibits_consuming_form: Callable[[Value], bool] = (
 )
 """Shared callable for languages whose consume form (e.g. C++
 ``std::move``) is valid for every value type.  Languages whose consume
-operator rejects certain value types (notably Mojo's ``^``, which is a
+operator rejects certain value types (notably the Mojo ``^``, which is a
 hard error on register-trivial scalars under ``--Werror``) override
 :attr:`Language.consumable_ref_value_inhibits_consuming_form` to a
 predicate that returns ``True`` for those values.

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2216,6 +2216,47 @@ def _compute_call_arg_ref_single_use_names(
 
 
 @beartype
+def _compute_call_arg_ref_consume_inhibited_names(
+    *,
+    elements: list[Value],
+    ref_values: Mapping[str, Value],
+    ref_key: str,
+    language: Language,
+) -> frozenset[str]:
+    """Return ref identifiers whose underlying value inhibits the
+    language's consume form.
+
+    Languages whose consume operator rejects certain value types (notably
+    Mojo's ``^`` on register-trivial scalars) expose
+    :attr:`~literalizer._language.Language.consumable_ref_value_inhibits_consuming_form`
+    so the call site can route those refs through the non-consuming
+    formatter instead.  Names are returned in the original (pre-``ref_case``)
+    form so they can be compared against the user-supplied
+    ``consumable_refs`` set without further conversion.
+
+    Refs whose value is not present in *ref_values* fall through with the
+    consume form intact, matching the historical behavior for callers
+    that omit ``ref_values``.
+    """
+    if not ref_values:
+        return frozenset[str]()
+    inhibits = language.consumable_ref_value_inhibits_consuming_form
+    referenced: set[str] = set()
+    for element in elements:
+        arg_values = element if isinstance(element, list) else [element]
+        for value in arg_values:
+            ref_name = _extract_call_arg_ref_name(value=value, ref_key=ref_key)
+            if ref_name is None:
+                continue
+            referenced.add(ref_name)
+    return frozenset(
+        name
+        for name in referenced
+        if name in ref_values and inhibits(ref_values[name])
+    )
+
+
+@beartype
 def _strip_call_arg_refs_for_preamble(
     *,
     data: Value,
@@ -2286,6 +2327,7 @@ def _format_single_call_arg(
     ref_case: IdentifierCase | None,
     consumable_ref_names: frozenset[str],
     single_use_ref_names: frozenset[str],
+    consume_inhibited_ref_names: frozenset[str],
     ref_key: str,
     collection_layout: CollectionLayout,
 ) -> str:
@@ -2299,14 +2341,17 @@ def _format_single_call_arg(
     *consumable_ref_names* is the caller's declaration of which refs
     this call owns and may move from.  *single_use_ref_names* is the
     set of refs that appear exactly once across this call's argument
-    lists.  Both sets use the original (pre-``ref_case``) name.  A ref
-    is rendered via the language's
-    ``format_call_arg_ref_identifier_consumable`` hook only when it is
-    in both sets; otherwise it goes through the regular
-    ``format_call_arg_ref_identifier`` hook.  This ensures that a ref
-    used in more than one call (or more than once in a single call's
-    arguments) is never consumed, even when the caller listed it as
-    consumable.
+    lists.  *consume_inhibited_ref_names* is the set of refs whose
+    underlying value type inhibits the language's consume form (e.g.
+    Mojo's ``^`` on register-trivial scalars).  All three sets use the
+    original (pre-``ref_case``) name.  A ref is rendered via the
+    language's ``format_call_arg_ref_identifier_consumable`` hook only
+    when it is in *consumable_ref_names* and *single_use_ref_names* and
+    not in *consume_inhibited_ref_names*; otherwise it goes through the
+    regular ``format_call_arg_ref_identifier`` hook.  This ensures that
+    a ref used in more than one call -- or whose value type the
+    language's consume operator rejects -- is never consumed, even when
+    the caller listed it as consumable.
     """
     raw_ref_name = _extract_call_arg_ref_name(value=value, ref_key=ref_key)
     if raw_ref_name is not None:
@@ -2318,6 +2363,7 @@ def _format_single_call_arg(
         is_consumable = (
             raw_ref_name in consumable_ref_names
             and raw_ref_name in single_use_ref_names
+            and raw_ref_name not in consume_inhibited_ref_names
         )
         if is_consumable:
             return language.format_call_arg_ref_identifier_consumable(ref_name)
@@ -2380,6 +2426,7 @@ def _format_call_args(
     ref_case: IdentifierCase | None,
     consumable_ref_names: frozenset[str],
     single_use_ref_names: frozenset[str],
+    consume_inhibited_ref_names: frozenset[str],
     ref_key: str,
     collection_layout: CollectionLayout,
 ) -> str:
@@ -2414,6 +2461,7 @@ def _format_call_args(
             ref_case=ref_case,
             consumable_ref_names=consumable_ref_names,
             single_use_ref_names=single_use_ref_names,
+            consume_inhibited_ref_names=consume_inhibited_ref_names,
             ref_key=ref_key,
             collection_layout=collection_layout,
         )
@@ -2625,6 +2673,7 @@ def _render_call_per_element(
     call_transform: Callable[[str], str] | None,
     ref_case: IdentifierCase | None,
     consumable_ref_names: frozenset[str],
+    ref_values: Mapping[str, Value],
     ref_key: str,
     collection_comments: CollectionComments | None = None,
     collection_layout: CollectionLayout = CollectionLayout.COMPACT,
@@ -2659,6 +2708,14 @@ def _render_call_per_element(
         elements=data,
         ref_key=ref_key,
     )
+    consume_inhibited_ref_names = (
+        _compute_call_arg_ref_consume_inhibited_names(
+            elements=data,
+            ref_values=ref_values,
+            ref_key=ref_key,
+            language=language,
+        )
+    )
     rendered_elements: list[str] = []
     for element in data:
         arg_values = element if isinstance(element, list) else [element]
@@ -2687,6 +2744,7 @@ def _render_call_per_element(
             ref_case=ref_case,
             consumable_ref_names=consumable_ref_names,
             single_use_ref_names=single_use_ref_names,
+            consume_inhibited_ref_names=consume_inhibited_ref_names,
             ref_key=ref_key,
             collection_layout=collection_layout,
         )
@@ -2723,6 +2781,7 @@ def _render_call_whole(
     call_transform: Callable[[str], str] | None,
     ref_case: IdentifierCase | None,
     consumable_ref_names: frozenset[str],
+    ref_values: Mapping[str, Value],
     ref_key: str,
     collection_layout: CollectionLayout,
 ) -> str:
@@ -2751,6 +2810,14 @@ def _render_call_whole(
         single_use_ref_names=_compute_call_arg_ref_single_use_names(
             elements=[[data]],
             ref_key=ref_key,
+        ),
+        consume_inhibited_ref_names=(
+            _compute_call_arg_ref_consume_inhibited_names(
+                elements=[[data]],
+                ref_values=ref_values,
+                ref_key=ref_key,
+                language=language,
+            )
         ),
         ref_key=ref_key,
         collection_layout=collection_layout,
@@ -3084,6 +3151,7 @@ def literalize_call(
             call_transform=call_transform,
             ref_case=ref_case,
             consumable_ref_names=consumable_refs,
+            ref_values=ref_values or {},
             ref_key=ref_key,
             collection_comments=collection_comments,
             collection_layout=collection_layout,
@@ -3098,6 +3166,7 @@ def literalize_call(
             call_transform=call_transform,
             ref_case=ref_case,
             consumable_ref_names=consumable_refs,
+            ref_values=ref_values or {},
             ref_key=ref_key,
             collection_layout=collection_layout,
         )

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2227,7 +2227,7 @@ def _compute_call_arg_ref_consume_inhibited_names(
     language's consume form.
 
     Languages whose consume operator rejects certain value types (notably
-    Mojo's ``^`` on register-trivial scalars) expose
+    the Mojo ``^`` on register-trivial scalars) expose
     :attr:`~literalizer._language.Language.consumable_ref_value_inhibits_consuming_form`
     so the call site can route those refs through the non-consuming
     formatter instead.  Names are returned in the original (pre-``ref_case``)
@@ -2343,7 +2343,7 @@ def _format_single_call_arg(
     set of refs that appear exactly once across this call's argument
     lists.  *consume_inhibited_ref_names* is the set of refs whose
     underlying value type inhibits the language's consume form (e.g.
-    Mojo's ``^`` on register-trivial scalars).  All three sets use the
+    the Mojo ``^`` on register-trivial scalars).  All three sets use the
     original (pre-``ref_case``) name.  A ref is rendered via the
     language's ``format_call_arg_ref_identifier_consumable`` hook only
     when it is in *consumable_ref_names* and *single_use_ref_names* and

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -710,7 +710,7 @@ class Ada(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     identity_call_ref_identifier,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -699,6 +700,19 @@ class Ada(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -627,6 +628,19 @@ class Bash(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -638,7 +638,7 @@ class Bash(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -647,6 +648,19 @@ class C(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -658,7 +658,7 @@ class C(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -542,6 +543,19 @@ class Clojure(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -553,7 +553,7 @@ class Clojure(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     default_wrap_calls_with_declarations,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -813,6 +814,19 @@ class Cobol(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -824,7 +824,7 @@ class Cobol(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -575,7 +575,7 @@ class CommonLisp(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -564,6 +565,19 @@ class CommonLisp(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -243,11 +243,11 @@ def _cpp_value_inhibits_consuming_form(value: Value, /) -> bool:
 
     The literalize-generated C++ maps Python ``bool`` / ``int`` /
     ``float`` to ``bool`` / a narrow integer / ``double``, all of which
-    are trivially copyable.  ``date`` and ``datetime`` map to
+    are register-trivial.  ``date`` and ``datetime`` map to
     ``std::chrono::year_month_day`` and
-    ``std::chrono::system_clock::time_point``, both also trivially
-    copyable.  Strings, bytes, lists, and dicts allocate or own heap
-    storage, so ``std::move`` continues to deliver value for those.
+    ``std::chrono::system_clock::time_point``, both also
+    register-trivial.  Strings, bytes, lists, and dicts allocate or own
+    heap storage, so ``std::move`` continues to deliver value for those.
     """
     if isinstance(value, (list, dict, set)):
         return False
@@ -1480,12 +1480,12 @@ class Cpp(metaclass=LanguageCls):
     def consumable_ref_value_inhibits_consuming_form(
         self,
     ) -> Callable[[Value], bool]:
-        """Return ``True`` for ref values whose C++ type is trivially
-        copyable.
+        """Return ``True`` for ref values whose C++ type is register-
+        trivial.
 
         ``clang-tidy``'s ``performance-move-const-arg`` rule (and the
         equivalent ``hicpp-move-const-arg``) reports ``std::move`` on a
-        trivially-copyable value as an error: the move has no effect and
+        register-trivial value as an error: the move has no effect and
         the wrapping is wasteful.  The call site routes these refs
         through the non-consuming formatter so the emitted C++ compiles
         cleanly under ``--warnings-as-errors``.

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -74,7 +74,6 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
-    never_inhibits_consuming_form,
     no_call_stub,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -235,6 +234,24 @@ def _make_cpp_element_to_type(
         dict_type_template="std::map<std::string, {inner}>",
         fallback_value_type=None,
     )
+
+
+@beartype
+def _cpp_value_inhibits_consuming_form(value: Value, /) -> bool:
+    """Return ``True`` when ``std::move`` is unhelpful for *value*'s C++
+    type.
+
+    The literalize-generated C++ maps Python ``bool`` / ``int`` /
+    ``float`` to ``bool`` / a narrow integer / ``double``, all of which
+    are trivially copyable.  ``date`` and ``datetime`` map to
+    ``std::chrono::year_month_day`` and
+    ``std::chrono::system_clock::time_point``, both also trivially
+    copyable.  Strings, bytes, lists, and dicts allocate or own heap
+    storage, so ``std::move`` continues to deliver value for those.
+    """
+    if isinstance(value, (list, dict, set)):
+        return False
+    return isinstance(value, (bool, int, float, datetime.date))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1463,13 +1480,17 @@ class Cpp(metaclass=LanguageCls):
     def consumable_ref_value_inhibits_consuming_form(
         self,
     ) -> Callable[[Value], bool]:
-        """Predicate deciding whether a ref's underlying value type
-        inhibits the consume form.
+        """Return ``True`` for ref values whose C++ type is trivially
+        copyable.
 
-        Delegates to :data:`never_inhibits_consuming_form`.  ``std::move``
-        is valid for every value type in this codebase.
+        ``clang-tidy``'s ``performance-move-const-arg`` rule (and the
+        equivalent ``hicpp-move-const-arg``) reports ``std::move`` on a
+        trivially-copyable value as an error: the move has no effect and
+        the wrapping is wasteful.  The call site routes these refs
+        through the non-consuming formatter so the emitted C++ compiles
+        cleanly under ``--warnings-as-errors``.
         """
-        return never_inhibits_consuming_form
+        return _cpp_value_inhibits_consuming_form
 
     @cached_property
     def _cpp_date_type(self) -> str:

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -74,6 +74,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -1457,6 +1458,18 @@ class Cpp(metaclass=LanguageCls):
             return f"std::move({name})"
 
         return _format_cpp_ref_identifier_consumable
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  ``std::move``
+        is valid for every value type in this codebase.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _cpp_date_type(self) -> str:

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -659,6 +660,19 @@ class Crystal(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -670,7 +670,7 @@ class Crystal(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -83,6 +83,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -959,6 +960,19 @@ class CSharp(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _date_tp(self) -> type:

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -970,7 +970,7 @@ class CSharp(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -619,6 +620,19 @@ class D(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -630,7 +630,7 @@ class D(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -73,6 +73,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -888,6 +889,19 @@ class Dart(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _date_tp(self) -> type:

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -899,7 +899,7 @@ class Dart(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -1052,7 +1052,7 @@ class Dhall(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
+    never_inhibits_consuming_form,
     no_compute_call_slot_wrap_ids,
     no_data_preamble,
     no_type_hint_preamble,
@@ -1041,6 +1042,19 @@ class Dhall(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -709,7 +709,7 @@ class Elixir(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -68,6 +68,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -698,6 +699,19 @@ class Elixir(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def call_style_config(self) -> CallStyle:

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -994,7 +994,7 @@ class Elm(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_ref_identifier,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -983,6 +984,19 @@ class Elm(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def null_literal(self) -> str:

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -666,6 +667,19 @@ class Erlang(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -677,7 +677,7 @@ class Erlang(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -48,6 +48,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -625,6 +626,19 @@ class Forth(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -636,7 +636,7 @@ class Forth(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -56,6 +56,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     body_preamble_from_scalars,
     identity_call_ref_identifier,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -798,6 +799,19 @@ class Fortran(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     def wrap_calls_with_declarations(
         self,

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -809,7 +809,7 @@ class Fortran(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -739,6 +740,19 @@ class FSharp(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _entry_formatter(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -750,7 +750,7 @@ class FSharp(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -1041,7 +1041,7 @@ class Gleam(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -66,6 +66,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_ref_identifier,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -1030,6 +1031,19 @@ class Gleam(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def null_literal(self) -> str:

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -752,7 +752,7 @@ class Go(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -75,6 +75,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -741,6 +742,19 @@ class Go(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _init_element_to_type(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -574,6 +575,19 @@ class Groovy(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -585,7 +585,7 @@ class Groovy(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -1683,3 +1684,16 @@ class Haskell(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1694,6 +1694,6 @@ class Haskell(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -597,7 +597,7 @@ class Hcl(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -586,6 +587,19 @@ class Hcl(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1286,7 +1286,7 @@ class Java(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -74,6 +74,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -1275,6 +1276,19 @@ class Java(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _suffix_is_auto(self) -> bool:

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -72,6 +72,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -640,6 +641,19 @@ class JavaScript(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -651,7 +651,7 @@ class JavaScript(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -60,6 +60,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -538,6 +539,19 @@ class Json5(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -549,7 +549,7 @@ class Json5(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -571,6 +572,19 @@ class Jsonnet(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -582,7 +582,7 @@ class Jsonnet(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -671,6 +672,19 @@ class Julia(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -682,7 +682,7 @@ class Julia(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -1034,7 +1034,7 @@ class Kotlin(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -84,6 +84,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -1023,6 +1024,19 @@ class Kotlin(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _date_type_name(self) -> str | None:

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -61,6 +61,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -564,6 +565,19 @@ class Lua(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -575,7 +575,7 @@ class Lua(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -662,7 +662,7 @@ class Matlab(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -651,6 +652,19 @@ class Matlab(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -1205,8 +1205,8 @@ class Mojo(metaclass=LanguageCls):
         Mojo 0.26.1.0+ rejects ``^`` on ``Int``, ``Bool``, and
         ``Float64`` values under ``--Werror`` because the transfer has
         no effect.  The trivial-register set is derived from
-        :func:`_mojo_variant_for_scalar` so the formatter layer does not
-        hardcode Mojo type-name strings.
+        :func:`_mojo_variant_for_scalar` so the formatter layer avoids
+        hard-coded Mojo type-name strings.
         """
         return _mojo_value_inhibits_consuming_form
 

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -498,6 +498,29 @@ def _mojo_variant_for_scalar(value: Scalar, /) -> _VariantSignature:  # noqa: PL
             assert_never(unreachable)
 
 
+_REGISTER_TRIVIAL_VARIANT_TYPE_NAMES: frozenset[str] = frozenset(
+    {"Bool", "Int", "Float64"},
+)
+"""Mojo ``Variant`` type-name buckets that map to register-trivial
+scalars.  Applying the ``^`` transfer operator to one of these is a
+hard error under ``--Werror`` in Mojo 0.26.1.0+.
+"""
+
+
+@beartype
+def _mojo_value_inhibits_consuming_form(value: Value, /) -> bool:
+    """Return ``True`` when ``^`` is illegal for *value*'s Mojo type.
+
+    Non-scalar values (lists, dicts, sets) and scalars that map to
+    non-trivial Mojo types (``String``, ``NoneType``) keep the existing
+    consuming-form behavior.
+    """
+    if isinstance(value, (list, dict, set)):
+        return False
+    signature = _mojo_variant_for_scalar(value)
+    return signature.type_name in _REGISTER_TRIVIAL_VARIANT_TYPE_NAMES
+
+
 @dataclasses.dataclass(frozen=True)
 class _HeterogeneousStrategyConfig:
     """Configuration for one Mojo heterogeneous-values strategy.
@@ -1164,8 +1187,28 @@ class Mojo(metaclass=LanguageCls):
         Used only for refs the caller declared as consumable on
         :func:`~literalizer.literalize_call` and that appear in just
         one call argument, so the transfer cannot strand a later use.
+        Refs whose underlying value is a register-trivial scalar
+        (``Int``, ``Bool``, ``Float64``) are routed away from this
+        formatter at the call site (see
+        :attr:`consumable_ref_value_inhibits_consuming_form`), because
+        applying ``^`` to such a value is a hard error under ``--Werror``.
         """
         return self.format_call_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Return ``True`` for ref values whose Mojo type is register-
+        trivial.
+
+        Mojo 0.26.1.0+ rejects ``^`` on ``Int``, ``Bool``, and
+        ``Float64`` values under ``--Werror`` because the transfer has
+        no effect.  The trivial-register set is derived from
+        :func:`_mojo_variant_for_scalar` so the formatter layer does not
+        hardcode Mojo type-name strings.
+        """
+        return _mojo_value_inhibits_consuming_form
 
     @cached_property
     def call_style_config(self) -> CallStyle:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1213,7 +1213,7 @@ class Nim(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -72,6 +72,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_compute_call_slot_wrap_ids,
     no_data_preamble,
@@ -1202,6 +1203,19 @@ class Nim(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -616,7 +616,7 @@ class Nix(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -605,6 +606,19 @@ class Nix(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -58,6 +58,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -510,6 +511,19 @@ class Norg(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -521,7 +521,7 @@ class Norg(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -733,7 +733,7 @@ class ObjectiveC(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -722,6 +723,19 @@ class ObjectiveC(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_ref_identifier,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -716,6 +717,19 @@ class OCaml(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def null_literal(self) -> str:

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -727,7 +727,7 @@ class OCaml(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -592,7 +592,7 @@ class Occam(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -581,6 +582,19 @@ class Occam(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -693,7 +693,7 @@ class Odin(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
@@ -682,6 +683,19 @@ class Odin(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -618,7 +618,7 @@ class Perl(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -607,6 +608,19 @@ class Perl(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -622,7 +622,7 @@ class Php(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -611,6 +612,19 @@ class Php(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def format_call_preamble_stub(

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -606,7 +606,7 @@ class PowerShell(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -55,6 +55,7 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -595,6 +596,19 @@ class PowerShell(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -63,6 +63,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -1119,6 +1120,19 @@ class PureScript(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -1130,7 +1130,7 @@ class PureScript(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -75,6 +75,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_validate_call_arg,
@@ -1114,6 +1115,19 @@ class Python(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1125,7 +1125,7 @@ class Python(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -632,7 +632,7 @@ class R(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -621,6 +622,19 @@ class R(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -553,6 +554,19 @@ class Racket(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -564,7 +564,7 @@ class Racket(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -655,7 +655,7 @@ class Raku(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -69,6 +69,7 @@ from literalizer._language import (
     default_wrap_calls_with_declarations,
     identity_call_arg,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -644,6 +645,19 @@ class Raku(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     TrailingCommaConfig,
     identity_call_ref_identifier,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -1020,6 +1021,19 @@ class Roc(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def null_literal(self) -> str:

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -1031,7 +1031,7 @@ class Roc(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -72,6 +72,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -674,6 +675,19 @@ class Ruby(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -685,7 +685,7 @@ class Ruby(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -77,6 +77,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_compute_call_slot_wrap_ids,
     no_data_preamble,
@@ -1472,6 +1473,19 @@ class Rust(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1483,7 +1483,7 @@ class Rust(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -73,6 +73,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -758,6 +759,19 @@ class Scala(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -769,7 +769,7 @@ class Scala(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -559,7 +559,7 @@ class Scheme(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -548,6 +549,19 @@ class Scheme(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -767,7 +767,7 @@ class Sml(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_ref_identifier,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -756,6 +757,19 @@ class Sml(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -74,6 +74,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -928,6 +929,19 @@ class Swift(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -939,7 +939,7 @@ class Swift(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -708,7 +708,7 @@ class SystemVerilog(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -697,6 +698,19 @@ class SystemVerilog(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     scalar_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}
     scalar_body_preamble: ClassVar[dict[type, tuple[str, ...]]] = {}

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -585,7 +585,7 @@ class Tcl(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -57,6 +57,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -574,6 +575,19 @@ class Tcl(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -555,6 +556,19 @@ class Toml(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -566,7 +566,7 @@ class Toml(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -75,6 +75,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -858,6 +859,19 @@ class TypeScript(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -869,7 +869,7 @@ class TypeScript(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -840,7 +840,7 @@ class V(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_compute_call_slot_wrap_ids,
     no_data_preamble,
     no_type_hint_preamble,
@@ -829,6 +830,19 @@ class V(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -778,7 +778,7 @@ class VisualBasic(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -767,6 +768,19 @@ class VisualBasic(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def _element_to_type(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -609,7 +609,7 @@ class Wren(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -59,6 +59,7 @@ from literalizer._language import (
     identity_call_arg,
     identity_call_ref_identifier,
     identity_call_statement,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -598,6 +599,19 @@ class Wren(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -522,7 +522,7 @@ class Yaml(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -62,6 +62,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -511,6 +512,19 @@ class Yaml(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
+    never_inhibits_consuming_form,
     no_call_stub,
     no_data_preamble,
     no_type_hint_preamble,
@@ -717,6 +718,19 @@ class Zig(metaclass=LanguageCls):
         this to opt into a consuming form (e.g. C++ ``std::move``).
         """
         return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+
+        Delegates to :data:`never_inhibits_consuming_form`.  Languages
+        whose consume operator rejects certain value types (notably
+        Mojo's ``^`` on register-trivial scalars) override this.
+        """
+        return never_inhibits_consuming_form
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -728,7 +728,7 @@ class Zig(metaclass=LanguageCls):
 
         Delegates to :data:`never_inhibits_consuming_form`.  Languages
         whose consume operator rejects certain value types (notably
-        Mojo's ``^`` on register-trivial scalars) override this.
+        the Mojo ``^`` on register-trivial scalars) override this.
         """
         return never_inhibits_consuming_form
 

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -445,6 +445,36 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_inline_multiline_dict_args=False,
     ),
     CallCaseConfig(
+        # Mix of register-trivial (Int / Bool / Float64) and non-trivial
+        # (List) consumable refs.  Each ref is single-use, so without
+        # the consume-suppression hook every ref would be eligible for
+        # the consuming form.  Mojo's ``^`` is a hard error under
+        # ``--Werror`` for register-trivial scalars, so the trivial refs
+        # must emit as bare identifiers while ``my_list`` keeps ``^``.
+        # Other languages that move consumable refs (notably C++) still
+        # render the consuming form for every ref.
+        case_dir_name="call_ref_args_trivial_register",
+        target_function="process",
+        parameter_names=["value", "count"],
+        call_transform=None,
+        transform_stub_names=[],
+        per_element=True,
+        call_style_type=None,
+        ref_declarations={
+            "my_int": "1",
+            "my_bool": "true",
+            "my_float": "3.14",
+            "my_list": "[1, 2, 3]",
+        },
+        wrap_in_file=False,
+        ref_case_per_language=False,
+        consumable_refs=frozenset(
+            {"my_int", "my_bool", "my_float", "my_list"},
+        ),
+        requires_call_returns_expression=False,
+        requires_inline_multiline_dict_args=False,
+    ),
+    CallCaseConfig(
         case_dir_name="call_ref_args_converted",
         target_function="process",
         parameter_names=["data", "count"],

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -448,7 +448,7 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         # Mix of register-trivial (Int / Bool / Float64) and non-trivial
         # (List) consumable refs.  Each ref is single-use, so without
         # the consume-suppression hook every ref would be eligible for
-        # the consuming form.  Mojo's ``^`` is a hard error under
+        # the consuming form.  the Mojo ``^`` is a hard error under
         # ``--Werror`` for register-trivial scalars, so the trivial refs
         # must emit as bare identifiers while ``my_list`` keeps ``^``.
         # Other languages that move consumable refs (notably C++) still

--- a/tests/integration/call_variant_cases.py
+++ b/tests/integration/call_variant_cases.py
@@ -125,6 +125,10 @@ CALL_VARIANT_SOURCES: list[tuple[str, Callable[[], Iterable[Variant]]]] = [
         "call_ref_args_reused",
         build_heterogeneous_strategy_call_variants,
     ),
+    (
+        "call_ref_args_trivial_register",
+        build_heterogeneous_strategy_call_variants,
+    ),
 ]
 
 

--- a/tests/integration/cases/call_ref_args_trivial_register/Ada_call.adb
+++ b/tests/integration/cases/call_ref_args_trivial_register/Ada_call.adb
@@ -1,0 +1,17 @@
+with A_Stub; use A_Stub;
+procedure Main is
+    procedure Process (Value : A_Val; Count : A_Val) is begin null; end Process;
+    my_int : A_Val := AInt (1);
+    my_bool : A_Val := ABool (True);
+    my_float : A_Val := AFloat (3.14);
+    my_list : A_Val := AList'[
+        AInt (1),
+        AInt (2),
+        AInt (3)
+    ];
+begin
+    Process(value => my_int, count => AInt (42));
+    Process(value => my_bool, count => AInt (7));
+    Process(value => my_float, count => AInt (9));
+    Process(value => my_list, count => AInt (1));
+end Main;

--- a/tests/integration/cases/call_ref_args_trivial_register/Bash_call.sh
+++ b/tests/integration/cases/call_ref_args_trivial_register/Bash_call.sh
@@ -1,0 +1,13 @@
+process() { :; }
+declare my_int=1
+declare my_bool=true
+declare my_float=3.14
+declare my_list=(
+    1
+    2
+    3
+)
+process my_int 42
+process my_bool 7
+process my_float 9
+process my_list 1

--- a/tests/integration/cases/call_ref_args_trivial_register/CSharp_call.cs
+++ b/tests/integration/cases/call_ref_args_trivial_register/CSharp_call.cs
@@ -1,0 +1,18 @@
+using System;
+class Check {
+static object process(object value = null, object count = null) => null;
+    public static void Main() {
+var my_int = 1;
+var my_bool = true;
+var my_float = 3.14;
+var my_list = (
+    1,
+    2,
+    3
+);
+process(my_int, 42);
+process(my_bool, 7);
+process(my_float, 9);
+process(my_list, 1);
+    }
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/C_call.c
+++ b/tests/integration/cases/call_ref_args_trivial_register/C_call.c
@@ -1,0 +1,32 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        unsigned long long u;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+static void process(CVal _a0, CVal _a1) { (void)_a0; (void)_a1; }
+int main(void) {
+CVal my_int = ((CVal){.i = 1});
+CVal my_bool = ((CVal){.b = true});
+CVal my_float = ((CVal){.f = 3.14});
+CVal my_list = ((CVal){.a = (CVal[]){
+    ((CVal){.i = 1}),
+    ((CVal){.i = 2}),
+    ((CVal){.i = 3}),
+}});
+process(my_int, ((CVal){.i = 42}));
+process(my_bool, ((CVal){.i = 7}));
+process(my_float, ((CVal){.i = 9}));
+process(my_list, ((CVal){.i = 1}));
+    return 0;
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args_trivial_register/Cpp_call.cpp
@@ -1,0 +1,19 @@
+#include <initializer_list>
+#include <vector>
+#include <variant>
+auto process(auto...) { return 0; }
+int main() {
+auto my_int = 1;
+auto my_bool = true;
+auto my_float = 3.14;
+auto my_list = std::vector<int>{
+    1,
+    2,
+    3,
+};
+process(std::move(my_int), 42);
+process(std::move(my_bool), 7);
+process(std::move(my_float), 9);
+process(std::move(my_list), 1);
+    return 0;
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Cpp_call.cpp
+++ b/tests/integration/cases/call_ref_args_trivial_register/Cpp_call.cpp
@@ -11,9 +11,9 @@ auto my_list = std::vector<int>{
     2,
     3,
 };
-process(std::move(my_int), 42);
-process(std::move(my_bool), 7);
-process(std::move(my_float), 9);
+process(my_int, 42);
+process(my_bool, 7);
+process(my_float, 9);
 process(std::move(my_list), 1);
     return 0;
 }

--- a/tests/integration/cases/call_ref_args_trivial_register/Crystal_call.cr
+++ b/tests/integration/cases/call_ref_args_trivial_register/Crystal_call.cr
@@ -1,0 +1,16 @@
+module Fixture_call_ref_args_trivial_register_Crystal_call
+extend self
+def process(value = nil, count = nil); 0; end
+my_int = 1
+my_bool = true
+my_float = 3.14
+my_list = [
+    1,
+    2,
+    3,
+]
+process(value: my_int, count: 42);
+process(value: my_bool, count: 7);
+process(value: my_float, count: 9);
+process(value: my_list, count: 1);
+end

--- a/tests/integration/cases/call_ref_args_trivial_register/D_call.d
+++ b/tests/integration/cases/call_ref_args_trivial_register/D_call.d
@@ -1,0 +1,16 @@
+import std.json;
+void main() {
+int process(T...)(T args) { return 0; }
+auto my_int = JSONValue(1);
+auto my_bool = JSONValue(true);
+auto my_float = JSONValue(3.14);
+auto my_list = JSONValue([
+    JSONValue(1),
+    JSONValue(2),
+    JSONValue(3),
+]);
+process(my_int, 42);
+process(my_bool, 7);
+process(my_float, 9);
+process(my_list, 1);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Dart_call.dart
+++ b/tests/integration/cases/call_ref_args_trivial_register/Dart_call.dart
@@ -1,0 +1,16 @@
+dynamic process({dynamic value, dynamic count}) => null;
+final my_data = null;
+void main() {
+    final my_int = 1;
+    final my_bool = true;
+    final my_float = 3.14;
+    final my_list = <int>[
+        1,
+        2,
+        3,
+    ];
+    process(value: my_int, count: 42);
+    process(value: my_bool, count: 7);
+    process(value: my_float, count: 9);
+    process(value: my_list, count: 1);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Elixir_call.ex
+++ b/tests/integration/cases/call_ref_args_trivial_register/Elixir_call.ex
@@ -1,0 +1,17 @@
+defmodule Check do
+  def process(_value, _count), do: nil
+  def x do
+    my_int = 1
+    my_bool = true
+    my_float = 3.14
+    my_list = [
+        1,
+        2,
+        3,
+    ]
+    process(my_int, 42)
+    process(my_bool, 7)
+    process(my_float, 9)
+    process(my_list, 1)
+  end
+end

--- a/tests/integration/cases/call_ref_args_trivial_register/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_trivial_register/Elm_call.elm
@@ -1,0 +1,37 @@
+module Check exposing (..)
+
+
+type Val
+    = EBool Bool
+    | EInt Int
+    | EFloat Float
+    | EList (List Val)
+process : ( a, b ) -> ()
+process _ = ()
+
+
+main : Program () () Never
+main =
+    let
+        my_int : Val
+        my_int = EInt 1
+        my_bool : Val
+        my_bool = EBool True
+        my_float : Val
+        my_float = EFloat 3.14
+        my_list : Val
+        my_list = EList [
+            EInt 1,
+            EInt 2,
+            EInt 3
+            ]
+        _ = process(my_int, EInt 42)
+        _ = process(my_bool, EInt 7)
+        _ = process(my_float, EInt 9)
+        _ = process(my_list, EInt 1)
+    in
+    Platform.worker
+        { init = \_ -> ( (), Cmd.none )
+        , update = \_ m -> ( m, Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }

--- a/tests/integration/cases/call_ref_args_trivial_register/Erlang_call.erl
+++ b/tests/integration/cases/call_ref_args_trivial_register/Erlang_call.erl
@@ -1,0 +1,16 @@
+-module(fixture_call_ref_args_trivial_register_erlang_call).
+-export([x/0]).
+process(_, _) -> ok.
+x() ->
+    My_int = 1,
+    My_bool = true,
+    My_float = 3.14,
+    My_list = [
+        1,
+        2,
+        3
+    ],
+    process(My_int, 42),
+    process(My_bool, 7),
+    process(My_float, 9),
+    process(My_list, 1).

--- a/tests/integration/cases/call_ref_args_trivial_register/FSharp_call.fs
+++ b/tests/integration/cases/call_ref_args_trivial_register/FSharp_call.fs
@@ -1,0 +1,20 @@
+module Main
+
+type Val =
+    | FBool of bool
+    | FInt of int64
+    | FFloat of float
+    | FList of Val list
+let process (_value: obj, _count: obj) : obj = null
+let my_int: Val = FInt 1L
+let my_bool: Val = FBool true
+let my_float: Val = FFloat 3.14
+let my_list: Val = FList [
+    FInt 1L;
+    FInt 2L;
+    FInt 3L
+]
+process(my_int, 42)
+process(my_bool, 7)
+process(my_float, 9)
+process(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Forth_call.fth
+++ b/tests/integration/cases/call_ref_args_trivial_register/Forth_call.fth
@@ -1,0 +1,13 @@
+: process ;
+: my_int 1 ;
+: my_bool true ;
+: my_float 3.14e0 ;
+: my_list
+    1
+    2
+    3
+;
+my_int 42 process
+my_bool 7 process
+my_float 9 process
+my_list 1 process

--- a/tests/integration/cases/call_ref_args_trivial_register/Fortran_call.f90
+++ b/tests/integration/cases/call_ref_args_trivial_register/Fortran_call.f90
@@ -1,0 +1,42 @@
+module fval_m
+  use, intrinsic :: iso_fortran_env, only: int64
+  implicit none
+  type :: fval_t
+    integer :: t = 0
+  end type fval_t
+contains
+  function fnull() result(v); type(fval_t) :: v; end function
+  function fbool(b) result(v); logical, intent(in) :: b; type(fval_t) :: v; end function
+  function fint(n) result(v); integer(kind=int64), intent(in) :: n; type(fval_t) :: v; end function
+  function freal(x) result(v); real, intent(in) :: x; type(fval_t) :: v; end function
+  function fstr(s) result(v); character(len=*), intent(in) :: s; type(fval_t) :: v; end function
+  function flist(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fmap(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fset(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fentry(k, u) result(v); character(len=*), intent(in) :: k; type(fval_t), intent(in) :: u; type(fval_t) :: v; end function
+end module fval_m
+program main
+    use fval_m
+    implicit none
+    type(fval_t) :: my_int
+    type(fval_t) :: my_bool
+    type(fval_t) :: my_float
+    type(fval_t) :: my_list
+    my_int = fint(1_int64)
+    my_bool = fbool(.true.)
+    my_float = freal(3.14)
+    my_list = flist([fval_t :: &
+        fint(1_int64), &
+        fint(2_int64), &
+        fint(3_int64) &
+    ])
+    call process(my_int, fint(42_int64))
+    call process(my_bool, fint(7_int64))
+    call process(my_float, fint(9_int64))
+    call process(my_list, fint(1_int64))
+contains
+    subroutine process(value, count)
+        implicit none
+        type(fval_t), intent(in) :: value, count
+    end subroutine process
+end program main

--- a/tests/integration/cases/call_ref_args_trivial_register/Go_call.go
+++ b/tests/integration/cases/call_ref_args_trivial_register/Go_call.go
@@ -1,0 +1,17 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+my_int := 1
+my_bool := true
+my_float := 3.14
+my_list := []int{
+	1,
+	2,
+	3,
+}
+process(my_int, 42)
+process(my_bool, 7)
+process(my_float, 9)
+process(my_list, 1)
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Groovy_call.groovy
+++ b/tests/integration/cases/call_ref_args_trivial_register/Groovy_call.groovy
@@ -1,0 +1,13 @@
+def process(Map _args) { null }
+def my_int = 1
+def my_bool = true
+def my_float = 3.14
+def my_list = [
+    1,
+    2,
+    3,
+]
+process(value: my_int, count: 42)
+process(value: my_bool, count: 7)
+process(value: my_float, count: 9)
+process(value: my_list, count: 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Haskell_call.hs
+++ b/tests/integration/cases/call_ref_args_trivial_register/Haskell_call.hs
@@ -1,0 +1,35 @@
+module Fixture_call_ref_args_trivial_register_Haskell_call where
+data Val = HBool Bool | HInt Integer | HFloat Double | HList [Val]
+instance Num Val where
+    fromInteger = HInt
+    _ + _ = error "not implemented"
+    _ * _ = error "not implemented"
+    abs _ = error "not implemented"
+    signum _ = error "not implemented"
+    negate (HInt n) = HInt (negate n)
+    negate (HFloat f) = HFloat (negate f)
+    negate _ = error "not implemented"
+instance Fractional Val where
+    fromRational r = HFloat (realToFrac r)
+    _ / _ = error "not implemented"
+process :: (Val, Val) -> IO ()
+process _ = return ()
+my_int :: Val
+my_int = 1
+my_bool :: Val
+my_bool = HBool True
+my_float :: Val
+my_float = 3.14
+my_list :: Val
+my_list = HList [
+    1,
+    2,
+    3
+    ]
+main :: IO ()
+main = do
+    _ <- process(my_int, 42)
+    _ <- process(my_bool, 7)
+    _ <- process(my_float, 9)
+    _ <- process(my_list, 1)
+    pure ()

--- a/tests/integration/cases/call_ref_args_trivial_register/Hcl_call.hcl
+++ b/tests/integration/cases/call_ref_args_trivial_register/Hcl_call.hcl
@@ -1,0 +1,12 @@
+my_int = 1
+my_bool = true
+my_float = 3.14
+my_list = [
+    1,
+    2,
+    3,
+]
+_0 = process(my_int, 42)
+_1 = process(my_bool, 7)
+_2 = process(my_float, 9)
+_3 = process(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/JavaScript_call.js
+++ b/tests/integration/cases/call_ref_args_trivial_register/JavaScript_call.js
@@ -1,0 +1,13 @@
+function process() {}
+const my_int = 1;
+const my_bool = true;
+const my_float = 3.14;
+const my_list = [
+  1,
+  2,
+  3,
+];
+process({ value: my_int, count: 42 });
+process({ value: my_bool, count: 7 });
+process({ value: my_float, count: 9 });
+process({ value: my_list, count: 1 });

--- a/tests/integration/cases/call_ref_args_trivial_register/Java_call.java
+++ b/tests/integration/cases/call_ref_args_trivial_register/Java_call.java
@@ -1,0 +1,17 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var my_int = 1;
+var my_bool = true;
+var my_float = 3.14;
+var my_list = new int[]{
+    1,
+    2,
+    3
+};
+process(my_int, 42);
+process(my_bool, 7);
+process(my_float, 9);
+process(my_list, 1);
+    }
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Kotlin_call.kts
+++ b/tests/integration/cases/call_ref_args_trivial_register/Kotlin_call.kts
@@ -1,0 +1,13 @@
+fun process(value: Any? = null, count: Any? = null): Any? = null
+val my_int = 1
+val my_bool = true
+val my_float = 3.14
+val my_list = intArrayOf(
+    1,
+    2,
+    3,
+)
+process(value = my_int, count = 42)
+process(value = my_bool, count = 7)
+process(value = my_float, count = 9)
+process(value = my_list, count = 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Lua_call.lua
+++ b/tests/integration/cases/call_ref_args_trivial_register/Lua_call.lua
@@ -1,0 +1,13 @@
+function process(...) end
+local my_int = 1
+local my_bool = true
+local my_float = 3.14
+local my_list = {
+    1,
+    2,
+    3,
+}
+process(my_int, 42)
+process(my_bool, 7)
+process(my_float, 9)
+process(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Matlab_call.m
+++ b/tests/integration/cases/call_ref_args_trivial_register/Matlab_call.m
@@ -1,0 +1,13 @@
+process = @(varargin) [];
+my_int = 1;
+my_bool = true;
+my_float = 3.14;
+my_list = {
+    1,
+    2,
+    3
+};
+process(my_int, 42)
+process(my_bool, 7)
+process(my_float, 9)
+process(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Mojo_heterogeneous_strategy_variant_call.mojo
+++ b/tests/integration/cases/call_ref_args_trivial_register/Mojo_heterogeneous_strategy_variant_call.mojo
@@ -1,0 +1,17 @@
+from std.utils.variant import Variant
+comptime Value = Variant[Bool, Int, Float64]
+def process[*Ts: AnyType](*args: *Ts):
+    pass
+def main():
+    var my_int = 1
+    var my_bool = True
+    var my_float = 3.14
+    var my_list = [
+        1,
+        2,
+        3,
+    ]
+    process(my_int, 42)
+    process(my_bool, 7)
+    process(my_float, 9)
+    process(my_list^, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Nim_call.nim
+++ b/tests/integration/cases/call_ref_args_trivial_register/Nim_call.nim
@@ -1,0 +1,14 @@
+import json
+template process(args: varargs[untyped]) = discard
+var my_int = %* 1
+var my_bool = %* true
+var my_float = %* 3.14
+var my_list = @[
+    1,
+    2,
+    3
+]
+process(my_int, 42)
+process(my_bool, 7)
+process(my_float, 9)
+process(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Nim_heterogeneous_strategy_object_variant_call.nim
+++ b/tests/integration/cases/call_ref_args_trivial_register/Nim_heterogeneous_strategy_object_variant_call.nim
@@ -1,0 +1,22 @@
+{.warning[UnusedImport]:off.}
+type
+  ValueKind = enum
+    vkBool, vkInt, vkFloat
+  Value = object
+    case kind: ValueKind
+    of vkBool: boolVal: bool
+    of vkInt: intVal: int
+    of vkFloat: floatVal: float
+template process(args: varargs[untyped]) = discard
+var my_int = 1
+var my_bool = true
+var my_float = 3.14
+var my_list = @[
+    1,
+    2,
+    3
+]
+process(my_int, 42)
+process(my_bool, 7)
+process(my_float, 9)
+process(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/OCaml_call.ml
+++ b/tests/integration/cases/call_ref_args_trivial_register/OCaml_call.ml
@@ -1,0 +1,22 @@
+module Check = struct
+
+type val_t =
+  | OBool of bool
+  | OInt of int
+  | OFloat of float
+  | OList of val_t list
+let process _ = ()
+let my_int : val_t = OInt 1
+let my_bool : val_t = OBool true
+let my_float : val_t = OFloat 3.14
+let my_list : val_t = OList [
+    OInt 1;
+    OInt 2;
+    OInt 3
+]
+let _ = process(my_int, 42)
+let _ = process(my_bool, 7)
+let _ = process(my_float, 9)
+let _ = process(my_list, 1)
+
+end

--- a/tests/integration/cases/call_ref_args_trivial_register/ObjectiveC_call.m
+++ b/tests/integration/cases/call_ref_args_trivial_register/ObjectiveC_call.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+static void process(id _a0, id _a1) { (void)_a0; (void)_a1; }
+int main(void) {
+@autoreleasepool {
+id my_int = @1;
+id my_bool = @YES;
+id my_float = @3.14;
+id my_list = @[
+    @1,
+    @2,
+    @3,
+];
+process(my_int, @42);
+process(my_bool, @7);
+process(my_float, @9);
+process(my_list, @1);
+}
+    return 0;
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Occam_call.occ
+++ b/tests/integration/cases/call_ref_args_trivial_register/Occam_call.occ
@@ -1,0 +1,32 @@
+MOBILE DATA TYPE LIT IS
+  CASE
+    lit.null
+    lit.bool ; BOOL
+    lit.int ; INT
+    lit.float ; REAL32
+    lit.str ; MOBILE []BYTE
+    lit.list ; MOBILE []MOBILE LIT
+    lit.map ; MOBILE []MOBILE LIT
+    lit.pair ; MOBILE []BYTE ; MOBILE LIT
+    lit.set ; MOBILE []MOBILE LIT
+:
+
+PROC process (VAL MOBILE LIT value, VAL MOBILE LIT count)
+    SKIP
+:
+PROC main ()
+    VAL MOBILE LIT my_int IS 1:
+    VAL MOBILE LIT my_bool IS MOBILE LIT(lit.bool; TRUE):
+    VAL MOBILE LIT my_float IS 3.14:
+    VAL MOBILE LIT my_list IS MOBILE LIT(lit.list; MOBILE []MOBILE LIT [
+        MOBILE LIT(lit.int; 1),
+        MOBILE LIT(lit.int; 2),
+        MOBILE LIT(lit.int; 3)
+    ]):
+    process(my_int, MOBILE LIT(lit.int; 42))
+    process(my_bool, MOBILE LIT(lit.int; 7))
+    process(my_float, MOBILE LIT(lit.int; 9))
+    process(my_list, MOBILE LIT(lit.int; 1))
+    SEQ
+        SKIP
+:

--- a/tests/integration/cases/call_ref_args_trivial_register/Odin_call.odin
+++ b/tests/integration/cases/call_ref_args_trivial_register/Odin_call.odin
@@ -1,0 +1,18 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+my_int := 1
+my_bool := true
+my_float := 3.14
+my_list := [dynamic]any{
+	1,
+	2,
+	3,
+}
+process(my_int, 42);
+process(my_bool, 7);
+process(my_float, 9);
+process(my_list, 1);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Perl_call.pl
+++ b/tests/integration/cases/call_ref_args_trivial_register/Perl_call.pl
@@ -1,0 +1,13 @@
+sub process {}
+my $my_int = 1;
+my $my_bool = 1;
+my $my_float = 3.14;
+my $my_list = [
+    1,
+    2,
+    3,
+];
+process($my_int, 42);
+process($my_bool, 7);
+process($my_float, 9);
+process($my_list, 1);

--- a/tests/integration/cases/call_ref_args_trivial_register/Php_call.php
+++ b/tests/integration/cases/call_ref_args_trivial_register/Php_call.php
@@ -1,0 +1,14 @@
+<?php
+function process($value, $count) {}
+$my_int = 1;
+$my_bool = true;
+$my_float = 3.14;
+$my_list = [
+    1,
+    2,
+    3,
+];
+process(value: $my_int, count: 42);
+process(value: $my_bool, count: 7);
+process(value: $my_float, count: 9);
+process(value: $my_list, count: 1);

--- a/tests/integration/cases/call_ref_args_trivial_register/PowerShell_call.ps1
+++ b/tests/integration/cases/call_ref_args_trivial_register/PowerShell_call.ps1
@@ -1,0 +1,13 @@
+function process {}
+$my_int = 1
+$my_bool = $true
+$my_float = 3.14
+$my_list = @(
+    1;
+    2;
+    3
+)
+process($my_int, 42)
+process($my_bool, 7)
+process($my_float, 9)
+process($my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/PureScript_call.purs
+++ b/tests/integration/cases/call_ref_args_trivial_register/PureScript_call.purs
@@ -1,0 +1,34 @@
+module Check where
+
+
+import Prelude
+data Val
+    = PBool Boolean
+    | PInt Int
+    | PFloat Number
+    | PList (Array Val)
+process :: Val -> Val -> Unit
+process _ _ = unit
+my_int :: Val
+my_int = PInt 1
+my_bool :: Val
+my_bool = PBool true
+my_float :: Val
+my_float = PFloat 3.14
+my_list :: Val
+my_list = PList [
+    PInt 1,
+    PInt 2,
+    PInt 3
+    ]
+
+
+main :: Unit
+main =
+    let
+        _ = process my_int (PInt 42)
+        _ = process my_bool (PInt 7)
+        _ = process my_float (PInt 9)
+        _ = process my_list (PInt 1)
+    in
+    unit

--- a/tests/integration/cases/call_ref_args_trivial_register/Python_call.py
+++ b/tests/integration/cases/call_ref_args_trivial_register/Python_call.py
@@ -1,0 +1,13 @@
+def process(*_args: object, **_kwargs: object) -> object: ...
+my_int = 1
+my_bool = True
+my_float = 3.14
+my_list = (
+    1,
+    2,
+    3,
+)
+process(value=my_int, count=42)
+process(value=my_bool, count=7)
+process(value=my_float, count=9)
+process(value=my_list, count=1)

--- a/tests/integration/cases/call_ref_args_trivial_register/R_call.R
+++ b/tests/integration/cases/call_ref_args_trivial_register/R_call.R
@@ -1,0 +1,13 @@
+process <- function(...) NULL
+my_int <- 1
+my_bool <- TRUE
+my_float <- 3.14
+my_list <- list(
+    1,
+    2,
+    3
+)
+process(value = my_int, count = 42)
+process(value = my_bool, count = 7)
+process(value = my_float, count = 9)
+process(value = my_list, count = 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Raku_call.raku
+++ b/tests/integration/cases/call_ref_args_trivial_register/Raku_call.raku
@@ -1,0 +1,13 @@
+sub process(*@a, *%kw) {}
+my $my_int = 1;
+my $my_bool = True;
+my $my_float = 3.14;
+my $my_list = [
+    1,
+    2,
+    3,
+];
+process($my_int, 42);
+process($my_bool, 7);
+process($my_float, 9);
+process($my_list, 1);

--- a/tests/integration/cases/call_ref_args_trivial_register/Roc_call.roc
+++ b/tests/integration/cases/call_ref_args_trivial_register/Roc_call.roc
@@ -1,0 +1,29 @@
+module [main]
+
+Val : [
+    RBool Bool,
+    RInt I128,
+    RFloat F64,
+    RList (List Val),
+]
+process : a, b -> {}
+process = \_, _ -> {}
+
+my_int : Val
+my_int = RInt 1i128
+my_bool : Val
+my_bool = RBool Bool.true
+my_float : Val
+my_float = RFloat 3.14
+my_list : Val
+my_list = RList [
+    RInt 1i128,
+    RInt 2i128,
+    RInt 3i128,
+    ]
+main =
+    dbg (process my_int (RInt 42i128))
+    dbg (process my_bool (RInt 7i128))
+    dbg (process my_float (RInt 9i128))
+    dbg (process my_list (RInt 1i128))
+    {}

--- a/tests/integration/cases/call_ref_args_trivial_register/Ruby_call.rb
+++ b/tests/integration/cases/call_ref_args_trivial_register/Ruby_call.rb
@@ -1,0 +1,13 @@
+def process(*a); end
+my_int = 1
+my_bool = true
+my_float = 3.14
+my_list = [
+  1,
+  2,
+  3,
+]
+process(value: my_int, count: 42)
+process(value: my_bool, count: 7)
+process(value: my_float, count: 9)
+process(value: my_list, count: 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Rust_call.rs
+++ b/tests/integration/cases/call_ref_args_trivial_register/Rust_call.rs
@@ -1,0 +1,15 @@
+fn main() {
+    fn process<A, B>(_value: A, _count: B) {}
+    let my_int = 1;
+    let my_bool = true;
+    let my_float = 3.14;
+    let my_list = vec![
+        1,
+        2,
+        3,
+    ];
+    process(my_int, 42);
+    process(my_bool, 7);
+    process(my_float, 9);
+    process(my_list, 1);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Rust_heterogeneous_strategy_tagged_enum_call.rs
+++ b/tests/integration/cases/call_ref_args_trivial_register/Rust_heterogeneous_strategy_tagged_enum_call.rs
@@ -1,0 +1,20 @@
+enum Value {
+    Bool(bool),
+    I32(i32),
+    F64(f64),
+}
+fn main() {
+    fn process<A, B>(_value: A, _count: B) {}
+    let my_int = 1;
+    let my_bool = true;
+    let my_float = 3.14;
+    let my_list = vec![
+        1,
+        2,
+        3,
+    ];
+    process(my_int, 42);
+    process(my_bool, 7);
+    process(my_float, 9);
+    process(my_list, 1);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Scala_call.scala
+++ b/tests/integration/cases/call_ref_args_trivial_register/Scala_call.scala
@@ -1,0 +1,15 @@
+object Fixture_call_ref_args_trivial_register_Scala_call {
+def process(value: Any = null, count: Any = null): Any = null
+val my_int = 1
+val my_bool = true
+val my_float = 3.14
+val my_list = List[Int](
+    1,
+    2,
+    3,
+)
+process(value = my_int, count = 42)
+process(value = my_bool, count = 7)
+process(value = my_float, count = 9)
+process(value = my_list, count = 1)
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Sml_call.sml
+++ b/tests/integration/cases/call_ref_args_trivial_register/Sml_call.sml
@@ -1,0 +1,18 @@
+datatype val_t =
+    SBool of bool
+  | SInt of LargeInt.int
+  | SReal of real
+  | SList of val_t list
+fun process _ = ()
+val my_int : val_t = SInt 1
+val my_bool : val_t = SBool true
+val my_float : val_t = SReal 3.14
+val my_list : val_t = SList [
+    SInt 1,
+    SInt 2,
+    SInt 3
+]
+val _ = process(my_int, 42)
+val _ = process(my_bool, 7)
+val _ = process(my_float, 9)
+val _ = process(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Swift_call.swift
+++ b/tests/integration/cases/call_ref_args_trivial_register/Swift_call.swift
@@ -1,0 +1,13 @@
+@discardableResult func process(value: Any = 0, count: Any = 0) -> Any { 0 }
+let my_int: Any = 1
+let my_bool: Any = true
+let my_float: Any = 3.14
+let my_list: Any = [
+    1,
+    2,
+    3,
+]
+process(value: my_int, count: 42);
+process(value: my_bool, count: 7);
+process(value: my_float, count: 9);
+process(value: my_list, count: 1);

--- a/tests/integration/cases/call_ref_args_trivial_register/SystemVerilog_call.sv
+++ b/tests/integration/cases/call_ref_args_trivial_register/SystemVerilog_call.sv
@@ -1,0 +1,28 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+task process(input _VVal value, input _VVal count); endtask
+initial begin
+static _VVal my_int = _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""};
+static _VVal my_bool = _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""};
+static _VVal my_float = _VVal'{tag: _VVAL_REAL, i: 0, r: 3.14, s: ""};
+static _VVal my_list[] = '{
+    _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 2, r: 0.0, s: ""},
+    _VVal'{tag: _VVAL_INT, i: 3, r: 0.0, s: ""}
+};
+process(my_int, _VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+process(my_bool, _VVal'{tag: _VVAL_INT, i: 7, r: 0.0, s: ""});
+process(my_float, _VVal'{tag: _VVAL_INT, i: 9, r: 0.0, s: ""});
+process(my_list, _VVal'{tag: _VVAL_INT, i: 1, r: 0.0, s: ""});
+end
+endmodule

--- a/tests/integration/cases/call_ref_args_trivial_register/Tcl_call.tcl
+++ b/tests/integration/cases/call_ref_args_trivial_register/Tcl_call.tcl
@@ -1,0 +1,13 @@
+proc process {args} {}
+set my_int 1
+set my_bool 1
+set my_float 3.14
+set my_list [list \
+    1 \
+    2 \
+    3 \
+]
+process my_int 42
+process my_bool 7
+process my_float 9
+process my_list 1

--- a/tests/integration/cases/call_ref_args_trivial_register/TypeScript_call.ts
+++ b/tests/integration/cases/call_ref_args_trivial_register/TypeScript_call.ts
@@ -1,0 +1,14 @@
+const process: any = () => {};
+const my_int = 1;
+const my_bool = true;
+const my_float = 3.14;
+const my_list = [
+  1,
+  2,
+  3,
+];
+process({ value: my_int, count: 42 });
+process({ value: my_bool, count: 7 });
+process({ value: my_float, count: 9 });
+process({ value: my_list, count: 1 });
+export {};

--- a/tests/integration/cases/call_ref_args_trivial_register/V_call.v
+++ b/tests/integration/cases/call_ref_args_trivial_register/V_call.v
@@ -1,0 +1,18 @@
+interface IVal {}
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	my_int := 1
+	my_bool := true
+	my_float := 3.14
+	my_list := [
+		1,
+		2,
+		3,
+	]
+	process(my_int, 42);
+	process(my_bool, 7);
+	process(my_float, 9);
+	process(my_list, 1);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/V_heterogeneous_strategy_error_call.v
+++ b/tests/integration/cases/call_ref_args_trivial_register/V_heterogeneous_strategy_error_call.v
@@ -1,0 +1,17 @@
+interface ICallArg_ {}
+fn process(args ...ICallArg_) {}
+
+fn main() {
+	my_int := 1
+	my_bool := true
+	my_float := 3.14
+	my_list := [
+		1,
+		2,
+		3,
+	]
+	process(my_int, 42);
+	process(my_bool, 7);
+	process(my_float, 9);
+	process(my_list, 1);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/VisualBasic_call.vb
+++ b/tests/integration/cases/call_ref_args_trivial_register/VisualBasic_call.vb
@@ -1,0 +1,20 @@
+Imports System.Collections.Generic
+Module Check
+    Function process(value As Object, count As Object) As Object
+        Return Nothing
+    End Function
+    Sub _calls()
+        Dim my_int = 1
+        Dim my_bool = True
+        Dim my_float = 3.14
+        Dim my_list = New Integer() {
+            1,
+            2,
+            3
+        }
+        process(my_int, 42)
+        process(my_bool, 7)
+        process(my_float, 9)
+        process(my_list, 1)
+    End Sub
+End Module

--- a/tests/integration/cases/call_ref_args_trivial_register/Wren_call.wren
+++ b/tests/integration/cases/call_ref_args_trivial_register/Wren_call.wren
@@ -1,0 +1,17 @@
+class Process_ {
+    construct new() {}
+    call(value, count) {}
+}
+var process = Process_.new()
+var my_int = 1
+var my_bool = true
+var my_float = 3.14
+var my_list = [
+    1,
+    2,
+    3,
+]
+process.call(my_int, 42)
+process.call(my_bool, 7)
+process.call(my_float, 9)
+process.call(my_list, 1)

--- a/tests/integration/cases/call_ref_args_trivial_register/Zig_call.zig
+++ b/tests/integration/cases/call_ref_args_trivial_register/Zig_call.zig
@@ -1,0 +1,27 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn process(value: ZVal, count: ZVal) void { _ = value; _ = count; }
+pub fn main() void {
+    const my_int: ZVal = .{ .int = 1 };
+    const my_bool: ZVal = .{ .bool = true };
+    const my_float: ZVal = .{ .float = 3.14 };
+    const my_list: ZVal = .{ .arr = &.{
+        .{ .int = 1 },
+        .{ .int = 2 },
+        .{ .int = 3 },
+    }};
+    process(my_int, .{ .int = 42 });
+    process(my_bool, .{ .int = 7 });
+    process(my_float, .{ .int = 9 });
+    process(my_list, .{ .int = 1 });
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/gleam_call.gleam
+++ b/tests/integration/cases/call_ref_args_trivial_register/gleam_call.gleam
@@ -1,0 +1,22 @@
+pub type GVal {
+  GBool(Bool)
+  GInt(Int)
+  GFloat(Float)
+  GList(List(GVal))
+}
+pub fn process(_value: a, _count: b) -> Nil { Nil }
+
+pub fn main() {
+  let my_int = GInt(1)
+  let my_bool = GBool(True)
+  let my_float = GFloat(3.14)
+  let my_list = GList([
+    GInt(1),
+    GInt(2),
+    GInt(3),
+  ])
+  process(my_int, GInt(42))
+  process(my_bool, GInt(7))
+  process(my_float, GInt(9))
+  process(my_list, GInt(1))
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/input.yaml
+++ b/tests/integration/cases/call_ref_args_trivial_register/input.yaml
@@ -1,0 +1,9 @@
+---
+- - { $ref: my_int }
+  - 42
+- - { $ref: my_bool }
+  - 7
+- - { $ref: my_float }
+  - 9
+- - { $ref: my_list }
+  - 1

--- a/tests/integration/test_language_metadata.py
+++ b/tests/integration/test_language_metadata.py
@@ -72,6 +72,7 @@ def test_protocol_properties_accessible(
     assert callable(spec.format_call_ref_identifier)
     assert callable(spec.format_call_arg_ref_identifier)
     assert callable(spec.format_call_arg_ref_identifier_consumable)
+    assert callable(spec.consumable_ref_value_inhibits_consuming_form)
     assert callable(spec.format_variable_declaration)
     assert callable(spec.format_variable_assignment)
     assert callable(spec.type_hint_collection_preamble_lines)


### PR DESCRIPTION
## Summary

- Mojo 0.26.1.0+ rejects `^` on register-trivial scalars (`Int`, `Bool`, `Float64`) under `--Werror` with "transfer from a value of trivial register type ... has no effect and can be removed". `literalize_call` now emits these refs bare; non-trivial refs (`List[...]`, `Dict[...]`) keep `^`.
- Added a new `Language.consumable_ref_value_inhibits_consuming_form` predicate. Default (`never_inhibits_consuming_form`) preserves existing behavior; Mojo overrides it to consult `_mojo_variant_for_scalar` so the trivial-register set is derived rather than hardcoded at the formatter layer.
- Threaded `ref_values` through `_render_call_per_element` / `_render_call_whole` → `_format_call_args` → `_format_single_call_arg`, pre-computing the inhibited ref set and routing those refs through `format_call_arg_ref_identifier` instead of the consumable formatter.
- New `call_ref_args_trivial_register` fixture exercises consumable `Int` / `Bool` / `Float64` / `List` refs; the Mojo variant golden shows bare `my_int`, `my_bool`, `my_float` and `my_list^`.

Fixes #2062.

## Test plan

- [ ] `uv run pytest tests/` (3212 pass, 717 skipped)
- [ ] `uv run mypy src/literalizer/` (clean)
- [ ] `uv run ruff check src/literalizer/` (clean)
- [ ] Coverage on `_literalize.py`, `_language.py`, `languages/mojo.py` is 100% line + branch
- [ ] Mojo variant golden for the new fixture compiles under `mojo build --Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)