### PR TITLE
Detect Mojo string-list var decls from data, not rendered value

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -632,26 +632,38 @@ def _mojo_list_open(items: list[Value]) -> str:
 def _mojo_format_variable_declaration(
     name: str,
     value: str,
-    data: Value,
+    _data: Value,
     _modifiers: frozenset[enum.Enum],
 ) -> str:
-    """Format a Mojo ``var`` declaration.
-
-    Emits ``var name: List[String] = value`` when *data* is a non-empty
-    list whose rendered elements open with a double-quoted ``String``
-    literal (``str`` / ``bytes`` / ISO-rendered ``date`` / ISO-rendered
-    ``datetime`` lists).  Mojo does not infer ``List[String]`` from a
-    bare ``["a", "b"]`` literal; the result is a list of string
-    literals and is rejected when assigned into a ``Variant`` slot
-    expecting ``List[String]``.  Other element types (``Int``,
-    ``Float64``, ``Bool``, epoch-rendered datetimes, nested
-    collections) infer directly from the literal and need no
-    annotation.  A non-empty list ``data`` always renders with a ``[``
-    opener, so checking the character after ``[`` is sufficient.
-    """
-    if isinstance(data, list) and data and value[1:].lstrip().startswith('"'):
-        return f"var {name}: List[String] = {value}"
+    """Format a plain Mojo ``var name = value`` declaration."""
     return f"var {name} = {value}"
+
+
+@beartype
+def _mojo_element_renders_as_string(
+    item: Value,
+    *,
+    date_renders_as_string: bool,
+    datetime_renders_as_string: bool,
+) -> bool:
+    """Return whether *item* would render as a quoted ``String``.
+
+    Used to decide when a Mojo list literal needs an explicit
+    ``List[String]`` annotation: Mojo infers ``List[StringLiteral]`` from
+    a bare ``["a", "b"]`` literal, which is rejected when assigned into
+    a ``Variant`` slot expecting ``List[String]``.  ``str`` and ``bytes``
+    always render quoted; ``datetime`` and ``date`` only when the
+    configured formatter produces a string.
+    """
+    match item:
+        case str() | bytes():
+            return True
+        case datetime.datetime():
+            return datetime_renders_as_string
+        case datetime.date():
+            return date_renders_as_string
+        case _:
+            return False
 
 
 def _mojo_list_format(default_type: str, /) -> SequenceFormatConfig:
@@ -1335,8 +1347,38 @@ class Mojo(metaclass=LanguageCls):
     def format_variable_declaration(
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
-        """Callable that formats a new variable declaration."""
-        return self.declaration_style.value.formatter
+        """Callable that formats a new variable declaration.
+
+        Wraps the configured declaration formatter so a non-empty list of
+        string-rendering elements gets an explicit ``List[String]``
+        annotation.  Mojo infers ``List[StringLiteral]`` from a bare
+        ``["a", "b"]`` literal, which is rejected when assigned into a
+        ``Variant`` slot expecting ``List[String]``.
+        """
+        base_formatter = self.declaration_style.value.formatter
+        date_renders_as_string = self.date_format.value.type_produced is str
+        datetime_renders_as_string = (
+            self.datetime_format.value.type_produced is str
+        )
+
+        def _format(
+            name: str,
+            value: str,
+            data: Value,
+            modifiers: frozenset[enum.Enum],
+        ) -> str:
+            """Format the declaration, annotating string lists."""
+            match data:
+                case [first, *_] if _mojo_element_renders_as_string(
+                    item=first,
+                    date_renders_as_string=date_renders_as_string,
+                    datetime_renders_as_string=datetime_renders_as_string,
+                ):
+                    return f"var {name}: List[String] = {value}"
+                case _:
+                    return base_formatter(name, value, data, modifiers)
+
+        return _format
 
     @cached_property
     def format_variable_assignment(

--- a/tests/integration/cases/comments_double_hash/Mojo.mojo
+++ b/tests/integration/cases/comments_double_hash/Mojo.mojo
@@ -1,5 +1,5 @@
 def main():
-    var my_data = [
+    var my_data: List[String] = [
         # # section
         "a",
     ]

--- a/tests/integration/cases/comments_double_hash/Mojo_combined.mojo
+++ b/tests/integration/cases/comments_double_hash/Mojo_combined.mojo
@@ -1,5 +1,5 @@
 def main():
-    var my_data = [
+    var my_data: List[String] = [
         # # section
         "a",
     ]

--- a/tests/integration/cases/comments_multi_line/Mojo.mojo
+++ b/tests/integration/cases/comments_multi_line/Mojo.mojo
@@ -1,5 +1,5 @@
 def main():
-    var my_data = [
+    var my_data: List[String] = [
         # line 1
         # line 2
         "a",

--- a/tests/integration/cases/comments_multi_line/Mojo_combined.mojo
+++ b/tests/integration/cases/comments_multi_line/Mojo_combined.mojo
@@ -1,5 +1,5 @@
 def main():
-    var my_data = [
+    var my_data: List[String] = [
         # line 1
         # line 2
         "a",

--- a/tests/integration/cases/comments_sequence_before/Mojo.mojo
+++ b/tests/integration/cases/comments_sequence_before/Mojo.mojo
@@ -1,5 +1,5 @@
 def main():
-    var my_data = [
+    var my_data: List[String] = [
         # first
         "a",
         # second

--- a/tests/integration/cases/comments_sequence_before/Mojo_combined.mojo
+++ b/tests/integration/cases/comments_sequence_before/Mojo_combined.mojo
@@ -1,5 +1,5 @@
 def main():
-    var my_data = [
+    var my_data: List[String] = [
         # first
         "a",
         # second


### PR DESCRIPTION
## Summary
- Replace the rendered-string heuristic in Mojo's variable-declaration formatter with a data-driven check that inspects the actual Python list element type via `match`/`case`, binding `date_format` / `datetime_format` `type_produced` configs into the closure.
- Fixes the bug flagged on PR #2066 where leading comments before the first element (e.g. `[\n# first\n\"a\", ...]`) defeated the heuristic and dropped the required `List[String]` annotation.
- Updates the `comments_double_hash`, `comments_multi_line`, and `comments_sequence_before` Mojo goldens to include the now-correct annotation.

## Test plan
- [x] \`pytest tests/integration/test_literalize_golden.py -k Mojo\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: confined to Mojo code generation logic and updates a few golden integration outputs; main risk is unintended `List[String]` annotations for edge-case lists depending on date/datetime formatting configs.
> 
> **Overview**
> Fixes Mojo variable-declaration rendering so non-empty lists that *render as strings* (e.g. `str`/`bytes`, and `date`/`datetime` when configured to produce strings) are declared as `var name: List[String] = ...` based on the underlying data rather than heuristics on the rendered text (which could be broken by leading comments).
> 
> Updates Mojo golden integration cases for commented lists to reflect the now-consistent `List[String]` annotation in declarations (assignments remain unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a95d943664c663ee0d71eeae2ce349f4a74d19c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->