### PR TITLE
Replace cast in variant_cases _safe_variant_matches_never with annotated variable

### DIFF
--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -10,7 +10,7 @@ import enum
 import functools
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from beartype import beartype
 
@@ -1479,7 +1479,7 @@ def _safe_variant_matches_never(
         for m in variant.spec.variable_type_hints_formats
         if m.name == "NEVER"
     )
-    spec_as_dataclass = cast("Any", variant.spec)
+    spec_as_dataclass: Any = variant.spec
     spec_kwargs: dict[str, object] = {
         f.name: getattr(variant.spec, f.name)
         for f in dataclasses.fields(class_or_instance=spec_as_dataclass)


### PR DESCRIPTION
## Summary
- Removes `cast("Any", variant.spec)` in `tests/integration/variant_cases.py` by using an annotated local (`spec_as_dataclass: Any = variant.spec`), matching the pattern from prior v1–v7 cast-removal PRs.
- Drops the now-unused `cast` import.

## Test plan
- [x] `uv run pyright tests/integration/variant_cases.py`
- [x] `uv run --extra dev pytest tests/integration --co` (collection exercises `_safe_variant_matches_never`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that only adjusts typing/casting and removes an unused import, with no behavioral changes expected.
> 
> **Overview**
> Simplifies `_safe_variant_matches_never` in `tests/integration/variant_cases.py` by replacing `cast("Any", variant.spec)` with an explicitly annotated local (`spec_as_dataclass: Any = variant.spec`) for the dataclass-field iteration.
> 
> Also removes the now-unused `cast` import from `typing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64991de58d2076a51cb4afbbd5b8adf768e087f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->