### PR TITLE
Raise UnsupportedCallShapeError for call_transform on statement-only languages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- :func:`~literalizer.literalize_call` now raises
+  :class:`~literalizer.exceptions.UnsupportedCallShapeError` when a
+  ``call_transform`` wrapper is supplied for a language whose calls are
+  statements rather than expressions (i.e. ``call_returns_expression``
+  is ``False``).  The wrapper cannot consume the call as a value in
+  that case, and the renderer previously emitted invalid output.
+
 - :func:`~literalizer.literalize_call` no longer rejects identity
   ``call_transform`` values on Ada, Fortran, and SystemVerilog.  Bare
   procedure-call statements (``Process(x);``, ``call process(x)``,

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -1353,6 +1353,16 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
     @property
+    def call_returns_expression(self) -> bool:
+        """Whether a function call in this language is an expression
+        whose value can be consumed by an enclosing expression.  When
+        ``False``, :func:`~literalizer.literalize_call` rejects a
+        ``call_transform`` (whose output wraps the call as a value)
+        with :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
     def supports_inline_multiline_dict_args(self) -> bool:
         """Whether the language can render a call argument as an inline
         dict literal that spans multiple lines.  When ``False``,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2957,6 +2957,15 @@ def _validate_call_preconditions(
                 "representation in this language"
             ),
         )
+    if call_transform is not None and not language.call_returns_expression:
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                "calls in this language are statements, not expressions, "
+                "so a call_transform wrapper cannot consume the call as a "
+                "value"
+            ),
+        )
     if len(target_function_parts) > 1 and not language.supports_dotted_calls:
         raise DottedCallTargetNotSupportedError(
             language_name=type(language).__name__,

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -751,6 +751,11 @@ def _expected_call_shape_exception(
     ):
         return UnsupportedCallShapeError
     if (
+        config.requires_call_returns_expression
+        and not lang_cls.call_returns_expression
+    ):
+        return UnsupportedCallShapeError
+    if (
         config.case_dir_name in _CASES_REQUIRING_STANDALONE_WRAPPED_COMMENTS
         and not lang_cls.supports_standalone_comments_in_wrapped_calls
     ):
@@ -766,11 +771,6 @@ def _lang_satisfies_config_constraints(
     """Return False if *lang_cls* does not satisfy *config*'s language
     constraints.
     """
-    if (
-        config.requires_call_returns_expression
-        and not lang_cls.call_returns_expression
-    ):
-        return False
     innermost_target_function = config.target_function.split(sep=".")[-1]
     if innermost_target_function in lang_cls.reserved_identifiers:
         return False


### PR DESCRIPTION
## Summary
- Closes #2112. `literalize_call` now raises `UnsupportedCallShapeError` when a `call_transform` is supplied for a language whose `call_returns_expression` is `False` (e.g. COBOL), since the wrapper cannot consume a statement as a value.
- Adds `call_returns_expression` to the `Language` Protocol so production code can read it (previously only the metaclass exposed it).
- Drops the matching filter in `tests/integration/call_cases.py::_lang_satisfies_config_constraints` and wires `_expected_call_shape_exception` to assert the raise instead, so previously-filtered (config, language) pairs now execute via `pytest.raises`.

## Test plan
- [x] `pytest tests/` passes (3275 passed, 811 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `literalize_call` validation to raise `UnsupportedCallShapeError` for certain language/call shapes, which can break previously-accepted inputs and affects core call rendering across languages.
> 
> **Overview**
> `literalize_call` now **rejects `call_transform`** when the target language’s calls are *statements rather than expressions* (`call_returns_expression=False`), raising `UnsupportedCallShapeError` instead of emitting invalid wrapped output.
> 
> The `Language` protocol is extended to include the `call_returns_expression` capability, and the integration call golden tests are adjusted to expect this exception (rather than filtering out those language/case pairs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37724fd58dae05fa4dee99a42b53ad36bdf50807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->