### PR TITLE
Remove noqa: PLR0911 from _heterogeneous_variant_for_scalar

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -428,7 +428,7 @@ class _VariantSignature:
 
 
 @beartype
-def _heterogeneous_variant_for_scalar(  # pylint: disable=too-complex  # noqa: PLR0911
+def _heterogeneous_variant_for_scalar(  # pylint: disable=too-complex
     *,
     value: Scalar,
     date_type: str,
@@ -442,41 +442,42 @@ def _heterogeneous_variant_for_scalar(  # pylint: disable=too-complex  # noqa: P
     """
     match value:
         case bool():
-            return _VariantSignature(name="Bool", inner_type="bool")
+            signature = _VariantSignature(name="Bool", inner_type="bool")
         case int():
             int_type = _rust_integer_type(value=value)
-            return _VariantSignature(
+            signature = _VariantSignature(
                 name=int_type.upper(),
                 inner_type=int_type,
             )
         case float():
-            return _VariantSignature(name="F64", inner_type="f64")
+            signature = _VariantSignature(name="F64", inner_type="f64")
         case str():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 name="Str",
                 inner_type="&'static str",
             )
         case bytes():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 name="Bytes",
                 inner_type="&'static str",
             )
         case datetime.datetime() if datetime_type in {"i32", "i64", "i128"}:
-            return _VariantSignature(
+            signature = _VariantSignature(
                 name=datetime_type.upper(),
                 inner_type=datetime_type,
             )
         case datetime.datetime():
-            return _VariantSignature(
+            signature = _VariantSignature(
                 name="DateTime",
                 inner_type=datetime_type,
             )
         case datetime.date():
-            return _VariantSignature(name="Date", inner_type=date_type)
+            signature = _VariantSignature(name="Date", inner_type=date_type)
         case None:
-            return _VariantSignature(name="Null", inner_type=None)
+            signature = _VariantSignature(name="Null", inner_type=None)
         case _ as unreachable:
             assert_never(unreachable)
+    return signature
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Collapse the nine `return` statements in `_heterogeneous_variant_for_scalar` into a single `return signature` after the `match` block so the function no longer trips `PLR0911`, letting the `# noqa: PLR0911` suppression be dropped.

## Test plan
- [x] `uv run --extra dev pytest tests/ -k "rust and heterogeneous"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to `_heterogeneous_variant_for_scalar` that should be behavior-preserving; low risk aside from the possibility of accidentally changing match fallthrough/return semantics.
> 
> **Overview**
> Refactors Rust heterogeneous tagged-enum variant inference in `_heterogeneous_variant_for_scalar` to assign a `signature` in each `match` arm and perform a single `return signature` after the `match`, allowing removal of the `# noqa: PLR0911` early-return suppression while keeping the same variant selection logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f284349e9a0280ba3b9a2510bfdb91082bb4a783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->