### PR TITLE
Drop Windows from heavy lint stages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,17 @@ jobs:
         python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
         hook-stage: [pre-commit, pre-push, manual]
+        # Windows is dropped from the heavy stages (pre-push, manual)
+        # because the type checkers and pylint dominate wall time on
+        # Windows runners and are platform-agnostic in practice. Re-add
+        # Windows here once prek supports hook groups so we can shard
+        # the heavy hooks across runners:
+        # https://github.com/j178/prek/issues/1385
+        exclude:
+          - platform: windows-latest
+            hook-stage: pre-push
+          - platform: windows-latest
+            hook-stage: manual
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
The `pre-push` and `manual` lint matrix cells are dominated by type checkers (mypy, pyright, ty, pyrefly) and pylint, all of which are platform-agnostic in practice. Running them on Windows roughly doubles the Lint workflow wall time (worst cell was ~5m29s on Windows pre-push vs ~1m13s on Ubuntu) without catching anything platform-specific. This excludes `windows-latest` from those two stages; Windows still runs in the `pre-commit` stage. A comment on the matrix links to https://github.com/j178/prek/issues/1385 so we can re-add Windows once prek supports hook groups and we can shard the heavy hooks across runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that reduces lint coverage on Windows for the heavier `pre-push`/`manual` stages; could miss Windows-specific issues in those hooks but keeps `pre-commit` coverage.
> 
> **Overview**
> **Speeds up the `Lint` GitHub Actions workflow** by excluding `windows-latest` from the `pre-push` and `manual` matrix stages in `.github/workflows/lint.yml`.
> 
> Adds an in-file rationale and a link to the upstream `prek` hook-group/sharding issue to revisit re-adding Windows once heavy hooks can be split across runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570edd8930aad7f1b7a45db1c8864343ec482ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->