### PR TITLE
Raise UnsupportedCallShapeError for reserved-identifier target_function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Next
 ----
 
 - :func:`~literalizer.literalize_call` now raises
+  :class:`~literalizer.exceptions.UnsupportedCallShapeError` when the
+  innermost segment of ``target_function`` collides with one of the
+  target language's reserved identifiers.  The renderer previously
+  produced output that would not parse in the target language.
+
+- :func:`~literalizer.literalize_call` now raises
   :class:`~literalizer.exceptions.UnsupportedCallShapeError` when a
   ``call_transform`` wrapper is supplied for a language whose calls are
   statements rather than expressions (i.e. ``call_returns_expression``

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -867,6 +867,15 @@ class Language(Protocol):
     :class:`~literalizer.exceptions.FreeFunctionCallNotSupportedError`.
     """
 
+    @property
+    def reserved_identifiers(self) -> frozenset[str]:
+        """Identifiers that are reserved by the language and therefore
+        cannot appear as the innermost segment of ``target_function``.
+        :func:`~literalizer.literalize_call` rejects such targets with
+        :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
     supports_variable_names: bool
     """Whether the language supports wrapping output in a named variable
     via the ``variable_form`` argument to

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2966,6 +2966,14 @@ def _validate_call_preconditions(
                 "value"
             ),
         )
+    if target_function_parts[-1] in language.reserved_identifiers:
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                f"target_function {target_function!r} ends in a reserved "
+                f"identifier of this language"
+            ),
+        )
     if len(target_function_parts) > 1 and not language.supports_dotted_calls:
         raise DottedCallTargetNotSupportedError(
             language_name=type(language).__name__,

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -760,6 +760,9 @@ def _expected_call_shape_exception(
         and not lang_cls.supports_standalone_comments_in_wrapped_calls
     ):
         return UnsupportedCallShapeError
+    innermost_target_function = config.target_function.split(sep=".")[-1]
+    if innermost_target_function in lang_cls.reserved_identifiers:
+        return UnsupportedCallShapeError
     return None
 
 
@@ -771,9 +774,6 @@ def _lang_satisfies_config_constraints(
     """Return False if *lang_cls* does not satisfy *config*'s language
     constraints.
     """
-    innermost_target_function = config.target_function.split(sep=".")[-1]
-    if innermost_target_function in lang_cls.reserved_identifiers:
-        return False
     return _lang_satisfies_call_shape_constraints(
         lang_cls=lang_cls,
         config=config,


### PR DESCRIPTION
## Summary
Closes #2113. `literalize_call` now raises `UnsupportedCallShapeError` when the innermost segment of `target_function` is in the target language's `reserved_identifiers`, instead of silently emitting output that would not parse. The test harness's pre-filter is replaced by a `pytest.raises` expectation so previously-skipped (lang, config) pairs now exercise the raise.

## Test plan
- [x] `pytest tests/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `literalize_call` behavior to raise `UnsupportedCallShapeError` for some previously-accepted `target_function` values, which may break existing callers relying on the old (invalid) output.
> 
> **Overview**
> `literalize_call` now raises `UnsupportedCallShapeError` when the innermost segment of `target_function` is a language `reserved_identifiers` keyword, preventing generation of code that cannot parse.
> 
> The call integration harness is updated to treat these (language, case) pairs as *expected failures* (exception assertions) rather than filtering them out, so the new validation path is exercised in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd1c2d94d74fe4ad38664826b1187e7b78edc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->