### PR TITLE
Remove PLR0911 noqa from _rust_scalar_type

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -154,7 +154,7 @@ def _unify_rust_types(types: Sequence[str]) -> str:
 
 
 @beartype
-def _rust_scalar_type(  # noqa: PLR0911
+def _rust_scalar_type(
     *,
     data: Scalar,
     date_type: str,
@@ -163,23 +163,22 @@ def _rust_scalar_type(  # noqa: PLR0911
     """Return the Rust type annotation for a scalar value."""
     match data:
         case bool():
-            return "bool"
+            result = "bool"
         case int():
-            return _rust_integer_type(value=data)
+            result = _rust_integer_type(value=data)
         case float():
-            return "f64"
-        case str():
-            return "&str"
-        case bytes():
-            return "&str"
+            result = "f64"
+        case str() | bytes():
+            result = "&str"
         case datetime.datetime():
-            return datetime_type
+            result = datetime_type
         case datetime.date():
-            return date_type
+            result = date_type
         case None:
-            return "Option<()>"
+            result = "Option<()>"
         case _ as unreachable:
             assert_never(unreachable)
+    return result
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Collapse the `match` arms in `_rust_scalar_type` to assign a `result` variable and return once, dropping the `# noqa: PLR0911` suppression.

## Test plan
- [x] `ruff check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Rust type inference for scalars; behavior should be unchanged but relies on correct `match` coverage for all scalar variants.
> 
> **Overview**
> Refactors Rust scalar type inference in `src/literalizer/languages/rust.py` by collapsing `_rust_scalar_type` into a single-return implementation and removing the `# noqa: PLR0911` suppression.
> 
> Also merges the `str` and `bytes` match arms into `case str() | bytes():` while preserving the same inferred Rust type output (`&str`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb1bf573e3e46b5b4710a512970cd52830b884e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->