### PR TITLE
Fold ordereddict case into dict() in _needs_variant_type

### DIFF
--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -558,13 +558,6 @@ def _needs_variant_type(
                 items=sorted_items,
                 element_to_type=element_to_type,
             )
-        case ordereddict():
-            omap_vals = data.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-            values: list[Value] = list(omap_vals)  # pyright: ignore[reportUnknownArgumentType]
-            return _items_need_variant(
-                items=values,
-                element_to_type=element_to_type,
-            )
         case list():
             return _items_need_variant(
                 items=data,


### PR DESCRIPTION
## Summary
- Drop the unknown-type pyright ignores in `_needs_variant_type` by folding the `ordereddict()` arm into the `dict()` arm. `ordereddict` subclasses `dict`, so the `dict()` case still matches at runtime and pyright narrows cleanly — same pattern as 4c07f9e15 / 638b9b72e / 77f0d95e4.

## Test plan
- [x] `uv run pyright src/literalizer/languages/cpp.py`
- [x] `uv run pytest tests/integration -k "cpp and call_per_element_false"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small refactor to pattern-matching logic for variant header detection, relying on `ordereddict` being a `dict` subclass; behavior should remain the same aside from type-checking cleanup.
> 
> **Overview**
> Simplifies C++ variant-header detection by removing the dedicated `ordereddict()` match arm in `_needs_variant_type` and letting it fall through the existing `dict()` handling.
> 
> This drops the associated pyright unknown-type ignores while keeping the same runtime behavior for ordered maps (since `ordereddict` subclasses `dict`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768e2722eaf822bd48dd1d8f5decde22f1d8225a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->