### PR TITLE
Extract YAML case loader to drop a pyright ignore

### DIFF
--- a/tests/integration/case_discovery.py
+++ b/tests/integration/case_discovery.py
@@ -111,6 +111,15 @@ type YamlData = (
 )
 
 
+def _load_case_input_yaml(case_dir: Path) -> YamlData:
+    """Parse ``input.yaml`` from a case directory into ``YamlData``."""
+    yaml = YAML()
+    loaded: YamlData = yaml.load(  # pyright: ignore[reportUnknownMemberType]
+        stream=(case_dir / "input.yaml").read_text(),
+    )
+    return loaded
+
+
 def has_non_printable_ascii_dict_keys(data: YamlData) -> bool:
     """Return ``True`` if *data* contains a dict key that is empty or
     has characters outside printable ASCII.
@@ -142,12 +151,9 @@ def cases_with_non_trivial_dict_keys(
     """Return case directory names whose input YAML has dict keys that
     some languages cannot represent (empty or non-printable-ASCII).
     """
-    yaml = YAML()
     result: set[str] = set()
     for case_dir in cases_dir.iterdir():
-        loaded: YamlData = yaml.load(  # pyright: ignore[reportUnknownMemberType]
-            stream=(case_dir / "input.yaml").read_text(),
-        )
+        loaded = _load_case_input_yaml(case_dir=case_dir)
         if has_non_printable_ascii_dict_keys(data=loaded):
             result.add(case_dir.name)
     return frozenset(result)
@@ -176,12 +182,9 @@ def cases_with_special_floats(
     """Return case directory names whose input YAML contains a
     non-finite float that some languages cannot produce at runtime.
     """
-    yaml = YAML()
     result: set[str] = set()
     for case_dir in cases_dir.iterdir():
-        loaded: YamlData = yaml.load(  # pyright: ignore[reportUnknownMemberType]
-            stream=(case_dir / "input.yaml").read_text(),
-        )
+        loaded = _load_case_input_yaml(case_dir=case_dir)
         if has_special_floats(data=loaded):
             result.add(case_dir.name)
     return frozenset(result)


### PR DESCRIPTION
## Summary
Extracts the duplicated `yaml.load(...)` calls in `tests/integration/case_discovery.py` into a shared `_load_case_input_yaml` helper, reducing the file's `pyright: ignore[reportUnknownMemberType]` count from two to one.

## Test plan
- [x] pyright, ty, ruff clean
- [x] `tests/integration/test_orphan_golden_files.py` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to test case discovery; behavior should be unchanged aside from centralizing YAML loading and its type-ignore annotation.
> 
> **Overview**
> Extracts duplicated `ruamel.yaml.YAML().load(...)` logic in `tests/integration/case_discovery.py` into a shared `_load_case_input_yaml` helper.
> 
> Updates `cases_with_non_trivial_dict_keys` and `cases_with_special_floats` to use the helper, reducing duplicated code and consolidating the remaining `pyright: ignore[reportUnknownMemberType]` to a single location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d8bd0a1b3e89e2c83a79753cbaeffe37c139a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->