### PR TITLE
Drive Cpp string-literal classifier from parsed Value and type_produced

### DIFF
--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -783,8 +783,8 @@ class _CppDeclarationStyleConfig:
 
     Unlike :class:`DeclarationStyleConfig`, this carries no
     ``formatter`` slot: Cpp builds its declaration formatter
-    per-instance via :meth:`Cpp.DeclarationStyles.build_formatter`
-    so it can close over the chosen date/datetime ``type_produced``.
+    per-instance in :attr:`Cpp.format_variable_declaration` so it can
+    close over the chosen date/datetime ``type_produced``.
     """
 
     supports_redefinition: bool
@@ -1079,36 +1079,6 @@ class Cpp(metaclass=LanguageCls):
         """Declaration style options."""
 
         AUTO = _CppDeclarationStyleConfig(supports_redefinition=True)
-
-        def build_formatter(
-            self,
-            *,
-            date_type: type,
-            datetime_type: type,
-        ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
-            """Return a formatter bound to the date/datetime
-            ``type_produced`` for this language instance.
-            """
-
-            def _formatter(
-                name: str,
-                value: str,
-                data: Value,
-                modifiers: frozenset[enum.Enum],
-            ) -> str:
-                """Adapt :func:`_format_variable_declaration` to the
-                positional formatter interface.
-                """
-                return _format_variable_declaration(
-                    name=name,
-                    value=value,
-                    data=data,
-                    modifiers=modifiers,
-                    date_type=date_type,
-                    datetime_type=datetime_type,
-                )
-
-            return _formatter
 
     class DictEntryStyles(enum.Enum):
         """Dict entry style options."""
@@ -1676,11 +1646,34 @@ class Cpp(metaclass=LanguageCls):
     def format_variable_declaration(
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
-        """Callable that formats a new variable declaration."""
-        return self.declaration_style.build_formatter(
-            date_type=self.date_format.value.type_produced,
-            datetime_type=self.datetime_format.value.type_produced,
-        )
+        """Callable that formats a new variable declaration.
+
+        Closes over the chosen date/datetime ``type_produced`` so the
+        ``const auto*`` vs ``auto`` decision can be driven by the parsed
+        :class:`Value` rather than the rendered text.
+        """
+        date_type = self.date_format.value.type_produced
+        datetime_type = self.datetime_format.value.type_produced
+
+        def _formatter(
+            name: str,
+            value: str,
+            data: Value,
+            modifiers: frozenset[enum.Enum],
+        ) -> str:
+            """Adapt :func:`_format_variable_declaration` to the
+            positional formatter interface.
+            """
+            return _format_variable_declaration(
+                name=name,
+                value=value,
+                data=data,
+                modifiers=modifiers,
+                date_type=date_type,
+                datetime_type=datetime_type,
+            )
+
+        return _formatter
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -779,25 +779,58 @@ def _cpp_modifier_prefix(modifiers: frozenset[enum.Enum]) -> str:
 
 
 @beartype
+def _format_variable_declaration_placeholder(
+    _name: str,
+    _value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Unreachable placeholder for the ``AUTO`` config formatter.
+
+    The real formatter is built per-instance by
+    :meth:`Cpp.DeclarationStyles.build_formatter`, which closes over
+    the date/datetime ``type_produced`` metadata so the
+    ``const auto*`` vs ``auto`` decision can be driven by the parsed
+    :class:`Value` rather than the rendered text.  This stub exists
+    only to satisfy :class:`DeclarationStyleConfig`'s required
+    ``formatter`` field.
+    """
+    msg = (
+        "Cpp AUTO requires the type-aware formatter built by "
+        "build_formatter; the DeclarationStyleConfig formatter is a "
+        "placeholder and must not be called directly."
+    )
+    raise NotImplementedError(msg)
+
+
+@beartype
 def _format_variable_declaration(
+    *,
     name: str,
     value: str,
-    _data: Value,
+    data: Value,
     modifiers: frozenset[enum.Enum],
+    date_type: type,
+    datetime_type: type,
 ) -> str:
     """Format a C++ variable declaration.
 
     * ``const auto*`` — string literal (``"..."``), required by
-      ``readability-qualified-auto``.  The check is on the rendered
-      value, not the parsed type, because date/datetime variants emit
-      ISO strings for ``datetime.date``/``datetime.datetime`` inputs.
+      ``readability-qualified-auto``.  Driven by the parsed *data*
+      together with the chosen date/datetime ``type_produced``: bytes
+      and strings always render as quoted strings, and dates/datetimes
+      do so when their format produces a :class:`str`.
     * ``auto`` — typed expression (e.g. ``std::vector<int>{...}``).
 
     When *modifiers* is non-empty, applicable modifier keywords
     (``static``, ``const``) are prepended.  ``const`` is not duplicated
     against the built-in ``const auto*`` for string literals.
     """
-    if _renders_as_string_literal(value=value):
+    if _renders_as_string_literal(
+        data=data,
+        date_type=date_type,
+        datetime_type=datetime_type,
+    ):
         type_keyword = "const auto*"
         extra = modifiers - {_CppModifiers.CONST}
     else:
@@ -807,25 +840,29 @@ def _format_variable_declaration(
     return f"{prefix}{type_keyword} {name} = {value};"
 
 
-def _renders_as_string_literal(*, value: str) -> bool:
-    """Return whether *value* renders as a C string literal.
+@beartype
+def _renders_as_string_literal(
+    *,
+    data: Value,
+    date_type: type,
+    datetime_type: type,
+) -> bool:
+    """Return whether *data* renders as a C string literal.
 
-    A YAML scalar may carry *before* comments which are emitted as
-    ``//`` lines inserted between ``=`` and the underlying literal; the
-    formatted comments may also carry the caller's ``line_prefix``
-    indent (e.g. when ``pre_indent_level > 0``).  Skip any leading
-    whitespace-then-``//`` lines before inspecting the underlying
-    literal.
+    ``bytes`` and ``str`` always render as quoted strings in C++.
+    ``datetime.datetime`` and ``datetime.date`` do so only when their
+    format's ``type_produced`` is :class:`str` (the ISO variants);
+    other variants render as ``std::chrono`` or numeric expressions.
     """
-    literal_line = next(
-        (
-            line.lstrip()
-            for line in value.splitlines()
-            if not line.lstrip().startswith("//")
-        ),
-        "",
-    )
-    return literal_line.startswith('"')
+    match data:
+        case bytes() | str():
+            return True
+        case datetime.datetime():
+            return datetime_type is str
+        case datetime.date():
+            return date_type is str
+        case _:
+            return False
 
 
 def _cpp_call_stub(
@@ -1055,9 +1092,39 @@ class Cpp(metaclass=LanguageCls):
         """Declaration style options."""
 
         AUTO = DeclarationStyleConfig(
-            formatter=_format_variable_declaration,
+            formatter=_format_variable_declaration_placeholder,
             supports_redefinition=True,
         )
+
+        def build_formatter(
+            self,
+            *,
+            date_type: type,
+            datetime_type: type,
+        ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+            """Return a formatter bound to the date/datetime
+            ``type_produced`` for this language instance.
+            """
+
+            def _formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_variable_declaration` to the
+                positional formatter interface.
+                """
+                return _format_variable_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    modifiers=modifiers,
+                    date_type=date_type,
+                    datetime_type=datetime_type,
+                )
+
+            return _formatter
 
     class DictEntryStyles(enum.Enum):
         """Dict entry style options."""
@@ -1626,7 +1693,10 @@ class Cpp(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a new variable declaration."""
-        return self.declaration_style.value.formatter
+        return self.declaration_style.build_formatter(
+            date_type=self.date_format.value.type_produced,
+            datetime_type=self.datetime_format.value.type_produced,
+        )
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -54,7 +54,6 @@ from literalizer._language import (
     CommentConfig,
     DateFormatConfig,
     DatetimeFormatConfig,
-    DeclarationStyleConfig,
     DictFormatConfig,
     FloatSpecialsMixin,
     HeterogeneousBehavior,
@@ -778,29 +777,17 @@ def _cpp_modifier_prefix(modifiers: frozenset[enum.Enum]) -> str:
     return " ".join(keywords) + " "
 
 
-@beartype
-def _format_variable_declaration_placeholder(
-    _name: str,
-    _value: str,
-    _data: Value,
-    _modifiers: frozenset[enum.Enum],
-) -> str:
-    """Unreachable placeholder for the ``AUTO`` config formatter.
+@dataclasses.dataclass(frozen=True)
+class _CppDeclarationStyleConfig:
+    """Configuration for a Cpp declaration style.
 
-    The real formatter is built per-instance by
-    :meth:`Cpp.DeclarationStyles.build_formatter`, which closes over
-    the date/datetime ``type_produced`` metadata so the
-    ``const auto*`` vs ``auto`` decision can be driven by the parsed
-    :class:`Value` rather than the rendered text.  This stub exists
-    only to satisfy :class:`DeclarationStyleConfig`'s required
-    ``formatter`` field.
+    Unlike :class:`DeclarationStyleConfig`, this carries no
+    ``formatter`` slot: Cpp builds its declaration formatter
+    per-instance via :meth:`Cpp.DeclarationStyles.build_formatter`
+    so it can close over the chosen date/datetime ``type_produced``.
     """
-    msg = (  # pragma: no cover
-        "Cpp AUTO requires the type-aware formatter built by "
-        "build_formatter; the DeclarationStyleConfig formatter is a "
-        "placeholder and must not be called directly."
-    )
-    raise NotImplementedError(msg)  # pragma: no cover
+
+    supports_redefinition: bool
 
 
 @beartype
@@ -1091,10 +1078,7 @@ class Cpp(metaclass=LanguageCls):
     class DeclarationStyles(enum.Enum):
         """Declaration style options."""
 
-        AUTO = DeclarationStyleConfig(
-            formatter=_format_variable_declaration_placeholder,
-            supports_redefinition=True,
-        )
+        AUTO = _CppDeclarationStyleConfig(supports_redefinition=True)
 
         def build_formatter(
             self,

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -795,12 +795,12 @@ def _format_variable_declaration_placeholder(
     only to satisfy :class:`DeclarationStyleConfig`'s required
     ``formatter`` field.
     """
-    msg = (
+    msg = (  # pragma: no cover
         "Cpp AUTO requires the type-aware formatter built by "
         "build_formatter; the DeclarationStyleConfig formatter is a "
         "placeholder and must not be called directly."
     )
-    raise NotImplementedError(msg)
+    raise NotImplementedError(msg)  # pragma: no cover
 
 
 @beartype

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -15,7 +15,7 @@ from literalizer import (
 from literalizer.exceptions import (
     IncompatibleFormatsError,
 )
-from literalizer.languages import Cpp, CSharp, Nim, Rust
+from literalizer.languages import CSharp, Nim, Rust
 
 RUST_CONST = Rust(
     date_format=Rust.date_formats.ISO,
@@ -258,20 +258,6 @@ def test_rust_lazy_static_config_formatter_raises_if_called_directly() -> None:
     raises instead.
     """
     style = Rust.declaration_styles.LAZY_STATIC
-    with pytest.raises(expected_exception=NotImplementedError):
-        style.value.formatter("x", "v", None, frozenset())
-
-
-def test_cpp_auto_config_formatter_raises_if_called_directly() -> None:
-    """The ``AUTO`` ``DeclarationStyleConfig`` formatter is a
-    placeholder.
-
-    The real formatter is built by
-    :meth:`Cpp.DeclarationStyles.build_formatter`; calling the
-    stored one directly would silently emit ``auto`` for string
-    values, so it raises instead.
-    """
-    style = Cpp.declaration_styles.AUTO
     with pytest.raises(expected_exception=NotImplementedError):
         style.value.formatter("x", "v", None, frozenset())
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -15,7 +15,7 @@ from literalizer import (
 from literalizer.exceptions import (
     IncompatibleFormatsError,
 )
-from literalizer.languages import CSharp, Nim, Rust
+from literalizer.languages import Cpp, CSharp, Nim, Rust
 
 RUST_CONST = Rust(
     date_format=Rust.date_formats.ISO,
@@ -258,6 +258,20 @@ def test_rust_lazy_static_config_formatter_raises_if_called_directly() -> None:
     raises instead.
     """
     style = Rust.declaration_styles.LAZY_STATIC
+    with pytest.raises(expected_exception=NotImplementedError):
+        style.value.formatter("x", "v", None, frozenset())
+
+
+def test_cpp_auto_config_formatter_raises_if_called_directly() -> None:
+    """The ``AUTO`` ``DeclarationStyleConfig`` formatter is a
+    placeholder.
+
+    The real formatter is built by
+    :meth:`Cpp.DeclarationStyles.build_formatter`; calling the
+    stored one directly would silently emit ``auto`` for string
+    values, so it raises instead.
+    """
+    style = Cpp.declaration_styles.AUTO
     with pytest.raises(expected_exception=NotImplementedError):
         style.value.formatter("x", "v", None, frozenset())
 


### PR DESCRIPTION
## Summary
- Replace ``_renders_as_string_literal``'s post-format string inspection (skipping ``//`` lines, looking for a leading ``"``) with a ``match`` on the parsed ``Value`` plus the chosen date/datetime ``type_produced``.
- Bind the per-instance ``date_type``/``datetime_type`` through a new ``Cpp.DeclarationStyles.build_formatter`` (mirroring Rust's ``LAZY_STATIC`` pattern); the ``AUTO`` enum config formatter is now an unreachable placeholder.

Closes #2155.

## Test plan
- [x] ``pytest`` (3428 passed, including ``Cpp_pre_indent_1_static_const_comment_scalar_before_and_inline`` and all other Cpp goldens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how C++ variable declarations choose `const auto*` vs `auto`, which can alter generated code for strings/bytes and date/datetime formats (especially ISO vs chrono/epoch). Scope is limited to C++ literalization and covered by golden tests, reducing regression risk.
> 
> **Overview**
> Updates C++ variable declaration generation to choose `const auto*` vs `auto` based on the parsed `Value` and the configured date/datetime format output type (`type_produced`), rather than inspecting the already-rendered text.
> 
> To support this, C++ now builds the declaration formatter per `Cpp` instance (closing over date/datetime `type_produced`) and replaces the shared `DeclarationStyleConfig` usage with a C++-specific `_CppDeclarationStyleConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f64eddde7efa2ad6b3ac2aa891f8c00b0670ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->