### PR TITLE
Iterate CommentedMap directly to drop pyright ignore

### DIFF
--- a/src/literalizer/_comments.py
+++ b/src/literalizer/_comments.py
@@ -165,7 +165,7 @@ def _collection_targets(
         case CommentedMap():
             return _CollectionTargets(
                 token_idx=2,
-                keys=list(ruamel_data.keys()),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                keys=list(ruamel_data),
             )
         case CommentedSeq():
             return _CollectionTargets(


### PR DESCRIPTION
## Summary
- Replace `list(ruamel_data.keys())` with `list(ruamel_data)` in `_collection_targets` so the typed iteration removes the need for `# pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]`.

## Test plan
- [x] `uv run --extra=dev -m pyright src/literalizer/_comments.py`
- [x] `uv run --extra=dev -m pytest tests/ -k comment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior should be unchanged, but it slightly alters how `CommentedMap` keys are collected, which could affect ordering/iteration edge cases if ruamel.yaml differs from `keys()`.
> 
> **Overview**
> Simplifies YAML comment extraction by iterating `CommentedMap` directly (`list(ruamel_data)`) instead of calling `keys()`, removing the need for a Pyright suppression in `_collection_targets`.
> 
> No functional logic changes are intended beyond relying on the map’s native iteration for key collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 118b1a36a6b8d718a8e3c55bb377a8411ba7368b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->