### PR TITLE
Make HeterogeneousBehavior.wrap_scalar optional

### DIFF
--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -443,6 +443,9 @@ class HeterogeneousBehavior:
     ``wrap_scalar`` wraps a formatted scalar value (e.g. Rust's
     tagged-enum ``Value::Variant(…)``).  For non-scalar inputs the
     implementation is expected to return *formatted* unchanged.
+    ``None`` indicates the language does not wrap; in that case
+    ``compute_wrap_ids`` and ``compute_call_slot_wrap_ids`` must
+    always return an empty set.
 
     ``compute_call_slot_wrap_ids`` is called per positional-argument
     slot with the per-call values gathered at that slot.  It returns
@@ -458,18 +461,13 @@ class HeterogeneousBehavior:
 
     skip_scalar_checks: bool
     compute_wrap_ids: Callable[[Value], frozenset[int]]
-    wrap_scalar: Callable[[Value, str], str]
+    wrap_scalar: Callable[[Value, str], str] | None
     compute_call_slot_wrap_ids: Callable[[Sequence[Value]], frozenset[int]]
 
 
 def _no_compute_wrap_ids(_data: Value, /) -> frozenset[int]:
     """Return an empty wrap-id set — used by non-wrapping languages."""
     return frozenset()
-
-
-def _no_wrap_scalar(_raw: Value, formatted: str, /) -> str:
-    """Return *formatted* unchanged — used by non-wrapping languages."""
-    return formatted  # pragma: no cover
 
 
 def _no_compute_call_slot_wrap_ids(
@@ -493,7 +491,7 @@ wrapping (every non-Mojo VARIANT-style behavior).
 NO_HETEROGENEOUS_BEHAVIOR = HeterogeneousBehavior(
     skip_scalar_checks=False,
     compute_wrap_ids=_no_compute_wrap_ids,
-    wrap_scalar=_no_wrap_scalar,
+    wrap_scalar=None,
     compute_call_slot_wrap_ids=_no_compute_call_slot_wrap_ids,
 )
 """Shared behavior for languages that do not wrap heterogeneous scalar

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -238,12 +238,10 @@ def _maybe_wrap_child(
     on the spec's
     :attr:`~literalizer._language.Language.heterogeneous_behavior`.
     """
-    if parent_id not in wrap_ids:
+    wrap_scalar = spec.heterogeneous_behavior.wrap_scalar
+    if wrap_scalar is None or parent_id not in wrap_ids:
         return formatted_value
-    return spec.heterogeneous_behavior.wrap_scalar(
-        raw_value,
-        formatted_value,
-    )
+    return wrap_scalar(raw_value, formatted_value)
 
 
 @beartype
@@ -2383,9 +2381,10 @@ def _format_single_call_arg(
             multiline_prefix="",
         ),
     )
-    if id(value) in scalar_wrap_ids:
-        return language.heterogeneous_behavior.wrap_scalar(value, formatted)
-    return formatted
+    wrap_scalar = language.heterogeneous_behavior.wrap_scalar
+    if wrap_scalar is None or id(value) not in scalar_wrap_ids:
+        return formatted
+    return wrap_scalar(value, formatted)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Replace the unreachable `_no_wrap_scalar` stub (marked `# pragma: no cover`) with `None` on `HeterogeneousBehavior.wrap_scalar`, making the "non-wrapping language" case explicit in the type.
- Update the two call sites in `_literalize.py` to short-circuit on `None`, so the no-op branch is naturally exercised by tests instead of needing a coverage pragma.

## Test plan
- [x] `pytest tests/` (3212 passed)
- [x] Coverage remains 100% on `_language.py` and `_literalize.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small internal API/typing change that makes the no-wrapping case explicit and adds `None` short-circuiting at the two wrapping call sites, without changing wrapping behavior for languages that implement it.
> 
> **Overview**
> **Makes heterogeneous scalar wrapping optional.** `HeterogeneousBehavior.wrap_scalar` is now typed as `Callable[..., str] | None`, and `NO_HETEROGENEOUS_BEHAVIOR` uses `None` instead of an unreachable no-op wrapper.
> 
> **Updates wrapping call sites to handle `None`.** The scalar-wrapping paths in `_literalize.py` now early-return when `wrap_scalar` is `None`, removing the need for the previous no-op stub and ensuring the no-wrap branch is exercised naturally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7eed702ec8a185cc78e1856fda066dd2f269e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->