### PR TITLE
Use match for character-dispatch scanners in HCL/Fortran/Dhall

### DIFF
--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -308,35 +308,35 @@ def _dhall_validate_call_stmt(call_expr: str) -> None:
     prev_is_word = False
     for c in sanitized:
         next_prev_is_word = False
-        if c == "(":
-            if prev_is_word:
+        match c:
+            case "(":
+                if prev_is_word:
+                    raise CallArgNotSupportedError(
+                        language_name="Dhall",
+                        reason=(
+                            "call_transform produces a function application "
+                            "without the whitespace Dhall requires before '(' "
+                            f"(in: {call_expr!r})"
+                        ),
+                    )
+                depths["paren"] += 1
+            case "," if (
+                depths["paren"] >= 1
+                and depths["brace"] == 0
+                and depths["bracket"] == 0
+            ):
                 raise CallArgNotSupportedError(
                     language_name="Dhall",
                     reason=(
-                        "call_transform produces a function application "
-                        "without the whitespace Dhall requires before '(' "
-                        f"(in: {call_expr!r})"
+                        "Dhall has no tuple type; PositionalCallStyle cannot "
+                        "represent calls with more than one argument"
                     ),
                 )
-            depths["paren"] += 1
-        elif c in _DHALL_BRACKET_DELTA:
-            key, delta = _DHALL_BRACKET_DELTA[c]
-            depths[key] += delta
-        elif (
-            c == ","
-            and depths["paren"] >= 1
-            and depths["brace"] == 0
-            and depths["bracket"] == 0
-        ):
-            raise CallArgNotSupportedError(
-                language_name="Dhall",
-                reason=(
-                    "Dhall has no tuple type; PositionalCallStyle cannot "
-                    "represent calls with more than one argument"
-                ),
-            )
-        else:
-            next_prev_is_word = c.isalnum() or c == "_"
+            case _ if c in _DHALL_BRACKET_DELTA:
+                key, delta = _DHALL_BRACKET_DELTA[c]
+                depths[key] += delta
+            case _:
+                next_prev_is_word = c.isalnum() or c == "_"
         prev_is_word = next_prev_is_word
 
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -134,15 +134,22 @@ def _fortran_comment_pos(line: str) -> int | None:
     i = 0
     while i < len(line):
         c = line[i]
-        if c == "'" and not in_double_quote:
-            if in_single_quote and i + 1 < len(line) and line[i + 1] == "'":
-                i += 2
-                continue
-            in_single_quote = not in_single_quote
-        elif c == '"' and not in_single_quote:
-            in_double_quote = not in_double_quote
-        elif c == "!" and not in_single_quote and not in_double_quote:
-            return i
+        match c:
+            case "'" if not in_double_quote:
+                if (
+                    in_single_quote
+                    and i + 1 < len(line)
+                    and line[i + 1] == "'"
+                ):
+                    i += 2
+                    continue
+                in_single_quote = not in_single_quote
+            case '"' if not in_single_quote:
+                in_double_quote = not in_double_quote
+            case "!" if not in_single_quote and not in_double_quote:
+                return i
+            case _:
+                pass
         i += 1
     return None
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -98,17 +98,23 @@ def _advance_scan_state(*, line: str, state: _HclScanState) -> None:
             state.escaped = False
             continue
         if state.in_string:
-            if char == "\\":
-                state.escaped = True
-            elif char == '"':
-                state.in_string = False
+            match char:
+                case "\\":
+                    state.escaped = True
+                case '"':
+                    state.in_string = False
+                case _:
+                    pass
             continue
-        if char == '"':
-            state.in_string = True
-        elif char in "[{(":
-            state.depth += 1
-        elif char in "]})":
-            state.depth -= 1
+        match char:
+            case '"':
+                state.in_string = True
+            case "[" | "{" | "(":
+                state.depth += 1
+            case "]" | "}" | ")":
+                state.depth -= 1
+            case _:
+                pass
 
 
 @beartype

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -84,6 +84,20 @@ class _HclScanState:
 
 
 @beartype
+def _advance_outside_string(*, char: str, state: _HclScanState) -> None:
+    """Update *state* for a character that is not inside a string."""
+    match char:
+        case '"':
+            state.in_string = True
+        case "[" | "{" | "(":
+            state.depth += 1
+        case "]" | "}" | ")":
+            state.depth -= 1
+        case _:
+            pass
+
+
+@beartype
 def _advance_scan_state(*, line: str, state: _HclScanState) -> None:
     r"""Update *state* by scanning brackets and strings in *line*.
 
@@ -106,15 +120,7 @@ def _advance_scan_state(*, line: str, state: _HclScanState) -> None:
                 case _:
                     pass
             continue
-        match char:
-            case '"':
-                state.in_string = True
-            case "[" | "{" | "(":
-                state.depth += 1
-            case "]" | "}" | ")":
-                state.depth -= 1
-            case _:
-                pass
+        _advance_outside_string(char=char, state=state)
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Convert `if/elif` character-dispatch chains to `match` statements in three language scanners: HCL's bracket/string tracker, Fortran's comment-position finder, and Dhall's call-expression validator.
- Match-with-guards reads more clearly than predicate chains here, and the patterns make the dispatched values explicit.

## Test plan
- [x] `pytest tests/ -k "hcl or fortran or dhall"` (142 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of character-scanning logic in Dhall/Fortran/HCL helpers with no intended behavioral changes; risk is limited to subtle edge-case regressions in parsing/scanning.
> 
> **Overview**
> Refactors three small character-dispatch scanners to use Python `match` (with guards) instead of `if/elif`, improving readability while preserving existing behavior.
> 
> In HCL, extracts non-string scan handling into a new `_advance_outside_string()` helper and updates `_advance_scan_state()` accordingly; Fortran’s `_fortran_comment_pos()` and Dhall’s `_dhall_validate_call_stmt()` are similarly rewritten with `match` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a797536dba7b400c2c594b76550fbb270d57694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->