### PR TITLE
Ban typing.cast via ruff flake8-tidy-imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ lint.per-file-ignores."tests/test_*.py" = [
 # We comment out code during development, and with VSCode auto-save, this code
 # is sometimes annoyingly removed.
 lint.unfixable = [ "ERA001" ]
+lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]


### PR DESCRIPTION
## Summary
- Add a `flake8-tidy-imports.banned-api` entry to `pyproject.toml` so ruff flags any use of `typing.cast` with TID251.

## Test plan
- [x] `uv run ruff check` passes (no existing `cast` usages).
- [x] Confirmed TID251 fires on a synthetic `from typing import cast` snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens lint configuration and does not change runtime code paths; the main impact is potential future CI failures if new `typing.cast` usages are introduced.
> 
> **Overview**
> Adds a Ruff `flake8-tidy-imports` `banned-api` rule in `pyproject.toml` to flag any use of `typing.cast` with a custom message, steering contributors toward explicit type narrowing or typed variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd6eec2f4abd783f3d739b2ce7cd01fdfb41efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->