### PR TITLE
Drop PLR0911 noqa from Zig _format_zig_entry

### DIFF
--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -100,7 +100,7 @@ def _format_datetime_zig(value: datetime.datetime) -> str:
 
 
 @beartype
-def _format_zig_entry(original: Value, formatted: str) -> str:  # noqa: PLR0911
+def _format_zig_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in the appropriate Zig ``ZVal`` union
     tag.
     """
@@ -108,8 +108,6 @@ def _format_zig_entry(original: Value, formatted: str) -> str:  # noqa: PLR0911
         case bool():
             return formatted
         case int():
-            if original > I64_MAX:
-                return f".{{ .uint = {formatted} }}"
             if original < I64_MIN:
                 msg = (
                     f"Zig cannot represent negative integer {original} "
@@ -117,16 +115,16 @@ def _format_zig_entry(original: Value, formatted: str) -> str:  # noqa: PLR0911
                     "union's unsigned variant."
                 )
                 raise UnrepresentableIntegerError(msg)
-            return f".{{ .int = {formatted} }}"
+            tag = "uint" if original > I64_MAX else "int"
         case float():
-            return f".{{ .float = {formatted} }}"
+            tag = "float"
         case str() | bytes():
-            return f".{{ .str = {formatted} }}"
+            tag = "str"
         case datetime.date():
             tag = "str" if formatted.startswith('"') else "int"
-            return f".{{ .{tag} = {formatted} }}"
         case _:
             return formatted
+    return f".{{ .{tag} = {formatted} }}"
 
 
 @beartype


### PR DESCRIPTION
## Summary

Refactor `_format_zig_entry` so the per-case `return` statements collapse into a single trailing `return`. Each match arm sets a `tag` string instead, dropping the return count below `PLR0911`'s threshold and removing the `# noqa: PLR0911`.

## Test plan

- [x] `uv run ruff check src/literalizer/languages/zig.py`
- [x] `uv run pytest tests/ -k zig --ignore=tests/benchmarks` (56 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Zig literal wrapping logic; behavior should be unchanged but touches integer tagging (`int` vs `uint`) and could affect edge-case formatting if mistakes slip in.
> 
> **Overview**
> Refactors Zig value wrapping in `src/literalizer/languages/zig.py` by collapsing multiple `match`-arm `return`s in `_format_zig_entry` into a single trailing `return` that formats `.{ .{tag} = ... }`.
> 
> The `int`/`uint` selection and other tag choices are now expressed by assigning a `tag` variable per type, removing the `# noqa: PLR0911` suppression while keeping the existing out-of-range negative integer error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8c2e00d3462f20a7e93b18a5650962bfcfe169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->