### PR TITLE
Apply heterogeneity check to dict keys (#2201)

### DIFF
--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -14,6 +14,7 @@ from literalizer.exceptions import (
     HeterogeneousScalarCollectionError,
     HeterogeneousSetError,
     HeterogeneousSiblingListsError,
+    MixedDictKeysError,
     MixedDictShapesError,
     MixedDictValuesError,
     MixedListValuesError,
@@ -268,6 +269,46 @@ def _has_mixed_dict_shapes(*, data: Value) -> bool:
 
 
 @beartype
+def _has_mixed_dict_keys(*, data: Value) -> bool:
+    """Recursively check whether data contains any dict whose keys span
+    multiple type families.
+    """
+    match data:
+        case dict():
+            keys: list[Value] = list(data.keys())
+            if _values_mixed_types(values=keys):
+                return True
+            return any(_has_mixed_dict_keys(data=v) for v in data.values())
+        case list():
+            return any(_has_mixed_dict_keys(data=v) for v in data)
+        case _:
+            return False
+
+
+@beartype
+def _find_first_mixed_keys(*, data: Value) -> Sequence[Value]:
+    """Return the keys of the first dict in *data* whose keys span
+    multiple type families.
+    """
+    children: Sequence[Value]
+    match data:
+        case dict():
+            keys: list[Value] = list(data.keys())
+            if _values_mixed_types(values=keys):
+                return keys
+            children = list(data.values())
+        case list():
+            children = data
+        case _:
+            return []
+    for child in children:
+        result = _find_first_mixed_keys(data=child)
+        if result:
+            return result
+    return []
+
+
+@beartype
 def _has_mixed_dict_values(*, data: Value) -> bool:
     """Recursively check whether data contains any dict whose values span
     multiple type families.
@@ -386,6 +427,22 @@ def _check_mixed_dict_shapes(*, data: Value) -> None:
 
 
 @beartype
+def _check_mixed_dict_keys(*, data: Value) -> None:
+    """Raise if any dict has keys spanning multiple type families."""
+    if _has_mixed_dict_keys(data=data):
+        keys = _find_first_mixed_keys(data=data)
+        types = ", ".join(
+            sorted({_value_type_family(value=k) for k in keys}),
+        )
+        msg = (
+            "Dict contains keys of mixed types that cannot be "
+            "represented in the target language "
+            f"(found types: {types})"
+        )
+        raise MixedDictKeysError(msg)
+
+
+@beartype
 def _check_mixed_dict_values(*, data: Value) -> None:
     """Raise if any dict has values spanning multiple type families."""
     if _has_mixed_dict_values(data=data):
@@ -450,6 +507,7 @@ def check_data(*, data: Value, spec: Language) -> None:
             _check_heterogeneous(data=data)
             _check_heterogeneous_sibling_lists(data=data)
         if not dict_supports_het:
+            _check_mixed_dict_keys(data=data)
             _check_mixed_dict_values(data=data)
         if not seq_supports_het:
             _check_mixed_list_values(data=data)

--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -502,12 +502,13 @@ def check_data(*, data: Value, spec: Language) -> None:
     dict_supports_het = spec.dict_supports_heterogeneous_values
     set_supports_het = spec.set_format_config.supports_heterogeneity
     behavior = spec.heterogeneous_behavior
+    if not dict_supports_het:
+        _check_mixed_dict_keys(data=data)
     if not behavior.skip_scalar_checks:
         if not seq_supports_het:
             _check_heterogeneous(data=data)
             _check_heterogeneous_sibling_lists(data=data)
         if not dict_supports_het:
-            _check_mixed_dict_keys(data=data)
             _check_mixed_dict_values(data=data)
         if not seq_supports_het:
             _check_mixed_list_values(data=data)

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -65,6 +65,12 @@ class MixedDictValuesError(HeterogeneousCollectionError):
     """
 
 
+class MixedDictKeysError(HeterogeneousCollectionError):
+    """Raised when a dict has keys spanning multiple type families
+    and the target language requires homogeneous dict keys.
+    """
+
+
 class MixedListValuesError(HeterogeneousCollectionError):
     """Raised when a list has elements spanning multiple type families
     and the target language requires homogeneous list elements.

--- a/tests/errors/test_mixed_dict_keys.py
+++ b/tests/errors/test_mixed_dict_keys.py
@@ -3,9 +3,9 @@
 The check runs inside :func:`literalizer._checks.check_data` and rejects
 dicts whose keys span multiple type families when the target language
 sets ``dict_supports_heterogeneous_values = False``.  Today the surface
-parsers stringify non-string keys, so the check is wired but unreachable
-through :func:`literalizer.literalize`; the tests here invoke
-``check_data`` directly to exercise the contract.
+parsers coerce non-string keys to strings, so the check is wired but
+unreachable through :func:`literalizer.literalize`; the tests here
+invoke ``check_data`` directly to exercise the contract.
 """
 
 from __future__ import annotations
@@ -62,7 +62,7 @@ def test_nested_mixed_keys_raise() -> None:
 
 
 def test_mixed_keys_inside_dict_value_raise() -> None:
-    """Mixed-key dicts found by recursing through outer dict values
+    """Mixed-key dicts found by descending through outer dict values
     raise.
     """
     inner: dict[Scalar, Value] = {}

--- a/tests/errors/test_mixed_dict_keys.py
+++ b/tests/errors/test_mixed_dict_keys.py
@@ -1,0 +1,100 @@
+"""Heterogeneity check for dict keys.
+
+The check runs inside :func:`literalizer._checks.check_data` and rejects
+dicts whose keys span multiple type families when the target language
+sets ``dict_supports_heterogeneous_values = False``.  Today the surface
+parsers stringify non-string keys, so the check is wired but unreachable
+through :func:`literalizer.literalize`; the tests here invoke
+``check_data`` directly to exercise the contract.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from literalizer._checks import check_data
+from literalizer.exceptions import MixedDictKeysError
+from literalizer.languages import Mojo
+
+if TYPE_CHECKING:
+    from literalizer._types import Scalar, Value
+
+
+def test_mixed_int_str_keys_raise_on_homogeneous_target() -> None:
+    """Mojo rejects a dict mixing ``int`` and ``str`` keys."""
+    data: dict[Scalar, Value] = {}
+    data[1] = "a"
+    data["x"] = "b"
+    expected_msg = re.escape(
+        pattern="Dict contains keys of mixed types that cannot be "
+        "represented in the target language "
+        "(found types: int, str)",
+    )
+    with pytest.raises(
+        expected_exception=MixedDictKeysError,
+        match=f"^{expected_msg}$",
+    ):
+        check_data(data=data, spec=Mojo())
+
+
+def test_mixed_bool_int_keys_raise_on_homogeneous_target() -> None:
+    """``bool`` and ``int`` are distinct type families for key
+    checking.
+    """
+    data: dict[Scalar, Value] = {}
+    data[True] = "a"
+    data[2] = "b"
+    with pytest.raises(expected_exception=MixedDictKeysError):
+        check_data(data=data, spec=Mojo())
+
+
+def test_nested_mixed_keys_raise() -> None:
+    """Mixed-key dicts nested in a list raise."""
+    inner: dict[Scalar, Value] = {}
+    inner[1] = "a"
+    inner["x"] = "b"
+    data: list[Value] = [inner]
+    with pytest.raises(expected_exception=MixedDictKeysError):
+        check_data(data=data, spec=Mojo())
+
+
+def test_mixed_keys_inside_dict_value_raise() -> None:
+    """Mixed-key dicts found by recursing through outer dict values
+    raise.
+    """
+    inner: dict[Scalar, Value] = {}
+    inner[1] = "a"
+    inner["x"] = "b"
+    data: dict[Scalar, Value] = {}
+    data["outer"] = inner
+    with pytest.raises(expected_exception=MixedDictKeysError):
+        check_data(data=data, spec=Mojo())
+
+
+def test_mixed_keys_in_second_list_element_raise() -> None:
+    """Mixed-key dicts found past a homogeneous first list element
+    raise.
+    """
+    inner: dict[Scalar, Value] = {}
+    inner[1] = "a"
+    inner["x"] = "b"
+    sibling: dict[Scalar, Value] = {"only": "string"}
+    data: list[Value] = [sibling, inner]
+    with pytest.raises(expected_exception=MixedDictKeysError):
+        check_data(data=data, spec=Mojo())
+
+
+def test_mixed_keys_past_set_sibling_raise() -> None:
+    """Recursion skips past a set sibling before finding the mixed
+    dict.
+    """
+    inner: dict[Scalar, Value] = {}
+    inner[1] = "a"
+    inner["x"] = "b"
+    sibling: set[Scalar] = {1, 2}
+    data: list[Value] = [sibling, inner]
+    with pytest.raises(expected_exception=MixedDictKeysError):
+        check_data(data=data, spec=Mojo())

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -45,7 +45,10 @@ type _Scalar = (
     str | int | float | bool | None | datetime.date | datetime.datetime | bytes
 )
 type _ValueInput = (
-    _Scalar | Sequence[_ValueInput] | Mapping[str, _ValueInput] | set[_Scalar]
+    _Scalar
+    | Sequence[_ValueInput]
+    | Mapping[_Scalar, _ValueInput]
+    | set[_Scalar]
 )
 
 


### PR DESCRIPTION
## Summary

Adds `MixedDictKeysError` and `_check_mixed_dict_keys`, wired into `check_data` alongside the existing mixed-value check, so dicts with keys spanning multiple type families are rejected for languages requiring homogeneous dict shapes. Mixed-key inputs cannot yet reach the check through `literalize()` because the YAML parser still stringifies keys (#2204); tests invoke `check_data` directly following the precedent in `test_non_string_dict_key_guard.py`. Also widens the local `_ValueInput` alias in `tests/integration/literalize_ref_cases.py` to accept `Scalar` keys, matching the upstream `ValueInput` widening from dbf739658 and clearing a preexisting type error.

Closes #2201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new validation failure mode for languages that can’t represent heterogeneous dicts, which may surface as new `MixedDictKeysError` exceptions for some inputs. Logic is recursive and touches core `check_data` validation, but is well-scoped and covered by targeted tests.
> 
> **Overview**
> Extends heterogeneity validation to also reject dicts whose *keys* span multiple type families when the target language does not support heterogeneous dicts (new `MixedDictKeysError`, plus recursive mixed-key detection wired into `check_data`).
> 
> Adds focused error-path tests that exercise mixed-key dicts across nested structures, and widens the integration test `_ValueInput` type alias to allow non-string scalar mapping keys to match the library’s input typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e87b03768cf4c337c4842cfa39dbc375d724142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->