### PR TITLE
Remove unnecessary no-branch pragma on case list()

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -1104,7 +1104,7 @@ def _format_value(
                 spec=spec,
                 wrap_ids=wrap_ids,
             )
-        case list():  # pragma: no branch
+        case list():
             result = _format_list_value(
                 value=value,
                 spec=spec,


### PR DESCRIPTION
## Summary
- Drop the `# pragma: no branch` from the `case list():` arm in `_format_value`. Branch coverage exercises both outcomes (lists match it; scalars fall through to `case _:`), so the pragma is cosmetic noise.

## Test plan
- [ ] CI branch coverage stays at 100% for this line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cosmetic change only; it removes a coverage pragma without altering runtime behavior or formatting logic.
> 
> **Overview**
> Removes the `# pragma: no branch` annotation from the `case list():` arm in `_format_value` (in `_literalize.py`), leaving the match logic unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc0f0d83247197521792d9d327cb1f91ad49d02a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->