### PR TITLE
Mojo: split _build_variant_preamble into collector + renderer

### DIFF
--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -662,6 +662,48 @@ def _build_variant_behavior(
     )
 
 
+@beartype
+def _collect_variant_alternatives_from_data(data: Value, /) -> tuple[str, ...]:
+    """Return Mojo ``Variant`` alternative type names found in *data*.
+
+    The result is order-preserving and deduplicated.  Returns an empty
+    tuple when *data* contains no heterogeneous containers.
+    """
+    wrap_ids = collect_heterogeneous_container_ids(data=data)
+    if not wrap_ids:
+        return ()
+    scalars = iter_wrapped_scalars(data=data, wrap_ids=wrap_ids)
+    type_names: list[str] = []
+    seen: set[str] = set()
+    for scalar in scalars:
+        signature = _mojo_variant_for_scalar(scalar)
+        if signature.type_name in seen:
+            continue
+        seen.add(signature.type_name)
+        type_names.append(signature.type_name)
+    return tuple(type_names)
+
+
+@beartype
+def _render_variant_preamble(
+    alternatives: Sequence[str],
+    /,
+    *,
+    variant_name: str,
+) -> tuple[str, ...]:
+    """Render the ``Variant`` import + ``comptime`` declaration lines.
+
+    Returns ``()`` when *alternatives* is empty.
+    """
+    if not alternatives:
+        return ()
+    joined = ", ".join(alternatives)
+    return (
+        _VARIANT_IMPORT_LINE,
+        f"comptime {variant_name} = Variant[{joined}]",
+    )
+
+
 def _build_variant_preamble(
     variant_name: str,
     /,
@@ -672,22 +714,9 @@ def _build_variant_preamble(
         """Build the ``Variant`` import + ``comptime`` declaration for
         *data*.
         """
-        wrap_ids = collect_heterogeneous_container_ids(data=data)
-        if not wrap_ids:
-            return ()
-        scalars = iter_wrapped_scalars(data=data, wrap_ids=wrap_ids)
-        type_names: list[str] = []
-        seen: set[str] = set()
-        for scalar in scalars:
-            signature = _mojo_variant_for_scalar(scalar)
-            if signature.type_name in seen:
-                continue
-            seen.add(signature.type_name)
-            type_names.append(signature.type_name)
-        joined = ", ".join(type_names)
-        return (
-            _VARIANT_IMPORT_LINE,
-            f"comptime {variant_name} = Variant[{joined}]",
+        return _render_variant_preamble(
+            _collect_variant_alternatives_from_data(data),
+            variant_name=variant_name,
         )
 
     return _preamble


### PR DESCRIPTION
Closes #2077.

Behavior-preserving refactor of \`_build_variant_preamble\` in \`src/literalizer/languages/mojo.py\` into two pure helpers: \`_collect_variant_alternatives_from_data\` (extracts the order-preserving deduplicated tuple of Mojo \`Variant\` type names from input data) and \`_render_variant_preamble\` (renders the import + \`comptime\` lines, or \`()\` when there are no alternatives). \`_build_variant_preamble\` is rewritten to compose them; signature and observable output are unchanged.

## Test plan
- [x] Existing variant/heterogeneous integration tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior-preserving refactor limited to Mojo `VARIANT` heterogeneous preamble construction, with no changes to output format or wrapping logic expected.
> 
> **Overview**
> Refactors Mojo’s `VARIANT` heterogeneous-strategy preamble generation by extracting two pure helpers: `_collect_variant_alternatives_from_data` (order-preserving, deduped `Variant[...]` alternatives from heterogeneous positions) and `_render_variant_preamble` (renders the import + `comptime` alias lines, or `()` when unused).
> 
> `_build_variant_preamble` now composes these helpers instead of inlining the logic, keeping the emitted preamble and public behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6efaa65f28ae576dea674a6da190b3ab122e32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->