### PR TITLE
Re-expose supports_* flags for runtime constructor option dispatch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer._language.LanguageCls` now exposes
+  ``supports_empty_dict_key``, ``supports_call_style``,
+  ``supports_default_dict_key_type``, ``supports_default_dict_value_type``,
+  ``supports_default_sequence_element_type``,
+  ``supports_default_set_element_type``, and
+  ``supports_default_ordered_map_value_type`` flags alongside the existing
+  ``supports_module_name``.  Runtime-dispatched callers that look up a
+  language by name can use these to decide whether to pass the matching
+  constructor keyword argument without inspecting dataclass fields or the
+  ``__init__`` signature.
+
 2026.05.13
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -485,6 +485,13 @@ ignore_names = [
     "ZONED",
     # Used by downstream consumers
     "supports_module_name",
+    "supports_empty_dict_key",
+    "supports_call_style",
+    "supports_default_dict_key_type",
+    "supports_default_dict_value_type",
+    "supports_default_sequence_element_type",
+    "supports_default_set_element_type",
+    "supports_default_ordered_map_value_type",
     # Used in documentation code examples
     "custom",
     "result",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -606,6 +606,13 @@ class LanguageCls(type):
     supports_inline_multiline_dict_args: bool
     supports_standalone_comments_in_wrapped_calls: bool
     supports_module_name: bool
+    supports_empty_dict_key: bool
+    supports_call_style: bool
+    supports_default_dict_key_type: bool
+    supports_default_dict_value_type: bool
+    supports_default_sequence_element_type: bool
+    supports_default_set_element_type: bool
+    supports_default_ordered_map_value_type: bool
     dict_supports_heterogeneous_values: bool
     format_call_arg: FormatCallArg
     validate_call_arg: Callable[[Value], None]

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -227,6 +227,13 @@ class Ada(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -202,6 +202,13 @@ class Bash(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -232,6 +232,13 @@ class C(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for C."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -117,6 +117,13 @@ class Clojure(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -343,6 +343,13 @@ class Cobol(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = False
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -126,6 +126,13 @@ class CommonLisp(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -905,6 +905,13 @@ class Cpp(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -187,6 +187,13 @@ class Crystal(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -369,6 +369,13 @@ class CSharp(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = True
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -173,6 +173,13 @@ class D(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -295,6 +295,13 @@ class Dart(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -532,6 +532,13 @@ class Dhall(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Dhall."""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -215,6 +215,13 @@ class Elixir(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -513,6 +513,13 @@ class Elm(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Elm."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -208,6 +208,13 @@ class Erlang(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -211,6 +211,13 @@ class Forth(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = False
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -333,6 +333,13 @@ class Fortran(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -331,6 +331,13 @@ class FSharp(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for FSharp."""

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -535,6 +535,13 @@ class Gleam(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -273,6 +273,13 @@ class Go(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = True
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -153,6 +153,13 @@ class Groovy(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1011,6 +1011,13 @@ class Haskell(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Haskell."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -153,6 +153,13 @@ class Hcl(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -601,6 +601,13 @@ class Java(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -137,6 +137,13 @@ class JavaScript(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -129,6 +129,13 @@ class Json5(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = False
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -147,6 +147,13 @@ class Jsonnet(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -165,6 +165,13 @@ class Julia(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -441,6 +441,13 @@ class Kotlin(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -151,6 +151,13 @@ class Lua(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -218,6 +218,13 @@ class Matlab(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -894,6 +894,13 @@ class Mojo(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = True
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -547,6 +547,13 @@ class Nim(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -197,6 +197,13 @@ class Nix(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = False
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -101,6 +101,13 @@ class Norg(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = False
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -287,6 +287,13 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -304,6 +304,13 @@ class OCaml(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -144,6 +144,13 @@ class Occam(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -223,6 +223,13 @@ class Odin(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -161,6 +161,13 @@ class Perl(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -160,6 +160,13 @@ class Php(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -176,6 +176,13 @@ class PowerShell(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -672,6 +672,13 @@ class PureScript(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for PureScript."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -554,6 +554,13 @@ class Python(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = True
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -175,6 +175,13 @@ class R(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = True
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -118,6 +118,13 @@ class Racket(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -194,6 +194,13 @@ class Raku(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -521,6 +521,13 @@ class Roc(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = False
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
     supports_special_floats = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -197,6 +197,13 @@ class Ruby(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -703,6 +703,13 @@ class Rust(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = True
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -237,6 +237,13 @@ class Scala(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -114,6 +114,13 @@ class Scheme(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -362,6 +362,13 @@ class Sml(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -367,6 +367,13 @@ class Swift(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = True
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -246,6 +246,13 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -159,6 +159,13 @@ class Tcl(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -129,6 +129,13 @@ class Toml(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = False
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -274,6 +274,13 @@ class TypeScript(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -388,6 +388,13 @@ class V(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -278,6 +278,13 @@ class VisualBasic(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = True
+    supports_default_dict_value_type = True
+    supports_default_sequence_element_type = True
+    supports_default_set_element_type = True
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -177,6 +177,13 @@ class Wren(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -103,6 +103,13 @@ class Yaml(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = False
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -245,6 +245,13 @@ class Zig(metaclass=LanguageCls):
     supports_inline_multiline_dict_args = True
     supports_standalone_comments_in_wrapped_calls = True
     supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""


### PR DESCRIPTION
## Summary
- Adds seven ``ClassVar[bool]`` flags to ``LanguageCls`` (``supports_empty_dict_key``, ``supports_call_style``, ``supports_default_dict_key_type``, ``supports_default_dict_value_type``, ``supports_default_sequence_element_type``, ``supports_default_set_element_type``, ``supports_default_ordered_map_value_type``) mirroring the existing ``supports_module_name``.
- Sets each flag on all 63 language classes to match the constructor kwargs each accepts, so runtime-dispatched callers can probe support without reading ``__dataclass_fields__`` or ``inspect.signature``.
- Updates the vulture allowlist and adds a CHANGELOG entry.

Closes #2147

## Test plan
- [x] ``pytest tests/integration/test_language_metadata.py`` (271 passed)
- [x] Pre-commit hooks (mypy, pyright, ty, pyrefly, ruff, vulture, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to broad cross-language metadata changes and a public API surface expansion, though behavior is limited to capability introspection flags.
> 
> **Overview**
> Exposes additional `supports_*` capability flags on `LanguageCls` (beyond `supports_module_name`) so callers can decide at runtime which constructor keyword arguments are safe to pass.
> 
> Sets these flags on every built-in language class to match the kwargs each language supports, and updates vulture’s allowlist plus the `CHANGELOG` to document the new introspection surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51043854bb6c83ca865f31a215943a8c4d4d7d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->