### PR TITLE
Test TOML comment handling through the public literalize API

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -314,7 +314,7 @@ def extract_yaml_comments(
 @beartype
 def extract_toml_comments(
     *,
-    toml_doc: object,
+    toml_doc: TOMLDocument,
 ) -> CollectionComments:
     """Extract top-level comments from a parsed tomlkit document.
 
@@ -322,9 +322,6 @@ def extract_toml_comments(
     nodes as "before" comments for the next keyed item, and inline
     ``trivia.comment`` values as inline comments.
     """
-    if not isinstance(toml_doc, TOMLDocument):
-        return CollectionComments(elements=(), trailing=())
-
     pending_before: list[str] = []
     elements: list[ElementComments] = []
 

--- a/src/literalizer/_comments_resolve.py
+++ b/src/literalizer/_comments_resolve.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from beartype import beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
+from tomlkit.toml_document import TOMLDocument
 
 from literalizer._comments import (
     CollectionComments,
@@ -213,7 +214,7 @@ def resolve_yaml_comments(
 @beartype
 def resolve_toml_comments(
     *,
-    toml_doc: object,
+    toml_doc: TOMLDocument,
     base: str,
     language: Language,
     comment_prefix: str,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -9,6 +9,7 @@ from typing import Final, assert_never
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 from ruamel.yaml.compat import ordereddict
+from tomlkit.toml_document import TOMLDocument
 
 from literalizer._checks import check_data
 from literalizer._comments import (
@@ -1759,6 +1760,8 @@ def _literalize_pre_form(
             result = resolved.result
         case InputFormat.TOML:
             comment_cfg = language.comment_config
+            if not isinstance(parsed.raw_data, TOMLDocument):
+                raise NotImplementedError
             resolved = resolve_toml_comments(
                 toml_doc=parsed.raw_data,
                 base=result,

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -40,7 +40,13 @@ from literalizer._language import (
     PrefixCallStyle,
     StubReturn,
 )
-from literalizer._parsing import InputFormat, parse_input
+from literalizer._parsing import (
+    InputFormat,
+    ParsedInput,
+    ParsedToml,
+    ParsedYaml,
+    parse_input,
+)
 from literalizer._preamble import (
     compute_preamble,
     deduplicate_preamble_entries,
@@ -1740,8 +1746,8 @@ def _literalize_pre_form(
     )
 
     resolved: ResolvedComments | None = None
-    match input_format:
-        case InputFormat.YAML if parsed.yaml_needs_comment_resolve:
+    match parsed:
+        case ParsedYaml() if parsed.needs_comment_resolve:
             comment_cfg = language.comment_config
             cp = comment_cfg.prefix
             cs = comment_cfg.suffix
@@ -1757,10 +1763,8 @@ def _literalize_pre_form(
                 include_delimiters=include_delimiters,
             )
             result = resolved.result
-        case InputFormat.TOML:
+        case ParsedToml():
             comment_cfg = language.comment_config
-            if parsed.toml_doc is None:
-                raise NotImplementedError
             resolved = resolve_toml_comments(
                 toml_doc=parsed.toml_doc,
                 base=result,
@@ -2896,7 +2900,7 @@ def _value_is_multikey_non_ref_dict(*, value: Value, ref_key: str) -> bool:
 
 
 @beartype
-def _yaml_has_standalone_comments(*, raw_data: object) -> bool:
+def _yaml_has_standalone_comments(*, parsed: ParsedInput) -> bool:
     """Return ``True`` when the YAML source carries standalone comments.
 
     Standalone comments are comments that appear on their own line —
@@ -2906,9 +2910,13 @@ def _yaml_has_standalone_comments(*, raw_data: object) -> bool:
     scalar; ``ruamel.yaml`` only attaches collection-comment metadata
     to :class:`CommentedSeq` / :class:`CommentedMap` / :class:`CommentedSet`.
     """
-    if not isinstance(raw_data, CommentedSeq | CommentedMap | CommentedSet):
+    if not isinstance(parsed, ParsedYaml):
         return False
-    collection_comments = extract_yaml_comments(ruamel_data=raw_data)
+    if not isinstance(
+        parsed.raw_data, CommentedSeq | CommentedMap | CommentedSet
+    ):
+        return False
+    collection_comments = extract_yaml_comments(ruamel_data=parsed.raw_data)
     if collection_comments.trailing:
         return True
     return any(element.before for element in collection_comments.elements)
@@ -3145,9 +3153,7 @@ def literalize_call(
     """
     parsed = parse_input(source=source, input_format=input_format)
     data = parsed.data
-    contains_standalone_comments = _yaml_has_standalone_comments(
-        raw_data=parsed.raw_data,
-    )
+    contains_standalone_comments = _yaml_has_standalone_comments(parsed=parsed)
     match language.call_style_config:
         case CallSupport.NOT_IN_LANGUAGE:
             raise CallsNotSupportedByLanguageError(
@@ -3201,8 +3207,8 @@ def literalize_call(
     if per_element_data is not None:
         collection_comments: CollectionComments | None = None
         if (
-            input_format is InputFormat.YAML
-            and parsed.yaml_needs_comment_resolve
+            isinstance(parsed, ParsedYaml)
+            and parsed.needs_comment_resolve
             and isinstance(parsed.raw_data, CommentedSeq)
         ):
             collection_comments = extract_yaml_comments(

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -9,7 +9,6 @@ from typing import Final, assert_never
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 from ruamel.yaml.compat import ordereddict
-from tomlkit.toml_document import TOMLDocument
 
 from literalizer._checks import check_data
 from literalizer._comments import (
@@ -1760,10 +1759,10 @@ def _literalize_pre_form(
             result = resolved.result
         case InputFormat.TOML:
             comment_cfg = language.comment_config
-            if not isinstance(parsed.raw_data, TOMLDocument):
+            if parsed.toml_doc is None:
                 raise NotImplementedError
             resolved = resolve_toml_comments(
-                toml_doc=parsed.raw_data,
+                toml_doc=parsed.toml_doc,
                 base=result,
                 language=language,
                 comment_prefix=comment_cfg.prefix,

--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -18,6 +18,7 @@ from ruamel.yaml.comments import (
 from ruamel.yaml.compat import ordereddict
 from ruamel.yaml.error import YAMLError
 from tomlkit.exceptions import TOMLKitError
+from tomlkit.toml_document import TOMLDocument
 
 from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
@@ -59,6 +60,8 @@ class _ParsedInput:
     no round-trip metadata and must not be passed to
     ``resolve_yaml_comments``.
     """
+    toml_doc: TOMLDocument | None
+    """The parsed tomlkit document, or ``None`` for non-TOML inputs."""
 
 
 @beartype
@@ -177,6 +180,7 @@ def _parse_json(*, source: str) -> _ParsedInput:
         data=data,
         raw_data=data,
         yaml_needs_comment_resolve=False,
+        toml_doc=None,
     )
 
 
@@ -192,6 +196,7 @@ def _parse_json5(*, source: str) -> _ParsedInput:
         data=data,
         raw_data=data,
         yaml_needs_comment_resolve=False,
+        toml_doc=None,
     )
 
 
@@ -271,6 +276,7 @@ def _parse_yaml(*, source: str) -> _ParsedInput:
             data=data,
             raw_data=raw_data,
             yaml_needs_comment_resolve=True,
+            toml_doc=None,
         )
 
     safe_yaml = _get_safe_yaml()
@@ -284,6 +290,7 @@ def _parse_yaml(*, source: str) -> _ParsedInput:
         data=data,
         raw_data=plain_data,
         yaml_needs_comment_resolve=False,
+        toml_doc=None,
     )
 
 
@@ -301,6 +308,7 @@ def _parse_toml(*, source: str) -> _ParsedInput:
         data=toml_data,
         raw_data=toml_doc,
         yaml_needs_comment_resolve=False,
+        toml_doc=toml_doc,
     )
 
 

--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -47,21 +47,36 @@ class InputFormat(enum.Enum):
 
 
 @dataclasses.dataclass(frozen=True)
-class _ParsedInput:
-    """Result of parsing an input string."""
+class ParsedPlain:
+    """Result of parsing a comment-free input (JSON or JSON5)."""
+
+    data: Value
+
+
+@dataclasses.dataclass(frozen=True)
+class ParsedYaml:
+    """Result of parsing a YAML input string."""
 
     data: Value
     raw_data: object
-    yaml_needs_comment_resolve: bool
+    needs_comment_resolve: bool
     """Whether the YAML comment-resolution phase must run.
 
-    False for non-YAML inputs and for the YAML fast path (no comment
-    or tag markers in the source).  When False, ``raw_data`` carries
-    no round-trip metadata and must not be passed to
-    ``resolve_yaml_comments``.
+    False for the YAML fast path (no comment or tag markers in the
+    source).  When False, ``raw_data`` carries no round-trip metadata
+    and must not be passed to ``resolve_yaml_comments``.
     """
-    toml_doc: TOMLDocument | None
-    """The parsed tomlkit document, or ``None`` for non-TOML inputs."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ParsedToml:
+    """Result of parsing a TOML input string."""
+
+    data: Value
+    toml_doc: TOMLDocument
+
+
+ParsedInput = ParsedPlain | ParsedYaml | ParsedToml
 
 
 @beartype
@@ -167,8 +182,8 @@ def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:
 
 
 @beartype
-def _parse_json(*, source: str) -> _ParsedInput:
-    """Parse a JSON string into a ``_ParsedInput``."""
+def _parse_json(*, source: str) -> ParsedInput:
+    """Parse a JSON string into a ``ParsedInput``."""
     try:
         data = json.loads(s=source)
     except json.JSONDecodeError as exc:
@@ -176,28 +191,18 @@ def _parse_json(*, source: str) -> _ParsedInput:
             f"Invalid JSON: {exc.msg} at line {exc.lineno} column {exc.colno}"
         )
         raise JSONParseError(message) from exc
-    return _ParsedInput(
-        data=data,
-        raw_data=data,
-        yaml_needs_comment_resolve=False,
-        toml_doc=None,
-    )
+    return ParsedPlain(data=data)
 
 
 @beartype
-def _parse_json5(*, source: str) -> _ParsedInput:
-    """Parse a JSON5 string into a ``_ParsedInput``."""
+def _parse_json5(*, source: str) -> ParsedInput:
+    """Parse a JSON5 string into a ``ParsedInput``."""
     try:
         data = pyjson5.decode(data=source)  # pylint: disable=no-member
     except pyjson5.Json5DecoderException as exc:  # pylint: disable=no-member
         message = f"Invalid JSON5: {exc}"
         raise JSON5ParseError(message) from exc
-    return _ParsedInput(
-        data=data,
-        raw_data=data,
-        yaml_needs_comment_resolve=False,
-        toml_doc=None,
-    )
+    return ParsedPlain(data=data)
 
 
 @functools.cache
@@ -253,8 +258,8 @@ def _yaml_needs_roundtrip(*, source: str) -> bool:
 
 
 @beartype
-def _parse_yaml(*, source: str) -> _ParsedInput:
-    """Parse a YAML string into a ``_ParsedInput``.
+def _parse_yaml(*, source: str) -> ParsedInput:
+    """Parse a YAML string into a ``ParsedInput``.
 
     When the source contains no comments or other round-trip-only
     constructs, uses a C-backed safe loader and marks the result with
@@ -272,11 +277,10 @@ def _parse_yaml(*, source: str) -> _ParsedInput:
             message = f"Invalid YAML: {exc}"
             raise YAMLParseError(message) from exc
         data = _coerce_yaml_keys(data=raw_data)
-        return _ParsedInput(
+        return ParsedYaml(
             data=data,
             raw_data=raw_data,
-            yaml_needs_comment_resolve=True,
-            toml_doc=None,
+            needs_comment_resolve=True,
         )
 
     safe_yaml = _get_safe_yaml()
@@ -286,17 +290,16 @@ def _parse_yaml(*, source: str) -> _ParsedInput:
         message = f"Invalid YAML: {exc}"
         raise YAMLParseError(message) from exc
     data = _coerce_yaml_keys(data=plain_data)
-    return _ParsedInput(
+    return ParsedYaml(
         data=data,
         raw_data=plain_data,
-        yaml_needs_comment_resolve=False,
-        toml_doc=None,
+        needs_comment_resolve=False,
     )
 
 
 @beartype
-def _parse_toml(*, source: str) -> _ParsedInput:
-    """Parse a TOML string into a ``_ParsedInput``."""
+def _parse_toml(*, source: str) -> ParsedInput:
+    """Parse a TOML string into a ``ParsedInput``."""
     try:
         toml_doc = tomlkit.parse(string=source)
     except TOMLKitError as exc:
@@ -304,16 +307,11 @@ def _parse_toml(*, source: str) -> _ParsedInput:
         raise TOMLParseError(message) from exc
     unwrapped: _TomlData = toml_doc.unwrap()
     toml_data = _coerce_toml_values(data=unwrapped)
-    return _ParsedInput(
-        data=toml_data,
-        raw_data=toml_doc,
-        yaml_needs_comment_resolve=False,
-        toml_doc=toml_doc,
-    )
+    return ParsedToml(data=toml_data, toml_doc=toml_doc)
 
 
 @beartype
-def parse_input(*, source: str, input_format: InputFormat) -> _ParsedInput:
+def parse_input(*, source: str, input_format: InputFormat) -> ParsedInput:
     """Parse and coerce an input string according to its format."""
     match input_format:
         case InputFormat.JSON:

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -51,7 +51,9 @@ def test_invalid_toml_is_parse_error() -> None:
 
 
 def test_toml_comments_propagate() -> None:
-    """Standalone and inline TOML comments survive literalization."""
+    """Standalone and inline TOML comments survive in the rendered
+    output.
+    """
     result = literalize(
         source="# before\n\nanswer = 42 # inline\nplain = 'ok'\n# trailing\n",
         input_format=InputFormat.TOML,

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -3,13 +3,11 @@
 import datetime
 
 import pytest
-import tomlkit
 
 from literalizer import (
     InputFormat,
     literalize,
 )
-from literalizer._comments import extract_toml_comments
 from literalizer.exceptions import (
     ParseError,
     TOMLParseError,
@@ -52,38 +50,32 @@ def test_invalid_toml_is_parse_error() -> None:
         )
 
 
-def test_extract_toml_comments_non_document() -> None:
-    """``extract_toml_comments`` returns empty for non-document input."""
-    result = extract_toml_comments(toml_doc={"not": "a document"})
-    assert not result.elements
-    assert not result.trailing
-
-
-def test_extract_toml_comments_from_document() -> None:
-    """``extract_toml_comments`` keeps standalone and inline comments."""
-    toml_doc = tomlkit.parse(
-        string="# before\n\nanswer = 42 # inline\nplain = 'ok'\n# trailing\n",
+def test_toml_comments_propagate() -> None:
+    """Standalone and inline TOML comments survive literalization."""
+    result = literalize(
+        source="# before\n\nanswer = 42 # inline\nplain = 'ok'\n# trailing\n",
+        input_format=InputFormat.TOML,
+        language=PYTHON,
+        pre_indent_level=0,
+        include_delimiters=False,
     )
-    result = extract_toml_comments(toml_doc=toml_doc)
-    first, second = result.elements
 
-    assert first.before == ("before",)
-    assert first.inline == "inline"
-    assert second.before == ()
-    assert second.inline == ""
-    assert result.trailing == ("trailing",)
-
-
-def test_extract_toml_comments_includes_table_entries() -> None:
-    """TOML tables are included without inline comment metadata."""
-    toml_doc = tomlkit.parse(
-        string="[section]\nvalue = 1\n",
+    assert result.code == (
+        '# before\n"answer": 42,  # inline\n"plain": "ok",\n# trailing'
     )
-    result = extract_toml_comments(toml_doc=toml_doc)
 
-    assert len(result.elements) == 1
-    assert result.elements[0].before == ()
-    assert result.elements[0].inline == ""
+
+def test_toml_table_entries_literalize() -> None:
+    """TOML tables become dict entries in the rendered output."""
+    result = literalize(
+        source="[section]\nvalue = 1\n",
+        input_format=InputFormat.TOML,
+        language=PYTHON,
+        pre_indent_level=0,
+        include_delimiters=False,
+    )
+
+    assert result.code == '"section": {"value": 1},'
 
 
 def test_toml_time_values_literalize() -> None:


### PR DESCRIPTION
## Summary
- Drop the three `test_extract_toml_comments_*` tests in `tests/test_toml.py` that imported the private `extract_toml_comments` helper (part of #1947).
- Two are replaced with tests that exercise the same comment/table-entry behavior through `literalize`; the `_non_document` case covered a defensive `isinstance` guard unreachable from the public API and was removed outright.

## Test plan
- [x] `pytest tests/test_toml.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily type-tightening around parsed TOML/YAML structures and test changes, with minimal impact to runtime behavior aside from stricter typing expectations.
> 
> **Overview**
> Updates TOML parsing/comment plumbing to use concrete types end-to-end: `extract_toml_comments`/`resolve_toml_comments` now require a `TOMLDocument`, and parsing returns a tagged `ParsedInput` union (`ParsedPlain`/`ParsedYaml`/`ParsedToml`) instead of a generic parsed struct.
> 
> Refactors `literalize`/`literalize_call` to branch on the new parsed variants (including YAML standalone-comment detection), and updates TOML tests to stop importing the private `extract_toml_comments` helper and instead assert comment/table behavior through the public `literalize` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f045e1e63240e1355a4e14964df4e6ea639cd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->