### PR TITLE
Drop a pyright ignore in _comments_resolve

### DIFF
--- a/src/literalizer/_comments_resolve.py
+++ b/src/literalizer/_comments_resolve.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 from io import StringIO
-from typing import Any
 
 from beartype import beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
@@ -23,7 +22,7 @@ from literalizer._parsing import get_yaml
 @beartype
 def _filter_null_dict_comments(
     *,
-    data: dict[Any, Any],
+    data: CommentedMap,
     collection_comments: CollectionComments,
 ) -> CollectionComments:
     """Remove comments for null-valued dict entries.
@@ -33,7 +32,8 @@ def _filter_null_dict_comments(
     """
     pending: list[str] = []
     filtered_elements_list: list[ElementComments] = []
-    for key, ec in zip(data, collection_comments.elements, strict=True):
+    keys: list[object] = list(data)
+    for key, ec in zip(keys, collection_comments.elements, strict=True):
         if data[key] is None:
             pending.extend(ec.before)
             if ec.inline:
@@ -102,7 +102,6 @@ def _resolve_collection_comments(
 def _resolve_yaml_collection_comments(
     *,
     ruamel_data: CommentedSeq | CommentedMap,
-    data: object,
     base: str,
     language: Language,
     comment_prefix: str,
@@ -115,13 +114,11 @@ def _resolve_yaml_collection_comments(
         ruamel_data=ruamel_data,
     )
 
-    if (
-        language.skip_null_dict_values
-        and isinstance(ruamel_data, CommentedMap)
-        and isinstance(data, dict)
+    if language.skip_null_dict_values and isinstance(
+        ruamel_data, CommentedMap
     ):
         collection_comments = _filter_null_dict_comments(
-            data=data,  # pyright: ignore[reportUnknownArgumentType]
+            data=ruamel_data,
             collection_comments=collection_comments,
         )
 
@@ -174,7 +171,6 @@ def resolve_yaml_comments(
         case CommentedSeq() | CommentedMap():
             return _resolve_yaml_collection_comments(
                 ruamel_data=raw_data,
-                data=raw_data,
                 base=base,
                 language=language,
                 comment_prefix=comment_prefix,


### PR DESCRIPTION
## Summary
- Removed the redundant `data: object` parameter from `_resolve_yaml_collection_comments` since its only caller already passed the same `CommentedSeq | CommentedMap` as `ruamel_data`.
- Retyped `_filter_null_dict_comments` to accept `CommentedMap` directly, eliminating the `# pyright: ignore[reportUnknownArgumentType]` at the call site.

## Test plan
- [x] basedpyright clean
- [x] comment-related test suite passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small typing/cleanup change localized to YAML comment resolution, with minimal behavioral impact aside from slightly different key iteration for null filtering.
> 
> **Overview**
> Simplifies YAML comment resolution by removing the redundant `data` parameter from `_resolve_yaml_collection_comments` and relying solely on `ruamel_data`.
> 
> Tightens `_filter_null_dict_comments` to accept `CommentedMap` directly (and iterates via an explicit `keys` list), allowing the call site to drop the `# pyright: ignore[reportUnknownArgumentType]` and removing the unused `typing.Any` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19f24a62c6c3dd4a64aec040c5eab641ce1af366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->