### PR TITLE
Drop pyright ignore in TypeScript type-hint dict arm

### DIFF
--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -155,6 +155,7 @@ def _ts_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C90
         case None:
             return "null"
         case dict():
+            val_types = [recurse(data=v) for v in data.values()]
             template = (
                 "Record<string, {val}>"
                 if isinstance(data, (ordereddict, OrderedDict))
@@ -164,7 +165,6 @@ def _ts_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C90
             # type, so the annotation must match.
             if not data or "Map<" in template:
                 return template.format(val="unknown")
-            val_types = [recurse(data=v) for v in data.values()]  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportUnknownVariableType]
             val_union = _ts_element_union(types=val_types)
             return template.format(val=val_union)
         case set():


### PR DESCRIPTION
## Summary
- Move `val_types` computation to the top of the `case dict():` arm in `_ts_type_hint` so it runs while `data` is still narrowed by the match. The later `isinstance(data, (ordereddict, OrderedDict))` check involves ruamel's untyped `ordereddict` and was widening `data` back to a partially-unknown type, which previously required a `# pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportUnknownVariableType]`.

## Test plan
- [x] `uv run pyright src/literalizer/languages/typescript.py`
- [x] `uv run --extra dev pytest tests/ -k typescript`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to TypeScript type-hint generation; behavior should be unchanged aside from improved type-checking, with minimal chance of affecting inferred dict value unions.
> 
> **Overview**
> Updates TypeScript type-hint generation for `dict` values by computing `val_types` before the ordered-map `isinstance` check, keeping `data` narrowed within the `match` arm.
> 
> Removes the now-unneeded `# pyright: ignore[...]` on `data.values()` without changing the returned TypeScript annotation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d761bf9a73cbac066b96a920d0bbe6ad6224af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->