### PR TITLE
Drop PLR0911 noqa on _apply_format_c_entry

### DIFF
--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -74,7 +74,7 @@ from literalizer._types import Value
 
 
 @beartype
-def _apply_format_c_entry(  # noqa: PLR0911
+def _apply_format_c_entry(
     *,
     original: Value,
     formatted: str,
@@ -84,24 +84,25 @@ def _apply_format_c_entry(  # noqa: PLR0911
     string_field: str,
 ) -> str:
     """Wrap a formatted entry in the appropriate union literal."""
+    # Values above ``LLONG_MAX`` cannot be assigned to the signed
+    # ``long long`` field without an implementation-defined narrowing
+    # conversion; route them to the unsigned field.
     match original:
         case datetime.datetime() if formatted.lstrip("-").isdigit():
-            return f"((CVal){{.{int_field} = {formatted}}})"
+            field = int_field
         case str() | bytes() | datetime.date():
-            return f"((CVal){{.{string_field} = {formatted}}})"
+            field = string_field
         case bool():
             return formatted
+        case int() if original > I64_MAX:
+            field = uint_field
         case int():
-            # Values above ``LLONG_MAX`` cannot be assigned to the signed
-            # ``long long`` field without an implementation-defined
-            # narrowing conversion; route them to the unsigned field.
-            if original > I64_MAX:
-                return f"((CVal){{.{uint_field} = {formatted}}})"
-            return f"((CVal){{.{int_field} = {formatted}}})"
+            field = int_field
         case float():
-            return f"((CVal){{.{float_field} = {formatted}}})"
+            field = float_field
         case _:
             return formatted
+    return f"((CVal){{.{field} = {formatted}}})"
 
 
 @beartype

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -84,9 +84,6 @@ def _apply_format_c_entry(
     string_field: str,
 ) -> str:
     """Wrap a formatted entry in the appropriate union literal."""
-    # Values above ``LLONG_MAX`` cannot be assigned to the signed
-    # ``long long`` field without an implementation-defined narrowing
-    # conversion; route them to the unsigned field.
     match original:
         case datetime.datetime() if formatted.lstrip("-").isdigit():
             field = int_field
@@ -94,6 +91,9 @@ def _apply_format_c_entry(
             field = string_field
         case bool():
             return formatted
+        # Values above ``LLONG_MAX`` cannot be assigned to the signed
+        # ``long long`` field without an implementation-defined
+        # narrowing conversion; route them to the unsigned field.
         case int() if original > I64_MAX:
             field = uint_field
         case int():


### PR DESCRIPTION
## Summary
- Route the C union-wrap match arms through a shared trailing return so `_apply_format_c_entry` no longer needs `# noqa: PLR0911`.

## Test plan
- [x] `uv run ruff check src/literalizer/languages/c.py`
- [x] `uv run pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to C literal formatting logic; behavior should be unchanged aside from clearer handling of large integers routed to the unsigned field.
> 
> **Overview**
> Refactors `_apply_format_c_entry` in `src/literalizer/languages/c.py` to avoid multiple early returns by selecting a `field` in the `match` arms and emitting a single trailing `CVal` union wrapper.
> 
> This preserves the existing special cases (e.g., passthrough booleans and non-union-wrapped fallthrough) while making the *"int > I64_MAX" → unsigned field* routing explicit as its own match case, allowing removal of the `# noqa: PLR0911`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5a767d894908283b4b85af0265593137bd1157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->