### PR TITLE
Split HeterogeneousBehavior wrap hook into wrap_scalar and wrap_non_scalar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     # path is available on every platform where a wheel is published.
     "ruamel-yaml-clib>=0.2.15; platform_python_implementation=='CPython'",
     "tomlkit>=0.12",
-    "typing-extensions>=4.10",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     # path is available on every platform where a wheel is published.
     "ruamel-yaml-clib>=0.2.15; platform_python_implementation=='CPython'",
     "tomlkit>=0.12",
+    "typing-extensions>=4.10",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -441,8 +441,13 @@ class HeterogeneousBehavior:
     of containers whose scalar children must be wrapped.
 
     ``wrap_scalar`` wraps a formatted scalar value (e.g. Rust's
-    tagged-enum ``Value::Variant(…)``).  For non-scalar inputs the
-    implementation is expected to return *formatted* unchanged.
+    tagged-enum ``Value::Variant(…)``).
+
+    ``wrap_non_scalar`` wraps a formatted ref-marker or container value
+    when its parent is in ``wrap_ids``.  Used by V's interface strategy,
+    which renders ``IVal(...)`` around every formatted child regardless
+    of underlying type.  Languages whose ``compute_wrap_ids`` only marks
+    parents with all-scalar children leave this as the identity.
 
     ``compute_call_slot_wrap_ids`` is called per positional-argument
     slot with the per-call values gathered at that slot.  It returns
@@ -459,6 +464,7 @@ class HeterogeneousBehavior:
     skip_scalar_checks: bool
     compute_wrap_ids: Callable[[Value], frozenset[int]]
     wrap_scalar: Callable[[Scalar, str], str]
+    wrap_non_scalar: Callable[[Value, str], str]
     compute_call_slot_wrap_ids: Callable[[Sequence[Value]], frozenset[int]]
 
 
@@ -470,6 +476,19 @@ def _no_compute_wrap_ids(_data: Value, /) -> frozenset[int]:
 def _no_wrap_scalar(_raw: Scalar, formatted: str, /) -> str:
     """Return *formatted* unchanged — used by non-wrapping languages."""
     return formatted  # pragma: no cover
+
+
+def _no_wrap_non_scalar(_raw: Value, formatted: str, /) -> str:
+    """Return *formatted* unchanged — default for languages whose
+    ``compute_wrap_ids`` only marks parents with all-scalar children.
+    """
+    return formatted
+
+
+no_wrap_non_scalar: Callable[[Value, str], str] = _no_wrap_non_scalar
+"""Shared identity ``wrap_non_scalar`` for languages whose
+``compute_wrap_ids`` only marks parents with all-scalar children.
+"""
 
 
 def _no_compute_call_slot_wrap_ids(
@@ -494,6 +513,7 @@ NO_HETEROGENEOUS_BEHAVIOR = HeterogeneousBehavior(
     skip_scalar_checks=False,
     compute_wrap_ids=_no_compute_wrap_ids,
     wrap_scalar=_no_wrap_scalar,
+    wrap_non_scalar=_no_wrap_non_scalar,
     compute_call_slot_wrap_ids=_no_compute_call_slot_wrap_ids,
 )
 """Shared behavior for languages that do not wrap heterogeneous scalar

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4,11 +4,12 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Mapping, Sequence
-from typing import TypeIs, assert_never
+from typing import assert_never
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 from ruamel.yaml.compat import ordereddict
+from typing_extensions import TypeIs
 
 from literalizer._checks import check_data
 from literalizer._comments import (

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -250,16 +250,14 @@ def _maybe_wrap_child(
     and non-scalar children (ref markers, containers) through
     :attr:`~literalizer._language.HeterogeneousBehavior.wrap_non_scalar`.
     """
-    if parent_id not in wrap_ids:
-        return formatted_value
     behavior = spec.heterogeneous_behavior
     if isinstance(raw_value, _SCALAR_TYPES):
         wrap_scalar = behavior.wrap_scalar
-        if wrap_scalar is None:
+        if wrap_scalar is None or parent_id not in wrap_ids:
             return formatted_value
         return wrap_scalar(raw_value, formatted_value)
     wrap_non_scalar = behavior.wrap_non_scalar
-    if wrap_non_scalar is None:
+    if wrap_non_scalar is None or parent_id not in wrap_ids:
         return formatted_value
     return wrap_non_scalar(raw_value, formatted_value)
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, assert_never
+from typing import TypeIs, assert_never
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
@@ -222,6 +222,23 @@ def _format_scalar(*, value: Scalar, spec: Language) -> str:
     return result
 
 
+_SCALAR_TYPES: tuple[type, ...] = (
+    str,
+    int,
+    float,
+    bool,
+    type(None),
+    datetime.date,
+    datetime.datetime,
+    bytes,
+)
+
+
+def _is_scalar(value: Value) -> TypeIs[Scalar]:
+    """Return whether *value* is a :data:`~literalizer._types.Scalar`."""
+    return isinstance(value, _SCALAR_TYPES)
+
+
 @beartype
 def _maybe_wrap_child(
     *,
@@ -233,18 +250,17 @@ def _maybe_wrap_child(
 ) -> str:
     """Wrap *formatted_value* when *parent_id* is in *wrap_ids*.
 
-    Delegates to
+    Routes scalar children through
     :attr:`~literalizer._language.HeterogeneousBehavior.wrap_scalar`
-    on the spec's
-    :attr:`~literalizer._language.Language.heterogeneous_behavior`.
+    and non-scalar children (ref markers, containers) through
+    :attr:`~literalizer._language.HeterogeneousBehavior.wrap_non_scalar`.
     """
     if parent_id not in wrap_ids:
         return formatted_value
-    raw_scalar: Any = raw_value
-    return spec.heterogeneous_behavior.wrap_scalar(
-        raw_scalar,
-        formatted_value,
-    )
+    behavior = spec.heterogeneous_behavior
+    if _is_scalar(raw_value):
+        return behavior.wrap_scalar(raw_value, formatted_value)
+    return behavior.wrap_non_scalar(raw_value, formatted_value)
 
 
 @beartype
@@ -2384,11 +2400,8 @@ def _format_single_call_arg(
             multiline_prefix="",
         ),
     )
-    if id(value) in scalar_wrap_ids:
-        raw_scalar: Any = value
-        return language.heterogeneous_behavior.wrap_scalar(
-            raw_scalar, formatted
-        )
+    if id(value) in scalar_wrap_ids and _is_scalar(value):
+        return language.heterogeneous_behavior.wrap_scalar(value, formatted)
     return formatted
 
 

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4,12 +4,11 @@ import dataclasses
 import datetime
 import enum
 from collections.abc import Callable, Mapping, Sequence
-from typing import assert_never
+from typing import Final, assert_never
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 from ruamel.yaml.compat import ordereddict
-from typing_extensions import TypeIs
 
 from literalizer._checks import check_data
 from literalizer._comments import (
@@ -223,7 +222,7 @@ def _format_scalar(*, value: Scalar, spec: Language) -> str:
     return result
 
 
-_SCALAR_TYPES: tuple[type, ...] = (
+_SCALAR_TYPES: Final = (
     str,
     int,
     float,
@@ -233,11 +232,6 @@ _SCALAR_TYPES: tuple[type, ...] = (
     datetime.datetime,
     bytes,
 )
-
-
-def _is_scalar(value: Value) -> TypeIs[Scalar]:
-    """Return whether *value* is a :data:`~literalizer._types.Scalar`."""
-    return isinstance(value, _SCALAR_TYPES)
 
 
 @beartype
@@ -259,7 +253,7 @@ def _maybe_wrap_child(
     if parent_id not in wrap_ids:
         return formatted_value
     behavior = spec.heterogeneous_behavior
-    if _is_scalar(raw_value):
+    if isinstance(raw_value, _SCALAR_TYPES):
         return behavior.wrap_scalar(raw_value, formatted_value)
     return behavior.wrap_non_scalar(raw_value, formatted_value)
 
@@ -2401,7 +2395,7 @@ def _format_single_call_arg(
             multiline_prefix="",
         ),
     )
-    if id(value) in scalar_wrap_ids and _is_scalar(value):
+    if id(value) in scalar_wrap_ids and isinstance(value, _SCALAR_TYPES):
         return language.heterogeneous_behavior.wrap_scalar(value, formatted)
     return formatted
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -67,6 +67,7 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    no_wrap_non_scalar,
     wrap_in_file_noop,
 )
 from literalizer._types import Scalar, Value
@@ -451,6 +452,7 @@ def _build_union_type_behavior(
         skip_scalar_checks=True,
         compute_wrap_ids=_compute,
         wrap_scalar=_wrap,
+        wrap_non_scalar=no_wrap_non_scalar,
         compute_call_slot_wrap_ids=no_compute_call_slot_wrap_ids,
     )
 

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -74,6 +74,7 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    no_wrap_non_scalar,
     prepend_body_preamble,
 )
 from literalizer._types import Scalar, Value
@@ -658,6 +659,7 @@ def _build_variant_behavior(
         skip_scalar_checks=True,
         compute_wrap_ids=_compute,
         wrap_scalar=_wrap,
+        wrap_non_scalar=no_wrap_non_scalar,
         compute_call_slot_wrap_ids=_mojo_cross_call_scalar_wrap_ids,
     )
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -79,6 +79,7 @@ from literalizer._language import (
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
+    no_wrap_non_scalar,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
@@ -359,6 +360,7 @@ def _build_object_variant_behavior(
         skip_scalar_checks=True,
         compute_wrap_ids=_compute,
         wrap_scalar=_wrap,
+        wrap_non_scalar=no_wrap_non_scalar,
         compute_call_slot_wrap_ids=no_compute_call_slot_wrap_ids,
     )
 

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -83,6 +83,7 @@ from literalizer._language import (
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
+    no_wrap_non_scalar,
     prepend_body_preamble,
     value_contains,
 )
@@ -545,6 +546,7 @@ def _build_tagged_enum_behavior(
         skip_scalar_checks=True,
         compute_wrap_ids=_compute,
         wrap_scalar=_wrap,
+        wrap_non_scalar=no_wrap_non_scalar,
         compute_call_slot_wrap_ids=no_compute_call_slot_wrap_ids,
     )
 

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -78,7 +78,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 _V_I32_MIN = -(2**31)  # -2147483648
 _V_I32_MAX = 2**31 - 1  # 2147483647
@@ -202,16 +202,23 @@ def _build_v_interface_behavior() -> HeterogeneousBehavior:
         """
         return _v_collect_ids_needing_wrap(data=data)
 
-    def _wrap(raw_value: Value, formatted: str) -> str:
+    def _wrap_scalar(raw_value: Scalar, formatted: str) -> str:
         """Wrap a scalar as ``IVal(formatted)`` or the null sentinel."""
         if raw_value is None:
             return _V_NULL_WRAPPED
         return f"{_V_IFACE_NAME}({formatted})"
 
+    def _wrap_non_scalar(_raw_value: Value, formatted: str) -> str:
+        """Wrap a ref marker or container's formatted form as
+        ``IVal(formatted)``.
+        """
+        return f"{_V_IFACE_NAME}({formatted})"
+
     return HeterogeneousBehavior(
         skip_scalar_checks=True,
         compute_wrap_ids=_compute,
-        wrap_scalar=_wrap,
+        wrap_scalar=_wrap_scalar,
+        wrap_non_scalar=_wrap_non_scalar,
         compute_call_slot_wrap_ids=no_compute_call_slot_wrap_ids,
     )
 


### PR DESCRIPTION
## Summary

The previous ``wrap_scalar: Callable[[Scalar, str], str]`` field was a type-level lie for V: V's ``compute_wrap_ids`` marks list parents that mix ref markers with non-ref elements, so V's wrap callback receives ref-marker dicts (and nested containers) at runtime. The dispatcher worked around this with ``raw_scalar: Any = value`` to launder the type.

This change splits the hook into ``wrap_scalar`` (true ``Scalar``) and ``wrap_non_scalar`` (ref markers / containers). V keeps its ``IVal(...)`` rendering on both arms; the four other wrapping languages (Rust, Dhall, Nim, Mojo) use the shared identity ``no_wrap_non_scalar`` since their ``compute_wrap_ids`` only marks parents with all-scalar children. The dispatcher narrows ``Value`` to ``Scalar`` via an inline ``isinstance`` against a ``Final`` tuple, eliminating ``Any`` without introducing casts or asserts.

## Test plan

- [x] ``uv run pytest tests/`` (3212 passed, 724 skipped)
- [x] ``uv run mypy src/literalizer/_literalize.py`` (no errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core literal rendering and heterogeneous wrapping dispatch, which could subtly change output for languages that rely on wrapping (especially around refs/containers). Changes are localized but affect multiple language specs and call-argument formatting paths.
> 
> **Overview**
> Splits `HeterogeneousBehavior.wrap_scalar` into two hooks: `wrap_scalar` (true scalar values) and new `wrap_non_scalar` (ref markers/containers), and updates docs/defaults accordingly.
> 
> Updates the literalization dispatcher to route values based on a centralized `_SCALAR_TYPES` check, removing the prior `Any` laundering and ensuring only scalars reach `wrap_scalar`; non-scalars can now be wrapped via `wrap_non_scalar`. Language specs are updated to set `wrap_non_scalar=None` everywhere except V’s interface strategy, which now explicitly wraps both scalars and non-scalars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b156bcb6632e313a68ac790e6586b0b5b743c56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->