### PR TITLE
Run Matlab lint job in gnuoctave/octave container

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -302,21 +302,16 @@ jobs:
   lint-matlab:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Use a prebuilt Octave image instead of `apt-get install octave`, which
+    # is slow (the Ubuntu package pulls a large dependency tree) and which
+    # cache-apt-pkgs-action could not reliably restore (liblapack.so.3 kept
+    # going missing even with the package listed explicitly).
+    container:
+      image: gnuoctave/octave:9.2.0
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      # cache-apt-pkgs-action does not reliably restore octave's shared
-      # library dependencies to their system paths (liblapack.so.3 stays
-      # missing even with the package listed explicitly and ldconfig run
-      # after), so install via apt directly here.
-      - name: Install octave
-        run: |-
-          # Drop third-party apt sources (Microsoft, GitHub CLI, etc.) before
-          # update so we only refresh the Ubuntu archive we actually install from.
-          sudo rm -f /etc/apt/sources.list.d/*.list
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends octave
       - name: Lint Matlab
         run: |-
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab


### PR DESCRIPTION
## Summary
- Replaces `apt-get install octave` in the `lint-matlab` job with a prebuilt `gnuoctave/octave:9.2.0` container at the job level, avoiding the slow apt dependency install and the liblapack restore issues hit with `cache-apt-pkgs-action`.

## Test plan
- [ ] CI: `lint-matlab` job pulls the image and runs `bash .github/scripts/lint-matlab-fixture.sh` successfully against all `Matlab*.m` fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk; change is isolated to the `lint-matlab` GitHub Actions job, but could cause CI failures if the container image differs from the Ubuntu runner environment.
> 
> **Overview**
> Runs the `lint-matlab` job in a job-level `gnuoctave/octave:9.2.0` container and removes the `apt-get install octave` step.
> 
> This is intended to speed up CI and avoid flaky Octave dependency restores (notably missing `liblapack.so.3`) seen with apt/package caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee42d12b4c055463381de5f58063bb2b3e47df6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->