### PR TITLE
Remove PLW0603 noqas in elm_common by encapsulating state

### DIFF
--- a/.github/scripts/elm_common.py
+++ b/.github/scripts/elm_common.py
@@ -1,5 +1,6 @@
 """Shared helpers for the Elm lint scripts."""
 
+import dataclasses
 import json
 import os
 import shutil
@@ -76,9 +77,16 @@ def prime_elm_home(*, elm_path: str, elm_home: Path) -> None:
             raise RuntimeError(msg)
 
 
-_primed_elm_home: Path | None = None
-_worker_homes_root: Path | None = None
-_worker_elm_home_dir: Path | None = None
+@dataclasses.dataclass
+class _ElmHomeState:
+    """Mutable container for per-worker ELM_HOME state."""
+
+    primed: Path | None
+    workers_root: Path | None
+    worker_dir: Path | None
+
+
+_state = _ElmHomeState(primed=None, workers_root=None, worker_dir=None)
 
 
 def init_worker_elm_home(primed_elm_home: str, worker_homes_root: str) -> None:
@@ -93,9 +101,8 @@ def init_worker_elm_home(primed_elm_home: str, worker_homes_root: str) -> None:
     ``os._exit`` (CPython's ``multiprocessing._bootstrap``), which
     skips registered ``atexit`` callbacks on Python <= 3.14.
     """
-    global _primed_elm_home, _worker_homes_root  # noqa: PLW0603
-    _primed_elm_home = Path(primed_elm_home)
-    _worker_homes_root = Path(worker_homes_root)
+    _state.primed = Path(primed_elm_home)
+    _state.workers_root = Path(worker_homes_root)
 
 
 def worker_elm_home() -> Path:
@@ -106,22 +113,21 @@ def worker_elm_home() -> Path:
     ELM_HOME (it locks the cache and fails with "resource busy"),
     so each worker keeps its own copy for its lifetime.
     """
-    global _worker_elm_home_dir  # noqa: PLW0603
-    if _worker_elm_home_dir is not None:
-        return _worker_elm_home_dir
-    if _primed_elm_home is None or _worker_homes_root is None:
+    if _state.worker_dir is not None:
+        return _state.worker_dir
+    if _state.primed is None or _state.workers_root is None:
         msg = "init_worker_elm_home was not called"
         raise RuntimeError(msg)
     worker_dir = Path(
         tempfile.mkdtemp(
             prefix="elm-home-worker-",
             suffix=NOINDEX_SUFFIX,
-            dir=_worker_homes_root,
+            dir=_state.workers_root,
         ),
     )
-    shutil.copytree(src=_primed_elm_home, dst=worker_dir, dirs_exist_ok=True)
-    _worker_elm_home_dir = worker_dir
-    return _worker_elm_home_dir
+    shutil.copytree(src=_state.primed, dst=worker_dir, dirs_exist_ok=True)
+    _state.worker_dir = worker_dir
+    return _state.worker_dir
 
 
 _ELM_TRANSIENT_BINARY_FILE_MARKERS = ("openBinaryFile", "withBinaryFile")


### PR DESCRIPTION
## Summary
- Replace three module-level mutable `Path` variables in `.github/scripts/elm_common.py` with a single `_ElmHomeState` dataclass instance.
- Mutating the dataclass's fields removes the need for the `global` statements that required `# noqa: PLW0603`.

## Test plan
- [x] `uv run ruff check .github/scripts/elm_common.py`
- [x] `uv run ty check .github/scripts/elm_common.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to GitHub CI helper scripts; behavior should be unchanged aside from how per-worker `ELM_HOME` state is stored.
> 
> **Overview**
> Refactors `.github/scripts/elm_common.py` to replace three module-level mutable `Path` globals (and their `global` statements / `# noqa: PLW0603`) with a single `_ElmHomeState` `@dataclass` instance (`_state`).
> 
> `init_worker_elm_home` and `worker_elm_home` now mutate/read `_state` fields instead of separate globals, keeping the worker `ELM_HOME` copy behavior the same while simplifying state management.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c36a11e288d4a4cdb990df5070fac1bc5dfbef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->