### PR TITLE
Replace cast in CommentedOrderedMap value iteration with annotated dict

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -134,10 +134,10 @@ def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:
     # represents ``!!omap`` and must be demoted to ``ordereddict``.
     match data:
         case CommentedOrderedMap():
-            omap_src: dict[object, object] = dict(data)
+            omap_src: dict[object, YamlCoercible] = dict(data)
             omap = ordereddict(
                 [
-                    (f"{k}", _coerce_yaml_keys(data=cast("YamlCoercible", v)))
+                    (f"{k}", _coerce_yaml_keys(data=v))
                     for k, v in omap_src.items()
                 ]
             )


### PR DESCRIPTION
## Summary
- Narrow `omap_src` to `dict[object, YamlCoercible]` in `_coerce_yaml_keys` so the recursive call no longer needs `cast("YamlCoercible", v)`.

## Test plan
- [x] `pytest -k omap`
- [x] pre-commit (mypy, pyright, ty, pyrefly all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type-annotation-only adjustment to remove an unnecessary `cast` during YAML `!!omap` coercion, with no intended runtime behavior change.
> 
> **Overview**
> Tightens typing in `_coerce_yaml_keys` for the YAML `!!omap` (`CommentedOrderedMap`) path by annotating the temporary `omap_src` as `dict[object, YamlCoercible]` and removing the per-item `cast` when recursing.
> 
> Runtime behavior should be unchanged; this primarily improves static type-checker correctness around ordered-map value iteration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af143b57f9ffba21cbba3399ee1c458f19079f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->