### PR TITLE
Replace cast in CommentedOrderedMap branch with annotated variable

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -134,7 +134,7 @@ def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:
     # represents ``!!omap`` and must be demoted to ``ordereddict``.
     match data:
         case CommentedOrderedMap():
-            omap_src = cast("dict[object, object]", data)
+            omap_src: dict[object, object] = dict(data)
             omap = ordereddict(
                 [
                     (f"{k}", _coerce_yaml_keys(data=cast("YamlCoercible", v)))


### PR DESCRIPTION
## Summary
- Remove `cast("dict[object, object]", data)` in `_coerce_yaml_keys`'s `CommentedOrderedMap` arm; use `omap_src: dict[object, object] = dict(data)` instead, matching the prior `CommentedSet` cast removal (7f8751bbe).

## Test plan
- [x] `uv run pyright src/literalizer/_parsing.py` — no new errors
- [x] `uv run pytest -k "yaml or omap"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to YAML `!!omap` key-coercion; behavior should be unchanged aside from materializing `data` via `dict()` before iteration.
> 
> **Overview**
> Simplifies `_coerce_yaml_keys` handling of YAML `CommentedOrderedMap` by replacing a `cast("dict[object, object]", data)` with an explicitly typed local `omap_src` created via `dict(data)` before building the `ordereddict`.
> 
> This is a typing/clarity refactor intended to align with similar cast removals elsewhere, without changing the surrounding coercion logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4d67613a44f1e7323a31291d9b9ef6b6c8701d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->