### PR TITLE
Use supports_* flags in _check_default_type_tables expected-set check

### DIFF
--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -142,21 +142,42 @@ def _check_default_type_tables() -> None:
     value must differ from that field's own default; either kind of
     drift would silently break variant coverage.
     """
-    tables: tuple[tuple[str, dict[literalizer.LanguageCls, str]], ...] = (
-        ("default_set_element_type", DEFAULT_SET_ELEMENT_TYPES),
-        ("default_sequence_element_type", DEFAULT_SEQUENCE_ELEMENT_TYPES),
-        ("default_dict_value_type", DEFAULT_DICT_VALUE_TYPES),
-        ("default_dict_key_type", DEFAULT_DICT_KEY_TYPES),
-        ("default_ordered_map_value_type", DEFAULT_ORDERED_MAP_VALUE_TYPES),
+    tables: tuple[
+        tuple[
+            str,
+            dict[literalizer.LanguageCls, str],
+            Callable[[literalizer.LanguageCls], bool],
+        ],
+        ...,
+    ] = (
+        (
+            "default_set_element_type",
+            DEFAULT_SET_ELEMENT_TYPES,
+            lambda cls: cls.supports_default_set_element_type,
+        ),
+        (
+            "default_sequence_element_type",
+            DEFAULT_SEQUENCE_ELEMENT_TYPES,
+            lambda cls: cls.supports_default_sequence_element_type,
+        ),
+        (
+            "default_dict_value_type",
+            DEFAULT_DICT_VALUE_TYPES,
+            lambda cls: cls.supports_default_dict_value_type,
+        ),
+        (
+            "default_dict_key_type",
+            DEFAULT_DICT_KEY_TYPES,
+            lambda cls: cls.supports_default_dict_key_type,
+        ),
+        (
+            "default_ordered_map_value_type",
+            DEFAULT_ORDERED_MAP_VALUE_TYPES,
+            lambda cls: cls.supports_default_ordered_map_value_type,
+        ),
     )
-    for field_name, table in tables:
-        expected: set[literalizer.LanguageCls] = set()
-        for cls in ALL_LANGUAGES:
-            cls_fields: dict[str, object] = getattr(
-                cls, "__dataclass_fields__", {}
-            )
-            if field_name in cls_fields:
-                expected.add(cls)
+    for field_name, table, supports in tables:
+        expected = {cls for cls in ALL_LANGUAGES if supports(cls)}
         assert set(table.keys()) == expected, field_name  # noqa: S101
         for lang_cls, override in table.items():
             fields_attr: dict[str, dataclasses.Field[object]] = getattr(


### PR DESCRIPTION
## Summary
- Replace `__dataclass_fields__` introspection in `_check_default_type_tables` with the public `supports_*` ClassVar flags re-exposed in #2148, pairing each `DEFAULT_*_TYPES` table with a typed lambda accessor for its supports flag.
- The default-value comparison still uses `__dataclass_fields__` since the `supports_*` flags don't expose default values and the base `LanguageCls` doesn't statically advertise dataclass-ness.

## Test plan
- [ ] CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that swaps internal dataclass-field introspection for public `supports_*` capability flags when validating integration-test override tables.
> 
> **Overview**
> Updates `_check_default_type_tables` in `tests/integration/variant_cases.py` to determine the expected set of languages for each `DEFAULT_*_TYPES` override table using per-language `supports_default_*` flags (via a per-table predicate) instead of `__dataclass_fields__` introspection.
> 
> Keeps the import-time assertion that each override value differs from the underlying field default, but scopes the membership check to the explicit capability flags for better drift detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a9c6b390ce262eecc49c0f0481a6e018a30dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->