### PR TITLE
Fold ordereddict case into dict() to drop pyright ignores

### DIFF
--- a/src/literalizer/_preamble.py
+++ b/src/literalizer/_preamble.py
@@ -16,16 +16,14 @@ from literalizer._types import Value
 def _collect_value_types(*, data: Value) -> frozenset[type]:
     """Return the set of Python types present in *data*."""
     match data:
-        case ordereddict():
-            child_types: frozenset[type] = frozenset()
-            for v in data.values():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-                child_types = child_types | _collect_value_types(data=v)  # pyright: ignore[reportUnknownArgumentType]
-            return frozenset({ordereddict, str}) | child_types
         case dict():
-            child_types = frozenset()
+            child_types: frozenset[type] = frozenset()
             for v in data.values():
                 child_types = child_types | _collect_value_types(data=v)
-            return frozenset({dict, str}) | child_types
+            container_type = (
+                ordereddict if isinstance(data, ordereddict) else dict
+            )
+            return frozenset({container_type, str}) | child_types
         case set():
             scalar_types: frozenset[type] = frozenset(
                 t


### PR DESCRIPTION
## Summary
- Collapse the `case ordereddict():` match arm in `_collect_value_types` into `case dict():`, detecting `ordereddict` via `isinstance` to pick the container type.
- Removes two `pyright: ignore[reportUnknownVariableType,reportUnknownMemberType,reportUnknownArgumentType]` comments, following the same pattern as commit 77f0d95e4.

## Test plan
- [x] `uv run pyright src/literalizer/_preamble.py`
- [x] Related preamble/types tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to type-collection logic; behavior should remain the same except for more explicit `ordereddict` detection within the `dict()` path.
> 
> **Overview**
> Simplifies `_collect_value_types` in `src/literalizer/_preamble.py` by removing the dedicated `case ordereddict()` branch and handling `ordereddict` instances inside the existing `case dict()` branch via an `isinstance` check.
> 
> This also drops the associated `pyright` ignore comments and makes the collected container type (`dict` vs `ordereddict`) explicit when building the returned type set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 638b9b72ed06d7afe49caaf027e7b10d2622f7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->