### PR TITLE
Raise UnsupportedCallShapeError for bare call statements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- :func:`~literalizer.literalize_call` now raises
+  :class:`~literalizer.exceptions.UnsupportedCallShapeError` when a
+  ``call_transform`` would leave the rendered call as a bare statement
+  (the wrapper returns its input unchanged) on a language whose
+  :attr:`~literalizer._language.Language.allows_bare_call_statement` is
+  ``False`` (Ada, Fortran, SystemVerilog).  Previously the integration
+  test discovery silently skipped these combinations.
+
 - ``Mojo`` :func:`~literalizer.literalize_call` now supports refs nested
   inside dict literals and commented dict-literal call arguments.  The
   typed-stub work landed in #1972 made both shapes compile cleanly under

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1345,6 +1345,16 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def allows_bare_call_statement(self) -> bool:
+        """Whether the language permits a bare call expression as a
+        top-level statement.  When ``False``,
+        :func:`~literalizer.literalize_call` rejects calls that would
+        render without a surrounding ``call_transform`` wrapper with
+        :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def supports_inline_multiline_dict_args(self) -> bool:
         """Whether the language can render a call argument as an inline
         dict literal that spans multiple lines.  When ``False``,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2947,6 +2947,18 @@ def _validate_call_preconditions(
                 "zero-parameter calls have no representation in this language"
             ),
         )
+    _probe = "__probe__"
+    if (
+        call_transform is not None
+        and call_transform(_probe) == _probe
+        and not language.allows_bare_call_statement
+    ):
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                "bare call statements have no representation in this language"
+            ),
+        )
     if (
         not language.supports_inline_multiline_dict_args
         and _has_inline_multiline_dict_arg(

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -754,6 +754,13 @@ def _expected_call_shape_exception(
         and not lang_cls.supports_standalone_comments_in_wrapped_calls
     ):
         return UnsupportedCallShapeError
+    _probe = "__probe__"
+    if (
+        config.call_transform is not None
+        and config.call_transform(_probe) == _probe
+        and not lang_cls.allows_bare_call_statement
+    ):
+        return UnsupportedCallShapeError
     return None
 
 
@@ -765,13 +772,6 @@ def _lang_satisfies_config_constraints(
     """Return False if *lang_cls* does not satisfy *config*'s language
     constraints.
     """
-    _probe = "__probe__"
-    if (
-        config.call_transform is not None
-        and config.call_transform(_probe) == _probe
-        and not lang_cls.allows_bare_call_statement
-    ):
-        return False
     if (
         config.requires_call_returns_expression
         and not lang_cls.call_returns_expression


### PR DESCRIPTION
## Summary
- Adds a render-time guard in `_validate_call_preconditions` that raises `UnsupportedCallShapeError` when `call_transform` is the identity wrapper on a language whose `allows_bare_call_statement` is `False` (Ada, Fortran, SystemVerilog).
- Drops the corresponding silent-skip branch from `_lang_satisfies_config_constraints` in the test runner and wires `_expected_call_shape_exception` to assert the raise.
- Exposes `allows_bare_call_statement` on the `Language` protocol so the guard typechecks.

Closes #2111. Feeds into #1956 / #1952.

## Test plan
- [x] `pytest tests/` — 3278 passed, 757 skipped (3 previously filtered Ada/Fortran/SystemVerilog × `call_transform_no_wrapper` cases now exercised via `pytest.raises`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 964fa4ca1f958fddb5bd4fda1561fc309cf99c25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->