### PR TITLE
Remove PLR0911 noqa from _dhall_variant_for_scalar

### DIFF
--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -371,7 +371,7 @@ class _VariantSignature:
 
 
 @beartype
-def _dhall_variant_for_scalar(value: Scalar) -> _VariantSignature:  # noqa: PLR0911
+def _dhall_variant_for_scalar(value: Scalar) -> _VariantSignature:
     """Return the Dhall union-type variant signature for *value*.
 
     Dhall has no per-width integer types, so all integers map to a
@@ -382,23 +382,24 @@ def _dhall_variant_for_scalar(value: Scalar) -> _VariantSignature:  # noqa: PLR0
     """
     match value:
         case bool():
-            return _VariantSignature(name="Bool", inner_type="Bool")
+            signature = _VariantSignature(name="Bool", inner_type="Bool")
         case int():
-            return _VariantSignature(name="Int", inner_type="Integer")
+            signature = _VariantSignature(name="Int", inner_type="Integer")
         case float():
-            return _VariantSignature(name="Double", inner_type="Double")
+            signature = _VariantSignature(name="Double", inner_type="Double")
         case str():
-            return _VariantSignature(name="Str", inner_type="Text")
+            signature = _VariantSignature(name="Str", inner_type="Text")
         case bytes():
-            return _VariantSignature(name="Bytes", inner_type="Text")
+            signature = _VariantSignature(name="Bytes", inner_type="Text")
         case datetime.datetime():
-            return _VariantSignature(name="DateTime", inner_type="Text")
+            signature = _VariantSignature(name="DateTime", inner_type="Text")
         case datetime.date():
-            return _VariantSignature(name="Date", inner_type="Text")
+            signature = _VariantSignature(name="Date", inner_type="Text")
         case None:
-            return _VariantSignature(name="Null", inner_type=None)
+            signature = _VariantSignature(name="Null", inner_type=None)
         case _ as unreachable:
             assert_never(unreachable)
+    return signature
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Refactor `_dhall_variant_for_scalar` to assign to a local `signature` in each match arm and return once at the end, eliminating the `# noqa: PLR0911` suppression.

## Test plan
- [x] Ruff clean
- [x] Pre-commit hooks pass (mypy, pyright, ty, pyrefly)
- [x] Smoke test confirms all scalar variants return unchanged signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to Dhall scalar-to-variant mapping; behavior should be unchanged aside from control flow and linting.
> 
> **Overview**
> Refactors `src/literalizer/languages/dhall.py`’s `_dhall_variant_for_scalar` to assign a `signature` in each `match` arm and `return` once at the end.
> 
> This removes the `# noqa: PLR0911` suppression without changing the Dhall union variant names or inner types produced for supported scalar inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4f79b16f6f7e6f55580db3486a5fb4b2f22ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->