### PR TITLE
Replace `assert ... in` checks with exact equality in tests

### DIFF
--- a/tests/integration/test_call_errors.py
+++ b/tests/integration/test_call_errors.py
@@ -322,7 +322,7 @@ def test_literalize_call_dotted_target_supported_language() -> None:
         target_function="module.fn",
         parameter_names=["a"],
     )
-    assert "module.fn(a=1)" in result.code
+    assert result.code == "module.fn(a=1)"
 
 
 def test_literalize_call_dotted_stub_unsupported_raises() -> None:
@@ -448,8 +448,19 @@ def test_literalize_accepts_syntactic_non_idiomatic_ref_case() -> None:
     legal Python identifier.  Validation uses ``supported_ref_cases``,
     which exposes ``CAMEL``.
     """
-    assert IdentifierCase.CAMEL not in Python().identifier_cases
-    assert IdentifierCase.CAMEL in Python().supported_ref_cases
+    assert Python().identifier_cases == (
+        IdentifierCase.SNAKE,
+        IdentifierCase.UPPER_SNAKE,
+        IdentifierCase.PASCAL,
+    )
+    assert Python().supported_ref_cases == frozenset(
+        {
+            IdentifierCase.SNAKE,
+            IdentifierCase.UPPER_SNAKE,
+            IdentifierCase.PASCAL,
+            IdentifierCase.CAMEL,
+        },
+    )
 
     result = literalize(
         source='{"$ref": "user_obj"}',
@@ -458,14 +469,22 @@ def test_literalize_accepts_syntactic_non_idiomatic_ref_case() -> None:
         ref_case=IdentifierCase.CAMEL,
     )
 
-    assert "userObj" in result.declaration_code
+    assert result.declaration_code == "userObj"
 
 
 def test_literalize_kebab_friendly_language_accepts_kebab_ref_case() -> None:
     """Kebab-friendly languages render kebab-form refs as legal
     symbols.
     """
-    assert IdentifierCase.KEBAB in Raku().supported_ref_cases
+    assert Raku().supported_ref_cases == frozenset(
+        {
+            IdentifierCase.SNAKE,
+            IdentifierCase.UPPER_SNAKE,
+            IdentifierCase.PASCAL,
+            IdentifierCase.CAMEL,
+            IdentifierCase.KEBAB,
+        },
+    )
 
     result = literalize(
         source='{"$ref": "user_obj"}',
@@ -474,7 +493,7 @@ def test_literalize_kebab_friendly_language_accepts_kebab_ref_case() -> None:
         ref_case=IdentifierCase.KEBAB,
     )
 
-    assert "user-obj" in result.declaration_code
+    assert result.declaration_code == "$user-obj"
 
 
 def test_supported_ref_cases_independent_of_identifier_cases() -> None:
@@ -646,4 +665,4 @@ def test_literalize_variable_names_supported_renders() -> None:
         variable_form=BothVariableForms(name="x"),
         wrap_in_file=True,
     )
-    assert "x = 42" in result.code
+    assert result.code == "x = 42\nx = 42"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 import json
 import re
+import textwrap
 from typing import ClassVar
 
 import pytest
@@ -477,14 +478,23 @@ def test_gleam_call_stub_more_than_26_parameters() -> None:
         parameter_names=parameter_names,
         wrap_in_file=True,
     )
-    assert (
-        "pub fn process("
-        "_p0: a, _p1: b, _p2: c, _p3: d, _p4: e, _p5: f, _p6: g, "
-        "_p7: h, _p8: i, _p9: j, _p10: k, _p11: l, _p12: m, _p13: n, "
-        "_p14: o, _p15: p, _p16: q, _p17: r, _p18: s, _p19: t, "
-        "_p20: u, _p21: v, _p22: w, _p23: x, _p24: y, _p25: z, "
-        "_p26: a1) -> Nil { Nil }"
-    ) in result.code
+    signature_params = ", ".join(
+        f"_p{i}: {chr(ord('a') + i)}" for i in range(26)
+    )
+    call_args = ", ".join(f"GInt({i})" for i in range(27))
+    expected = textwrap.dedent(
+        text=f"""\
+        pub type GVal {{
+          GInt(Int)
+          GList(List(GVal))
+        }}
+        pub fn process({signature_params}, _p26: a1) -> Nil {{ Nil }}
+
+        pub fn main() {{
+          process({call_args})
+        }}""",
+    )
+    assert result.code == expected
 
 
 @pytest.mark.parametrize(
@@ -526,9 +536,35 @@ def test_elm_call_wrap_in_file_multiline_dict_arg() -> None:
         wrap_in_file=True,
         collection_layout=CollectionLayout.MULTILINE,
     )
-    assert "        _ =     (" not in result.code
-    assert "        _ = process(EDict [" in result.code
-    assert '            ("a", EInt 1),' in result.code
+    expected = textwrap.dedent(
+        text="""\
+        module Check exposing (..)
+
+
+        process : ( a, b ) -> ()
+        process _ = ()
+        type Val
+            = EInt Int
+            | EStr String
+            | EList (List Val)
+            | EDict (List ( String, Val ))
+
+
+        main : Program () () Never
+        main =
+            let
+                _ = process(EDict [
+                    ("a", EInt 1),
+                    ("b", EInt 2)
+                    ], EInt 42)
+            in
+            Platform.worker
+                { init = \\_ -> ( (), Cmd.none )
+                , update = \\_ m -> ( m, Cmd.none )
+                , subscriptions = \\_ -> Sub.none
+                }""",
+    )
+    assert result.code == expected
 
 
 def test_elm_wrap_calls_with_declarations_multiline_continuation() -> None:
@@ -545,7 +581,28 @@ def test_elm_wrap_calls_with_declarations_multiline_continuation() -> None:
         calls='process(EDict [\n    ("a", EInt 1),\n    ("b", EInt 2)\n    ])',
         body_preamble=(),
     )
-    assert "        _ =     (" not in wrapped
-    assert "        _ = process(EDict [" in wrapped
-    assert '            ("a", EInt 1),' in wrapped
-    assert "        my_var = EInt 42" in wrapped
+    expected = textwrap.dedent(
+        text="""\
+        module Check exposing (..)
+
+
+
+
+
+        main : Program () () Never
+        main =
+            let
+                my_var : Val
+                my_var = EInt 42
+                _ = process(EDict [
+                    ("a", EInt 1),
+                    ("b", EInt 2)
+                    ])
+            in
+            Platform.worker
+                { init = \\_ -> ( (), Cmd.none )
+                , update = \\_ m -> ( m, Cmd.none )
+                , subscriptions = \\_ -> Sub.none
+                }""",
+    )
+    assert wrapped == expected


### PR DESCRIPTION
## Summary
- Replaced substring/membership `assert ... in` and `assert ... not in` checks in `tests/test_languages.py` and `tests/integration/test_call_errors.py` with exact `==` comparisons.
- Long expected outputs (Elm wrapped modules, full Gleam stub) now use `textwrap.dedent` for readability; the 27-parameter Gleam expected is built programmatically to avoid extremely long lines.
- Frozenset/tuple membership checks for `IdentifierCase` were swapped for full set/tuple equality, which pins down the exact supported cases.

## Test plan
- [x] `uv run pytest tests/test_languages.py tests/integration/test_call_errors.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test assertions and expected-string construction, with no production code modifications.
> 
> **Overview**
> Test expectations were tightened by replacing substring/negative substring assertions with exact `==` comparisons for generated code/declarations, making output checks more precise.
> 
> Long expected code blocks (notably Elm wrapped modules and the Gleam `wrap_in_file` stub with 27 parameters) were rewritten to build full expected strings using `textwrap.dedent` (and some programmatic assembly) for readability while pinning exact formatting and supported identifier-case sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff14e13cdb6637968427beda7c1bf706b0c060f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->