### PR TITLE
Collapse OCaml _apply_ocaml_entry tag to drop PLR0911 noqa

### DIFF
--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -81,9 +81,7 @@ from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
 @beartype
-def _apply_ocaml_entry(  # noqa: PLR0911
-    original: Value, formatted: str, prefix: str
-) -> str:
+def _apply_ocaml_entry(original: Value, formatted: str, prefix: str) -> str:
     """Wrap a formatted entry in the appropriate OCaml ``val_t``
     constructor.
     """
@@ -91,32 +89,19 @@ def _apply_ocaml_entry(  # noqa: PLR0911
         case bool():
             return formatted
         case int():
-            needs_parens = formatted.startswith("-")
-            return (
-                f"{prefix}Int ({formatted})"
-                if needs_parens
-                else f"{prefix}Int {formatted}"
-            )
+            tag = "Int"
         case float():
-            negative = formatted.startswith("-")
-            return (
-                f"{prefix}Float ({formatted})"
-                if negative
-                else f"{prefix}Float {formatted}"
-            )
+            tag = "Float"
         case str() | bytes():
-            return f"{prefix}Str {formatted}"
+            tag = "Str"
         case datetime.datetime() if formatted.lstrip("-").isdigit():
-            needs_parens = formatted.startswith("-")
-            return (
-                f"{prefix}Int ({formatted})"
-                if needs_parens
-                else f"{prefix}Int {formatted}"
-            )
+            tag = "Int"
         case datetime.date() if formatted.startswith('"'):
-            return f"{prefix}Str {formatted}"
+            tag = "Str"
         case _:
             return formatted
+    literal = f"({formatted})" if formatted.startswith("-") else formatted
+    return f"{prefix}{tag} {literal}"
 
 
 def _build_ocaml_entry_formatter(


### PR DESCRIPTION
## Summary
- Refactored `_apply_ocaml_entry` to set a `tag` variable per match arm and emit a single trailing `f"{prefix}{tag} {literal}"` return, mirroring the recent Zig change.
- Removed the `# noqa: PLR0911` suppression now that there are only two returns.

## Test plan
- [x] `uv run ruff check src/literalizer/languages/ocaml.py`
- [x] `uv run pytest tests/ -k ocaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to OCaml literal wrapping; behavior should be unchanged aside from how negative numeric literals are parenthesized before constructor application.
> 
> **Overview**
> Refactors OCaml value wrapping in `_apply_ocaml_entry` to reduce branching: each `match` arm now sets a constructor `tag` and a single shared return emits `f"{prefix}{tag} {literal}"`.
> 
> As part of this cleanup, negative formatted scalars are consistently parenthesized via a shared `literal` computation, and the `# noqa: PLR0911` suppression is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2b4cdfe306ba98964e5a5c4796abade0581ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->