### PR TITLE
Drop two easy pragma: no cover markers (refs #2089)

### DIFF
--- a/.github/scripts/elm_common.py
+++ b/.github/scripts/elm_common.py
@@ -148,9 +148,8 @@ def run_elm_make(
     env: Mapping[str, str],
 ) -> subprocess.CompletedProcess[str]:
     """Run ``elm make``, retrying transient cache failures."""
-    attempts = 5
-    result: subprocess.CompletedProcess[str] | None = None
-    for attempt in range(attempts):
+    retries = 4
+    for attempt in range(retries):
         result = subprocess.run(
             args=list(args),
             capture_output=True,
@@ -161,14 +160,17 @@ def run_elm_make(
         )
         if result.returncode == 0 or not _is_elm_transient_error(result):
             return result
-        if attempt + 1 < attempts:
-            # Transient failures (especially CORRUPT CACHE) leave a
-            # bad ``elm-stuff`` cache on disk; subsequent attempts
-            # would just re-read the corruption.  Wipe it so the
-            # retry starts from a clean cache.
-            shutil.rmtree(Path(cwd) / "elm-stuff", ignore_errors=True)
-            time.sleep(0.5 * (attempt + 1))
-    if result is None:  # pragma: no cover
-        msg = "elm make was not attempted"
-        raise RuntimeError(msg)
-    return result
+        # Transient failures (especially CORRUPT CACHE) leave a
+        # bad ``elm-stuff`` cache on disk; subsequent attempts
+        # would just re-read the corruption.  Wipe it so the
+        # retry starts from a clean cache.
+        shutil.rmtree(Path(cwd) / "elm-stuff", ignore_errors=True)
+        time.sleep(0.5 * (attempt + 1))
+    return subprocess.run(
+        args=list(args),
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+        env=dict(env),
+    )

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -966,11 +966,9 @@ def _check_call_result_includes_ref_declaration_types(
         *(d.types_present for d in decl_results),
     )
     missing_types = declaration_types - result.types_present
-    if missing_types == empty_types:
-        return
-    pytest.fail(  # pragma: no cover
+    assert missing_types == empty_types, (  # noqa: S101
         "literalize_call result types do not include ref declaration "
-        f"types: missing {missing_types!r}",
+        f"types: missing {missing_types!r}"
     )
 
 


### PR DESCRIPTION
## Summary
- Refactor `run_elm_make` so the retry loop guarantees a bound `result` (4 retries + a final attempt outside the loop), removing the `result is None` defensive arm.
- Collapse the `if missing_types == empty_types: return / pytest.fail(...)` guard in `_check_call_result_includes_ref_declaration_types` into a single `assert`.

Two of the easier pragmas listed in #2089; the remaining ones are tracked in sub-issues #2093, #2095, #2096, #2097, #2098.

## Test plan
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes retry/control-flow structure and a test assertion style; main behavior should be equivalent aside from the exact number/placement of `elm make` attempts.
> 
> **Overview**
> Refactors `.github/scripts/elm_common.py` `run_elm_make` to remove the defensive `result is None` branch by doing **4 retries with cache cleanup** and then a **final `elm make` attempt outside the loop**, keeping the transient-failure cleanup/sleep logic.
> 
> Simplifies an integration test helper in `tests/integration/call_cases.py` by replacing a `pytest.fail` guard with a single `assert` that ref declaration types are included in the `literalize_call` result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02dc8c30d37c572bb34af8843ea483e2ede10899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->