### PR TITLE
Default pytest to -n auto via pyproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run --extra=dev pytest -s -vvv -n auto --cov-fail-under 100 --cov=src/ --cov=tests --ignore=tests/benchmarks .
+          uv run --extra=dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests --ignore=tests/benchmarks .
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: uv run --extra=dev pytest tests/benchmarks --codspeed
+          run: uv run --extra=dev pytest tests/benchmarks --codspeed -n0
 
   completion-ci:
     needs: [build, benchmarks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,6 +352,7 @@ environment.extra-paths = [ ".github/scripts" ]
 [tool.pytest]
 ini_options.xfail_strict = true
 ini_options.log_cli = true
+ini_options.addopts = "-n auto"
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
Adds `addopts = "-n auto"` to `[tool.pytest]` ini_options so xdist parallelism is the default, and drops the now-redundant `-n auto` flag from the CI test invocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default pytest execution to use xdist parallelism, which can expose hidden test ordering/shared-state issues and increase flakiness. CI benchmarks are explicitly forced back to single-process (`-n0`) to keep performance measurements stable.
> 
> **Overview**
> Makes pytest run in parallel by default by setting `ini_options.addopts = "-n auto"` in `pyproject.toml`.
> 
> Updates CI to rely on this default by removing explicit `-n auto` from the main test command, while forcing benchmarks to run without xdist (`-n0`) for consistent CodSpeed results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79392028a40f76b03d4fff305e19aca9454ea46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->