### PR TITLE
Narrow wrap_scalar callback to Scalar; remove four cast() calls

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -12,7 +12,7 @@ from beartype import beartype
 
 from literalizer._formatters.collection_openers import typed_collection_open
 from literalizer._formatters.type_inference import DictType, ListType
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 @dataclasses.dataclass(frozen=True)
@@ -458,7 +458,7 @@ class HeterogeneousBehavior:
 
     skip_scalar_checks: bool
     compute_wrap_ids: Callable[[Value], frozenset[int]]
-    wrap_scalar: Callable[[Value, str], str]
+    wrap_scalar: Callable[[Scalar, str], str]
     compute_call_slot_wrap_ids: Callable[[Sequence[Value]], frozenset[int]]
 
 
@@ -467,7 +467,7 @@ def _no_compute_wrap_ids(_data: Value, /) -> frozenset[int]:
     return frozenset()
 
 
-def _no_wrap_scalar(_raw: Value, formatted: str, /) -> str:
+def _no_wrap_scalar(_raw: Scalar, formatted: str, /) -> str:
     """Return *formatted* unchanged — used by non-wrapping languages."""
     return formatted  # pragma: no cover
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Mapping, Sequence
-from typing import assert_never
+from typing import Any, assert_never
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
@@ -240,8 +240,9 @@ def _maybe_wrap_child(
     """
     if parent_id not in wrap_ids:
         return formatted_value
+    raw_scalar: Any = raw_value
     return spec.heterogeneous_behavior.wrap_scalar(
-        raw_value,
+        raw_scalar,
         formatted_value,
     )
 
@@ -2384,7 +2385,10 @@ def _format_single_call_arg(
         ),
     )
     if id(value) in scalar_wrap_ids:
-        return language.heterogeneous_behavior.wrap_scalar(value, formatted)
+        raw_scalar: Any = value
+        return language.heterogeneous_behavior.wrap_scalar(
+            raw_scalar, formatted
+        )
     return formatted
 
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -6,7 +6,7 @@ import enum
 import re
 from collections.abc import Callable, Sequence
 from functools import cached_property
-from typing import ClassVar, assert_never, cast
+from typing import ClassVar, assert_never
 
 from beartype import beartype
 
@@ -440,16 +440,9 @@ def _build_union_type_behavior(
         """Return container ids whose scalar children should wrap."""
         return collect_heterogeneous_container_ids(data=data)
 
-    def _wrap(raw_value: Value, formatted: str) -> str:
-        """Wrap a scalar as ``{union_name}.{Variant} payload``.
-
-        :func:`~literalizer._literalize._maybe_wrap_child` filters
-        non-scalar values before dispatching, so *raw_value* is always
-        a scalar.
-        """
-        signature = _dhall_variant_for_scalar(
-            value=cast("Scalar", raw_value),
-        )
+    def _wrap(raw_value: Scalar, formatted: str) -> str:
+        """Wrap a scalar as ``{union_name}.{Variant} payload``."""
+        signature = _dhall_variant_for_scalar(value=raw_value)
         if signature.inner_type is None:
             return f"{union_name}.{signature.name}"
         return f"{union_name}.{signature.name} {formatted}"

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -6,7 +6,7 @@ import enum
 import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property, partial
-from typing import ClassVar, assert_never, cast
+from typing import ClassVar, assert_never
 
 from beartype import beartype
 
@@ -562,12 +562,12 @@ def _build_variant_behavior(
         """Return container ids whose scalar children should wrap."""
         return collect_heterogeneous_container_ids(data=data)
 
-    def _wrap(raw_value: Value, formatted: str) -> str:
+    def _wrap(raw_value: Scalar, formatted: str) -> str:
         """Wrap a scalar as ``{variant_name}({payload})`` where the
         payload comes from the signature's ``payload_template`` (with
         ``{value}`` substituted by the formatted scalar).
         """
-        signature = _mojo_variant_for_scalar(cast("Scalar", raw_value))
+        signature = _mojo_variant_for_scalar(raw_value)
         payload = signature.payload_template.replace(
             _VARIANT_PAYLOAD_VALUE_PLACEHOLDER,
             formatted,

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -6,7 +6,7 @@ import enum
 from collections.abc import Callable, Sequence
 from functools import cached_property, partial
 from types import MappingProxyType
-from typing import ClassVar, assert_never, cast
+from typing import ClassVar, assert_never
 
 from beartype import beartype
 
@@ -336,10 +336,10 @@ def _build_object_variant_behavior(
         """Return container ids whose scalar children should wrap."""
         return collect_heterogeneous_container_ids(data=data)
 
-    def _wrap(raw_value: Value, formatted: str) -> str:
+    def _wrap(raw_value: Scalar, formatted: str) -> str:
         """Wrap a scalar as ``{variant_name}(kind: ..., ...Val: ...)``."""
         signature = _nim_variant_for_scalar(
-            value=cast("Scalar", raw_value),
+            value=raw_value,
             date_type=date_type,
             datetime_type=datetime_type,
         )

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -7,7 +7,7 @@ import textwrap
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from types import MappingProxyType
-from typing import ClassVar, assert_never, cast
+from typing import ClassVar, assert_never
 
 from beartype import beartype
 
@@ -530,15 +530,10 @@ def _build_tagged_enum_behavior(
         """Return container ids whose scalar children should wrap."""
         return collect_heterogeneous_container_ids(data=data)
 
-    def _wrap(raw_value: Value, formatted: str) -> str:
-        """Wrap a scalar in ``{enum_name}::{Variant}(formatted)``.
-
-        :func:`~literalizer._literalize._maybe_wrap_child` filters
-        non-scalar values before dispatching, so *raw_value* is always
-        a scalar.
-        """
+    def _wrap(raw_value: Scalar, formatted: str) -> str:
+        """Wrap a scalar in ``{enum_name}::{Variant}(formatted)``."""
         signature = _heterogeneous_variant_for_scalar(
-            value=cast("Scalar", raw_value),
+            value=raw_value,
             date_type=date_type,
             datetime_type=datetime_type,
         )


### PR DESCRIPTION
## Summary
- Changes ``HeterogeneousBehavior.wrap_scalar`` from ``Callable[[Value, str], str]`` to ``Callable[[Scalar, str], str]``, encoding the wrap_ids / scalar_wrap_ids invariant in the type system rather than per-language comments.
- ``_maybe_wrap_child`` and ``_format_single_call_arg`` perform the ``Value -> Scalar`` narrowing once at the dispatch boundary via an ``Any`` local; beartype validates at the callee.
- Drops four ``cast(\"Scalar\", raw_value)`` calls (Rust, Dhall, Nim, Mojo) and their stale \"filters non-scalar values\" comments; ``cast`` is removed from each module's ``typing`` imports.

## Test plan
- [x] ``pytest -k 'tagged_enum or union_type or object_variant or variant_strategy or mojo'`` (85 passed)
- [x] ``grep -rn 'cast(' src/`` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-level refactor that touches heterogeneous-scalar wrapping dispatch and a few language implementations; main risk is accidental behavior change in edge cases where non-scalars could previously reach `wrap_scalar`.
> 
> **Overview**
> Tightens `HeterogeneousBehavior.wrap_scalar`’s contract from `Value` to `Scalar`, encoding the “only scalars get wrapped” invariant in the type system.
> 
> Updates the two dispatch sites in `_literalize.py` to narrow `Value` to `Scalar` at the boundary (via an `Any` local) and adjusts Dhall/Mojo/Nim/Rust wrappers accordingly, removing now-unnecessary `cast()` usage and related comments/imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb448f7793d8407f93ed1a59d03af453193ad214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->