### PR TITLE
Remove remaining noqa suppressions from language type-hint helpers

### DIFF
--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -81,7 +81,7 @@ from literalizer._language import (
     value_contains,
     wrap_in_file_noop,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 from literalizer.exceptions import (
     IncompatibleFormatsError,
     WrapCombinedInFileNotSupportedError,
@@ -101,7 +101,91 @@ def _format_dart_bigint_literal(value: int) -> str:
 
 
 @beartype
-def _dart_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
+def _dart_scalar_hint(
+    *,
+    data: Scalar,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive the Dart annotation for a scalar value."""
+    match data:
+        case bool():
+            hint = "bool"
+        case int():
+            hint = "int"
+        case float():
+            hint = "double"
+        case str() | bytes():
+            hint = "String"
+        case datetime.datetime():
+            hint = datetime_hint
+        case datetime.date():
+            hint = date_hint
+        case None:
+            hint = "Null"
+        case _ as unreachable:
+            assert_never(unreachable)
+    return hint
+
+
+@beartype
+def _dart_unique_or_dynamic(types: list[str]) -> str:
+    """Return the sole element of *types* or ``dynamic`` if
+    heterogeneous.
+    """
+    unique = list(dict.fromkeys(types))
+    match unique:
+        case [single]:
+            return single
+        case _:
+            return "dynamic"
+
+
+@beartype
+def _dart_dict_hint(
+    *,
+    val_types: list[str],
+    is_empty: bool,
+    default_dict_key_type: str,
+    default_dict_value_type: str,
+) -> str:
+    """Derive a Dart Map type annotation."""
+    if is_empty:
+        return f"Map<{default_dict_key_type}, {default_dict_value_type}>"
+    val_type = _dart_unique_or_dynamic(types=val_types)
+    return f"Map<{default_dict_key_type}, {val_type}>"
+
+
+@beartype
+def _dart_set_hint(
+    *,
+    elem_types: list[str],
+    is_empty: bool,
+    default_set_element_type: str,
+) -> str:
+    """Derive a Dart Set type annotation."""
+    if is_empty:
+        return f"Set<{default_set_element_type}>"
+    return f"Set<{_dart_unique_or_dynamic(types=elem_types)}>"
+
+
+@beartype
+def _dart_list_hint(
+    *,
+    elem_types: list[str],
+    is_empty: bool,
+    sequence_is_tuple: bool,
+) -> str:
+    """Derive a Dart List/record type annotation."""
+    if is_empty:
+        return "()" if sequence_is_tuple else "List<dynamic>"
+    if sequence_is_tuple:
+        return f"({', '.join(elem_types)},)"
+    return f"List<{_dart_unique_or_dynamic(types=elem_types)}>"
+
+
+@beartype
+def _dart_type_hint(
     *,
     data: Value,
     date_hint: str,
@@ -122,63 +206,32 @@ def _dart_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C
         sequence_is_tuple=sequence_is_tuple,
     )
     match data:
-        case bool():
-            return "bool"
-        case int():
-            return "int"
-        case float():
-            return "double"
-        case str():
-            return "String"
-        case bytes():
-            return "String"
-        case datetime.datetime():
-            return datetime_hint
-        case datetime.date():
-            return date_hint
-        case None:
-            return "Null"
         case dict():
-            if not data:
-                return (
-                    f"Map<{default_dict_key_type}, {default_dict_value_type}>"
-                )
-            val_types = [recurse(data=v) for v in data.values()]
-            unique = list(dict.fromkeys(val_types))
-            match unique:
-                case [single]:
-                    val_type = single
-                case _:
-                    val_type = "dynamic"
-            return f"Map<{default_dict_key_type}, {val_type}>"
+            hint = _dart_dict_hint(
+                val_types=[recurse(data=v) for v in data.values()],
+                is_empty=not data,
+                default_dict_key_type=default_dict_key_type,
+                default_dict_value_type=default_dict_value_type,
+            )
         case set():
-            if not data:
-                return f"Set<{default_set_element_type}>"
-            elem_types_sorted = sorted({recurse(data=e) for e in data})
-            match elem_types_sorted:
-                case [single]:
-                    elem_type = single
-                case _:
-                    elem_type = "dynamic"
-            return f"Set<{elem_type}>"
+            hint = _dart_set_hint(
+                elem_types=sorted({recurse(data=e) for e in data}),
+                is_empty=not data,
+                default_set_element_type=default_set_element_type,
+            )
         case list():
-            if not data:
-                if sequence_is_tuple:
-                    return "()"
-                return "List<dynamic>"
-            if sequence_is_tuple:
-                elem_types = [recurse(data=e) for e in data]
-                return f"({', '.join(elem_types)},)"
-            elem_types = [recurse(data=e) for e in data]
-            unique = list(dict.fromkeys(elem_types))
-            match unique:
-                case [single]:
-                    elem_type = single
-                case _:
-                    elem_type = "dynamic"
-            return f"List<{elem_type}>"
-        case _ as unreachable:
-            assert_never(unreachable)
+            hint = _dart_list_hint(
+                elem_types=[recurse(data=e) for e in data],
+                is_empty=not data,
+                sequence_is_tuple=sequence_is_tuple,
+            )
+        case _:
+            hint = _dart_scalar_hint(
+                data=data,
+                date_hint=date_hint,
+                datetime_hint=datetime_hint,
+            )
+    return hint
 
 
 @beartype

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -578,8 +578,207 @@ def _datetime_import_items(
     return items
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class _HaskellPreambleConfig:
+    """Captured configuration for the Haskell body preamble
+    computation.
+    """
+
+    include_hdate: bool
+    include_hdatetime: bool
+    datetime_produces_int: bool
+    date_needs_is_string: bool
+    datetime_needs_is_string: bool
+    date_needs_str_explicit: bool
+    datetime_needs_str_explicit: bool
+    is_string_import: str
+    is_string_instance: str
+    type_name: str
+    constructor_prefix: str
+    emit_is_string: bool
+    emit_num: bool
+    indent: str
+
+
 @beartype
-def _build_scalar_body_preamble(  # pylint: disable=too-complex  # noqa: C901
+def _haskell_base_constructors(
+    *,
+    types: frozenset[type],
+    constructor_prefix: str,
+    type_name: str,
+) -> list[str]:
+    """Return base data-type constructors for the types present in
+    data.
+    """
+    p = constructor_prefix
+    return [
+        constructor
+        for type_set, constructor in (
+            (frozenset({type(None)}), f"{p}Null"),
+            (frozenset({bool}), f"{p}Bool Bool"),
+            (frozenset({int}), f"{p}Int Integer"),
+            (frozenset({float}), f"{p}Float Double"),
+            (frozenset({str, bytes}), f"{p}Str String"),
+            (frozenset({list}), f"{p}List [{type_name}]"),
+            (
+                frozenset({dict, ordereddict}),
+                f"{p}Map [(String, {type_name})]",
+            ),
+            (frozenset({set}), f"{p}Set [{type_name}]"),
+        )
+        if types & type_set
+    ]
+
+
+@beartype
+def _haskell_extend_for_dates(
+    *,
+    cfg: _HaskellPreambleConfig,
+    types: frozenset[type],
+    data: Value,
+    data_val_parts: list[str],
+) -> list[str]:
+    """Append date/datetime constructors and return the import-item
+    list.
+    """
+    p = cfg.constructor_prefix
+    import_items: list[str] = []
+    if cfg.include_hdate and datetime.date in types:
+        data_val_parts.append(f"{p}Date Day")
+        import_items.extend(["Day", "fromGregorian"])
+    if cfg.include_hdatetime and datetime.datetime in types:
+        data_val_parts.append(f"{p}Datetime UTCTime")
+        import_items.extend(
+            _datetime_import_items(
+                has_from_gregorian="fromGregorian" in import_items,
+                has_microsecond=_has_microsecond_datetime(data=data),
+                has_nonmicrosecond=_has_nonmicrosecond_datetime(data=data),
+            ),
+        )
+    if (
+        cfg.datetime_produces_int
+        and datetime.datetime in types
+        and f"{p}Int Integer" not in data_val_parts
+    ):
+        data_val_parts.append(f"{p}Int Integer")
+    return import_items
+
+
+@beartype
+def _haskell_needs_str_constructor(
+    *,
+    cfg: _HaskellPreambleConfig,
+    types: frozenset[type],
+) -> bool:
+    """Return True if an ``HStr String`` constructor must be present."""
+    return (
+        bool(types & {str, bytes})
+        or (cfg.date_needs_is_string and datetime.date in types)
+        or (cfg.datetime_needs_is_string and datetime.datetime in types)
+        or (cfg.date_needs_str_explicit and datetime.date in types)
+        or (cfg.datetime_needs_str_explicit and datetime.datetime in types)
+    )
+
+
+@beartype
+def _haskell_num_instances(
+    *,
+    cfg: _HaskellPreambleConfig,
+    types: frozenset[type],
+    data_val_parts: list[str],
+) -> list[str]:
+    """Return ``Num``/``Fractional`` instance lines for the data types."""
+    if not cfg.emit_num:
+        return []
+    p = cfg.constructor_prefix
+    has_float = float in types
+    has_int = int in types or (
+        cfg.datetime_produces_int and datetime.datetime in types
+    )
+    instances: list[str] = []
+    if has_float or has_int:
+        # The numeric catch-all for ``negate`` is redundant when ``Val``
+        # has only numeric constructors, because the specific
+        # ``HInt`` / ``HFloat`` clauses cover the type.
+        num_constructor_count = (1 if has_int else 0) + (1 if has_float else 0)
+        needs_catchall = len(data_val_parts) > num_constructor_count
+        instances.append(
+            _num_instance(
+                has_int=has_int,
+                has_float=has_float,
+                needs_catchall=needs_catchall,
+                type_name=cfg.type_name,
+                constructor_prefix=cfg.constructor_prefix,
+                indent=cfg.indent,
+            ),
+        )
+    if has_float:
+        instances.append(
+            f"instance Fractional {cfg.type_name} where\n"
+            f"{cfg.indent}fromRational r = {p}Float (realToFrac r)\n"
+            f'{cfg.indent}_ / _ = error "not implemented"'
+        )
+    return instances
+
+
+@beartype
+def _haskell_compute_preamble(
+    *,
+    cfg: _HaskellPreambleConfig,
+    types: frozenset[type],
+    data: Value,
+) -> tuple[str, ...]:
+    """Return body-preamble lines for the given *types* and *data*."""
+    p = cfg.constructor_prefix
+    data_val_parts = _haskell_base_constructors(
+        types=types,
+        constructor_prefix=p,
+        type_name=cfg.type_name,
+    )
+    import_items = _haskell_extend_for_dates(
+        cfg=cfg,
+        types=types,
+        data=data,
+        data_val_parts=data_val_parts,
+    )
+
+    needs_is_string = cfg.emit_is_string and (
+        bool(types & {str, bytes})
+        or (cfg.date_needs_is_string and datetime.date in types)
+        or (cfg.datetime_needs_is_string and datetime.datetime in types)
+    )
+    if (
+        _haskell_needs_str_constructor(cfg=cfg, types=types)
+        and f"{p}Str String" not in data_val_parts
+    ):
+        data_val_parts.append(f"{p}Str String")
+
+    # Emit imports first, then data declaration, then instances.
+    imports: list[str] = []
+    if import_items:
+        imports.append("import Data.Time (" + ", ".join(import_items) + ")")
+    if needs_is_string:
+        imports.append(cfg.is_string_import)
+
+    instances: list[str] = []
+    if needs_is_string:
+        instances.append(cfg.is_string_instance)
+    instances.extend(
+        _haskell_num_instances(
+            cfg=cfg,
+            types=types,
+            data_val_parts=data_val_parts,
+        ),
+    )
+
+    lines: list[str] = imports
+    lines.append(f"data {cfg.type_name} = " + " | ".join(data_val_parts))
+    lines.extend(instances)
+    return tuple(lines)
+
+
+@beartype
+def _build_scalar_body_preamble(
     *,
     date_format: enum.Enum,
     datetime_format: enum.Enum,
@@ -606,129 +805,38 @@ def _build_scalar_body_preamble(  # pylint: disable=too-complex  # noqa: C901
     When *emit_num* is ``False``, the ``Num`` and ``Fractional``
     instances are suppressed (used by the ``EXPLICIT`` numeric style).
     """
-    include_hdate = date_format.value.type_produced is datetime.date
-    include_hdatetime = (
-        datetime_format.value.type_produced is datetime.datetime
-    )
-    datetime_produces_int = datetime_format.value.type_produced is int
-    date_needs_is_string = bool(
-        emit_is_string and date_format.value.preamble_lines
-    )
-    datetime_needs_is_string = bool(
-        emit_is_string and datetime_format.value.preamble_lines
-    )
-    # In EXPLICIT mode, ISO dates/datetimes produce HStr-wrapped strings,
-    # so HStr String must appear in the data type.
-    date_needs_str_explicit = bool(
-        not emit_is_string and date_format.value.type_produced is str
-    )
-    datetime_needs_str_explicit = bool(
-        not emit_is_string and datetime_format.value.type_produced is str
+    cfg = _HaskellPreambleConfig(
+        include_hdate=date_format.value.type_produced is datetime.date,
+        include_hdatetime=(
+            datetime_format.value.type_produced is datetime.datetime
+        ),
+        datetime_produces_int=datetime_format.value.type_produced is int,
+        date_needs_is_string=bool(
+            emit_is_string and date_format.value.preamble_lines
+        ),
+        datetime_needs_is_string=bool(
+            emit_is_string and datetime_format.value.preamble_lines
+        ),
+        # In EXPLICIT mode, ISO dates/datetimes produce HStr-wrapped
+        # strings, so HStr String must appear in the data type.
+        date_needs_str_explicit=bool(
+            not emit_is_string and date_format.value.type_produced is str
+        ),
+        datetime_needs_str_explicit=bool(
+            not emit_is_string and datetime_format.value.type_produced is str
+        ),
+        is_string_import=is_string_import,
+        is_string_instance=is_string_instance,
+        type_name=type_name,
+        constructor_prefix=constructor_prefix,
+        emit_is_string=emit_is_string,
+        emit_num=emit_num,
+        indent=indent,
     )
 
     def _compute(types: frozenset[type], data: Value, /) -> tuple[str, ...]:
         """Return body-preamble lines for the given *types*."""
-        p = constructor_prefix
-        data_val_parts = [
-            constructor
-            for type_set, constructor in (
-                (frozenset({type(None)}), f"{p}Null"),
-                (frozenset({bool}), f"{p}Bool Bool"),
-                (frozenset({int}), f"{p}Int Integer"),
-                (frozenset({float}), f"{p}Float Double"),
-                (frozenset({str, bytes}), f"{p}Str String"),
-                (frozenset({list}), f"{p}List [{type_name}]"),
-                (
-                    frozenset({dict, ordereddict}),
-                    f"{p}Map [(String, {type_name})]",
-                ),
-                (frozenset({set}), f"{p}Set [{type_name}]"),
-            )
-            if types & type_set
-        ]
-        import_items: list[str] = []
-        if include_hdate and datetime.date in types:
-            data_val_parts.append(f"{p}Date Day")
-            import_items.extend(["Day", "fromGregorian"])
-        if include_hdatetime and datetime.datetime in types:
-            data_val_parts.append(f"{p}Datetime UTCTime")
-            import_items.extend(
-                _datetime_import_items(
-                    has_from_gregorian="fromGregorian" in import_items,
-                    has_microsecond=_has_microsecond_datetime(data=data),
-                    has_nonmicrosecond=_has_nonmicrosecond_datetime(
-                        data=data,
-                    ),
-                ),
-            )
-        if (
-            datetime_produces_int
-            and datetime.datetime in types
-            and f"{p}Int Integer" not in data_val_parts
-        ):
-            data_val_parts.append(f"{p}Int Integer")
-
-        needs_is_string = emit_is_string and (
-            bool(types & {str, bytes})
-            or (date_needs_is_string and datetime.date in types)
-            or (datetime_needs_is_string and datetime.datetime in types)
-        )
-        needs_str_constructor = (
-            bool(types & {str, bytes})
-            or (date_needs_is_string and datetime.date in types)
-            or (datetime_needs_is_string and datetime.datetime in types)
-            or (date_needs_str_explicit and datetime.date in types)
-            or (datetime_needs_str_explicit and datetime.datetime in types)
-        )
-        if needs_str_constructor and f"{p}Str String" not in data_val_parts:
-            data_val_parts.append(f"{p}Str String")
-
-        # Emit imports first, then data declaration, then instances.
-        imports: list[str] = []
-        if import_items:
-            imports.append(
-                "import Data.Time (" + ", ".join(import_items) + ")"
-            )
-        if needs_is_string:
-            imports.append(is_string_import)
-
-        instances: list[str] = []
-        if needs_is_string:
-            instances.append(is_string_instance)
-
-        has_float = float in types
-        has_int = int in types or (
-            datetime_produces_int and datetime.datetime in types
-        )
-        if emit_num and (has_float or has_int):
-            # The numeric catch-all for ``negate`` is redundant when
-            # ``Val`` has only numeric constructors, because the
-            # specific ``HInt`` / ``HFloat`` clauses cover the type.
-            num_constructor_count = (1 if has_int else 0) + (
-                1 if has_float else 0
-            )
-            needs_catchall = len(data_val_parts) > num_constructor_count
-            instances.append(
-                _num_instance(
-                    has_int=has_int,
-                    has_float=has_float,
-                    needs_catchall=needs_catchall,
-                    type_name=type_name,
-                    constructor_prefix=constructor_prefix,
-                    indent=indent,
-                ),
-            )
-        if emit_num and has_float:
-            instances.append(
-                f"instance Fractional {type_name} where\n"
-                f"{indent}fromRational r = {p}Float (realToFrac r)\n"
-                f'{indent}_ / _ = error "not implemented"'
-            )
-
-        lines: list[str] = imports
-        lines.append(f"data {type_name} = " + " | ".join(data_val_parts))
-        lines.extend(instances)
-        return tuple(lines)
+        return _haskell_compute_preamble(cfg=cfg, types=types, data=data)
 
     return _compute
 

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -81,7 +81,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 from literalizer.exceptions import NullInCollectionError
 
 
@@ -282,7 +282,36 @@ def _java_common_element_type(
 
 
 @beartype
-def _java_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
+def _java_scalar_hint(
+    *,
+    data: Scalar,
+    int_type: str,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive the Java annotation for a scalar value."""
+    match data:
+        case bool():
+            hint = "boolean"
+        case int():
+            hint = int_type
+        case float():
+            hint = "double"
+        case str() | bytes():
+            hint = "String"
+        case datetime.datetime():
+            hint = datetime_hint
+        case datetime.date():
+            hint = date_hint
+        case None:
+            hint = "Object"
+        case _ as unreachable:
+            assert_never(unreachable)
+    return hint
+
+
+@beartype
+def _java_type_hint(
     *,
     data: Value,
     int_type: str,
@@ -293,82 +322,45 @@ def _java_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C
     set_outer: str,
 ) -> str:
     """Derive a Java type from *data*."""
+    common = functools.partial(
+        _java_common_element_type,
+        int_type=int_type,
+        date_hint=date_hint,
+        datetime_hint=datetime_hint,
+        seq_is_array=seq_is_array,
+        dict_outer=dict_outer,
+        set_outer=set_outer,
+    )
     match data:
-        case bool():
-            return "boolean"
-        case int():
-            return int_type
-        case float():
-            return "double"
-        case str():
-            return "String"
-        case bytes():
-            return "String"
-        case datetime.datetime():
-            return datetime_hint
-        case datetime.date():
-            return date_hint
-        case None:
-            return "Object"
         case dict():
-            val_type = _java_common_element_type(
-                elements=list(data.values()),
-                boxed=True,
-                int_type=int_type,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                seq_is_array=seq_is_array,
-                dict_outer=dict_outer,
-                set_outer=set_outer,
-            )
+            val_type = common(elements=list(data.values()), boxed=True)
             outer = (
-                dict_outer
-                if not isinstance(data, (ordereddict, OrderedDict))
-                else "Map"
+                "Map"
+                if isinstance(data, (ordereddict, OrderedDict))
+                else dict_outer
             )
-            return f"{outer}<String, {val_type}>"
+            hint = f"{outer}<String, {val_type}>"
         case set():
-            elem_type = _java_common_element_type(
-                elements=list(data),
-                boxed=True,
-                int_type=int_type,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-                seq_is_array=seq_is_array,
-                dict_outer=dict_outer,
-                set_outer=set_outer,
-            )
-            return f"{set_outer}<{elem_type}>"
+            elem_type = common(elements=list(data), boxed=True)
+            hint = f"{set_outer}<{elem_type}>"
+        case list() if seq_is_array:
+            elem_type = common(elements=data, boxed=False)
+            # Java cannot create arrays of generic types, so fall back
+            # to Object[] when the element type is generic.
+            if "<" in elem_type:
+                elem_type = "Object"
+            hint = f"{elem_type}[]"
         case list():
-            if seq_is_array:
-                elem_type = _java_common_element_type(
-                    elements=data,
-                    boxed=False,
-                    int_type=int_type,
-                    date_hint=date_hint,
-                    datetime_hint=datetime_hint,
-                    seq_is_array=seq_is_array,
-                    dict_outer=dict_outer,
-                    set_outer=set_outer,
-                )
-                # Java cannot create arrays of generic types, so fall
-                # back to Object[] when the element type is generic.
-                if "<" in elem_type:
-                    elem_type = "Object"
-                return f"{elem_type}[]"
-            elem_type = _java_common_element_type(
-                elements=data,
-                boxed=True,
+            elem_type = common(elements=data, boxed=True)
+            hint = f"List<{elem_type}>"
+        case _:
+            hint = _java_scalar_hint(
+                data=data,
                 int_type=int_type,
                 date_hint=date_hint,
                 datetime_hint=datetime_hint,
-                seq_is_array=seq_is_array,
-                dict_outer=dict_outer,
-                set_outer=set_outer,
             )
-            return f"List<{elem_type}>"
-        case _ as unreachable:
-            assert_never(unreachable)
+    return hint
 
 
 @beartype

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -92,7 +92,7 @@ from literalizer._language import (
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 @beartype
@@ -206,7 +206,122 @@ def _kotlin_type_to_opener(
 
 
 @beartype
-def _kotlin_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
+def _kotlin_scalar_hint(
+    *,
+    data: Scalar,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive the Kotlin annotation for a scalar value."""
+    match data:
+        case bool():
+            hint = "Boolean"
+        case int():
+            hint = "Int"
+        case float():
+            hint = "Double"
+        case str() | bytes():
+            hint = "String"
+        case datetime.datetime():
+            hint = datetime_hint
+        case datetime.date():
+            hint = date_hint
+        case None:
+            hint = "Nothing?"
+        case _ as unreachable:
+            assert_never(unreachable)
+    return hint
+
+
+@beartype
+def _kotlin_dict_hint(
+    *,
+    is_empty: bool,
+    is_ordered: bool,
+    val_types: list[str],
+    default_dict_key_type: str,
+    default_dict_value_type: str,
+    dict_outer: str,
+) -> str:
+    """Derive a Kotlin map type annotation."""
+    outer = "LinkedHashMap" if is_ordered else dict_outer
+    if is_empty:
+        return f"{outer}<{default_dict_key_type}, {default_dict_value_type}>"
+    unique = list(dict.fromkeys(val_types))
+    val_type = unique[0] if len(unique) == 1 else "Any?"
+    return f"{outer}<{default_dict_key_type}, {val_type}>"
+
+
+@beartype
+def _kotlin_set_hint(
+    *,
+    elem_types_sorted: list[str],
+    is_empty: bool,
+    default_set_element_type: str,
+    set_outer: str,
+) -> str:
+    """Derive a Kotlin set type annotation."""
+    if is_empty:
+        return f"{set_outer}<{default_set_element_type}>"
+    elem_type = elem_types_sorted[0] if len(elem_types_sorted) == 1 else "Any?"
+    return f"{set_outer}<{elem_type}>"
+
+
+@beartype
+def _kotlin_tuple_hint(*, elem_types: list[str]) -> str:
+    """Derive a Kotlin tuple-shaped annotation."""
+    match elem_types:
+        case [_, _]:
+            return f"Pair<{', '.join(elem_types)}>"
+        case [_, _, _]:
+            return f"Triple<{', '.join(elem_types)}>"
+        case _:
+            return "List<Any?>"
+
+
+@beartype
+def _kotlin_array_or_list_hint(*, elem_types: list[str]) -> str:
+    """Derive a Kotlin array/list annotation for the ``LIST`` format."""
+    unique = list(dict.fromkeys(elem_types))
+    if len(unique) != 1:
+        return "List<Any?>"
+    elem_type = unique[0]
+    kotlin_prim = {
+        "Boolean": "BooleanArray",
+        "Int": "IntArray",
+        "Double": "DoubleArray",
+    }
+    if elem_type in kotlin_prim:
+        return kotlin_prim[elem_type]
+    # Generic element types (e.g. Map<…>) use listOf, not arrayOf, so
+    # the container type is List, not Array.
+    if "<" in elem_type:
+        return f"List<{elem_type}>"
+    return f"Array<{elem_type}>"
+
+
+@beartype
+def _kotlin_list_hint(
+    *,
+    data: list[Value],
+    recurse: Callable[..., str],
+    sequence_format_name: str,
+) -> str:
+    """Derive a Kotlin sequence type annotation."""
+    if not data:
+        return (
+            "Array<Any?>" if sequence_format_name == "ARRAY" else "List<Any?>"
+        )
+    elem_types = [recurse(data=e) for e in data]
+    if sequence_format_name == "TUPLE":
+        return _kotlin_tuple_hint(elem_types=elem_types)
+    if sequence_format_name == "ARRAY":
+        return "Array<Any?>"
+    return _kotlin_array_or_list_hint(elem_types=elem_types)
+
+
+@beartype
+def _kotlin_type_hint(
     *,
     data: Value,
     date_hint: str,
@@ -231,92 +346,35 @@ def _kotlin_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
         sequence_format_name=sequence_format_name,
     )
     match data:
-        case bool():
-            return "Boolean"
-        case int():
-            return "Int"
-        case float():
-            return "Double"
-        case str():
-            return "String"
-        case bytes():
-            return "String"
-        case datetime.datetime():
-            return datetime_hint
-        case datetime.date():
-            return date_hint
-        case None:
-            return "Nothing?"
         case dict():
-            if not data:
-                outer = (
-                    dict_outer
-                    if not isinstance(data, (ordereddict, OrderedDict))
-                    else "LinkedHashMap"
-                )
-                return (
-                    f"{outer}<{default_dict_key_type}"
-                    f", {default_dict_value_type}>"
-                )
-            val_types = [recurse(data=v) for v in data.values()]
-            unique = list(dict.fromkeys(val_types))
-            match unique:
-                case [single]:
-                    val_type = single
-                case _:
-                    val_type = "Any?"
-            outer = (
-                dict_outer
-                if not isinstance(data, (ordereddict, OrderedDict))
-                else "LinkedHashMap"
+            hint = _kotlin_dict_hint(
+                is_empty=not data,
+                is_ordered=isinstance(data, (ordereddict, OrderedDict)),
+                val_types=[recurse(data=v) for v in data.values()],
+                default_dict_key_type=default_dict_key_type,
+                default_dict_value_type=default_dict_value_type,
+                dict_outer=dict_outer,
             )
-            return f"{outer}<{default_dict_key_type}, {val_type}>"
         case set():
-            if not data:
-                return f"{set_outer}<{default_set_element_type}>"
-            elem_types = sorted({recurse(data=e) for e in data})
-            match elem_types:
-                case [single]:
-                    elem_type = single
-                case _:
-                    elem_type = "Any?"
-            return f"{set_outer}<{elem_type}>"
+            hint = _kotlin_set_hint(
+                elem_types_sorted=sorted({recurse(data=e) for e in data}),
+                is_empty=not data,
+                default_set_element_type=default_set_element_type,
+                set_outer=set_outer,
+            )
         case list():
-            if not data:
-                if sequence_format_name == "ARRAY":
-                    return "Array<Any?>"
-                return "List<Any?>"
-            if sequence_format_name == "TUPLE":
-                elem_types = [recurse(data=e) for e in data]
-                match data:
-                    case [_, _]:
-                        return f"Pair<{', '.join(elem_types)}>"
-                    case [_, _, _]:
-                        return f"Triple<{', '.join(elem_types)}>"
-                    case _:
-                        return "List<Any?>"
-            if sequence_format_name == "ARRAY":
-                return "Array<Any?>"
-            # LIST format — use typed arrays matching the opener
-            elem_types = [recurse(data=e) for e in data]
-            unique = list(dict.fromkeys(elem_types))
-            if len(unique) != 1:
-                return "List<Any?>"
-            elem_type = unique[0]
-            kotlin_prim = {
-                "Boolean": "BooleanArray",
-                "Int": "IntArray",
-                "Double": "DoubleArray",
-            }
-            if elem_type in kotlin_prim:
-                return kotlin_prim[elem_type]
-            # Generic element types (e.g. Map<…>) use listOf, not
-            # arrayOf, so the container type is List, not Array.
-            if "<" in elem_type:
-                return f"List<{elem_type}>"
-            return f"Array<{elem_type}>"
-        case _ as unreachable:
-            assert_never(unreachable)
+            hint = _kotlin_list_hint(
+                data=data,
+                recurse=recurse,
+                sequence_format_name=sequence_format_name,
+            )
+        case _:
+            hint = _kotlin_scalar_hint(
+                data=data,
+                date_hint=date_hint,
+                datetime_hint=datetime_hint,
+            )
+    return hint
 
 
 @beartype

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -312,11 +312,11 @@ def _kotlin_list_hint(
         return (
             "Array<Any?>" if sequence_format_name == "ARRAY" else "List<Any?>"
         )
+    if sequence_format_name == "ARRAY":
+        return "Array<Any?>"
     elem_types = [recurse(data=e) for e in data]
     if sequence_format_name == "TUPLE":
         return _kotlin_tuple_hint(elem_types=elem_types)
-    if sequence_format_name == "ARRAY":
-        return "Array<Any?>"
     return _kotlin_array_or_list_hint(elem_types=elem_types)
 
 

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -365,8 +365,41 @@ _format_purescript_string = _build_purescript_str_formatter(prefix="P")
 _purescript_dict_entry = _build_purescript_dict_entry(prefix="P")
 
 
+def _purescript_negative_float(val: float) -> bool:
+    """Return True if *val* is a float requiring ``import Prelude``."""
+    return math.copysign(1, val) < 0 or math.isinf(val) or math.isnan(val)
+
+
 @beartype
-def _build_purescript_body_preamble(  # pylint: disable=too-complex  # noqa: C901
+def _purescript_needs_prelude(val: Value) -> bool:
+    """Return True if *val* needs ``import Prelude``.
+
+    Prelude is required for ``negate`` (any negative int or float)
+    and for ``/`` (infinity / NaN expressed as ``1.0 / 0.0``).
+    """
+    if isinstance(val, bool):
+        result = False
+    elif isinstance(val, float):
+        result = _purescript_negative_float(val=val)
+    elif isinstance(val, int):
+        result = val < 0
+    elif isinstance(val, list):
+        result = any(_purescript_needs_prelude(val=v) for v in val)
+    elif isinstance(val, dict):
+        result = any(_purescript_needs_prelude(val=v) for v in val.values())
+    elif isinstance(val, set):
+        result = any(
+            _purescript_needs_prelude(val=v)
+            for v in val
+            if isinstance(v, (int, float)) and not isinstance(v, bool)
+        )
+    else:
+        result = False
+    return result
+
+
+@beartype
+def _build_purescript_body_preamble(
     *,
     type_name: str,
     constructor_prefix: str,
@@ -378,32 +411,6 @@ def _build_purescript_body_preamble(  # pylint: disable=too-complex  # noqa: C90
     the type declaration with only the constructors that are actually
     needed, plus any necessary imports.
     """
-
-    def _needs_prelude(val: Value) -> bool:
-        """Return True if *val* needs ``import Prelude``.
-
-        Prelude is required for ``negate`` (any negative int or float)
-        and for ``/`` (infinity / NaN expressed as ``1.0 / 0.0``).
-        """
-        if isinstance(val, (int, float)) and not isinstance(val, bool):
-            if isinstance(val, float):
-                return (
-                    math.copysign(1, val) < 0
-                    or math.isinf(val)
-                    or math.isnan(val)
-                )
-            return val < 0
-        if isinstance(val, list):
-            return any(_needs_prelude(val=v) for v in val)
-        if isinstance(val, dict):
-            return any(_needs_prelude(val=v) for v in val.values())
-        if isinstance(val, set):
-            return any(
-                _needs_prelude(val=v)
-                for v in val
-                if isinstance(v, (int, float)) and not isinstance(v, bool)
-            )
-        return False
 
     def _compute(types: frozenset[type], data: Value, /) -> tuple[str, ...]:
         """Return body-preamble lines for the given *types*."""
@@ -440,7 +447,9 @@ def _build_purescript_body_preamble(  # pylint: disable=too-complex  # noqa: C90
                 if c == f"{p}Int Int"
             )
             constructors.insert(int_idx + 1, f"{p}Long Number")
-        needs_prelude = bool(types & {int, float}) and _needs_prelude(val=data)
+        needs_prelude = bool(
+            types & {int, float}
+        ) and _purescript_needs_prelude(val=data)
         lines: list[str] = ["import Prelude"] if needs_prelude else []
         if needs_tuple:
             lines.append("data Tuple a b = Tuple a b")

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -83,7 +83,7 @@ from literalizer._language import (
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 @beartype
@@ -296,7 +296,40 @@ def _merge_dict_elements(*, elements: list[Value]) -> list[Value]:
 
 
 @beartype
-def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
+def _python_scalar_hint(
+    *,
+    data: Scalar,
+    bytes_hint: str,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive a Python type hint for a scalar value."""
+    # Order matters: datetime before date (datetime is a date subclass),
+    # bool before int (bool is an int subclass).
+    match data:
+        case bool():
+            hint = "bool"
+        case int():
+            hint = "int"
+        case float():
+            hint = "float"
+        case str():
+            hint = "str"
+        case bytes():
+            hint = bytes_hint
+        case datetime.datetime():
+            hint = datetime_hint
+        case datetime.date():
+            hint = date_hint
+        case None:
+            hint = "None"
+        case _ as unreachable:
+            assert_never(unreachable)
+    return hint
+
+
+@beartype
+def _python_type_hint(
     *,
     data: Value,
     bytes_hint: str,
@@ -325,25 +358,7 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
         default_dict_key_type=default_dict_key_type,
     )
 
-    # Order matters: datetime before date (datetime is a date subclass),
-    # bool before int (bool is an int subclass).
     match data:
-        case bool():
-            return "bool"
-        case int():
-            return "int"
-        case float():
-            return "float"
-        case str():
-            return "str"
-        case bytes():
-            return bytes_hint
-        case datetime.datetime():
-            return datetime_hint
-        case datetime.date():
-            return date_hint
-        case None:
-            return "None"
         case dict():
             outer = (
                 "OrderedDict"
@@ -358,7 +373,7 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
                 merge_dicts=False,
                 default_type=default_dict_value_type,
             )
-            return f"{outer}[{key_hint}, {val_union}]"
+            hint = f"{outer}[{key_hint}, {val_union}]"
         case set():
             elem_union = _collection_element_union(
                 elements=list(data),
@@ -367,7 +382,7 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
                 merge_dicts=False,
                 default_type=default_set_element_type,
             )
-            return f"{set_hint}[{elem_union}]"
+            hint = f"{set_hint}[{elem_union}]"
         case list():
             elem_union = _collection_element_union(
                 elements=data,
@@ -376,11 +391,19 @@ def _python_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa:
                 merge_dicts=True,
                 default_type=default_sequence_element_type,
             )
-            if sequence_hint == "tuple":
-                return f"{sequence_hint}[{elem_union}, ...]"
-            return f"{sequence_hint}[{elem_union}]"
-        case _ as unreachable:
-            assert_never(unreachable)
+            hint = (
+                f"{sequence_hint}[{elem_union}, ...]"
+                if sequence_hint == "tuple"
+                else f"{sequence_hint}[{elem_union}]"
+            )
+        case _:
+            hint = _python_scalar_hint(
+                data=data,
+                bytes_hint=bytes_hint,
+                date_hint=date_hint,
+                datetime_hint=datetime_hint,
+            )
+    return hint
 
 
 @beartype

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -83,7 +83,7 @@ from literalizer._language import (
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 @beartype
@@ -196,7 +196,81 @@ def _swift_call_stub(
 
 
 @beartype
-def _swift_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
+def _swift_scalar_hint(
+    *,
+    data: Scalar,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive the Swift annotation for a scalar value."""
+    match data:
+        case bool():
+            hint = "Bool"
+        case int():
+            hint = "Int"
+        case float():
+            hint = "Double"
+        case str() | bytes():
+            hint = "String"
+        case datetime.datetime():
+            hint = datetime_hint
+        case datetime.date():
+            hint = date_hint
+        case None:
+            hint = "Any?"
+        case _ as unreachable:
+            assert_never(unreachable)
+    return hint
+
+
+@beartype
+def _swift_collapse(types: list[str]) -> str:
+    """Return a single Swift element type or ``Any`` / ``Any?``
+    fallback.
+    """
+    unique = list(dict.fromkeys(types))
+    match unique:
+        case [single]:
+            return single
+        case _ if "Any?" in unique:
+            return "Any?"
+        case _:
+            return "Any"
+
+
+@beartype
+def _swift_dict_hint(
+    *,
+    val_types: list[str],
+    is_empty: bool,
+    default_dict_value_type: str,
+) -> str:
+    """Derive a Swift dictionary type annotation."""
+    if is_empty:
+        return f"[String: {default_dict_value_type}]"
+    return f"[String: {_swift_collapse(types=val_types)}]"
+
+
+@beartype
+def _swift_list_hint(
+    *,
+    elem_types: list[str],
+    is_empty: bool,
+    sequence_is_tuple: bool,
+    default_sequence_element_type: str,
+) -> str:
+    """Derive a Swift array/tuple type annotation."""
+    if is_empty:
+        return (
+            "()" if sequence_is_tuple else f"[{default_sequence_element_type}]"
+        )
+    if sequence_is_tuple:
+        return f"({', '.join(elem_types)})"
+    return f"[{_swift_collapse(types=elem_types)}]"
+
+
+@beartype
+def _swift_type_hint(
     *,
     data: Value,
     date_hint: str,
@@ -217,57 +291,28 @@ def _swift_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: 
         sequence_is_tuple=sequence_is_tuple,
     )
     match data:
-        case bool():
-            return "Bool"
-        case int():
-            return "Int"
-        case float():
-            return "Double"
-        case str():
-            return "String"
-        case bytes():
-            return "String"
-        case datetime.datetime():
-            return datetime_hint
-        case datetime.date():
-            return date_hint
-        case None:
-            return "Any?"
         case dict():
-            if not data:
-                return f"[String: {default_dict_value_type}]"
-            val_types = [recurse(data=v) for v in data.values()]
-            unique = list(dict.fromkeys(val_types))
-            match unique:
-                case [single]:
-                    val_type = single
-                case _ if "Any?" in unique:
-                    val_type = "Any?"
-                case _:
-                    val_type = "Any"
-            return f"[String: {val_type}]"
+            hint = _swift_dict_hint(
+                val_types=[recurse(data=v) for v in data.values()],
+                is_empty=not data,
+                default_dict_value_type=default_dict_value_type,
+            )
         case set():
-            return f"Set<{default_set_element_type}>"
+            hint = f"Set<{default_set_element_type}>"
         case list():
-            if not data:
-                if sequence_is_tuple:
-                    return "()"
-                return f"[{default_sequence_element_type}]"
-            if sequence_is_tuple:
-                elem_types = [recurse(data=e) for e in data]
-                return f"({', '.join(elem_types)})"
-            elem_types = [recurse(data=e) for e in data]
-            unique = list(dict.fromkeys(elem_types))
-            match unique:
-                case [single]:
-                    elem_type = single
-                case _ if "Any?" in unique:
-                    elem_type = "Any?"
-                case _:
-                    elem_type = "Any"
-            return f"[{elem_type}]"
-        case _ as unreachable:
-            assert_never(unreachable)
+            hint = _swift_list_hint(
+                elem_types=[recurse(data=e) for e in data],
+                is_empty=not data,
+                sequence_is_tuple=sequence_is_tuple,
+                default_sequence_element_type=default_sequence_element_type,
+            )
+        case _:
+            hint = _swift_scalar_hint(
+                data=data,
+                date_hint=date_hint,
+                datetime_hint=datetime_hint,
+            )
+    return hint
 
 
 @beartype

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -83,7 +83,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 def _ts_call_stub(
@@ -121,7 +121,80 @@ def _ts_element_union(*, types: list[str]) -> str:
 
 
 @beartype
-def _ts_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C901, PLR0911, PLR0912
+def _ts_scalar_hint(
+    *,
+    data: Scalar,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive a TypeScript annotation for a scalar value."""
+    match data:
+        case bool():
+            hint = "boolean"
+        case int() | float():
+            hint = "number"
+        case str() | bytes():
+            hint = "string"
+        case datetime.datetime():
+            hint = datetime_hint
+        case datetime.date():
+            hint = date_hint
+        case None:
+            hint = "null"
+        case _ as unreachable:
+            assert_never(unreachable)
+    return hint
+
+
+@beartype
+def _ts_dict_hint(
+    *,
+    is_ordered: bool,
+    is_empty: bool,
+    val_types: list[str],
+    dict_hint_template: str,
+) -> str:
+    """Derive a TypeScript type annotation for a dict value."""
+    template = "Record<string, {val}>" if is_ordered else dict_hint_template
+    # The MAP opener always uses ``unknown`` as the value type, so
+    # the annotation must match.
+    if is_empty or "Map<" in template:
+        return template.format(val="unknown")
+    return template.format(val=_ts_element_union(types=val_types))
+
+
+@beartype
+def _ts_set_hint(
+    *,
+    data: set[Scalar],
+    recurse: Callable[..., str],
+) -> str:
+    """Derive a TypeScript type annotation for a set value."""
+    if not data:
+        return "Set<unknown>"
+    elem_types = sorted(recurse(data=e) for e in data)
+    return f"Set<{_ts_element_union(types=elem_types)}>"
+
+
+@beartype
+def _ts_list_hint(
+    *,
+    data: list[Value],
+    recurse: Callable[..., str],
+    sequence_is_tuple: bool,
+) -> str:
+    """Derive a TypeScript type annotation for a list value."""
+    if not data:
+        return "readonly []" if sequence_is_tuple else "unknown[]"
+    elem_types = [recurse(data=e) for e in data]
+    if sequence_is_tuple:
+        return f"readonly [{', '.join(elem_types)}]"
+    elem_union = _ts_element_union(types=elem_types)
+    return f"({elem_union})[]" if " | " in elem_union else f"{elem_union}[]"
+
+
+@beartype
+def _ts_type_hint(
     *,
     data: Value,
     date_hint: str,
@@ -138,54 +211,28 @@ def _ts_type_hint(  # pylint: disable=too-complex,too-many-branches  # noqa: C90
         sequence_is_tuple=sequence_is_tuple,
     )
     match data:
-        case bool():
-            return "boolean"
-        case int():
-            return "number"
-        case float():
-            return "number"
-        case str():
-            return "string"
-        case bytes():
-            return "string"
-        case datetime.datetime():
-            return datetime_hint
-        case datetime.date():
-            return date_hint
-        case None:
-            return "null"
         case dict():
-            val_types = [recurse(data=v) for v in data.values()]
-            template = (
-                "Record<string, {val}>"
-                if isinstance(data, (ordereddict, OrderedDict))
-                else dict_hint_template
+            hint = _ts_dict_hint(
+                is_ordered=isinstance(data, (ordereddict, OrderedDict)),
+                is_empty=not data,
+                val_types=[recurse(data=v) for v in data.values()],
+                dict_hint_template=dict_hint_template,
             )
-            # The MAP opener always uses ``unknown`` as the value
-            # type, so the annotation must match.
-            if not data or "Map<" in template:
-                return template.format(val="unknown")
-            val_union = _ts_element_union(types=val_types)
-            return template.format(val=val_union)
         case set():
-            if not data:
-                return "Set<unknown>"
-            elem_types = sorted(recurse(data=e) for e in data)
-            elem_union = _ts_element_union(types=elem_types)
-            return f"Set<{elem_union}>"
+            hint = _ts_set_hint(data=data, recurse=recurse)
         case list():
-            if not data:
-                return "readonly []" if sequence_is_tuple else "unknown[]"
-            if sequence_is_tuple:
-                elem_types = [recurse(data=e) for e in data]
-                return f"readonly [{', '.join(elem_types)}]"
-            elem_types = [recurse(data=e) for e in data]
-            elem_union = _ts_element_union(types=elem_types)
-            if " | " in elem_union:
-                return f"({elem_union})[]"
-            return f"{elem_union}[]"
-        case _ as unreachable:
-            assert_never(unreachable)
+            hint = _ts_list_hint(
+                data=data,
+                recurse=recurse,
+                sequence_is_tuple=sequence_is_tuple,
+            )
+        case _:
+            hint = _ts_scalar_hint(
+                data=data,
+                date_hint=date_hint,
+                datetime_hint=datetime_hint,
+            )
+    return hint
 
 
 @beartype


### PR DESCRIPTION
## Summary
- Refactor the per-language `_*_type_hint` helpers (TypeScript, Dart, Swift, Python, Kotlin, Java) into scalar + collection sub-helpers so each function clears `C901`, `PLR0911`, and `PLR0912` without suppressions.
- Hoist the inner closures of `_build_purescript_body_preamble` and `_build_scalar_body_preamble` (Haskell) into module-level helpers for the same reason; introduce a `_HaskellPreambleConfig` dataclass to keep the captured context tidy.
- New helpers are decorated with `@beartype` for runtime type checking, in line with the rest of the package.
- Closes #2170 (\`git grep \"noqa\" src\` now returns nothing).

## Test plan
- [x] \`uv run ruff check src/\`
- [x] \`uv run pytest\` (3421 passed, 958 skipped, 20271 subtests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor, but it touches type-hint inference and preamble generation across several language backends, so small logic regressions could change emitted annotations/imports for edge-case values (empty/heterogeneous collections, date/datetime formats).
> 
> **Overview**
> Refactors per-language type-hint inference in `dart`, `java`, `kotlin`, `python`, `swift`, and `typescript` by splitting the old monolithic `_*_type_hint` functions into scalar vs collection helpers (plus small shared utilities like unique-type collapsing), and updating signatures to use the new `Scalar` alias.
> 
> Hoists previously-nested preamble builders into module-level helpers for `haskell` (new `_HaskellPreambleConfig` + `_haskell_compute_preamble`) and `purescript` (`_purescript_needs_prelude`), keeping generated output logic the same while eliminating `noqa`/complexity suppressions and adding `@beartype` on the new helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485143a535c8842bc6d9db03436be94fca5aa276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->