### PR TITLE
Remove PLR0911 noqa from _nim_variant_for_scalar

### DIFF
--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -213,7 +213,7 @@ class _VariantSignature:
 
 
 @beartype
-def _nim_variant_for_scalar(  # noqa: PLR0911
+def _nim_variant_for_scalar(
     *,
     value: Scalar,
     date_type: str,
@@ -222,55 +222,56 @@ def _nim_variant_for_scalar(  # noqa: PLR0911
     """Return the Nim object-variant signature for *value*."""
     match value:
         case bool():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkBool",
                 field_name="boolVal",
                 field_type="bool",
             )
         case int():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkInt",
                 field_name="intVal",
                 field_type="int",
             )
         case float():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkFloat",
                 field_name="floatVal",
                 field_type="float",
             )
         case str():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkStr",
                 field_name="strVal",
                 field_type="string",
             )
         case bytes():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkBytes",
                 field_name="bytesVal",
                 field_type="string",
             )
         case datetime.datetime():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkDateTime",
                 field_name="dateTimeVal",
                 field_type=datetime_type,
             )
         case datetime.date():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkDate",
                 field_name="dateVal",
                 field_type=date_type,
             )
         case None:
-            return _VariantSignature(
+            signature = _VariantSignature(
                 kind_name="vkNull",
                 field_name=None,
                 field_type=None,
             )
         case _ as unreachable:
             assert_never(unreachable)
+    return signature
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Refactor `_nim_variant_for_scalar` to assign into a local in each `match` arm and return once at the end, mirroring the recent dhall refactor in cb4f79b16, so the `# noqa: PLR0911` directive can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `_nim_variant_for_scalar`, intended to keep behavior identical while removing a linter suppression; only risk is an accidental mismatch in match-arm assignment/return.
> 
> **Overview**
> Refactors Nim’s `_nim_variant_for_scalar` to assign a `_VariantSignature` in each `match` arm and perform a single `return` at the end, allowing removal of the `# noqa: PLR0911` linter suppression without changing the mapping logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880e673ecadcd7ba4cff17d9d6f8508095bb97c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->