### PR TITLE
Widen Value type to allow Scalar dict keys (no-op foundation for #2200)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ Next
 ----
 
 
+- The internal :data:`~literalizer._types.Value` and
+  :data:`~literalizer._types.ValueInput` aliases now permit any
+  :data:`~literalizer._types.Scalar` as a dict key, in preparation for
+  surface formats that admit non-string dict keys.  A new
+  :exc:`~literalizer.exceptions.UnrepresentableInputError` and a
+  ``supports_non_string_dict_keys`` class attribute on
+  :class:`~literalizer.Language` (defaulting to ``True``; overridden to
+  ``False`` on :class:`~literalizer.Json5`,
+  :class:`~literalizer.Jsonnet`, and :class:`~literalizer.Toml`) wire a
+  centralized guard at the dict-formatting boundary.  The surface
+  parsers still produce only string-keyed dicts, so behavior is
+  unchanged.
+
 - :func:`~literalizer.literalize` now accepts a ``ref_values`` mapping
   from ref identifier to the value declared elsewhere for that ref.
   Languages whose ``$ref`` rendering depends on the referenced type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,6 +341,7 @@ reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 executionEnvironments = [
     { root = "tests/integration/cases", reportUnusedExpression = false, reportUndefinedVariable = false, reportUnknownVariableType = false },
+    { root = "tests/errors/test_non_string_dict_key_guard.py", reportPrivateUsage = false },
 ]
 
 [tool.ty]

--- a/src/literalizer/_formatters/collection_openers.py
+++ b/src/literalizer/_formatters/collection_openers.py
@@ -12,13 +12,13 @@ from literalizer._formatters.type_inference import (
     MixedNumeric,
     infer_element_type,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 @beartype
 def fixed_open(
     *, open_str: str
-) -> Callable[[list[Value] | dict[str, Value]], str]:
+) -> Callable[[list[Value] | dict[Scalar, Value]], str]:
     """Return an opener callable that always returns *open_str*.
 
     Use this as ``sequence_open``, ``set_open``, ``dict_open``, or
@@ -28,7 +28,7 @@ def fixed_open(
     Example: ``fixed_open(open_str="[")([1, 2, 3])`` -> ``"["``.
     """
 
-    def _open(_items: list[Value] | dict[str, Value], /) -> str:
+    def _open(_items: list[Value] | dict[Scalar, Value], /) -> str:
         """Return the fixed opening delimiter, ignoring *_items*."""
         return open_str
 
@@ -271,7 +271,7 @@ def typed_collection_open(
 
 @beartype
 def _typed_dict_open_impl(
-    items: dict[str, Value],
+    items: dict[Scalar, Value],
     type_to_opener: Callable[[type | ListType | DictType], str | None],
     fallback: str,
 ) -> str:
@@ -287,7 +287,7 @@ def typed_dict_open(
     *,
     type_to_opener: Callable[[type | ListType | DictType], str | None],
     fallback: str,
-) -> Callable[[dict[str, Value]], str]:
+) -> Callable[[dict[Scalar, Value]], str]:
     """Return a ``dict_open`` callable that infers a common value type
     and delegates to *type_to_opener*.
 
@@ -307,7 +307,7 @@ def typed_dict_open(
         )
     """
 
-    def _open(items: dict[str, Value]) -> str:
+    def _open(items: dict[Scalar, Value]) -> str:
         """Delegate to module-level implementation."""
         return _typed_dict_open_impl(
             items=items, type_to_opener=type_to_opener, fallback=fallback

--- a/src/literalizer/_heterogeneous.py
+++ b/src/literalizer/_heterogeneous.py
@@ -78,7 +78,7 @@ def _siblings_mixed_ids(
 
 
 @beartype
-def _collect_from_dict(data: dict[str, Value]) -> frozenset[int]:
+def _collect_from_dict(data: dict[Scalar, Value]) -> frozenset[int]:
     """Return container ids for a dict, its sibling-list values, and
     descendants.
     """
@@ -116,7 +116,9 @@ def _collect_from_list(data: list[Value]) -> frozenset[int]:
         total=len(data),
         combined=[e for sublist in sublists for e in sublist],
     )
-    subdicts: list[dict[str, Value]] = [v for v in data if isinstance(v, dict)]
+    subdicts: list[dict[Scalar, Value]] = [
+        v for v in data if isinstance(v, dict)
+    ]
     subdict_ids = _siblings_mixed_ids(
         siblings=subdicts,
         total=len(data),

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -130,7 +130,7 @@ class CommentConfig:
 class DictFormatConfig:
     """Configuration for dict formatting."""
 
-    dict_open: Callable[[dict[str, Value]], str]
+    dict_open: Callable[[dict[Scalar, Value]], str]
     close: str
     format_entry: Callable[[str, Value, str], str]
     empty_dict: str | None
@@ -143,7 +143,7 @@ class DictFormatConfig:
 class OrderedMapFormatConfig:
     """Configuration for ordered-map formatting."""
 
-    ordered_map_open: Callable[[dict[str, Value]], str]
+    ordered_map_open: Callable[[dict[Scalar, Value]], str]
     close: str
     preamble_lines: tuple[str, ...]
 
@@ -609,6 +609,7 @@ class LanguageCls(type):
     supports_empty_dict_key: bool
     supports_call_style: bool
     supports_default_dict_key_type: bool
+    supports_non_string_dict_keys: bool
     supports_default_dict_value_type: bool
     supports_default_sequence_element_type: bool
     supports_default_set_element_type: bool
@@ -1394,6 +1395,18 @@ class Language(Protocol):
         with :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
         """
         ...  # pylint: disable=unnecessary-ellipsis
+
+    supports_non_string_dict_keys: bool
+    """Whether the language can represent a dict whose keys include
+    values that are not strings.  When ``False``,
+    :func:`~literalizer.literalize` rejects such inputs at the
+    formatting boundary with
+    :class:`~literalizer.exceptions.UnrepresentableInputError`.
+
+    Most languages allow scalar dict keys natively; pure data formats
+    whose surface syntax only admits string keys (JSON-family, TOML)
+    set this to ``False``.
+    """
 
     @property
     def supports_inline_multiline_dict_args(self) -> bool:

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -61,6 +61,7 @@ from literalizer.exceptions import (
     FreeFunctionCallNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
+    UnrepresentableInputError,
     UnsupportedCallShapeError,
     UnsupportedIdentifierCaseError,
     VariableNameNotSupportedError,
@@ -326,6 +327,26 @@ def _format_set_value(
 
 
 @beartype
+def _guard_dict_keys_supported(
+    *,
+    value: Mapping[Scalar, Value],
+    spec: Language,
+) -> None:
+    """Reject non-string dict keys for languages that cannot represent
+    them.
+    """
+    if spec.supports_non_string_dict_keys:
+        return
+    for key in value:
+        if not isinstance(key, str):
+            msg = (
+                f"{type(spec).__name__} cannot represent dict key of "
+                f"type {type(key).__name__}"
+            )
+            raise UnrepresentableInputError(msg)
+
+
+@beartype
 def _format_ordered_map_value(
     *,
     value: ordereddict,
@@ -339,6 +360,7 @@ def _format_ordered_map_value(
     multiline_prefix: str,
 ) -> str:
     """Format an ordered map as a native language literal."""
+    _guard_dict_keys_supported(value=value, spec=spec)
     ordered_map_cfg = spec.ordered_map_format_config
 
     ordered_map_items: list[tuple[str, Value]] = [
@@ -409,7 +431,7 @@ def _format_ordered_map_value(
 @beartype
 def _format_dict_value(
     *,
-    value: dict[str, Value],
+    value: dict[Scalar, Value],
     spec: Language,
     open_override: str | None,
     wrap_ids: frozenset[int],
@@ -421,9 +443,10 @@ def _format_dict_value(
     multiline_prefix: str,
 ) -> str:
     """Format a dict as a native language literal."""
+    _guard_dict_keys_supported(value=value, spec=spec)
     dict_cfg = spec.dict_format_config
 
-    dict_items: dict[str, Value] = {
+    dict_items: dict[Scalar, Value] = {
         k: v
         for k, v in value.items()
         if not (spec.skip_null_dict_values and v is None)
@@ -573,7 +596,7 @@ def _compute_dict_open_override(
     different value types, or ``None`` when no widening is needed.
     """
     dict_open = spec.dict_format_config.dict_open
-    dicts: list[dict[str, Value]] = [
+    dicts: list[dict[Scalar, Value]] = [
         item
         for item in items
         if isinstance(item, dict) and not isinstance(item, ordereddict)
@@ -602,7 +625,7 @@ def _compute_dict_open_override(
     # "unknown type" to the widening — otherwise a dict that filters
     # to ``{}`` would narrow the widened type to the other dicts'
     # concrete value type, losing the null slot's uncertainty.
-    combined: dict[str, Value] = {}
+    combined: dict[Scalar, Value] = {}
     idx = 0
     for d in dicts:
         for v in d.values():
@@ -1179,7 +1202,7 @@ def _wrap_body(
     *,
     body: str,
     is_ordered_map: bool,
-    data: list[Value] | dict[str, Value] | set[Scalar],
+    data: list[Value] | dict[Scalar, Value] | set[Scalar],
     spec: Language,
     line_prefix: str,
 ) -> str:
@@ -1213,7 +1236,7 @@ def _wrap_body(
 @beartype
 def _collection_open_for_multiline_value(
     *,
-    data: dict[str, Value] | set[Scalar] | list[Value],
+    data: dict[Scalar, Value] | set[Scalar] | list[Value],
     spec: Language,
     is_ordered_map: bool,
     dict_open_override: str | None,
@@ -1265,7 +1288,7 @@ def _collection_open_for_multiline_value(
 @beartype
 def _format_multiline_collection_value(
     *,
-    value: dict[str, Value] | set[Scalar] | list[Value],
+    value: dict[Scalar, Value] | set[Scalar] | list[Value],
     spec: Language,
     line_prefix: str,
     wrap_ids: frozenset[int],
@@ -1349,7 +1372,7 @@ def _append_entries(
 @beartype
 def _format_collection_lines(
     *,
-    data: dict[str, Value] | set[Scalar] | list[Value],
+    data: dict[Scalar, Value] | set[Scalar] | list[Value],
     spec: Language,
     body_prefix: str,
     trailing_comma: bool,
@@ -1647,7 +1670,7 @@ def _literalize(
         and all(v is None for v in data.values())
     ):
         is_ordered_map = isinstance(data, ordereddict)
-        empty_value: ordereddict | dict[str, Value] = (
+        empty_value: ordereddict | dict[Scalar, Value] = (
             ordereddict() if is_ordered_map else {}
         )
         formatted = _format_value(
@@ -2305,7 +2328,7 @@ def _resolve_ref_for_preamble(
                 resolved_list.append(resolved.value)
         return _PreambleRefResolution(include=True, value=resolved_list)
     if isinstance(value, dict):
-        resolved_dict: dict[str, Value] = {}
+        resolved_dict: dict[Scalar, Value] = {}
         for key, item in value.items():
             resolved = _resolve_ref_for_preamble(
                 value=item,
@@ -3155,7 +3178,7 @@ def _validate_call_preconditions(
 
 def _is_value_mapping(
     value: ValueInput, /
-) -> TypeIs[Mapping[str, ValueInput]]:
+) -> TypeIs[Mapping[Scalar, ValueInput]]:
     """Narrow ``value`` to the ``Mapping`` arm of ``ValueInput``."""
     return isinstance(value, Mapping)
 

--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -156,7 +156,10 @@ def _coerce_yaml_keys(*, data: YamlCoercible) -> Value:
                 ]
             )
         case dict():
-            return {f"{k}": _coerce_yaml_keys(data=v) for k, v in data.items()}
+            coerced: dict[Scalar, Value] = {
+                f"{k}": _coerce_yaml_keys(data=v) for k, v in data.items()
+            }
+            return coerced
         case list():
             return [_coerce_yaml_keys(data=item) for item in data]
         case CommentedSet():
@@ -337,7 +340,10 @@ def _coerce_toml_values(*, data: _TomlData) -> Value:
     """
     match data:
         case dict():
-            return {k: _coerce_toml_values(data=v) for k, v in data.items()}
+            coerced: dict[Scalar, Value] = {
+                k: _coerce_toml_values(data=v) for k, v in data.items()
+            }
+            return coerced
         case list():
             return [_coerce_toml_values(data=item) for item in data]
         case datetime.time():

--- a/src/literalizer/_types.py
+++ b/src/literalizer/_types.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 type Scalar = (
     str | int | float | bool | None | datetime.date | datetime.datetime | bytes
 )
-type Value = Scalar | list[Value] | dict[str, Value] | set[Scalar]
+type Value = Scalar | list[Value] | dict[Scalar, Value] | set[Scalar]
 type ValueInput = (
-    Scalar | Sequence[ValueInput] | Mapping[str, ValueInput] | set[Scalar]
+    Scalar | Sequence[ValueInput] | Mapping[Scalar, ValueInput] | set[Scalar]
 )

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -30,6 +30,16 @@ class InvalidDictKeyError(Exception):
     """
 
 
+class UnrepresentableInputError(Exception):
+    """Raised when an input value cannot be represented in the target
+    language.
+
+    Used as the centralized error for shape-level rejections at the
+    formatting boundary, e.g. when a dict carries a non-string key for
+    a language whose surface syntax only admits string-typed keys.
+    """
+
+
 class HeterogeneousCollectionError(Exception):
     """Base class for errors raised when data is incompatible with the
     target language's collection-shape constraints.

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -234,6 +234,7 @@ class Ada(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Ada."""

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -133,7 +133,7 @@ def _bash_validate_dict_keys(data: Value) -> None:
     match data:
         case dict():
             for raw_key in data:
-                if (
+                if not isinstance(raw_key, str) or (
                     not raw_key
                     or not raw_key.isprintable()
                     or not raw_key.isascii()
@@ -209,6 +209,7 @@ class Bash(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -240,6 +240,7 @@ class C(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for C."""

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -124,6 +124,7 @@ class Clojure(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -350,6 +350,7 @@ class Cobol(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Cobol."""

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -133,6 +133,7 @@ class CommonLisp(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -79,7 +79,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 class _CppModifiers(enum.Enum):
@@ -627,7 +627,7 @@ def _apply_cpp_variant_sequence_open(
 @beartype
 def _apply_cpp_variant_dict_open(
     *,
-    items: dict[str, Value],
+    items: dict[Scalar, Value],
     type_ctx: _CppTypeCtx,
     opener_template: str,
 ) -> str:
@@ -656,7 +656,7 @@ def _apply_cpp_variant_set_open(
 @beartype
 def _apply_cpp_variant_ordered_map_open(
     *,
-    data: dict[str, Value],
+    data: dict[Scalar, Value],
     type_ctx: _CppTypeCtx,
 ) -> str:
     """Return a typed ordered-map opener."""
@@ -689,12 +689,12 @@ def _build_variant_dict_open(
     *,
     type_ctx: _CppTypeCtx,
     opener_template: str,
-) -> Callable[[dict[str, Value]], str]:
+) -> Callable[[dict[Scalar, Value]], str]:
     """Build a dict opener that uses ``std::variant`` for
     heterogeneous dict values.
     """
 
-    def _open(items: dict[str, Value]) -> str:
+    def _open(items: dict[Scalar, Value]) -> str:
         """Delegate to module-level implementation."""
         return _apply_cpp_variant_dict_open(
             items=items,
@@ -723,12 +723,12 @@ def _build_variant_set_open(
 def _build_variant_ordered_map_open(
     *,
     type_ctx: _CppTypeCtx,
-) -> Callable[[dict[str, Value]], str]:
+) -> Callable[[dict[Scalar, Value]], str]:
     """Build an ordered-map opener that uses
     ``std::vector<std::pair<...>>``.
     """
 
-    def _open(data: dict[str, Value]) -> str:
+    def _open(data: dict[Scalar, Value]) -> str:
         """Delegate to module-level implementation."""
         return _apply_cpp_variant_ordered_map_open(
             data=data,
@@ -939,6 +939,7 @@ class Cpp(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -194,6 +194,7 @@ class Crystal(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -376,6 +376,7 @@ class CSharp(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -180,6 +180,7 @@ class D(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -355,6 +355,7 @@ class Dart(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -540,6 +540,7 @@ class Dhall(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Dhall."""

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -222,6 +222,7 @@ class Elixir(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -520,6 +520,7 @@ class Elm(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Elm."""

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -217,6 +217,7 @@ class Erlang(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -218,6 +218,7 @@ class Forth(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -347,6 +347,7 @@ class Fortran(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Fortran."""

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -338,6 +338,7 @@ class FSharp(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for FSharp."""

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -542,6 +542,7 @@ class Gleam(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -280,6 +280,7 @@ class Go(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = True
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -160,6 +160,7 @@ class Groovy(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1124,6 +1124,7 @@ class Haskell(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Haskell."""

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -172,6 +172,7 @@ class Hcl(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -600,6 +600,7 @@ class Java(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -144,6 +144,7 @@ class JavaScript(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -136,6 +136,7 @@ class Json5(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -154,6 +154,7 @@ class Jsonnet(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -172,6 +172,7 @@ class Julia(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -506,6 +506,7 @@ class Kotlin(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -158,6 +158,7 @@ class Lua(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -67,7 +67,7 @@ from literalizer._language import (
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
-from literalizer._types import Value
+from literalizer._types import Scalar, Value
 
 
 @beartype
@@ -157,9 +157,9 @@ def _format_datetime_matlab(value: datetime.datetime) -> str:
 
 
 @beartype
-def _containers_map_open(data: dict[str, Value]) -> str:
+def _containers_map_open(data: dict[Scalar, Value]) -> str:
     """Build the ``containers.Map`` opener with all keys collected."""
-    keys = ", ".join(_matlab_char_key(s=k) for k in data)
+    keys = ", ".join(_matlab_char_key(s=k) for k in data if isinstance(k, str))
     return f"containers.Map({{{keys}}}, {{"
 
 
@@ -225,6 +225,7 @@ class Matlab(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -894,6 +894,7 @@ class Mojo(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -555,6 +555,7 @@ class Nim(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -204,6 +204,7 @@ class Nix(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -108,6 +108,7 @@ class Norg(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -294,6 +294,7 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for ObjectiveC."""

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -296,6 +296,7 @@ class OCaml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for OCaml."""

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -151,6 +151,7 @@ class Occam(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Occam."""

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -230,6 +230,7 @@ class Odin(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -170,6 +170,7 @@ class Perl(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -167,6 +167,7 @@ class Php(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -183,6 +183,7 @@ class PowerShell(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -688,6 +688,7 @@ class PureScript(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for PureScript."""

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -283,15 +283,15 @@ def _merge_dict_elements(*, elements: list[Value]) -> list[Value]:
                 non_dict.append(elem)
     merged: list[Value] = list(non_dict)
     if has_plain:
-        merged.append(
-            {str(object=i): v for i, v in enumerate(iterable=plain_vals)}
-        )
+        plain_repr: dict[Scalar, Value] = {
+            str(object=i): v for i, v in enumerate(iterable=plain_vals)
+        }
+        merged.append(plain_repr)
     if has_ordered:
-        merged.append(
-            OrderedDict(
-                {str(object=i): v for i, v in enumerate(iterable=ordered_vals)}
-            )
-        )
+        ordered_repr: dict[Scalar, Value] = {
+            str(object=i): v for i, v in enumerate(iterable=ordered_vals)
+        }
+        merged.append(OrderedDict(ordered_repr))
     return merged
 
 
@@ -586,6 +586,7 @@ class Python(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -182,6 +182,7 @@ class R(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -125,6 +125,7 @@ class Racket(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -202,6 +202,7 @@ class Raku(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -528,6 +528,7 @@ class Roc(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
     supports_special_floats = True
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -204,6 +204,7 @@ class Ruby(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -710,6 +710,7 @@ class Rust(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -244,6 +244,7 @@ class Scala(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -121,6 +121,7 @@ class Scheme(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -370,6 +370,7 @@ class Sml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Standard ML."""

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -419,6 +419,7 @@ class Swift(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -255,6 +255,7 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for SystemVerilog."""

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -166,6 +166,7 @@ class Tcl(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -136,6 +136,7 @@ class Toml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -328,6 +328,7 @@ class TypeScript(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -398,6 +398,7 @@ class V(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -285,6 +285,7 @@ class VisualBasic(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -184,6 +184,7 @@ class Wren(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -110,6 +110,7 @@ class Yaml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
         staticmethod(

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -250,6 +250,7 @@ class Zig(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_non_string_dict_keys = True
 
     class DateFormats(enum.Enum):
         """Date format options for Zig."""

--- a/tests/errors/test_non_string_dict_key_guard.py
+++ b/tests/errors/test_non_string_dict_key_guard.py
@@ -1,0 +1,66 @@
+"""Centralized non-string dict key guard for unsupported languages.
+
+The guard runs inside ``_format_dict_value`` and
+``_format_ordered_map_value`` and rejects non-string dict keys when the
+target language sets ``supports_non_string_dict_keys = False``.  Today
+the surface parsers only produce string-keyed dicts, so the guard is
+wired but unreachable through :func:`literalizer.literalize`; the tests
+here invoke the helper directly to exercise the contract.
+"""
+
+import re
+
+import pytest
+
+from literalizer import Language
+from literalizer._literalize import _guard_dict_keys_supported
+from literalizer.exceptions import UnrepresentableInputError
+from literalizer.languages import Json5, Jsonnet, Python, Toml
+
+_JSON5 = Json5(indent="  ")
+_JSONNET = Jsonnet(indent="  ")
+_TOML = Toml(indent="  ")
+_PYTHON = Python(indent="  ")
+
+
+def test_guard_raises_for_int_key_on_json5() -> None:
+    """Json5 rejects non-string keys with
+    ``UnrepresentableInputError``.
+    """
+    expected_msg = re.escape(
+        pattern="Json5 cannot represent dict key of type int",
+    )
+    with pytest.raises(
+        expected_exception=UnrepresentableInputError,
+        match=f"^{expected_msg}$",
+    ):
+        _guard_dict_keys_supported(value={1: "v"}, spec=_JSON5)
+
+
+@pytest.mark.parametrize(
+    argnames="spec",
+    argvalues=[_JSON5, _JSONNET, _TOML],
+    ids=["json5", "jsonnet", "toml"],
+)
+def test_guard_raises_for_bytes_key_on_unsupported(
+    *,
+    spec: Language,
+) -> None:
+    """Languages opted out raise for any non-string scalar key."""
+    with pytest.raises(expected_exception=UnrepresentableInputError):
+        _guard_dict_keys_supported(value={b"k": "v"}, spec=spec)
+
+
+@pytest.mark.parametrize(
+    argnames="spec",
+    argvalues=[_JSON5, _JSONNET, _TOML],
+    ids=["json5", "jsonnet", "toml"],
+)
+def test_guard_accepts_string_key_on_unsupported(*, spec: Language) -> None:
+    """String keys pass through the guard even for opted-out languages."""
+    _guard_dict_keys_supported(value={"k": "v"}, spec=spec)
+
+
+def test_guard_accepts_non_string_key_on_supported() -> None:
+    """Languages with the default ``True`` accept non-string keys."""
+    _guard_dict_keys_supported(value={1: "v"}, spec=_PYTHON)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import re
 import textwrap
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
@@ -34,6 +34,11 @@ from literalizer.languages import (
     Rust,
     Sml,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from literalizer._types import Scalar, ValueInput
 
 COBOL = Cobol(
     date_format=Cobol.date_formats.ISO,
@@ -586,6 +591,9 @@ def test_haskell_unknown_refs_strip_from_nested_preamble() -> None:
     """Haskell unknown nested refs do not shape preamble type
     inference.
     """
+    inner_arg: Mapping[Scalar, ValueInput] = {"nested": "value"}
+    known_arg: list[ValueInput] = [1, inner_arg]
+    ref_values: dict[str, ValueInput] = {"known": known_arg}
     result = literalize_call(
         source=(
             '[[{"$ref": "known"}, {"$ref": "missing"}, '
@@ -595,7 +603,7 @@ def test_haskell_unknown_refs_strip_from_nested_preamble() -> None:
         language=Haskell(),
         target_function="process",
         parameter_names=["a", "b", "c"],
-        ref_values={"known": [1, {"nested": "value"}]},
+        ref_values=ref_values,
     )
 
     assert result.body_preamble == (


### PR DESCRIPTION
## Summary

Foundation for [#2200](https://github.com/adamtheturtle/literalizer/issues/2200): prepares the dispatch path for surface formats that admit non-string dict keys.

- Widens `Value`/`ValueInput` to allow any `Scalar` dict key, plus matching annotation updates across `_literalize.py`, `_language.py`, `_heterogeneous.py`, `_parsing.py`, `_formatters/`, and the language modules that consume them.
- Adds `UnrepresentableInputError` and a `supports_non_string_dict_keys` class attribute on every `Language` (default `True`; `False` on `Json5`, `Jsonnet`, and `Toml`), wired through a centralized guard at the top of `_format_dict_value` and `_format_ordered_map_value`.
- Surface parsers still produce only string-keyed dicts, so behavior is unchanged and no golden fixtures move; the new guard is exercised directly in `tests/errors/test_non_string_dict_key_guard.py`.

## Test plan

- [x] `uv run pytest tests/` — 3475 passed, 970 skipped, 0 golden-file changes
- [x] `uv run ruff check`, `uv run pyright`, `uv run pyrefly check` all clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Value` typing and dict formatting paths across many languages; behavior is intended to be unchanged for current parsers, but mistakes could surface as new formatting errors or type-checking regressions.
> 
> **Overview**
> Broadens internal `Value`/`ValueInput` so dict keys can be any `Scalar` (not just `str`), updating type annotations throughout formatting, parsing, and heterogeneous-wrapping codepaths to match.
> 
> Introduces `UnrepresentableInputError` plus a new `Language.supports_non_string_dict_keys` capability flag, and enforces it via a centralized `_guard_dict_keys_supported` check in `_format_dict_value` and `_format_ordered_map_value` (with `Json5`, `Jsonnet`, and `Toml` opting out).
> 
> Adds targeted tests that exercise the new guard directly, and updates tooling config (`pyright`) to accommodate the private-helper test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf73965837446989d28af644d413727d04d5ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->