### PR TITLE
Inline preamble dedup loop in call_cases test runner

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -17,7 +17,6 @@ from pytest_regressions.file_regression import FileRegressionFixture
 
 import literalizer
 from literalizer._language import StubReturn
-from literalizer._preamble import deduplicate_preamble_entries
 from literalizer._types import Value
 from literalizer.exceptions import (
     CallArgNotSupportedError,
@@ -1206,9 +1205,12 @@ def run_call_golden_case(
         for entry in d.preamble
         if "\n" not in entry
     )
-    all_preamble = deduplicate_preamble_entries(
-        entries=decl_preamble_lines + result.preamble + tuple(preamble_stubs),
-    )
+    seen: set[str] = set()
+    all_preamble: tuple[str, ...] = ()
+    for entry in decl_preamble_lines + result.preamble + tuple(preamble_stubs):
+        if entry not in seen:
+            seen.add(entry)
+            all_preamble += (entry,)
     wrapped = _prepend_preamble(wrapped=wrapped, preamble=all_preamble)
     check_golden(
         file_regression=file_regression,


### PR DESCRIPTION
## Summary
- Drop the `deduplicate_preamble_entries` import in `tests/integration/call_cases.py` and inline the dedup loop at its single call site, so the test no longer reaches into `literalizer._preamble`.

## Test plan
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only refactor that replaces a helper call with an equivalent local deduplication loop; behavior should remain the same aside from potential ordering/dedup edge cases.
> 
> **Overview**
> Stops importing `deduplicate_preamble_entries` from `literalizer._preamble` in `tests/integration/call_cases.py` and inlines preamble de-duplication at the single call site.
> 
> The call golden-case runner now builds `all_preamble` by iterating combined preamble entries and keeping the first occurrence of each line, avoiding reliance on a private internal module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08146e68e8ef1e6dce5789ab2892ff2d1fd73d43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->