### PR TITLE
Drop final getattr from _check_default_type_tables; ban getattr/hasattr/setattr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,9 @@ lint.per-file-ignores."tests/test_*.py" = [
 # We comment out code during development, and with VSCode auto-save, this code
 # is sometimes annoyingly removed.
 lint.unfixable = [ "ERA001" ]
+lint.flake8-tidy-imports.banned-api."builtins.getattr".msg = "getattr is banned: declare a typed protocol and use isinstance narrowing, or access the attribute directly."
+lint.flake8-tidy-imports.banned-api."builtins.hasattr".msg = "hasattr is banned: declare a typed protocol and use isinstance narrowing instead."
+lint.flake8-tidy-imports.banned-api."builtins.setattr".msg = "setattr is banned: assign through a typed attribute or constructor instead."
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -134,6 +134,99 @@ DEFAULT_ORDERED_MAP_VALUE_TYPES: dict[literalizer.LanguageCls, str] = {
 }
 
 
+@runtime_checkable
+class _HasDefaultSetElementType(Protocol):
+    """Structural type for languages with a ``default_set_element_type``
+    field.
+    """
+
+    default_set_element_type: str
+
+
+@runtime_checkable
+class _HasDefaultSequenceElementType(Protocol):
+    """Structural type for languages with a
+    ``default_sequence_element_type`` field.
+    """
+
+    default_sequence_element_type: str
+
+
+@runtime_checkable
+class _HasDefaultDictValueType(Protocol):
+    """Structural type for languages with a ``default_dict_value_type``
+    field.
+    """
+
+    default_dict_value_type: str
+
+
+@runtime_checkable
+class _HasDefaultDictKeyType(Protocol):
+    """Structural type for languages with a ``default_dict_key_type``
+    field.
+    """
+
+    default_dict_key_type: str
+
+
+@runtime_checkable
+class _HasDefaultOrderedMapValueType(Protocol):
+    """Structural type for languages with a
+    ``default_ordered_map_value_type`` field.
+    """
+
+    default_ordered_map_value_type: str
+
+
+def _read_default_set_element_type(spec: literalizer.Language) -> str:
+    """Read ``default_set_element_type`` from a default-constructed
+    spec.
+    """
+    assert isinstance(spec, _HasDefaultSetElementType)  # noqa: S101
+    return spec.default_set_element_type
+
+
+def _read_default_sequence_element_type(spec: literalizer.Language) -> str:
+    """Read ``default_sequence_element_type`` from a default-constructed
+    spec.
+    """
+    assert isinstance(spec, _HasDefaultSequenceElementType)  # noqa: S101
+    return spec.default_sequence_element_type
+
+
+def _read_default_dict_value_type(spec: literalizer.Language) -> str:
+    """Read ``default_dict_value_type`` from a default-constructed
+    spec.
+    """
+    assert isinstance(spec, _HasDefaultDictValueType)  # noqa: S101
+    return spec.default_dict_value_type
+
+
+def _read_default_dict_key_type(spec: literalizer.Language) -> str:
+    """Read ``default_dict_key_type`` from a default-constructed spec."""
+    assert isinstance(spec, _HasDefaultDictKeyType)  # noqa: S101
+    return spec.default_dict_key_type
+
+
+def _read_default_ordered_map_value_type(spec: literalizer.Language) -> str:
+    """Read ``default_ordered_map_value_type`` from a default-constructed
+    spec.
+    """
+    assert isinstance(spec, _HasDefaultOrderedMapValueType)  # noqa: S101
+    return spec.default_ordered_map_value_type
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class _DefaultTypeTable:
+    """Validation entry for one ``DEFAULT_*_TYPES`` override table."""
+
+    field_name: str
+    table: dict[literalizer.LanguageCls, str]
+    supports: Callable[[literalizer.LanguageCls], bool]
+    read_default: Callable[[literalizer.Language], str]
+
+
 def _check_default_type_tables() -> None:
     """Validate the ``DEFAULT_*_TYPES`` tables at import time.
 
@@ -142,49 +235,45 @@ def _check_default_type_tables() -> None:
     value must differ from that field's own default; either kind of
     drift would silently break variant coverage.
     """
-    tables: tuple[
-        tuple[
-            str,
-            dict[literalizer.LanguageCls, str],
-            Callable[[literalizer.LanguageCls], bool],
-        ],
-        ...,
-    ] = (
-        (
-            "default_set_element_type",
-            DEFAULT_SET_ELEMENT_TYPES,
-            lambda cls: cls.supports_default_set_element_type,
+    tables: tuple[_DefaultTypeTable, ...] = (
+        _DefaultTypeTable(
+            field_name="default_set_element_type",
+            table=DEFAULT_SET_ELEMENT_TYPES,
+            supports=lambda cls: cls.supports_default_set_element_type,
+            read_default=_read_default_set_element_type,
         ),
-        (
-            "default_sequence_element_type",
-            DEFAULT_SEQUENCE_ELEMENT_TYPES,
-            lambda cls: cls.supports_default_sequence_element_type,
+        _DefaultTypeTable(
+            field_name="default_sequence_element_type",
+            table=DEFAULT_SEQUENCE_ELEMENT_TYPES,
+            supports=lambda cls: cls.supports_default_sequence_element_type,
+            read_default=_read_default_sequence_element_type,
         ),
-        (
-            "default_dict_value_type",
-            DEFAULT_DICT_VALUE_TYPES,
-            lambda cls: cls.supports_default_dict_value_type,
+        _DefaultTypeTable(
+            field_name="default_dict_value_type",
+            table=DEFAULT_DICT_VALUE_TYPES,
+            supports=lambda cls: cls.supports_default_dict_value_type,
+            read_default=_read_default_dict_value_type,
         ),
-        (
-            "default_dict_key_type",
-            DEFAULT_DICT_KEY_TYPES,
-            lambda cls: cls.supports_default_dict_key_type,
+        _DefaultTypeTable(
+            field_name="default_dict_key_type",
+            table=DEFAULT_DICT_KEY_TYPES,
+            supports=lambda cls: cls.supports_default_dict_key_type,
+            read_default=_read_default_dict_key_type,
         ),
-        (
-            "default_ordered_map_value_type",
-            DEFAULT_ORDERED_MAP_VALUE_TYPES,
-            lambda cls: cls.supports_default_ordered_map_value_type,
+        _DefaultTypeTable(
+            field_name="default_ordered_map_value_type",
+            table=DEFAULT_ORDERED_MAP_VALUE_TYPES,
+            supports=lambda cls: cls.supports_default_ordered_map_value_type,
+            read_default=_read_default_ordered_map_value_type,
         ),
     )
-    for field_name, table, supports in tables:
-        expected = {cls for cls in ALL_LANGUAGES if supports(cls)}
-        assert set(table.keys()) == expected, field_name  # noqa: S101
-        for lang_cls, override in table.items():
-            fields_attr: dict[str, dataclasses.Field[object]] = getattr(
-                lang_cls, "__dataclass_fields__", {}
-            )
-            assert override != fields_attr[field_name].default, (  # noqa: S101
-                f"{lang_cls.__name__}.{field_name}={override!r}"
+    for entry in tables:
+        expected = {cls for cls in ALL_LANGUAGES if entry.supports(cls)}
+        assert set(entry.table.keys()) == expected, entry.field_name  # noqa: S101
+        for lang_cls, override in entry.table.items():
+            default = entry.read_default(make_spec(lang_cls=lang_cls))
+            assert override != default, (  # noqa: S101
+                f"{lang_cls.__name__}.{entry.field_name}={override!r}"
             )
 
 


### PR DESCRIPTION
## Summary
- Replace `getattr(lang_cls, "__dataclass_fields__", {})` in `tests/integration/variant_cases.py:_check_default_type_tables` with typed `Protocol` narrowing: each `default_*_type` field has a `_HasDefault*` runtime-checkable protocol and a `_read_default_*` helper, and the per-row `_DefaultTypeTable` dataclass carries the typed accessor; the default value now comes from `make_spec(lang_cls=lang_cls)` rather than from dataclass field introspection.
- Add `builtins.getattr`, `builtins.hasattr`, and `builtins.setattr` to `lint.flake8-tidy-imports.banned-api` alongside the existing `typing.cast` ban so future stringly-typed introspection is caught at lint time.

Closes #2151.

## Test plan
- [ ] `uv run ruff check .` (only pre-existing fixture-file errors remain)
- [ ] `uv run --extra dev python -c "from tests.integration import variant_cases"` exercises `_check_default_type_tables()` at import time
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new Ruff banned-API rules that may break lint/CI for any existing or future uses of `getattr`/`hasattr`/`setattr`, and refactors import-time test validation logic that could cause false failures if the protocol narrowing assumptions drift.
> 
> **Overview**
> Refactors `tests/integration/variant_cases.py` default-type override validation to stop introspecting `__dataclass_fields__` via `getattr`; it now builds default specs via `make_spec()` and uses runtime-checkable `Protocol` narrowing plus per-field accessor helpers stored in a new `_DefaultTypeTable` row object.
> 
> Updates Ruff configuration to **ban** `builtins.getattr`, `builtins.hasattr`, and `builtins.setattr` (alongside the existing `typing.cast` ban) to discourage stringly-typed introspection and mutation across the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2141ef387d471f141182155f2fb1039b64b95af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->