### PR TITLE
Replace cast in CommentedSet branch with annotated variable

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -147,7 +147,7 @@ def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:
         case list():
             return [_coerce_yaml_keys(data=item) for item in data]
         case CommentedSet():
-            members = cast("set[Scalar]", set(data))
+            members: set[Scalar] = set(data)
             return {_unwrap_yaml_scalar(value=item) for item in members}
         case (
             bool()


### PR DESCRIPTION
## Summary
- Drop the `cast("set[Scalar]", set(data))` in `_coerce_yaml_keys`'s `CommentedSet` arm in favor of a `members: set[Scalar]` annotation, which is enough for pyright/mypy to accept the downstream unwrapping without any `cast` or `# type: ignore`.

## Test plan
- [x] `uv run --extra dev pytest tests/ -k "yaml or set"`
- [x] pre-commit hooks (mypy, pyright, ty, pyrefly) pass on push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only refactor in YAML parsing; runtime behavior should be unchanged aside from potential typing/linters effects.
> 
> **Overview**
> Removes an explicit `cast("set[Scalar]", set(data))` in `_coerce_yaml_keys` when handling YAML `CommentedSet`, replacing it with a typed local `members: set[Scalar] = set(data)` before unwrapping scalars.
> 
> This is a small typing/clarity adjustment intended to satisfy type checkers without `cast`/ignores, with no intended change to parsed output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8751bbebe8c748cd4ba4ab99061a13b13f063e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->