### PR TITLE
Remove cast in _coerce_yaml_keys ordered-map return

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import functools
 import json
-from typing import assert_never, cast
+from typing import assert_never
 
 import pyjson5
 import tomlkit
@@ -135,13 +135,12 @@ def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:
     match data:
         case CommentedOrderedMap():
             omap_src: dict[object, YamlCoercible] = dict(data)
-            omap = ordereddict(
+            return ordereddict(
                 [
                     (f"{k}", _coerce_yaml_keys(data=v))
                     for k, v in omap_src.items()
                 ]
             )
-            return cast("Value", omap)
         case dict():
             return {f"{k}": _coerce_yaml_keys(data=v) for k, v in data.items()}
         case list():


### PR DESCRIPTION
## Summary
- Drop `cast("Value", omap)` in `_coerce_yaml_keys`; ruamel's `ordereddict` is already a `dict` subclass and satisfies the `Value` return type, so the cast was unnecessary.

## Test plan
- [x] mypy / pyright / ty / pyrefly pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a typing-only cleanup in YAML `!!omap` coercion that should not change runtime behavior beyond simplifying the return path.
> 
> **Overview**
> Simplifies `_coerce_yaml_keys` by returning `ruamel.yaml`’s `ordereddict` directly for `CommentedOrderedMap` (`!!omap`) nodes, removing an unnecessary intermediate variable and `cast("Value", ...)`.
> 
> Also drops the now-unused `cast` import from `_parsing.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844b114a100d2b8b3da97c3f2ac92293784b128c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->