### PR TITLE
Remove supports_commented_dict_call_args and dead test-discovery wrappers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- The ``supports_commented_dict_call_args`` flag has been removed from
+  ``Language``.  Every (language, shape) pair previously dropped by the
+  test-discovery filter on this flag is either already short-circuited
+  by an earlier exception path or now renders cleanly, leaving the flag
+  with no load-bearing callers.
+
 - :func:`~literalizer.literalize_call` now raises
   :class:`~literalizer.exceptions.UnsupportedCallShapeError` when the
   innermost segment of ``target_function`` collides with one of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -490,7 +490,6 @@ ignore_names = [
     # ruamel.yaml configuration attributes
     "default_flow_style",
     "sort_base_mapping_type_on_output",
-    # Used by _lang_satisfies_config_constraints once issue #1828 is resolved
     "reserved_identifiers",
 ]
 # Duplicate some of .gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -490,7 +490,6 @@ ignore_names = [
     # ruamel.yaml configuration attributes
     "default_flow_style",
     "sort_base_mapping_type_on_output",
-    "reserved_identifiers",
 ]
 # Duplicate some of .gitignore
 exclude = [

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -604,7 +604,6 @@ class LanguageCls(type):
     supports_zero_parameter_calls: bool
     supports_inline_multiline_dict_args: bool
     supports_standalone_comments_in_wrapped_calls: bool
-    supports_commented_dict_call_args: bool
     supports_module_name: bool
     dict_supports_heterogeneous_values: bool
     format_call_arg: FormatCallArg
@@ -1385,13 +1384,6 @@ class Language(Protocol):
     def supports_standalone_comments_in_wrapped_calls(self) -> bool:
         """Whether manually wrapped call output can contain standalone
         comment lines between call statements.
-        """
-        ...  # pylint: disable=unnecessary-ellipsis
-
-    @property
-    def supports_commented_dict_call_args(self) -> bool:
-        """Whether manually wrapped call output can pass commented dict
-        literals as call arguments.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -225,7 +225,6 @@ class Ada(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -200,7 +200,6 @@ class Bash(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -230,7 +230,6 @@ class C(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -115,7 +115,6 @@ class Clojure(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -341,7 +341,6 @@ class Cobol(metaclass=LanguageCls):
     supports_zero_parameter_calls = False
     supports_inline_multiline_dict_args = False
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = False
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -124,7 +124,6 @@ class CommonLisp(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -903,7 +903,6 @@ class Cpp(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -185,7 +185,6 @@ class Crystal(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -367,7 +367,6 @@ class CSharp(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -171,7 +171,6 @@ class D(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -293,7 +293,6 @@ class Dart(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -530,7 +530,6 @@ class Dhall(metaclass=LanguageCls):
     supports_zero_parameter_calls = False
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = False
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -213,7 +213,6 @@ class Elixir(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -538,7 +538,6 @@ class Elm(metaclass=LanguageCls):
     supports_zero_parameter_calls = False
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -206,7 +206,6 @@ class Erlang(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -209,7 +209,6 @@ class Forth(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -331,7 +331,6 @@ class Fortran(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -291,7 +291,6 @@ class FSharp(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -533,7 +533,6 @@ class Gleam(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -271,7 +271,6 @@ class Go(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -151,7 +151,6 @@ class Groovy(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -969,7 +969,6 @@ class Haskell(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -151,7 +151,6 @@ class Hcl(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -599,7 +599,6 @@ class Java(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -135,7 +135,6 @@ class JavaScript(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -127,7 +127,6 @@ class Json5(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -145,7 +145,6 @@ class Jsonnet(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -163,7 +163,6 @@ class Julia(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -439,7 +439,6 @@ class Kotlin(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -149,7 +149,6 @@ class Lua(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -216,7 +216,6 @@ class Matlab(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -892,7 +892,6 @@ class Mojo(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -545,7 +545,6 @@ class Nim(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -195,7 +195,6 @@ class Nix(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -99,7 +99,6 @@ class Norg(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -285,7 +285,6 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -261,7 +261,6 @@ class OCaml(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -142,7 +142,6 @@ class Occam(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -221,7 +221,6 @@ class Odin(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -159,7 +159,6 @@ class Perl(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -158,7 +158,6 @@ class Php(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -174,7 +174,6 @@ class PowerShell(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -668,7 +668,6 @@ class PureScript(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -552,7 +552,6 @@ class Python(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -173,7 +173,6 @@ class R(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -116,7 +116,6 @@ class Racket(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -192,7 +192,6 @@ class Raku(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -528,7 +528,6 @@ class Roc(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
-    supports_commented_dict_call_args = True
     supports_module_name = False
     supports_special_floats = True
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -195,7 +195,6 @@ class Ruby(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -701,7 +701,6 @@ class Rust(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -235,7 +235,6 @@ class Scala(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -112,7 +112,6 @@ class Scheme(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -316,7 +316,6 @@ class Sml(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -365,7 +365,6 @@ class Swift(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -244,7 +244,6 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -157,7 +157,6 @@ class Tcl(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -127,7 +127,6 @@ class Toml(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -272,7 +272,6 @@ class TypeScript(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -386,7 +386,6 @@ class V(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -276,7 +276,6 @@ class VisualBasic(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -175,7 +175,6 @@ class Wren(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -101,7 +101,6 @@ class Yaml(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -243,7 +243,6 @@ class Zig(metaclass=LanguageCls):
     supports_zero_parameter_calls = True
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
-    supports_commented_dict_call_args = True
     supports_module_name = False
 
     class DateFormats(enum.Enum):

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -717,9 +717,6 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
 _CASES_REQUIRING_STANDALONE_WRAPPED_COMMENTS = frozenset(
     {"call_comments", "call_comments_dict_args"}
 )
-_CASES_REQUIRING_COMMENTED_DICT_CALL_ARGS = frozenset(
-    {"call_comments_dict_args"}
-)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -766,36 +763,6 @@ def _expected_call_shape_exception(
     return None
 
 
-@beartype
-def _lang_satisfies_config_constraints(
-    lang_cls: literalizer.LanguageCls,
-    config: CallCaseConfig,
-) -> bool:
-    """Return False if *lang_cls* does not satisfy *config*'s language
-    constraints.
-    """
-    return _lang_satisfies_call_shape_constraints(
-        lang_cls=lang_cls,
-        config=config,
-    )
-
-
-@beartype
-def _lang_satisfies_call_shape_constraints(
-    *,
-    lang_cls: literalizer.LanguageCls,
-    config: CallCaseConfig,
-) -> bool:
-    """Return False if *lang_cls* cannot represent *config*'s call
-    shape.
-    """
-    return not (
-        config.case_dir_name in _CASES_REQUIRING_COMMENTED_DICT_CALL_ARGS
-        and lang_cls.supports_inline_multiline_dict_args
-        and not lang_cls.supports_commented_dict_call_args
-    )
-
-
 @functools.cache
 @beartype
 def discover_call_cases() -> list[CallCase]:
@@ -804,10 +771,6 @@ def discover_call_cases() -> list[CallCase]:
     for config in CALL_CASE_CONFIGS:
         for lang_cls in sorted_languages():
             if len(lang_cls.CallStyles) == 0:
-                continue
-            if not _lang_satisfies_config_constraints(
-                lang_cls=lang_cls, config=config
-            ):
                 continue
             if config.call_style_type is not None:
                 # Only include languages that have this as a

--- a/tests/integration/test_language_metadata.py
+++ b/tests/integration/test_language_metadata.py
@@ -78,7 +78,6 @@ def test_protocol_properties_accessible(
     assert callable(spec.type_hint_collection_preamble_lines)
     assert isinstance(spec.scalar_body_preamble, dict)
     assert isinstance(spec.supports_standalone_comments_in_wrapped_calls, bool)
-    assert isinstance(spec.supports_commented_dict_call_args, bool)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Drops the `supports_commented_dict_call_args` flag from `LanguageCls` and every language module — per #2124, no language uses `=False` as a load-bearing guard.
- Deletes `_lang_satisfies_call_shape_constraints`, `_lang_satisfies_config_constraints`, and `_CASES_REQUIRING_COMMENTED_DICT_CALL_ARGS` from `tests/integration/call_cases.py`. The discovery loop is now flat — every (language, shape) pair either renders or is asserted via `pytest.raises` through `_expected_call_shape_exception`.
- Cleans up the stale `_lang_satisfies_config_constraints` comment in `pyproject.toml`.

Closes #2125. Closes #1952.

## Test plan

- [x] `uv run pytest` — 3280 passed, 812 skipped (no new failures, no test count regression from main).
- [x] Pre-commit hooks pass (ruff, pyright, vulture, interrogate, deptry, ...).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused capability flag and simplifies test discovery logic; behavior changes are limited to which (language, call-shape) combinations are exercised by integration tests.
> 
> **Overview**
> Removes the `Language.supports_commented_dict_call_args` capability flag from the `Language` protocol/meta-class and deletes the per-language overrides that set it.
> 
> Simplifies integration call-case discovery by dropping the commented-dict-arg filter helpers and relying on `_expected_call_shape_exception` for any unsupported (language, case) pairs, and updates metadata tests/changelog/config comments accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657a9e5d94bd53e5be22e0224f7cbd1fe7adfc21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->