### PR TITLE
Fold ordereddict case into dict() in _merge_dict_elements

### DIFF
--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -271,12 +271,14 @@ def _merge_dict_elements(*, elements: list[Value]) -> list[Value]:
     has_ordered = False
     for elem in elements:
         match elem:
-            case ordereddict() | OrderedDict():
-                has_ordered = True
-                ordered_vals.extend(elem.values())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
             case dict():
-                has_plain = True
-                plain_vals.extend(elem.values())
+                is_ordered = isinstance(elem, (ordereddict, OrderedDict))
+                target = ordered_vals if is_ordered else plain_vals
+                target.extend(elem.values())
+                if is_ordered:
+                    has_ordered = True
+                else:
+                    has_plain = True
             case _:
                 non_dict.append(elem)
     merged: list[Value] = list(non_dict)


### PR DESCRIPTION
Detects ordereddict/OrderedDict via isinstance inside the dict() match arm in _merge_dict_elements, extending into the chosen target list before narrowing. Drops the unknown-type pyright ignores on the ordereddict arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Python type-hint dict-merging logic; behavior should be equivalent but could subtly affect how ordered vs plain dict values are pooled.
> 
> **Overview**
> Refactors `_merge_dict_elements` to handle `ordereddict`/`OrderedDict` inside the `case dict()` match arm via `isinstance`, routing values into `plain_vals` vs `ordered_vals` and setting `has_plain`/`has_ordered` accordingly.
> 
> This removes the dedicated ordered-dict match arm and its Pyright ignore comments, relying on shared `dict()` narrowing for `elem.values()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025d5a36cca4dfa3b2e86bd45e79e94d06ab00d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->