### PR TITLE
Mojo: flip dict-literal call flags True; drop dead supports_call_refs_in_dict_literals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- ``Mojo`` :func:`~literalizer.literalize_call` now supports refs nested
+  inside dict literals and commented dict-literal call arguments.  The
+  typed-stub work landed in #1972 made both shapes compile cleanly under
+  ``mojo run --Werror``, so the corresponding
+  ``supports_call_refs_in_dict_literals`` and
+  ``supports_commented_dict_call_args`` flags flip to ``True`` for Mojo
+  and two new ``call_*`` golden cases are exercised.
+
 - ``Mojo`` and ``C++`` :func:`~literalizer.literalize_call` no longer
   wrap a consumable ``$ref`` in the language's consume form when the
   underlying value's type would make the wrapping a hard error or a

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -607,7 +607,6 @@ class LanguageCls(type):
     supports_standalone_comments_in_wrapped_calls: bool
     supports_commented_dict_call_args: bool
     supports_module_name: bool
-    supports_call_refs_in_dict_literals: bool
     format_call_arg: FormatCallArg
     validate_call_arg: Callable[[Value], None]
     format_call_statement: Callable[[str], str]

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -227,7 +227,6 @@ class Ada(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -202,7 +202,6 @@ class Bash(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -232,7 +232,6 @@ class C(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for C."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -117,7 +117,6 @@ class Clojure(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -343,7 +343,6 @@ class Cobol(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = False
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -126,7 +126,6 @@ class CommonLisp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -903,7 +903,6 @@ class Cpp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -187,7 +187,6 @@ class Crystal(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -369,7 +369,6 @@ class CSharp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -173,7 +173,6 @@ class D(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -295,7 +295,6 @@ class Dart(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -532,7 +532,6 @@ class Dhall(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = False
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for Dhall."""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -215,7 +215,6 @@ class Elixir(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -540,7 +540,6 @@ class Elm(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -208,7 +208,6 @@ class Erlang(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -211,7 +211,6 @@ class Forth(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -333,7 +333,6 @@ class Fortran(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -293,7 +293,6 @@ class FSharp(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -535,7 +535,6 @@ class Gleam(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -273,7 +273,6 @@ class Go(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -153,7 +153,6 @@ class Groovy(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -971,7 +971,6 @@ class Haskell(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -153,7 +153,6 @@ class Hcl(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -601,7 +601,6 @@ class Java(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -137,7 +137,6 @@ class JavaScript(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -129,7 +129,6 @@ class Json5(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -147,7 +147,6 @@ class Jsonnet(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -165,7 +165,6 @@ class Julia(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -441,7 +441,6 @@ class Kotlin(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -151,7 +151,6 @@ class Lua(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -218,7 +218,6 @@ class Matlab(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -892,9 +892,8 @@ class Mojo(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = False
+    supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -547,7 +547,6 @@ class Nim(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -197,7 +197,6 @@ class Nix(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -101,7 +101,6 @@ class Norg(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -287,7 +287,6 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -263,7 +263,6 @@ class OCaml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -144,7 +144,6 @@ class Occam(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -223,7 +223,6 @@ class Odin(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -161,7 +161,6 @@ class Perl(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -160,7 +160,6 @@ class Php(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -176,7 +176,6 @@ class PowerShell(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -679,7 +679,6 @@ class PureScript(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for PureScript."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -554,7 +554,6 @@ class Python(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -175,7 +175,6 @@ class R(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -118,7 +118,6 @@ class Racket(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -194,7 +194,6 @@ class Raku(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -534,7 +534,6 @@ class Roc(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
     supports_special_floats = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -197,7 +197,6 @@ class Ruby(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -703,7 +703,6 @@ class Rust(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -237,7 +237,6 @@ class Scala(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -114,7 +114,6 @@ class Scheme(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -318,7 +318,6 @@ class Sml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -367,7 +367,6 @@ class Swift(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -246,7 +246,6 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = True
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -159,7 +159,6 @@ class Tcl(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -129,7 +129,6 @@ class Toml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -274,7 +274,6 @@ class TypeScript(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -357,7 +357,6 @@ class V(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -278,7 +278,6 @@ class VisualBasic(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -177,7 +177,6 @@ class Wren(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -103,7 +103,6 @@ class Yaml(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -245,7 +245,6 @@ class Zig(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = True
     supports_commented_dict_call_args = True
     supports_module_name = False
-    supports_call_refs_in_dict_literals = True
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import pytest
 from beartype import beartype
 from pytest_regressions.file_regression import FileRegressionFixture
-from ruamel.yaml import YAML
 
 import literalizer
 from literalizer._language import StubReturn
@@ -758,65 +757,6 @@ def _expected_call_shape_exception(
     return None
 
 
-CALL_CASES_DIR = Path(__file__).parent / "cases"
-
-
-@beartype
-def _has_ref_inside_dict_literal(
-    *,
-    value: Value,
-    ref_key: str,
-    inside_dict_literal: bool,
-) -> bool:
-    """Return ``True`` if *value* contains a ref beneath a dict
-    literal.
-    """
-    match value:
-        case dict() if len(value) == 1 and isinstance(value.get(ref_key), str):
-            return inside_dict_literal
-        case dict():
-            return any(
-                _has_ref_inside_dict_literal(
-                    value=child,
-                    ref_key=ref_key,
-                    inside_dict_literal=True,
-                )
-                for child in value.values()
-            )
-        case list():
-            return any(
-                _has_ref_inside_dict_literal(
-                    value=child,
-                    ref_key=ref_key,
-                    inside_dict_literal=inside_dict_literal,
-                )
-                for child in value
-            )
-        case _:
-            return False
-
-
-@functools.cache
-@beartype
-def case_uses_ref_inside_dict_literal(
-    *,
-    case_dir_name: str,
-    ref_key: str,
-) -> bool:
-    """Return whether the call case input needs refs inside dict
-    literals.
-    """
-    yaml = YAML(typ="safe", pure=False)
-    loaded: Value = yaml.load(  # pyright: ignore[reportUnknownMemberType]
-        stream=(CALL_CASES_DIR / case_dir_name / "input.yaml").read_text(),
-    )
-    return _has_ref_inside_dict_literal(
-        value=loaded,
-        ref_key=ref_key,
-        inside_dict_literal=False,
-    )
-
-
 @beartype
 def _lang_satisfies_config_constraints(
     lang_cls: literalizer.LanguageCls,
@@ -855,14 +795,6 @@ def _lang_satisfies_call_shape_constraints(
     """Return False if *lang_cls* cannot represent *config*'s call
     shape.
     """
-    if (
-        case_uses_ref_inside_dict_literal(
-            case_dir_name=config.case_dir_name,
-            ref_key="$ref",
-        )
-        and not lang_cls.supports_call_refs_in_dict_literals
-    ):
-        return False
     return not (
         config.case_dir_name in _CASES_REQUIRING_COMMENTED_DICT_CALL_ARGS
         and lang_cls.supports_inline_multiline_dict_args

--- a/tests/integration/cases/call_comments_dict_args/Mojo_call.mojo
+++ b/tests/integration/cases/call_comments_dict_args/Mojo_call.mojo
@@ -1,0 +1,8 @@
+def process(value: Dict[String, String]):
+    pass
+def main():
+    # Test cases
+    process({"type": "create", "pr_id": "pr_1"})  # first case
+    process({"type": "update", "pr_id": "pr_2"})  # second case
+    # third case
+    process({"type": "delete", "pr_id": "pr_3"})

--- a/tests/integration/cases/call_ref_nested_in_dict/Mojo_call.mojo
+++ b/tests/integration/cases/call_ref_nested_in_dict/Mojo_call.mojo
@@ -1,0 +1,5 @@
+def process(data: Dict[String, Int]):
+    pass
+def main():
+    var my_var = 42
+    process({"key": my_var, "count": 42})


### PR DESCRIPTION
## Summary

Path A from #1973, following the #1959 compiler verification (https://github.com/adamtheturtle/literalizer/issues/1959#issuecomment-4429305382).

- Flip Mojo's `supports_call_refs_in_dict_literals` and `supports_commented_dict_call_args` to `True`. Both rendered outputs compile cleanly under `mojo run --Werror` with mojo-compiler 1.0.0b1.
- Drop the now-dead `supports_call_refs_in_dict_literals` attribute from `LanguageCls` and every language file (no language gated on it after Mojo flipped). Removes the corresponding branch + helpers (`case_uses_ref_inside_dict_literal`, `_has_ref_inside_dict_literal`, `CALL_CASES_DIR`) from `_lang_satisfies_call_shape_constraints`.
- Keep `supports_commented_dict_call_args` and its filter branch: Cobol and Dhall still set it `False` while having `supports_inline_multiline_dict_args=True`, so the branch is still load-bearing for Dhall on `call_comments_dict_args`.
- Add two new Mojo goldens for `call_ref_nested_in_dict` and `call_comments_dict_args`.

Closes #1973. Closes #1956.

Partial progress on #1957 (the `supports_commented_dict_call_args` flag stays; the remaining Dhall `supports_zero_parameter_calls` candidate is unaffected).

## Test plan

- [x] `pytest tests/` — 3273 passed, 757 skipped
- [x] `mojo run --Werror` (mojo-compiler 1.0.0b1) on both new goldens and the full Mojo golden suite — all pass
- [x] `pre-commit run` — all standard hooks pass (pylint manual stage has pre-existing spelling warnings on untouched lines, also present on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `LanguageCls` interface by removing `supports_call_refs_in_dict_literals`, which could break downstream custom language implementations, and it adjusts call-case filtering behavior in the integration harness.
> 
> **Overview**
> **Mojo call rendering now treats two previously-excluded call shapes as supported**: refs nested within dict-literal arguments and commented dict-literal call arguments, and adds new Mojo golden fixtures to exercise both (`call_ref_nested_in_dict`, `call_comments_dict_args`).
> 
> **Removes the now-unused `supports_call_refs_in_dict_literals` capability flag** from `LanguageCls` and all language definitions, and deletes the associated integration-test YAML inspection/helpers and gating logic in `tests/integration/call_cases.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8cbe3aeb48f678cf0fa2f293b7306c6270152a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->