### PR TITLE
Remove PLR0911 noqa from _apply_fsharp_entry

### DIFF
--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -83,9 +83,7 @@ from literalizer._types import Value
 
 
 @beartype
-def _apply_fsharp_entry(  # noqa: PLR0911
-    original: Value, formatted: str, prefix: str
-) -> str:
+def _apply_fsharp_entry(original: Value, formatted: str, prefix: str) -> str:
     """Wrap a formatted entry in the appropriate F# ``Val``
     constructor.
     """
@@ -117,9 +115,11 @@ def _apply_fsharp_entry(  # noqa: PLR0911
         case datetime.datetime() if formatted.startswith(f"{prefix}Int"):
             return formatted
         case str() | bytes() | datetime.date():
-            if formatted.startswith("System."):
-                return f"{prefix}Str (string ({formatted}))"
-            return f"{prefix}Str {formatted}"
+            return (
+                f"{prefix}Str (string ({formatted}))"
+                if formatted.startswith("System.")
+                else f"{prefix}Str {formatted}"
+            )
         case _:
             return formatted
 


### PR DESCRIPTION
## Summary
- Collapsed the str/bytes/date arm's two returns into a single ternary in `_apply_fsharp_entry`, dropping return count from 7 to 6 and removing the `# noqa: PLR0911`.

## Test plan
- [x] ruff check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor confined to F# value wrapping logic; behavior should be unchanged aside from equivalent conditional formatting, with minimal risk of a minor string-format regression.
> 
> **Overview**
> Refactors `src/literalizer/languages/fsharp.py` to remove the `# noqa: PLR0911` on `_apply_fsharp_entry` by collapsing the `str`/`bytes`/`date` match arm into a single conditional expression.
> 
> Also applies a minor signature formatting cleanup; no functional changes are intended beyond the equivalent `System.*` string-wrapping branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e703f8d092c5b410cadb9115012c35657bf2dd8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->