### PR TITLE
Collapse SystemVerilog _format_sv_entry payload into trailing return to drop PLR0911

### DIFF
--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -104,24 +104,25 @@ def _escape_nested(text: str) -> str:
 
 
 @beartype
-def _format_sv_entry(original: Value, formatted: str) -> str:  # noqa: PLR0911
+def _format_sv_entry(original: Value, formatted: str) -> str:
     """Wrap a formatted entry in a named ``_VVal`` struct literal."""
     match original:
-        case datetime.datetime() if formatted.lstrip("-").isdigit():
-            return f'_VVal\'{{tag: _VVAL_INT, i: {formatted}, r: 0.0, s: ""}}'
-        case str() | bytes() | datetime.date():
-            return f"_VVal'{{tag: _VVAL_STR, i: 0, r: 0.0, s: {formatted}}}"
         case bool():
             return formatted
+        case datetime.datetime() if formatted.lstrip("-").isdigit():
+            payload = f'_VVAL_INT, i: {formatted}, r: 0.0, s: ""'
         case int():
-            return f'_VVal\'{{tag: _VVAL_INT, i: {formatted}, r: 0.0, s: ""}}'
+            payload = f'_VVAL_INT, i: {formatted}, r: 0.0, s: ""'
         case float():
-            return f'_VVal\'{{tag: _VVAL_REAL, i: 0, r: {formatted}, s: ""}}'
+            payload = f'_VVAL_REAL, i: 0, r: {formatted}, s: ""'
+        case str() | bytes() | datetime.date():
+            payload = f"_VVAL_STR, i: 0, r: 0.0, s: {formatted}"
         case list() | dict() | set():
             escaped = _escape_nested(text=formatted)
-            return f'_VVal\'{{tag: _VVAL_STR, i: 0, r: 0.0, s: "{escaped}"}}'
+            payload = f'_VVAL_STR, i: 0, r: 0.0, s: "{escaped}"'
         case _:
             return formatted
+    return f"_VVal'{{tag: {payload}}}"
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Extract the common `_VVal'{tag: ...}` wrapper from `_format_sv_entry` into a single trailing return, dropping the `# noqa: PLR0911` (mirrors the recent Zig fix).

## Test plan
- [x] `uv run ruff check src/literalizer/languages/systemverilog.py`
- [x] `uv run pytest tests/ -k systemverilog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to SystemVerilog literal formatting; behavior should be unchanged aside from any subtle string formatting differences in `_format_sv_entry`.
> 
> **Overview**
> Refactors `SystemVerilog`’s `_format_sv_entry` to build a `payload` for `_VVal` in the `match` arms and emit a single trailing `return` for the wrapper, removing multiple duplicated wrapper returns and the `# noqa: PLR0911`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01dbb84fba69be604294e075dbc58b37a2ca6f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->