### PR TITLE
Drop PLR0911 noqa on _unwrap_yaml_scalar

### DIFF
--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -80,7 +80,7 @@ ParsedInput = ParsedPlain | ParsedYaml | ParsedToml
 
 
 @beartype
-def _unwrap_yaml_scalar(*, value: Scalar) -> Scalar:  # noqa: PLR0911
+def _unwrap_yaml_scalar(*, value: Scalar) -> Scalar:
     """Convert a *ruamel.yaml* scalar wrapper to its plain Python type.
 
     The round-trip loader returns subclasses (``ScalarInt``, ``HexInt``,
@@ -118,11 +118,7 @@ def _unwrap_yaml_scalar(*, value: Scalar) -> Scalar:  # noqa: PLR0911
                 microsecond=value.microsecond,
                 tzinfo=value.tzinfo,
             )
-        case datetime.date():
-            return value
-        case bytes():
-            return value
-        case None:
+        case datetime.date() | bytes() | None:
             return value
         case _ as unreachable:
             assert_never(unreachable)


### PR DESCRIPTION
## Summary
- Fold the three trivial passthrough match arms (`datetime.date`, `bytes`, `None`) into a single OR pattern in `_unwrap_yaml_scalar`, bringing the return count under the PLR0911 threshold so the `# noqa: PLR0911` can be removed.

## Test plan
- [x] `uv run ruff check src/literalizer/_parsing.py`
- [x] pre-commit hooks (mypy, pyright, ty, pyrefly) pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to YAML scalar match-case structure, with no behavioral change expected beyond equivalent passthrough handling.
> 
> **Overview**
> Simplifies `_unwrap_yaml_scalar` by merging the trivial passthrough cases for `datetime.date`, `bytes`, and `None` into a single OR-pattern match arm.
> 
> Removes the `# noqa: PLR0911` suppression since the function no longer exceeds Ruff's return-count threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8a6b2f671becd0507f16d53fcbea14992d8606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->