### PR TITLE
Replace cast in lint workflow fixture with annotated variable

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,6 +1,6 @@
 """Meta-tests for project structure and CI configuration."""
 
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from beartype import beartype
@@ -17,8 +17,8 @@ def fixture_lint_workflow(
     """Parse ``.github/workflows/lint.yml`` once per session."""
     lint_yml = pytestconfig.rootpath / ".github" / "workflows" / "lint.yml"
     ruamel_yaml = YAML()
-    loaded = ruamel_yaml.load(stream=lint_yml)  # pyright: ignore[reportUnknownMemberType]
-    return cast("dict[str, Any]", loaded)
+    loaded: dict[str, Any] = ruamel_yaml.load(stream=lint_yml)  # pyright: ignore[reportUnknownMemberType]
+    return loaded
 
 
 def test_all_languages_have_lint_workflow(


### PR DESCRIPTION
Removes the `cast("dict[str, Any]", ...)` in `tests/test_meta.py` by annotating the `loaded` variable directly, eliminating one more usage of `typing.cast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only typing refactor; behavior should be unchanged aside from stricter type annotation at assignment.
> 
> **Overview**
> Simplifies the `lint_workflow` session fixture in `tests/test_meta.py` by removing `typing.cast` usage and instead annotating the `loaded` value returned from `ruamel_yaml.load` as `dict[str, Any]` before returning it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84acfcd655d63835d010eecc85b03f2811b389e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->