### PR TITLE
Pass lang_cls explicitly to run_call_golden_case

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -10,7 +10,6 @@ import dataclasses
 import functools
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import cast
 
 import pytest
 from beartype import beartype
@@ -1075,6 +1074,7 @@ def run_call_golden_case(
     *,
     config: CallCaseConfig,
     spec: literalizer.Language,
+    lang_cls: literalizer.LanguageCls,
     golden_name: str,
     cases_dir: Path,
     file_regression: FileRegressionFixture,
@@ -1086,7 +1086,6 @@ def run_call_golden_case(
     variants, e.g. Rust's ``TAGGED_ENUM`` on an input the default
     ``ERROR`` strategy rejects).
     """
-    lang_cls = cast("literalizer.LanguageCls", type(spec))
     input_path = cases_dir / config.case_dir_name / "input.yaml"
     yaml_string = input_path.read_text()
     golden_path = make_golden_path(

--- a/tests/integration/test_calls.py
+++ b/tests/integration/test_calls.py
@@ -50,6 +50,7 @@ def test_call_golden_file(
             run_call_golden_case(
                 config=config,
                 spec=spec,
+                lang_cls=lang_cls,
                 golden_name=f"{lang_cls.__name__}_call",
                 cases_dir=cases_dir,
                 file_regression=file_regression,
@@ -58,6 +59,7 @@ def test_call_golden_file(
     run_call_golden_case(
         config=config,
         spec=spec,
+        lang_cls=lang_cls,
         golden_name=f"{lang_cls.__name__}_call",
         cases_dir=cases_dir,
         file_regression=file_regression,
@@ -85,6 +87,7 @@ def test_call_variant_golden_file(
     run_call_golden_case(
         config=call_variant_case.config,
         spec=call_variant_case.variant.spec,
+        lang_cls=call_variant_case.variant.lang_cls,
         golden_name=f"{call_variant_case.variant.name}_call",
         cases_dir=cases_dir,
         file_regression=file_regression,


### PR DESCRIPTION
## Summary
- Removes the `cast(\"LanguageCls\", type(spec))` in `run_call_golden_case` by accepting `lang_cls` as an explicit parameter; both call sites already had it in scope.

## Test plan
- [x] `pytest tests/integration/test_calls.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test harness refactor only, removing a runtime `type(spec)` cast and threading an already-known `lang_cls` through call sites.
> 
> **Overview**
> Refactors the `literalize_call` integration test harness so `run_call_golden_case` takes `lang_cls` explicitly instead of deriving it from `type(spec)`.
> 
> Updates both default and variant call test runners to pass `lang_cls`, and drops the now-unneeded `typing.cast` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d7b287c4a3c7ad7f88983279360a19f521d16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->