### PR TITLE
Inline ValueInput in literalize_ref_cases to drop private import

### DIFF
--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -9,11 +9,12 @@ language's default identifier case.  The runner
 """
 
 import dataclasses
+import datetime
 import functools
 import json
 import re
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 from beartype import beartype
@@ -40,8 +41,12 @@ from .language_specs import (
 )
 from .variant_cases import wrap_variable_form
 
-if TYPE_CHECKING:
-    from literalizer._types import ValueInput
+type _Scalar = (
+    str | int | float | bool | None | datetime.date | datetime.datetime | bytes
+)
+type _ValueInput = (
+    _Scalar | Sequence[_ValueInput] | Mapping[str, _ValueInput] | set[_Scalar]
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -342,7 +347,7 @@ def run_literalize_ref_golden_case(
         )
     except VariableNameNotSupportedError:
         variable_form_obj = None
-    ref_values_input: dict[str, ValueInput] | None = (
+    ref_values_input: dict[str, _ValueInput] | None = (
         {
             name: json.loads(s=source_json)
             for name, source_json in config.ref_value_sources


### PR DESCRIPTION
Replaces the `TYPE_CHECKING` import of `literalizer._types.ValueInput` in `tests/integration/literalize_ref_cases.py` with a module-private `_ValueInput` alias (plus a `_Scalar` helper) so the test keeps the same structural precision without depending on a private symbol. Refs #1947.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only type annotation change that removes a dependency on a private `literalizer` symbol without altering runtime logic.
> 
> **Overview**
> Removes the `TYPE_CHECKING` import of the private `literalizer._types.ValueInput` from `tests/integration/literalize_ref_cases.py` and replaces it with module-local `_Scalar`/`_ValueInput` type aliases (including `datetime`/`bytes` support) using `collections.abc` `Sequence`/`Mapping`.
> 
> Updates `ref_values_input`’s annotation to use `_ValueInput`, keeping the same structural typing while avoiding reliance on a private API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64b343c85aa57f6c96d66c74621990d2e8925c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->