### PR TITLE
Plumb self.indent through hardcoded indent literals (#2084)

### DIFF
--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -489,10 +489,12 @@ class C(metaclass=LanguageCls):
             content=content,
             body_preamble=body_preamble,
         )
-        use_line = f"\n    (void){variable_name};" if variable_name else ""
+        use_line = (
+            f"\n{self.indent}(void){variable_name};" if variable_name else ""
+        )
         return (
             f"int {self.module_name}(void) {{\n{content}{use_line}\n"
-            "    return 0;\n}"
+            f"{self.indent}return 0;\n}}"
         )
 
     def wrap_combined_in_file(

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1297,10 +1297,12 @@ class Cpp(metaclass=LanguageCls):
             content=content,
             body_preamble=body_preamble,
         )
-        use_line = f"\n    (void){variable_name};" if variable_name else ""
+        use_line = (
+            f"\n{self.indent}(void){variable_name};" if variable_name else ""
+        )
         return (
             f"int {self.module_name}() {{\n{content}{use_line}\n"
-            "    return 0;\n}"
+            f"{self.indent}return 0;\n}}"
         )
 
     def wrap_combined_in_file(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -722,8 +722,8 @@ class CSharp(metaclass=LanguageCls):
 
     call_styles = CallStyles
 
-    @staticmethod
     def wrap_in_file(
+        self,
         content: str,
         variable_name: str,
         body_preamble: tuple[str, ...],
@@ -765,7 +765,7 @@ class CSharp(metaclass=LanguageCls):
             return (
                 f"{preamble_block}class Check {{\n"
                 f"{content}\n"
-                "    public static void Main() {}\n"
+                f"{self.indent}public static void Main() {{}}\n"
                 "}"
             )
         stub_prefixes = ("class ", "static ")
@@ -786,9 +786,9 @@ class CSharp(metaclass=LanguageCls):
             return (
                 f"class Check {{\n"
                 f"{stub_block}"
-                f"    public static void Main() {{\n"
+                f"{self.indent}public static void Main() {{\n"
                 f"{body}\n"
-                f"    }}\n"
+                f"{self.indent}}}\n"
                 f"}}"
             )
         return wrap_in_file_noop(

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -314,6 +314,7 @@ def _build_elm_body_preamble(
     type_name: str,
     constructor_prefix: str,
     datetime_type_produced: type,
+    indent: str,
 ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
     """Build a callable that computes body-preamble lines for Elm.
 
@@ -349,8 +350,8 @@ def _build_elm_body_preamble(
             )
             if types & type_set
         ]
-        first_line = f"type {type_name}\n    = {constructors[0]}"
-        rest_lines = [f"    | {c}" for c in constructors[1:]]
+        first_line = f"type {type_name}\n{indent}= {constructors[0]}"
+        rest_lines = [f"{indent}| {c}" for c in constructors[1:]]
         return ("\n".join([first_line, *rest_lines]),)
 
     return _compute
@@ -446,26 +447,33 @@ _BYTES_FORMATTERS: dict[
     "BASE64": _build_elm_bytes_base64,
 }
 
-_ELM_PLATFORM_WORKER_SUFFIX: str = (
-    "\n    in\n"
-    "    Platform.worker\n"
-    "        { init = \\_ -> ( (), Cmd.none )\n"
-    "        , update = \\_ m -> ( m, Cmd.none )\n"
-    "        , subscriptions = \\_ -> Sub.none\n"
-    "        }"
-)
+
+def _elm_platform_worker_suffix(indent: str) -> str:
+    """Return the Elm ``Platform.worker`` suffix indented by
+    ``indent``.
+    """
+    one = indent
+    two = indent * 2
+    return (
+        f"\n{one}in\n"
+        f"{one}Platform.worker\n"
+        f"{two}{{ init = \\_ -> ( (), Cmd.none )\n"
+        f"{two}, update = \\_ m -> ( m, Cmd.none )\n"
+        f"{two}, subscriptions = \\_ -> Sub.none\n"
+        f"{two}}}"
+    )
 
 
-def _elm_call_module(preamble: str, let_lines: list[str]) -> str:
+def _elm_call_module(preamble: str, let_lines: list[str], indent: str) -> str:
     """Build a complete Elm call-mode module from preamble and let-
     bindings.
     """
     return (
         f"module Check exposing (..)\n\n\n"
         f"{preamble}\n\n\n"
-        "main : Program () () Never\nmain =\n    let\n"
+        f"main : Program () () Never\nmain =\n{indent}let\n"
         + "\n".join(let_lines)
-        + _ELM_PLATFORM_WORKER_SUFFIX
+        + _elm_platform_worker_suffix(indent=indent)
     )
 
 
@@ -777,8 +785,8 @@ class Elm(metaclass=LanguageCls):
         """Return call-statement formatting for this language."""
         return identity_call_statement
 
-    @staticmethod
     def wrap_in_file(
+        self,
         content: str,
         variable_name: str,
         body_preamble: tuple[str, ...],
@@ -790,20 +798,25 @@ class Elm(metaclass=LanguageCls):
         the generated file is syntactically valid Elm.
         """
         preamble = "\n".join(body_preamble)
+        let_indent = self.indent * 2
         if not variable_name:
             let_lines: list[str] = []
             for line in content.split(sep="\n"):
                 if not line:  # pragma: no cover
                     let_lines.append("")
                 elif not line[0].isspace():
-                    let_lines.append(f"        _ = {line}")
+                    let_lines.append(f"{let_indent}_ = {line}")
                 else:  # pragma: no cover
-                    let_lines.append(f"        {line}")
-            return _elm_call_module(preamble=preamble, let_lines=let_lines)
+                    let_lines.append(f"{let_indent}{line}")
+            return _elm_call_module(
+                preamble=preamble,
+                let_lines=let_lines,
+                indent=self.indent,
+            )
         return f"module Check exposing (..)\n\n\n{preamble}\n\n\n{content}"
 
-    @staticmethod
     def wrap_calls_with_declarations(
+        self,
         declarations: tuple[str, ...],
         calls: str,
         body_preamble: tuple[str, ...],
@@ -817,21 +830,26 @@ class Elm(metaclass=LanguageCls):
         that every ``let`` binding produces a value.
         """
         preamble = "\n".join(body_preamble)
+        let_indent = self.indent * 2
         let_lines: list[str] = []
         for decl in declarations:
             for line in decl.split(sep="\n"):
                 if not line:  # pragma: no cover
                     let_lines.append("")
                 else:
-                    let_lines.append(f"        {line}")
+                    let_lines.append(f"{let_indent}{line}")
         for line in calls.split(sep="\n"):
             if not line:  # pragma: no cover
                 let_lines.append("")
             elif not line[0].isspace():
-                let_lines.append(f"        _ = {line}")
+                let_lines.append(f"{let_indent}_ = {line}")
             else:  # pragma: no cover
-                let_lines.append(f"        {line}")
-        return _elm_call_module(preamble=preamble, let_lines=let_lines)
+                let_lines.append(f"{let_indent}{line}")
+        return _elm_call_module(
+            preamble=preamble,
+            let_lines=let_lines,
+            indent=self.indent,
+        )
 
     @staticmethod
     def wrap_combined_in_file(
@@ -1213,4 +1231,5 @@ class Elm(metaclass=LanguageCls):
             type_name=self.type_name,
             constructor_prefix=self.constructor_prefix,
             datetime_type_produced=self.datetime_format.value.type_produced,
+            indent=self.indent,
         )

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -437,6 +437,7 @@ def _num_instance(
     needs_catchall: bool,
     type_name: str,
     constructor_prefix: str,
+    indent: str,
 ) -> str:
     """Build the ``Num`` instance with only relevant constructors.
 
@@ -446,32 +447,33 @@ def _num_instance(
     exhaustive, and a catch-all would be redundant.
     """
     if has_int:
-        from_integer = f"    fromInteger = {constructor_prefix}Int"
+        from_integer = f"{indent}fromInteger = {constructor_prefix}Int"
     else:
         from_integer = (
-            f"    fromInteger n = {constructor_prefix}Float (fromIntegral n)"
+            f"{indent}fromInteger n = "
+            f"{constructor_prefix}Float (fromIntegral n)"
         )
     negate_parts: list[str] = []
     if has_int:
         negate_parts.append(
-            f"    negate ({constructor_prefix}Int n) = "
+            f"{indent}negate ({constructor_prefix}Int n) = "
             f"{constructor_prefix}Int (negate n)"
         )
     if has_float:
         negate_parts.append(
-            f"    negate ({constructor_prefix}Float f) = "
+            f"{indent}negate ({constructor_prefix}Float f) = "
             f"{constructor_prefix}Float (negate f)"
         )
     if needs_catchall:
-        negate_parts.append('    negate _ = error "not implemented"')
+        negate_parts.append(f'{indent}negate _ = error "not implemented"')
     return "\n".join(
         [
             f"instance Num {type_name} where",
             from_integer,
-            '    _ + _ = error "not implemented"',
-            '    _ * _ = error "not implemented"',
-            '    abs _ = error "not implemented"',
-            '    signum _ = error "not implemented"',
+            f'{indent}_ + _ = error "not implemented"',
+            f'{indent}_ * _ = error "not implemented"',
+            f'{indent}abs _ = error "not implemented"',
+            f'{indent}signum _ = error "not implemented"',
             *negate_parts,
         ]
     )
@@ -549,6 +551,7 @@ def _build_scalar_body_preamble(  # pylint: disable=too-complex  # noqa: C901
     constructor_prefix: str,
     emit_is_string: bool,
     emit_num: bool,
+    indent: str,
 ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
     """Build a callable that computes body-preamble lines for Haskell.
 
@@ -674,13 +677,14 @@ def _build_scalar_body_preamble(  # pylint: disable=too-complex  # noqa: C901
                     needs_catchall=needs_catchall,
                     type_name=type_name,
                     constructor_prefix=constructor_prefix,
+                    indent=indent,
                 ),
             )
         if emit_num and has_float:
             instances.append(
                 f"instance Fractional {type_name} where\n"
-                f"    fromRational r = {p}Float (realToFrac r)\n"
-                '    _ / _ = error "not implemented"'
+                f"{indent}fromRational r = {p}Float (realToFrac r)\n"
+                f'{indent}_ / _ = error "not implemented"'
             )
 
         lines: list[str] = imports
@@ -815,6 +819,7 @@ def _build_preamble_setup(
     type_name: str,
     constructor_prefix: str,
     emit_num: bool,
+    indent: str,
 ) -> _PreambleSetup:
     """Build scalar preamble and body-preamble computation."""
     _overloaded_strings = ("{-# LANGUAGE OverloadedStrings #-}",)
@@ -840,12 +845,13 @@ def _build_preamble_setup(
             is_string_import="import Data.String (IsString(fromString))",
             is_string_instance=(
                 f"instance IsString {type_name} where\n"
-                f"    fromString = {constructor_prefix}Str"
+                f"{indent}fromString = {constructor_prefix}Str"
             ),
             type_name=type_name,
             constructor_prefix=constructor_prefix,
             emit_is_string=not is_explicit,
             emit_num=emit_num,
+            indent=indent,
         ),
     )
 
@@ -1268,7 +1274,7 @@ class Haskell(metaclass=LanguageCls):
             # ``-Wunused-do-bind``. ``_ <-`` is also valid when the
             # action returns ``IO ()``.
             indented = "\n".join(
-                f"    _ <- {line}" if line.strip() else line
+                f"{self.indent}_ <- {line}" if line.strip() else line
                 for line in content.split(sep="\n")
             )
             return (
@@ -1276,7 +1282,7 @@ class Haskell(metaclass=LanguageCls):
                 + preamble
                 + "\nmain :: IO ()\nmain = do\n"
                 + indented
-                + "\n    pure ()"
+                + f"\n{self.indent}pure ()"
             )
         return (
             f"module {self.module_name} where\n"
@@ -1305,7 +1311,7 @@ class Haskell(metaclass=LanguageCls):
         """
         preamble = "\n".join(body_preamble)
         indented_calls = "\n".join(
-            f"    _ <- {line}" if line.strip() else line
+            f"{self.indent}_ <- {line}" if line.strip() else line
             for line in calls.split(sep="\n")
         )
         declaration_block = "\n".join(declarations)
@@ -1316,7 +1322,7 @@ class Haskell(metaclass=LanguageCls):
             + (declaration_block + "\n" if declaration_block else "")
             + "main :: IO ()\nmain = do\n"
             + indented_calls
-            + "\n    pure ()"
+            + f"\n{self.indent}pure ()"
         )
 
     @staticmethod
@@ -1606,6 +1612,7 @@ class Haskell(metaclass=LanguageCls):
             type_name=self.type_name,
             constructor_prefix=self.constructor_prefix,
             emit_num=self.numeric_style.name != "EXPLICIT",
+            indent=self.indent,
         )
 
     @cached_property

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1115,9 +1115,9 @@ class Java(metaclass=LanguageCls):
         return (
             f"class {self.module_name} {{\n"
             f"{class_block}"
-            f"    public static void {method_name}() {{\n"
+            f"{self.indent}public static void {method_name}() {{\n"
             f"{content}\n"
-            "    }\n"
+            f"{self.indent}}}\n"
             "}"
         )
 

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -388,8 +388,8 @@ class Jsonnet(metaclass=LanguageCls):
 
     wrap_calls_with_declarations = default_wrap_calls_with_declarations
 
-    @staticmethod
     def wrap_in_file(
+        self,
         content: str,
         variable_name: str,
         body_preamble: tuple[str, ...],
@@ -407,7 +407,7 @@ class Jsonnet(metaclass=LanguageCls):
             )
         preamble_str = "\n".join(body_preamble) + "\n"
         lines = content.split(sep="\n")
-        elements = [f"    {line}," for line in lines if line]
+        elements = [f"{self.indent}{line}," for line in lines if line]
         return preamble_str + "[\n" + "\n".join(elements) + "\n]"
 
     @staticmethod

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -548,11 +548,13 @@ class ObjectiveC(metaclass=LanguageCls):
             content=content,
             body_preamble=body_preamble,
         )
-        use_line = f"\n    (void){variable_name};" if variable_name else ""
+        use_line = (
+            f"\n{self.indent}(void){variable_name};" if variable_name else ""
+        )
         return (
             f"int {self.module_name}(void) {{\n"
             f"@autoreleasepool {{\n{content}{use_line}\n"
-            "}\n    return 0;\n}"
+            f"}}\n{self.indent}return 0;\n}}"
         )
 
     def wrap_combined_in_file(

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -422,42 +422,53 @@ def _build_type_hint_preamble(
     return _preamble
 
 
-def _python_call_stub(
-    parts: Sequence[str],
-    _params: Sequence[str],
-    _stub_return: StubReturn,
-    _args: Sequence[Value],
-    /,
-) -> tuple[str, ...]:
-    """Return Python stub declarations for a call name."""
-    variadic = "*_args: object, **_kwargs: object"
-    if len(parts) == 1:
-        return (f"def {parts[0]}({variadic}) -> object: ...",)
-    root = parts[0]
-    method = parts[-1]
-    fields = parts[1:-1]
-    if not fields:
-        cls = f"_{root.capitalize()}Type"
-        return (
-            f"class {cls}:",
-            f"    def {method}(self, {variadic}) -> object: ...",
-            f"{root} = {cls}()",
-        )
-    lines: list[str] = []
-    inner_cls = f"_{fields[-1].capitalize()}Type"
-    lines.append(f"class {inner_cls}:")
-    lines.append(f"    def {method}(self, {variadic}) -> object: ...")
-    prev_cls = inner_cls
-    for i in range(len(fields) - 2, -1, -1):
-        cls = f"_{fields[i].capitalize()}Type"
-        lines.append(f"class {cls}:")
-        lines.append(f"    {fields[i + 1]} = {prev_cls}()")
-        prev_cls = cls
-    root_cls = f"_{root.capitalize()}Type"
-    lines.append(f"class {root_cls}:")
-    lines.append(f"    {fields[0]} = {prev_cls}()")
-    lines.append(f"{root} = {root_cls}()")
-    return tuple(lines)
+def _build_python_call_stub(
+    *,
+    indent: str,
+) -> Callable[
+    [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
+    tuple[str, ...],
+]:
+    """Return a Python call-stub builder bound to ``indent``."""
+
+    def _python_call_stub(
+        parts: Sequence[str],
+        _params: Sequence[str],
+        _stub_return: StubReturn,
+        _args: Sequence[Value],
+        /,
+    ) -> tuple[str, ...]:
+        """Return Python stub declarations for a call name."""
+        variadic = "*_args: object, **_kwargs: object"
+        if len(parts) == 1:
+            return (f"def {parts[0]}({variadic}) -> object: ...",)
+        root = parts[0]
+        method = parts[-1]
+        fields = parts[1:-1]
+        if not fields:
+            cls = f"_{root.capitalize()}Type"
+            return (
+                f"class {cls}:",
+                f"{indent}def {method}(self, {variadic}) -> object: ...",
+                f"{root} = {cls}()",
+            )
+        lines: list[str] = []
+        inner_cls = f"_{fields[-1].capitalize()}Type"
+        lines.append(f"class {inner_cls}:")
+        lines.append(f"{indent}def {method}(self, {variadic}) -> object: ...")
+        prev_cls = inner_cls
+        for i in range(len(fields) - 2, -1, -1):
+            cls = f"_{fields[i].capitalize()}Type"
+            lines.append(f"class {cls}:")
+            lines.append(f"{indent}{fields[i + 1]} = {prev_cls}()")
+            prev_cls = cls
+        root_cls = f"_{root.capitalize()}Type"
+        lines.append(f"class {root_cls}:")
+        lines.append(f"{indent}{fields[0]} = {prev_cls}()")
+        lines.append(f"{root} = {root_cls}()")
+        return tuple(lines)
+
+    return _python_call_stub
 
 
 @beartype
@@ -1069,7 +1080,7 @@ class Python(metaclass=LanguageCls):
         tuple[str, ...],
     ]:
         """Return stub declarations for a call expression."""
-        return _python_call_stub
+        return _build_python_call_stub(indent=self.indent)
 
     @cached_property
     def format_call_preamble_stub(


### PR DESCRIPTION
## Summary

Resolves the per-language part of #2084: nine language specs hardcoded `"    "` literals in their `wrap_in_file` / `wrap_calls_with_declarations` / body-preamble / call-stub output instead of using their own `indent` field. Plumbed `self.indent` through `c`, `cpp`, `csharp`, `elm`, `haskell`, `java`, `jsonnet`, `objective_c`, and `python` so customizing `indent="  "` actually changes the output. Default behavior is byte-identical, so no golden files needed regenerating.

The remaining group-B languages from the issue (bash, clojure, common_lisp, crystal, d, forth, groovy, hcl, json5, julia, kotlin, lua, matlab, norg, ocaml, perl, php, powershell, r, racket, raku, scala, scheme, swift, tcl, toml, yaml) all had noop wrappers or framework helpers with no hardcoded indent literals in their own code, so they were left untouched — the `indent` field on those classes is consumed only by core engine collection layout.

## Test plan

- [x] `uv run pytest` — 3212 passed, 724 skipped (all goldens unchanged)
- [x] Verified `Language(indent="  ")` now produces 2-space-indented output for each updated language

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatting-only change: replaces hardcoded 4-space indentation in several language backends with `self.indent`, which may alter generated code layout when non-default indentation is configured.
> 
> **Overview**
> Makes per-language indentation configurable by replacing hardcoded `"    "` literals with `self.indent` (and derived indents) across multiple language emitters.
> 
> This updates wrapper generation for C/C++/Objective‑C `main` bodies, Java/C# method wrappers, Jsonnet call-mode arrays, Elm module/type/`let` formatting (including a new `_elm_platform_worker_suffix(indent)` helper), and Haskell `main`/typeclass instance emission. Python call stub generation is refactored into `_build_python_call_stub(indent=...)` so dotted-call stub class bodies also honor the configured indent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72f51a17ed387ab44b3bc31830e05db086bf75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->