### PR TITLE
Cache Coursier artifacts in lint-scala job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1112,6 +1112,8 @@ jobs:
       - name: Find files to lint
         shell: bash
         run: find tests/integration/cases -name '*.scala' -print0 > /tmp/files-to-lint
+      - name: Cache Coursier artifacts
+        uses: coursier/cache-action@v6
       - name: Install scala-cli
         uses: VirtusLab/scala-cli-setup@v1
       # Compile every fixture in a single scala-cli invocation to pay


### PR DESCRIPTION
The `lint-scala` job re-downloads the full Scala 3 compiler toolchain on every run because the Coursier cache is ephemeral on GitHub-hosted runners. Adding `coursier/cache-action@v6` before `VirtusLab/scala-cli-setup` caches `~/.cache/coursier` between runs so subsequent jobs skip the ~50s of artifact resolution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds caching to speed up Scala lint runs; potential impact is limited to workflow behavior if the cache step misbehaves.
> 
> **Overview**
> Speeds up the `lint-scala` GitHub Actions job by caching Coursier artifacts via `coursier/cache-action@v6` before installing `scala-cli`, reducing repeated dependency/toolchain downloads between workflow runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00aaef3fb207648b8aaac1afb33d9f4ab0775671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->