### PR TITLE
Drop pyright ignores in _filter_null_dict_comments

### DIFF
--- a/src/literalizer/_comments_resolve.py
+++ b/src/literalizer/_comments_resolve.py
@@ -24,7 +24,6 @@ from literalizer._parsing import get_yaml
 def _filter_null_dict_comments(
     *,
     data: dict[Any, Any],
-    ruamel_data: CommentedMap,
     collection_comments: CollectionComments,
 ) -> CollectionComments:
     """Remove comments for null-valued dict entries.
@@ -34,11 +33,7 @@ def _filter_null_dict_comments(
     """
     pending: list[str] = []
     filtered_elements_list: list[ElementComments] = []
-    for key, ec in zip(  # pyright: ignore[reportUnknownVariableType]
-        ruamel_data.keys(),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-        collection_comments.elements,
-        strict=True,
-    ):
+    for key, ec in zip(data, collection_comments.elements, strict=True):
         if data[key] is None:
             pending.extend(ec.before)
             if ec.inline:
@@ -127,7 +122,6 @@ def _resolve_yaml_collection_comments(
     ):
         collection_comments = _filter_null_dict_comments(
             data=data,  # pyright: ignore[reportUnknownArgumentType]
-            ruamel_data=ruamel_data,
             collection_comments=collection_comments,
         )
 


### PR DESCRIPTION
## Summary
- Removed the redundant `ruamel_data` parameter from `_filter_null_dict_comments` and iterated the already-typed `data: dict[Any, Any]` directly, dropping two pyright ignores (`reportUnknownVariableType`, `reportUnknownMemberType`, `reportUnknownArgumentType`) on `ruamel_data.keys()`. The keys are identical and in the same order since `data` is the round-trip object.

## Test plan
- [x] `uv run pytest -k comment` passes
- [x] Pre-commit hooks (pyright, ty, pyrefly) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how keys are iterated when redistributing comments for null dict entries; behavior should remain the same aside from type-checker annotations.
> 
> **Overview**
> Simplifies YAML null-dict comment filtering by removing the redundant `ruamel_data` parameter from `_filter_null_dict_comments` and zipping `collection_comments.elements` against the already-parsed `data` keys.
> 
> This drops several `pyright` ignore directives around `ruamel_data.keys()` and updates the call site accordingly, with no intended behavior change beyond cleaner typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7994775d09fa92f718aeb87ffaea38e170f8db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->