### PR TITLE
Remove Fortran continuation unit test covered by golden fixtures

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -22,7 +22,6 @@ from literalizer.exceptions import (
 from literalizer.languages import (
     Cobol,
     Dart,
-    Fortran,
     Gleam,
     Haskell,
     Java,
@@ -37,13 +36,6 @@ COBOL = Cobol(
     datetime_format=Cobol.datetime_formats.ISO,
     bytes_format=Cobol.bytes_formats.HEX,
     sequence_format=Cobol.sequence_formats.SEQUENCE,
-)
-FORTRAN = Fortran(
-    date_format=Fortran.date_formats.ISO,
-    datetime_format=Fortran.datetime_formats.ISO,
-    bytes_format=Fortran.bytes_formats.HEX,
-    sequence_format=Fortran.sequence_formats.LIST,
-    module_name="check",
 )
 
 
@@ -363,27 +355,6 @@ def test_cobol_level_number_cap() -> None:
         "45 F-I.\n"
         '49 F-VALUE PIC X(4) VALUE "deep".\n'
         "    "
-    )
-
-
-def test_fortran_continuation_with_escaped_quote_and_comment() -> None:
-    """Line continuation handles escaped quotes before inline comments."""
-    yaml_string = "host: it's here  # a comment\nport: 80  # another\n"
-    result = literalize(
-        source=yaml_string,
-        input_format=InputFormat.YAML,
-        language=FORTRAN,
-        pre_indent_level=0,
-        variable_form=NewVariable(name="cfg"),
-        include_delimiters=True,
-    )
-
-    assert result.code == (
-        "type(fval_t) :: cfg\n"
-        "cfg = fmap([fval_t :: &\n"
-        "    fentry('host', fstr('it''s here')), &  ! a comment\n"
-        "    fentry('port', fint(80_int64)) &  ! another\n"
-        "])"
     )
 
 


### PR DESCRIPTION
## Summary
- Delete `test_fortran_continuation_with_escaped_quote_and_comment` and its now-unused `FORTRAN` helper / `Fortran` import.
- The escaped-quote + inline-comment + continuation path is already covered by the `comments_escaped_single_quote` golden case, and the multi-entry inline-comment shape by `comments_sequence_inline`, so this pytest string-assertion test added no unique coverage.

## Test plan
- [x] `tests/test_languages.py` passes (16 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only deletes a Fortran-specific unit test and related helpers/imports, with no production code changes.
> 
> **Overview**
> Removes the Fortran-specific continuation/escaped-quote inline-comment unit test from `tests/test_languages.py`, along with the now-unused `Fortran` import and `FORTRAN` helper instance.
> 
> This reduces duplicate coverage that is already exercised by existing golden fixture cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea3e76fefd31da53e1d2ea0f8b0e257f643dc04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->