### PR TITLE
Use a list call arg in 27-parameter Gleam test

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -468,8 +468,8 @@ def test_gleam_call_stub_more_than_26_parameters() -> None:
     ``a1`` for the next one in the generated stub signature.
     """
     parameter_names = [f"p{i}" for i in range(27)]
-    yaml_row = "\n".join(f"  - {i}" for i in range(27))
-    source = f"---\n-\n{yaml_row}\n"
+    yaml_row = "\n".join(f"  - {i}" for i in range(26))
+    source = f"---\n-\n{yaml_row}\n  - [100]\n"
     result = literalize_call(
         source=source,
         input_format=InputFormat.YAML,
@@ -481,7 +481,8 @@ def test_gleam_call_stub_more_than_26_parameters() -> None:
     signature_params = ", ".join(
         f"_p{i}: {chr(ord('a') + i)}" for i in range(26)
     )
-    call_args = ", ".join(f"GInt({i})" for i in range(27))
+    int_args = ", ".join(f"GInt({i})" for i in range(26))
+    call_args = f"{int_args}, GList([GInt(100)])"
     expected = textwrap.dedent(
         text=f"""\
         pub type GVal {{


### PR DESCRIPTION
## Summary

Addresses [Cursor Bugbot feedback](https://github.com/adamtheturtle/literalizer/pull/2108#discussion_r3225385945) on #2108: the expected output of `test_gleam_call_stub_more_than_26_parameters` pinned `GList(List(GVal))` even though every call arg was an integer, making the assertion sensitive to a preamble-inference artifact. The test now passes one list arg so that `GList` is legitimately required.

## Test plan

- [x] `pytest tests/test_languages.py::test_gleam_call_stub_more_than_26_parameters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust a Gleam unit test to include a list argument, reducing brittleness without affecting production code paths.
> 
> **Overview**
> Updates `test_gleam_call_stub_more_than_26_parameters` to pass 26 integer args plus one list arg (instead of 27 ints), and adjusts the expected call site accordingly so the `GList` variant in the generated Gleam preamble is asserted for a real input rather than inference artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c01faf797307e67ae4a0dc17b983e50fdf742e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->