### PR TITLE
Import Language and LanguageCls from the public literalizer module in tests

### DIFF
--- a/tests/integration/test_language_metadata.py
+++ b/tests/integration/test_language_metadata.py
@@ -6,7 +6,7 @@ import pytest
 from pygments.lexers import find_lexer_class_by_name
 
 import literalizer.languages
-from literalizer._language import LanguageCls
+from literalizer import LanguageCls
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 _SORTED_LANGUAGES: list[LanguageCls] = sorted(

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -9,8 +9,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from literalizer import InputFormat, literalize
-from literalizer._language import Language
+from literalizer import InputFormat, Language, literalize
 from literalizer.languages import (
     Cpp,
     Erlang,


### PR DESCRIPTION
## Summary

- Two test files imported `Language` / `LanguageCls` from `literalizer._language`, even though both names are already exported from the public `literalizer` package. Switch to the public import path.

Partial step toward #1947 — does not address the other private-module imports under `tests/` or add the lint rule.

## Test plan

- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that just swaps imports from the private `literalizer._language` module to the public `literalizer` package exports.
> 
> **Overview**
> Updates tests to stop importing `Language`/`LanguageCls` from the private `literalizer._language` module.
> 
> `tests/integration/test_language_metadata.py` and `tests/test_roundtrip.py` now import these types from the public `literalizer` package (and consolidates the `literalizer` imports in `test_roundtrip.py`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecfcf599ab84731c0fbc67abf609558517d7156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->