### PR TITLE
Trim third-party apt sources before update in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -249,7 +249,10 @@ jobs:
           persist-credentials: false
       - name: Install gforth
         run: |-
-          sudo apt-get update
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends gforth
       - name: Lint Forth
         run: |-
@@ -265,7 +268,10 @@ jobs:
           persist-credentials: false
       - name: Install tcl
         run: |-
-          sudo apt-get update
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends tcl
       - name: Lint Tcl
         run: |-
@@ -281,7 +287,10 @@ jobs:
           persist-credentials: false
       - name: Install guile
         run: |-
-          sudo apt-get update
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends guile-3.0
       - name: Lint Scheme
         run: |-
@@ -301,7 +310,10 @@ jobs:
           persist-credentials: false
       - name: Install octave
         run: |-
-          sudo apt-get update
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends octave
       - name: Lint Matlab
         run: |-
@@ -317,7 +329,10 @@ jobs:
           persist-credentials: false
       - name: Install Perl deps
         run: |-
-          sudo apt-get update
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends cpanminus
           sudo cpanm --notest DateTime
       - name: Lint Perl
@@ -482,8 +497,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Install apt packages for Ada
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends
-          gnat
+        run: |-
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends gnat
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -786,7 +805,12 @@ jobs:
           clj-kondo: latest
           bb: latest
       - name: Install Groovy
-        run: sudo apt-get install -y --no-install-recommends groovy
+        run: |-
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends groovy
 
       - name: Lint Clojure
         run: |-


### PR DESCRIPTION
## Summary
- In `.github/workflows/lint.yml`, remove `/etc/apt/sources.list.d/*.list` before each `apt-get update -qq` so CI only refreshes the Ubuntu archive it actually installs from (skips Microsoft, GitHub CLI, Docker, etc.).
- Add a missing `apt-get update` before the Groovy install, which previously relied on the stale runner index.

## Test plan
- [ ] Watch the lint workflow run on this PR and confirm all apt-based jobs (gforth, tcl, guile, octave, Perl, Ada, Groovy) install successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that adjust `apt-get` setup to reduce flakiness; main impact is potential package install issues if any job implicitly relied on third-party runner apt sources.
> 
> **Overview**
> Updates the `lint` GitHub Actions workflow to **remove third-party apt sources** (`/etc/apt/sources.list.d/*.list`) before running `apt-get update` in apt-installed jobs (Forth, Tcl, Scheme/Guile, Matlab/Octave, Perl, Ada, Groovy).
> 
> Also fixes the Groovy setup step to run `apt-get update -qq` before installing, instead of relying on the runner’s preexisting apt index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7322c167d8fbb01ce303e7afbaa44dedb094bc48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->