### PR TITLE
Remove redundant test_rust_vec_format_type_annotation

### DIFF
--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -87,15 +87,6 @@ def test_rust_tuple_format_type_annotation_raises() -> None:
         )
 
 
-def test_rust_vec_format_type_annotation() -> None:
-    """``format_type_annotation`` returns ``Vec<T>`` for vector format."""
-    result = Rust.sequence_formats.VEC.format_type_annotation(
-        element_type="i32",
-        length=3,
-    )
-    assert result == "Vec<i32>"
-
-
 def test_rust_static_set_annotation_unifies_integer_widths() -> None:
     """Set type annotations infer one element type for all values."""
     rust = Rust(


### PR DESCRIPTION
## Summary
- Remove the unit test that directly called `Rust.sequence_formats.VEC.format_type_annotation`; the same `Vec<i32>` annotation is already exercised end-to-end via the public API by the golden file at `tests/integration/cases/int_list/Rust_declaration_style_lazy_static.rs`.

## Test plan
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that removes redundant coverage; no production code paths are modified.
> 
> **Overview**
> Removes `test_rust_vec_format_type_annotation` from `tests/test_variables.py`, relying on existing integration/golden coverage for the `Vec<T>` type annotation behavior instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02004e578bc1024de7c7b66b43216e658ea79e2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->