### PR TITLE
Remove PLR0911 noqa from _apply_sml_entry_formatter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -314,6 +314,11 @@ jobs:
           # be listed explicitly here.
           packages: octave liblapack3
           version: 1.0
+      # cache-apt-pkgs-action skips package postinst scripts on cache hit,
+      # so the ld.so symlinks (e.g. liblapack.so.3) that ldconfig normally
+      # creates are missing until we run it ourselves.
+      - name: Register shared libraries
+        run: sudo ldconfig
       - name: Lint Matlab
         run: |-
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -286,10 +286,14 @@ jobs:
         with:
           packages: guile-3.0
           version: 1.0
+      # Invoke ``guile-3.0`` directly rather than ``guile`` because
+      # cache-apt-pkgs-action does not replay the package's
+      # ``update-alternatives`` postinst on cache hit, so ``/usr/bin/guile``
+      # is missing.
       - name: Lint Scheme
         run: |-
           find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme
-          xargs -0 -P "$(nproc)" -I{} guile --no-auto-compile -s {} < /tmp/files-scheme
+          xargs -0 -P "$(nproc)" -I{} guile-3.0 --no-auto-compile -s {} < /tmp/files-scheme
 
   # Octave is a practical CI substitute, but it does not support
   # every MATLAB builtin.  The per-fixture skip rules (for ``""``
@@ -814,10 +818,14 @@ jobs:
       # instead of cold-starting groovyc/groovy per file. A fresh
       # GroovyShell per fixture keeps classloaders isolated, since
       # some fixtures declare top-level classes with shared names.
+      # Invoke the wrapper at /usr/share/groovy/bin/groovy directly rather
+      # than ``groovy`` because cache-apt-pkgs-action does not replay the
+      # package's ``update-alternatives`` postinst on cache hit, so
+      # ``/usr/bin/groovy`` is missing.
       - name: Lint Groovy
         run: |-
           find tests/integration/cases -name '*.groovy' -print0 > /tmp/files-groovy
-          groovy .github/scripts/lint-groovy.groovy < /tmp/files-groovy
+          /usr/share/groovy/bin/groovy .github/scripts/lint-groovy.groovy < /tmp/files-groovy
 
   # Haskell + PureScript share the Haskell toolchain.
   lint-haskell-family:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -281,16 +281,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      # cache-apt-pkgs-action does not run post-install scripts, so the
-      # update-alternatives step that creates /usr/bin/guile never fires
-      # and the lint step fails with "guile: No such file or directory".
       - name: Install guile
-        run: |-
-          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
-          # update so we only refresh the Ubuntu archive we actually install from.
-          sudo rm -f /etc/apt/sources.list.d/*.list
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends guile-3.0
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: guile-3.0
+          version: 1.0
+          # Required so update-alternatives creates /usr/bin/guile on cache hit.
+          execute_install_scripts: true
       - name: Lint Scheme
         run: |-
           find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme
@@ -307,16 +304,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      # cache-apt-pkgs-action does not reliably restore octave's transitive
-      # library dependencies (e.g. liblapack3), leaving octave-cli unable to
-      # load liblapack.so.3 at runtime.
       - name: Install octave
-        run: |-
-          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
-          # update so we only refresh the Ubuntu archive we actually install from.
-          sudo rm -f /etc/apt/sources.list.d/*.list
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends octave
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: octave
+          version: 1.0
+          # Required so ldconfig registers transitive shared libraries
+          # (e.g. liblapack.so.3) after restore.
+          execute_install_scripts: true
       - name: Lint Matlab
         run: |-
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -281,11 +281,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # cache-apt-pkgs-action does not run post-install scripts, so the
+      # update-alternatives step that creates /usr/bin/guile never fires
+      # and the lint step fails with "guile: No such file or directory".
       - name: Install guile
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: guile-3.0
-          version: 1.0
+        run: |-
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends guile-3.0
       - name: Lint Scheme
         run: |-
           find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme
@@ -302,11 +307,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # cache-apt-pkgs-action does not reliably restore octave's transitive
+      # library dependencies (e.g. liblapack3), leaving octave-cli unable to
+      # load liblapack.so.3 at runtime.
       - name: Install octave
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: octave
-          version: 1.0
+        run: |-
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends octave
       - name: Lint Matlab
         run: |-
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -306,19 +306,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # cache-apt-pkgs-action does not reliably restore octave's shared
+      # library dependencies to their system paths (liblapack.so.3 stays
+      # missing even with the package listed explicitly and ldconfig run
+      # after), so install via apt directly here.
       - name: Install octave
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          # cache-apt-pkgs-action does not resolve transitive dependencies,
-          # so liblapack3 (needed for octave-cli's liblapack.so.3) has to
-          # be listed explicitly here.
-          packages: octave liblapack3
-          version: 1.0
-      # cache-apt-pkgs-action skips package postinst scripts on cache hit,
-      # so the ld.so symlinks (e.g. liblapack.so.3) that ldconfig normally
-      # creates are missing until we run it ourselves.
-      - name: Register shared libraries
-        run: sudo ldconfig
+        run: |-
+          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
+          # update so we only refresh the Ubuntu archive we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/*.list
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends octave
       - name: Lint Matlab
         run: |-
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -286,8 +286,6 @@ jobs:
         with:
           packages: guile-3.0
           version: 1.0
-          # Required so update-alternatives creates /usr/bin/guile on cache hit.
-          execute_install_scripts: true
       - name: Lint Scheme
         run: |-
           find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme
@@ -307,11 +305,11 @@ jobs:
       - name: Install octave
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: octave
+          # cache-apt-pkgs-action does not resolve transitive dependencies,
+          # so liblapack3 (needed for octave-cli's liblapack.so.3) has to
+          # be listed explicitly here.
+          packages: octave liblapack3
           version: 1.0
-          # Required so ldconfig registers transitive shared libraries
-          # (e.g. liblapack.so.3) after restore.
-          execute_install_scripts: true
       - name: Lint Matlab
         run: |-
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -138,7 +138,7 @@ def _sml_scientific(value: float) -> str:
 
 
 @beartype
-def _apply_sml_entry_formatter(  # noqa: PLR0911
+def _apply_sml_entry_formatter(
     original: Value, formatted: str, prefix: str
 ) -> str:
     """Wrap a formatted entry in the appropriate SML ``datatype``
@@ -146,35 +146,36 @@ def _apply_sml_entry_formatter(  # noqa: PLR0911
     """
     match original:
         case bool():
-            return formatted
+            result = formatted
         case int():
             negative = formatted.startswith("~")
-            return (
+            result = (
                 f"{prefix}Int ({formatted})"
                 if negative
                 else f"{prefix}Int {formatted}"
             )
         case float():
             negative = formatted.startswith(("~", "("))
-            return (
+            result = (
                 f"{prefix}Real ({formatted})"
                 if negative
                 else f"{prefix}Real {formatted}"
             )
         case str() | bytes():
-            return f"{prefix}Str {formatted}"
+            result = f"{prefix}Str {formatted}"
         case datetime.datetime() if formatted.lstrip("-").isdigit():
             negative = formatted.startswith("-")
             literal = f"~{formatted[1:]}" if negative else formatted
-            return (
+            result = (
                 f"{prefix}Int ({literal})"
                 if negative
                 else f"{prefix}Int {literal}"
             )
         case datetime.date() if formatted.startswith('"'):
-            return f"{prefix}Str {formatted}"
+            result = f"{prefix}Str {formatted}"
         case _:
-            return formatted
+            result = formatted
+    return result
 
 
 def _build_sml_entry_formatter(


### PR DESCRIPTION
Refactor \`_apply_sml_entry_formatter\` to assign each match branch to a single \`result\` variable and return once at the end, eliminating the \`# noqa: PLR0911\` suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk refactor plus CI command changes; main risk is potential CI breakage if runner paths/binaries differ, but changes are narrowly scoped to lint jobs.
> 
> **Overview**
> Improves lint workflow reliability by avoiding `cache-apt-pkgs-action` edge cases: Scheme lint now calls `guile-3.0` directly, Groovy lint calls `/usr/share/groovy/bin/groovy` directly, and Matlab lint installs `octave` via `apt-get` (after removing third-party apt sources) instead of using the apt cache action.
> 
> Refactors `src/literalizer/languages/sml.py`’s `_apply_sml_entry_formatter` to assign branch results to a single `result` and return once, removing the need for the `PLR0911` suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc1d1a68de310ebbdc8d6e7cd20c79e75f6e3251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->