### PR TITLE
Use curried calls for Elm and drop max_call_parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Elm` :func:`~literalizer.literalize_call` now
+  emits curried-application calls (``process (EInt 1) (EInt 2)``) with
+  curried type stubs (``process : a -> b -> ()``) in place of the prior
+  tuple-form (``process (EInt 1, EInt 2)``).  Elm tuple literals cap at
+  three elements, so the tuple form had no representation for calls
+  with four or more parameters; the curried form composes naturally
+  with ``|>`` and matches the convention used by ``elm-format`` and the
+  standard library.
+
+- The ``Language.max_call_parameters`` attribute has been removed.  No
+  remaining language sets a maximum parameter count, so the
+  upstream ``UnsupportedCallShapeError`` check in
+  :func:`~literalizer.literalize_call` and the corresponding
+  ``language_cls.max_call_parameters`` introspection no longer have a
+  load-bearing caller.
+
 - The ``supports_commented_dict_call_args`` flag has been removed from
   ``Language``.  Every (language, shape) pair previously dropped by the
   test-discovery filter on this flag is either already short-circuited

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -602,7 +602,6 @@ class LanguageCls(type):
     supports_dotted_call_stub: bool
     call_returns_expression: bool
     supports_zero_parameter_calls: bool
-    max_call_parameters: int | None
     supports_inline_multiline_dict_args: bool
     supports_standalone_comments_in_wrapped_calls: bool
     supports_module_name: bool
@@ -1357,16 +1356,6 @@ class Language(Protocol):
         parameters.  When ``False``,
         :func:`~literalizer.literalize_call` rejects empty
         ``parameter_names`` with
-        :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
-        """
-        ...  # pylint: disable=unnecessary-ellipsis
-
-    @property
-    def max_call_parameters(self) -> int | None:
-        """Maximum number of parameters the language can render in a
-        call, or ``None`` if there is no language-imposed limit.  When
-        set, :func:`~literalizer.literalize_call` rejects
-        ``parameter_names`` longer than this with
         :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
         """
         ...  # pylint: disable=unnecessary-ellipsis

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2940,18 +2940,6 @@ def _validate_parameter_count(
                 "zero-parameter calls have no representation in this language"
             ),
         )
-    max_call_parameters = language.max_call_parameters
-    if (
-        max_call_parameters is not None
-        and len(parameter_names) > max_call_parameters
-    ):
-        raise UnsupportedCallShapeError(
-            language_name=type(language).__name__,
-            reason=(
-                f"calls with more than {max_call_parameters} parameters "
-                f"have no representation in this language"
-            ),
-        )
 
 
 @beartype

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -223,7 +223,6 @@ class Ada(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -198,7 +198,6 @@ class Bash(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -228,7 +228,6 @@ class C(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -113,7 +113,6 @@ class Clojure(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -339,7 +339,6 @@ class Cobol(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = False
     supports_zero_parameter_calls = False
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = False
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -122,7 +122,6 @@ class CommonLisp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -901,7 +901,6 @@ class Cpp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -183,7 +183,6 @@ class Crystal(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -365,7 +365,6 @@ class CSharp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -169,7 +169,6 @@ class D(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -291,7 +291,6 @@ class Dart(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -528,7 +528,6 @@ class Dhall(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = False
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -211,7 +211,6 @@ class Elixir(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -513,13 +513,6 @@ class Elm(metaclass=LanguageCls):
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False
 
-    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
-        staticmethod(
-            _elm_format_call_arg,
-        )
-    )
-    """Callable that rewrites a formatted direct call argument."""
-
     class DateFormats(enum.Enum):
         """Date format options for Elm."""
 
@@ -751,6 +744,11 @@ class Elm(metaclass=LanguageCls):
     )
 
     validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Wrap each formatted call argument in parentheses."""
+        return _elm_format_call_arg
 
     @cached_property
     def validate_call_arg(self) -> Callable[[Value], None]:

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -394,7 +394,6 @@ def _elm_call_stub(
     return (type_signature, implementation)
 
 
-@beartype
 def _elm_format_call_arg(_original: Value, formatted: str, /) -> str:
     """Wrap a formatted Elm value in parentheses for curried application.
 

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -40,6 +40,7 @@ from literalizer._language import (
     NO_HETEROGENEOUS_BEHAVIOR,
     NON_KEBAB_REF_CASES,
     CallStyle,
+    CommandCallStyle,
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
@@ -51,12 +52,10 @@ from literalizer._language import (
     LanguageCls,
     ModifierCombination,
     OrderedMapFormatConfig,
-    PositionalCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
-    identity_call_arg,
     identity_call_ref_identifier,
     identity_call_statement,
     never_inhibits_consuming_form,
@@ -380,24 +379,30 @@ def _elm_call_stub(
     """Return Elm top-level stub declarations for a call target.
 
     Dotted names are flattened (the first character of each part after
-    the first is upper-cased).  For a single parameter the stub is
-    polymorphic (``a -> ()``); for 2 or 3 parameters the stub takes a
-    tuple (``( a, b ) -> ()`` or ``( a, b, c ) -> ()``), matching the
-    tuple that ``PositionalCallStyle`` emits at the call site.  Elm
-    tuples cap at 3 elements, so 4+ parameter calls are rejected
-    upstream by ``literalize_call`` via ``max_call_parameters``.
+    the first is upper-cased).  Elm calls are curried, so the stub
+    chains its type variables with ``->`` (``a -> ()``,
+    ``a -> b -> ()``, ``a -> b -> c -> d -> ()``) and the
+    implementation takes one ``_`` per parameter.
     """
     flat_name = _elm_flatten_dotted(parts=parts)
     parameter_count = len(params)
-    implementation = f"{flat_name} _ = ()"
-    if parameter_count == 1:
-        type_signature = f"{flat_name} : a -> ()"
-    else:
-        type_variables = ", ".join(
-            chr(ord("a") + position) for position in range(parameter_count)
-        )
-        type_signature = f"{flat_name} : ( {type_variables} ) -> ()"
+    type_variables = [
+        chr(ord("a") + position) for position in range(parameter_count)
+    ]
+    type_signature = f"{flat_name} : {' -> '.join([*type_variables, '()'])}"
+    implementation = f"{flat_name} {' '.join(['_'] * parameter_count)} = ()"
     return (type_signature, implementation)
+
+
+@beartype
+def _elm_format_call_arg(_original: Value, formatted: str, /) -> str:
+    """Wrap a formatted Elm value in parentheses for curried application.
+
+    Every literal Elm value is a constructor application (``EInt 1``,
+    ``EList […]``), so each argument must be parenthesized to avoid
+    being parsed as additional arguments to the outer call.
+    """
+    return f"({formatted})"
 
 
 _INT_BASE: dict[str, Callable[[int], str]] = {
@@ -505,18 +510,13 @@ class Elm(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = False
-    max_call_parameters: ClassVar[int] = 3
-    """Elm tuple literals cap at 3 elements, which caps the parameter
-    count for a call: ``PositionalCallStyle`` emits a tuple at the
-    call site.
-    """
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(
-            identity_call_arg,
+            _elm_format_call_arg,
         )
     )
     """Callable that rewrites a formatted direct call argument."""
@@ -714,7 +714,10 @@ class Elm(metaclass=LanguageCls):
     class CallStyles(enum.Enum):
         """Elm call style options."""
 
-        POSITIONAL = PositionalCallStyle()
+        CURRIED = CommandCallStyle(
+            arg_separator=" ",
+            wrapped_call_template="{wrapper} ({inner})",
+        )
 
     call_styles = CallStyles
 
@@ -858,7 +861,7 @@ class Elm(metaclass=LanguageCls):
     statement_terminator_style: StatementTerminatorStyles = (
         StatementTerminatorStyles.SEMICOLON
     )
-    call_style: CallStyles = CallStyles.POSITIONAL
+    call_style: CallStyles = CallStyles.CURRIED
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -204,7 +204,6 @@ class Erlang(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = True

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -207,7 +207,6 @@ class Forth(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -329,7 +329,6 @@ class Fortran(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -289,7 +289,6 @@ class FSharp(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -531,7 +531,6 @@ class Gleam(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -269,7 +269,6 @@ class Go(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -149,7 +149,6 @@ class Groovy(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -967,7 +967,6 @@ class Haskell(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = True

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -149,7 +149,6 @@ class Hcl(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -597,7 +597,6 @@ class Java(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -133,7 +133,6 @@ class JavaScript(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -125,7 +125,6 @@ class Json5(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -143,7 +143,6 @@ class Jsonnet(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -161,7 +161,6 @@ class Julia(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -437,7 +437,6 @@ class Kotlin(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -147,7 +147,6 @@ class Lua(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -214,7 +214,6 @@ class Matlab(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -890,7 +890,6 @@ class Mojo(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -543,7 +543,6 @@ class Nim(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -193,7 +193,6 @@ class Nix(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -97,7 +97,6 @@ class Norg(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -283,7 +283,6 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -259,7 +259,6 @@ class OCaml(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -140,7 +140,6 @@ class Occam(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -219,7 +219,6 @@ class Odin(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -157,7 +157,6 @@ class Perl(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -156,7 +156,6 @@ class Php(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -172,7 +172,6 @@ class PowerShell(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -666,7 +666,6 @@ class PureScript(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -550,7 +550,6 @@ class Python(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -171,7 +171,6 @@ class R(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -114,7 +114,6 @@ class Racket(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -190,7 +190,6 @@ class Raku(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -517,7 +517,6 @@ class Roc(metaclass=LanguageCls):
     supports_dotted_call_stub = False
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -193,7 +193,6 @@ class Ruby(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -699,7 +699,6 @@ class Rust(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -233,7 +233,6 @@ class Scala(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -110,7 +110,6 @@ class Scheme(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -314,7 +314,6 @@ class Sml(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -363,7 +363,6 @@ class Swift(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -242,7 +242,6 @@ class SystemVerilog(metaclass=LanguageCls):
     reserved_identifiers: ClassVar[frozenset[str]] = frozenset()
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -155,7 +155,6 @@ class Tcl(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -125,7 +125,6 @@ class Toml(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -270,7 +270,6 @@ class TypeScript(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -384,7 +384,6 @@ class V(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -274,7 +274,6 @@ class VisualBasic(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -173,7 +173,6 @@ class Wren(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -99,7 +99,6 @@ class Yaml(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -241,7 +241,6 @@ class Zig(metaclass=LanguageCls):
     supports_dotted_call_stub = True
     call_returns_expression = True
     supports_zero_parameter_calls = True
-    max_call_parameters: ClassVar[int | None] = None
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -194,10 +194,7 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_standalone_wrapped_comments=False,
     ),
     CallCaseConfig(
-        # Four-parameter call.  Elm rejects this because Elm tuples
-        # cap at three elements and ``PositionalCallStyle`` emits a
-        # tuple at the call site, so a four-element tuple has no
-        # representation.
+        # Four-parameter call.
         case_dir_name="call_quad_args",
         target_function="process",
         parameter_names=["a", "b", "c", "d"],
@@ -791,14 +788,7 @@ def _expected_call_shape_exception(
     this (lang, config) pair, or ``None`` if it should produce output.
     """
     parameter_count = len(config.parameter_names)
-    max_call_parameters = lang_cls.max_call_parameters
-    parameter_count_unsupported = (
-        parameter_count == 0 and not lang_cls.supports_zero_parameter_calls
-    ) or (
-        max_call_parameters is not None
-        and parameter_count > max_call_parameters
-    )
-    if parameter_count_unsupported:
+    if parameter_count == 0 and not lang_cls.supports_zero_parameter_calls:
         return UnsupportedCallShapeError
     if (
         config.requires_inline_multiline_dict_args

--- a/tests/integration/cases/call_deep_dotted_method/Elm_call.elm
+++ b/tests/integration/cases/call_deep_dotted_method/Elm_call.elm
@@ -13,9 +13,9 @@ objApiClientPost _ = ()
 main : Program () () Never
 main =
     let
-        _ = objApiClientPost(EStr "hello")
-        _ = objApiClientPost(EInt 42)
-        _ = objApiClientPost(EBool True)
+        _ = objApiClientPost (EStr "hello")
+        _ = objApiClientPost (EInt 42)
+        _ = objApiClientPost (EBool True)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_deep_dotted_transformed/Elm_call.elm
+++ b/tests/integration/cases/call_deep_dotted_transformed/Elm_call.elm
@@ -15,9 +15,9 @@ emit _ = ()
 main : Program () () Never
 main =
     let
-        _ = emit(appClientFetch(EStr "hello"))
-        _ = emit(appClientFetch(EInt 42))
-        _ = emit(appClientFetch(EBool True))
+        _ = emit (appClientFetch (EStr "hello"))
+        _ = emit (appClientFetch (EInt 42))
+        _ = emit (appClientFetch (EBool True))
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_dotted_method/Elm_call.elm
+++ b/tests/integration/cases/call_dotted_method/Elm_call.elm
@@ -13,9 +13,9 @@ appClientFetch _ = ()
 main : Program () () Never
 main =
     let
-        _ = appClientFetch(EStr "hello")
-        _ = appClientFetch(EInt 42)
-        _ = appClientFetch(EBool True)
+        _ = appClientFetch (EStr "hello")
+        _ = appClientFetch (EInt 42)
+        _ = appClientFetch (EBool True)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_existing_ref_arg/Elm_call.elm
+++ b/tests/integration/cases/call_existing_ref_arg/Elm_call.elm
@@ -13,7 +13,7 @@ main =
     let
         existing : Val
         existing = EInt 42
-        _ = process(existing)
+        _ = process existing
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_homogeneous_dotted_method/Elm_call.elm
+++ b/tests/integration/cases/call_homogeneous_dotted_method/Elm_call.elm
@@ -11,8 +11,8 @@ appClientFetch _ = ()
 main : Program () () Never
 main =
     let
-        _ = appClientFetch(EStr "hello")
-        _ = appClientFetch(EStr "world")
+        _ = appClientFetch (EStr "hello")
+        _ = appClientFetch (EStr "world")
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_homogeneous_value_dict_arg/Elm_call.elm
+++ b/tests/integration/cases/call_homogeneous_value_dict_arg/Elm_call.elm
@@ -12,7 +12,7 @@ process _ = ()
 main : Program () () Never
 main =
     let
-        _ = process(EDict [("a", EInt 1), ("b", EInt 2)])
+        _ = process (EDict [("a", EInt 1), ("b", EInt 2)])
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_keyword_args/Elm_call.elm
+++ b/tests/integration/cases/call_keyword_args/Elm_call.elm
@@ -5,8 +5,8 @@ type Val
     = EFloat Float
     | EStr String
     | EList (List Val)
-throttlerCheck : ( a, b ) -> ()
-throttlerCheck _ = ()
+throttlerCheck : a -> b -> ()
+throttlerCheck _ _ = ()
 emit : a -> ()
 emit _ = ()
 
@@ -14,8 +14,8 @@ emit _ = ()
 main : Program () () Never
 main =
     let
-        _ = emit(throttlerCheck(EStr "user_1", EFloat 1000.0))
-        _ = emit(throttlerCheck(EStr "user_2", EFloat 2000.5))
+        _ = emit (throttlerCheck (EStr "user_1") (EFloat 1000.0))
+        _ = emit (throttlerCheck (EStr "user_2") (EFloat 2000.5))
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_mixed_type_dicts/Elm_call.elm
+++ b/tests/integration/cases/call_mixed_type_dicts/Elm_call.elm
@@ -13,8 +13,8 @@ appMgrRun _ = ()
 main : Program () () Never
 main =
     let
-        _ = appMgrRun(EDict [("type", EStr "create"), ("pr_id", EStr "pr_1"), ("draft", EBool True)])
-        _ = appMgrRun(EDict [("type", EStr "create"), ("pr_id", EStr "pr_2")])
+        _ = appMgrRun (EDict [("type", EStr "create"), ("pr_id", EStr "pr_1"), ("draft", EBool True)])
+        _ = appMgrRun (EDict [("type", EStr "create"), ("pr_id", EStr "pr_2")])
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_multi_args/Elm_call.elm
+++ b/tests/integration/cases/call_multi_args/Elm_call.elm
@@ -4,15 +4,15 @@ module Check exposing (..)
 type Val
     = EInt Int
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
 main =
     let
-        _ = process(EInt 1, EInt 42)
-        _ = process(EInt 2, EInt 100)
+        _ = process (EInt 1) (EInt 42)
+        _ = process (EInt 2) (EInt 100)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_negative_int/Elm_call.elm
+++ b/tests/integration/cases/call_negative_int/Elm_call.elm
@@ -11,9 +11,9 @@ process _ = ()
 main : Program () () Never
 main =
     let
-        _ = process(EInt (-1))
-        _ = process(EInt (-2))
-        _ = process(EInt (-3))
+        _ = process (EInt (-1))
+        _ = process (EInt (-2))
+        _ = process (EInt (-3))
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_per_element_false/Elm_call.elm
+++ b/tests/integration/cases/call_per_element_false/Elm_call.elm
@@ -10,7 +10,7 @@ process _ = ()
 main : Program () () Never
 main =
     let
-        _ = process(EInt 1)
+        _ = process (EInt 1)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_per_element_false_dict_arg/Elm_call.elm
+++ b/tests/integration/cases/call_per_element_false_dict_arg/Elm_call.elm
@@ -12,7 +12,7 @@ process _ = ()
 main : Program () () Never
 main =
     let
-        _ = process(EDict [("a", EInt 1), ("b", EStr "x")])
+        _ = process (EDict [("a", EInt 1), ("b", EStr "x")])
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_quad_args/Elm_call.elm
+++ b/tests/integration/cases/call_quad_args/Elm_call.elm
@@ -2,16 +2,17 @@ module Check exposing (..)
 
 
 type Val
-    = EStr String
+    = EInt Int
     | EList (List Val)
-op : a -> ()
-op _ = ()
+process : a -> b -> c -> d -> ()
+process _ _ _ _ = ()
 
 
 main : Program () () Never
 main =
     let
-        _ = op (EStr "hello")
+        _ = process (EInt 1) (EInt 2) (EInt 3) (EInt 4)
+        _ = process (EInt 5) (EInt 6) (EInt 7) (EInt 8)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args/Elm_call.elm
@@ -4,8 +4,8 @@ module Check exposing (..)
 type Val
     = EInt Int
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
@@ -23,8 +23,8 @@ main =
             EInt 5,
             EInt 6
             ]
-        _ = process(my_var, EInt 42)
-        _ = process(my_other, EInt 7)
+        _ = process my_var (EInt 42)
+        _ = process my_other (EInt 7)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args_converted/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_converted/Elm_call.elm
@@ -4,8 +4,8 @@ module Check exposing (..)
 type Val
     = EInt Int
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
@@ -23,8 +23,8 @@ main =
             EInt 5,
             EInt 6
             ]
-        _ = process(myVar, EInt 42)
-        _ = process(myOther, EInt 7)
+        _ = process myVar (EInt 42)
+        _ = process myOther (EInt 7)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Elm_call.elm
@@ -4,8 +4,8 @@ module Check exposing (..)
 type Val
     = EInt Int
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
@@ -23,8 +23,8 @@ main =
             EInt 5,
             EInt 6
             ]
-        _ = process(myVar, EInt 42)
-        _ = process(myOther, EInt 7)
+        _ = process myVar (EInt 42)
+        _ = process myOther (EInt 7)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args_converted_whole/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_converted_whole/Elm_call.elm
@@ -17,7 +17,7 @@ main =
             EInt 2,
             EInt 3
             ]
-        _ = process(myVar)
+        _ = process myVar
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args_escaped_quote/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Elm_call.elm
@@ -13,7 +13,7 @@ main =
     let
         my_str : Val
         my_str = EStr "a\"b"
-        _ = process(my_str)
+        _ = process my_str
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Elm_call.elm
@@ -5,8 +5,8 @@ type Val
     = EInt Int
     | EStr String
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
@@ -25,9 +25,9 @@ main =
             ]
         my_empty : Val
         my_empty = EList []
-        _ = process(my_ints, EInt 42)
-        _ = process(my_strings, EInt 7)
-        _ = process(my_empty, EInt 99)
+        _ = process my_ints (EInt 42)
+        _ = process my_strings (EInt 7)
+        _ = process my_empty (EInt 99)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args_reused/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_reused/Elm_call.elm
@@ -4,8 +4,8 @@ module Check exposing (..)
 type Val
     = EInt Int
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
@@ -19,9 +19,9 @@ main =
             ]
         repeated_var : Val
         repeated_var = EInt 1
-        _ = process(repeated_var, EInt 1)
-        _ = process(single_var, EInt 0)
-        _ = process(repeated_var, EInt 8)
+        _ = process repeated_var (EInt 1)
+        _ = process single_var (EInt 0)
+        _ = process repeated_var (EInt 8)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_args_trivial_register/Elm_call.elm
+++ b/tests/integration/cases/call_ref_args_trivial_register/Elm_call.elm
@@ -6,8 +6,8 @@ type Val
     | EInt Int
     | EFloat Float
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
@@ -25,10 +25,10 @@ main =
             EInt 2,
             EInt 3
             ]
-        _ = process(my_int, EInt 42)
-        _ = process(my_bool, EInt 7)
-        _ = process(my_float, EInt 9)
-        _ = process(my_list, EInt 1)
+        _ = process my_int (EInt 42)
+        _ = process my_bool (EInt 7)
+        _ = process my_float (EInt 9)
+        _ = process my_list (EInt 1)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_nested_converted/Elm_call.elm
+++ b/tests/integration/cases/call_ref_nested_converted/Elm_call.elm
@@ -14,7 +14,7 @@ main =
     let
         myVar : Val
         myVar = EInt 42
-        _ = process(EList [myVar, EInt 42, EStr "static"])
+        _ = process (EList [myVar, EInt 42, EStr "static"])
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_nested_in_dict/Elm_call.elm
+++ b/tests/integration/cases/call_ref_nested_in_dict/Elm_call.elm
@@ -15,7 +15,7 @@ main =
     let
         my_var : Val
         my_var = EInt 42
-        _ = process(EDict [("key", my_var), ("count", EInt 42)])
+        _ = process (EDict [("key", my_var), ("count", EInt 42)])
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_ref_nested_in_list/Elm_call.elm
+++ b/tests/integration/cases/call_ref_nested_in_list/Elm_call.elm
@@ -16,8 +16,8 @@ main =
         my_var = EInt 42
         my_other : Val
         my_other = EInt 7
-        _ = process(EList [my_var, EInt 42, EStr "static"])
-        _ = process(EList [my_other, EInt 7, EStr "label"])
+        _ = process (EList [my_var, EInt 42, EStr "static"])
+        _ = process (EList [my_other, EInt 7, EStr "label"])
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_scalar_args/Elm_call.elm
+++ b/tests/integration/cases/call_scalar_args/Elm_call.elm
@@ -13,9 +13,9 @@ process _ = ()
 main : Program () () Never
 main =
     let
-        _ = process(EStr "hello")
-        _ = process(EInt 42)
-        _ = process(EBool True)
+        _ = process (EStr "hello")
+        _ = process (EInt 42)
+        _ = process (EBool True)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Elm_call.elm
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Elm_call.elm
@@ -6,16 +6,16 @@ type Val
     | EInt Int
     | EStr String
     | EList (List Val)
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 
 
 main : Program () () Never
 main =
     let
-        _ = process(EStr "hello", EStr "a")
-        _ = process(EInt 42, EStr "b")
-        _ = process(EBool True, EStr "c")
+        _ = process (EStr "hello") (EStr "a")
+        _ = process (EInt 42) (EStr "b")
+        _ = process (EBool True) (EStr "c")
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_scalar_args_with_null/Elm_call.elm
+++ b/tests/integration/cases/call_scalar_args_with_null/Elm_call.elm
@@ -12,8 +12,8 @@ process _ = ()
 main : Program () () Never
 main =
     let
-        _ = process(ENull)
-        _ = process(EStr "hello")
+        _ = process (ENull)
+        _ = process (EStr "hello")
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_snake_dotted_method/Elm_call.elm
+++ b/tests/integration/cases/call_snake_dotted_method/Elm_call.elm
@@ -13,9 +13,9 @@ my_appHttp_clientFetch _ = ()
 main : Program () () Never
 main =
     let
-        _ = my_appHttp_clientFetch(EStr "hello")
-        _ = my_appHttp_clientFetch(EInt 42)
-        _ = my_appHttp_clientFetch(EBool True)
+        _ = my_appHttp_clientFetch (EStr "hello")
+        _ = my_appHttp_clientFetch (EInt 42)
+        _ = my_appHttp_clientFetch (EBool True)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_transform_no_wrapper/Elm_call.elm
+++ b/tests/integration/cases/call_transform_no_wrapper/Elm_call.elm
@@ -13,9 +13,9 @@ process _ = ()
 main : Program () () Never
 main =
     let
-        _ = process(EStr "hello")
-        _ = process(EInt 42)
-        _ = process(EBool True)
+        _ = process (EStr "hello")
+        _ = process (EInt 42)
+        _ = process (EBool True)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_wrap_in_file/Elm_call.elm
+++ b/tests/integration/cases/call_wrap_in_file/Elm_call.elm
@@ -1,8 +1,8 @@
 module Check exposing (..)
 
 
-process : ( a, b ) -> ()
-process _ = ()
+process : a -> b -> ()
+process _ _ = ()
 type Val
     = EInt Int
     | EList (List Val)
@@ -11,8 +11,8 @@ type Val
 main : Program () () Never
 main =
     let
-        _ = process(EInt 1, EInt 2)
-        _ = process(EInt 3, EInt 4)
+        _ = process (EInt 1) (EInt 2)
+        _ = process (EInt 3) (EInt 4)
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/integration/cases/call_wrap_in_file_escaped_quote/Elm_call.elm
+++ b/tests/integration/cases/call_wrap_in_file_escaped_quote/Elm_call.elm
@@ -11,7 +11,7 @@ type Val
 main : Program () () Never
 main =
     let
-        _ = process(EStr "a\"b")
+        _ = process (EStr "a\"b")
     in
     Platform.worker
         { init = \_ -> ( (), Cmd.none )

--- a/tests/test_class_enum_access.py
+++ b/tests/test_class_enum_access.py
@@ -33,7 +33,4 @@ def test_format_enums_populated(*, language_cls: LanguageCls) -> None:
     assert len(language_cls.CallStyles) >= 0
     assert len(language_cls.identifier_cases) >= 1
     assert isinstance(language_cls.supports_zero_parameter_calls, bool)
-    assert language_cls.max_call_parameters is None or isinstance(
-        language_cls.max_call_parameters, int
-    )
     assert isinstance(language_cls.supports_inline_multiline_dict_args, bool)


### PR DESCRIPTION
## Summary

- Elm now emits curried calls (`process (EInt 1) (EInt 2)`) with curried type stubs (`process : a -> b -> ()`) via `CommandCallStyle`, lifting the prior 3-parameter ceiling imposed by tuple-form positional calls.
- Drops the `max_call_parameters` attribute from the `Language` protocol, the `LanguageCls` metaclass, every language module, and the upstream validation in `literalize_call`, since no remaining language constrains call arity.
- Regenerates 30 Elm call goldens and adds a new `call_quad_args` Elm golden where the prior tuple form raised `UnsupportedCallShapeError`.

Closes #2132

## Test plan

- [x] `uv run pytest tests/` (3337 passed, 20173 subtests)
- [x] `uv run ruff check` and `uv run ty check` clean
- [x] Pre-push hooks (mypy, pyright, ty, pyrefly) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Elm `literalize_call` output shape (calls and stubs) and removes the `Language.max_call_parameters` API, which could break custom language implementations or downstream snapshot expectations.
> 
> **Overview**
> **Elm call rendering is switched from tuple-style positional calls to curried application.** This updates Elm stubs to use chained `a -> b -> ... -> ()` signatures and multi-underscore implementations, and wraps each formatted call argument in parentheses to parse correctly under curried application.
> 
> **Arity limiting is removed from the call pipeline.** The `Language.max_call_parameters` attribute and its `UnsupportedCallShapeError` validation are deleted, along with per-language declarations and test expectations; Elm now supports 4+ argument calls (new `call_quad_args` golden) and existing Elm call goldens are regenerated to the new syntax.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dbc0fbc68bbf9b8c0785abea5f5f80bc474be2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->