### PR TITLE
CI: use --no-install-recommends for apt installs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Install gforth
         run: |-
           sudo apt-get update
-          sudo apt-get install -y gforth
+          sudo apt-get install -y --no-install-recommends gforth
       - name: Lint Forth
         run: |-
           find tests/integration/cases -name '*.fth' -print0 > /tmp/files-forth
@@ -266,7 +266,7 @@ jobs:
       - name: Install tcl
         run: |-
           sudo apt-get update
-          sudo apt-get install -y tcl
+          sudo apt-get install -y --no-install-recommends tcl
       - name: Lint Tcl
         run: |-
           find tests/integration/cases -name '*.tcl' -print0 > /tmp/files-tcl
@@ -282,7 +282,7 @@ jobs:
       - name: Install guile
         run: |-
           sudo apt-get update
-          sudo apt-get install -y guile-3.0
+          sudo apt-get install -y --no-install-recommends guile-3.0
       - name: Lint Scheme
         run: |-
           find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme
@@ -302,7 +302,7 @@ jobs:
       - name: Install octave
         run: |-
           sudo apt-get update
-          sudo apt-get install -y octave
+          sudo apt-get install -y --no-install-recommends octave
       - name: Lint Matlab
         run: |-
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab
@@ -318,7 +318,7 @@ jobs:
       - name: Install Perl deps
         run: |-
           sudo apt-get update
-          sudo apt-get install -y cpanminus
+          sudo apt-get install -y --no-install-recommends cpanminus
           sudo cpanm --notest DateTime
       - name: Lint Perl
         run: |-
@@ -482,7 +482,8 @@ jobs:
         with:
           persist-credentials: false
       - name: Install apt packages for Ada
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq gnat
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends
+          gnat
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -785,7 +786,7 @@ jobs:
           clj-kondo: latest
           bb: latest
       - name: Install Groovy
-        run: sudo apt-get install -y groovy
+        run: sudo apt-get install -y --no-install-recommends groovy
 
       - name: Lint Clojure
         run: |-


### PR DESCRIPTION
## Summary
- Pass \`--no-install-recommends\` to all \`apt-get install\` calls in the lint workflow (gforth, tcl, guile-3.0, octave, cpanminus, gnat, groovy) so CI skips docs, gnuplot/X libs, and other recommended-but-unnecessary packages.

## Test plan
- [ ] Workflow runs; each previously-affected lint job still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; the main risk is CI breakage if any lint job implicitly relied on a recommended apt dependency that will no longer be installed.
> 
> **Overview**
> The `lint.yml` workflow now passes `--no-install-recommends` to apt installs for several language lint jobs (e.g., `gforth`, `tcl`, `guile-3.0`, `octave`, `cpanminus`, `gnat`, `groovy`) to avoid pulling in extra recommended packages.
> 
> This is a CI footprint/consistency tweak only; no lint logic changes beyond how those dependencies are installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77bf550b79ceaa8ab40dccf4b2bcf99bea876518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->