### PR TITLE
Fold ordereddict case into dict() in unwrappable-mix check

### DIFF
--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -298,8 +298,8 @@ def _has_dict_with_unwrappable_value_mix(*, data: Value) -> bool:
     heterogeneous map.
     """
     match data:
-        case ordereddict() | dict():
-            values: list[Value] = list(data.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        case dict():
+            values: list[Value] = list(data.values())
             has_container = any(
                 isinstance(v, (list, dict, set)) for v in values
             )


### PR DESCRIPTION
## Summary
- Replace `case ordereddict() | dict():` with `case dict():` in `_has_dict_with_unwrappable_value_mix`, dropping the `reportUnknownMemberType`/`reportUnknownArgumentType` pyright ignores. ordereddict subclasses dict, so runtime behavior is unchanged.

## Test plan
- [x] pyright / ty / mypy / pyrefly clean (pre-commit)
- [x] `pytest -k "mixed or unwrap or heterog"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in validation logic; runtime behavior should remain unchanged because `ordereddict` is a `dict` subclass, with the main impact being stricter/static typing cleanup.
> 
> **Overview**
> Simplifies `_has_dict_with_unwrappable_value_mix` by collapsing the `ordereddict()`/`dict()` pattern into a single `case dict()` arm.
> 
> Removes the related pyright ignore comments by relying on normal `dict.values()` typing, without changing the surrounding mixed-type/container detection logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c07f9e15848332c36984ffb86104b7e0c899a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->