### PR TITLE
Sync language_version with linter flags and add cross-reference comments

### DIFF
--- a/.github/scripts/check_ada_syntax.py
+++ b/.github/scripts/check_ada_syntax.py
@@ -16,6 +16,8 @@ def main() -> None:
         tmp_src = Path(tmpdir) / "check.adb"
         content: str = src.read_text(encoding="utf-8")
         tmp_src.write_text(data=content, encoding="utf-8")
+        # `-gnat2022` matches `Ada.language_version` in
+        # `src/literalizer/languages/ada.py`; keep them in sync.
         result = subprocess.run(
             args=[gnatmake_path, "-gnat2022", "-gnats", "check.adb"],
             capture_output=True,

--- a/.github/scripts/lint-csharp/Program.cs
+++ b/.github/scripts/lint-csharp/Program.cs
@@ -18,7 +18,9 @@ var references = tpa.Split(Path.PathSeparator)
 var options = new CSharpCompilationOptions(OutputKind.ConsoleApplication)
     .WithNullableContextOptions(NullableContextOptions.Disable);
 
-var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+// `LanguageVersion.CSharp10` matches `CSharp.language_version` in
+// `src/literalizer/languages/csharp.py`; keep them in sync.
+var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp10);
 
 var input = Console.In.ReadToEnd();
 var paths = input.Split('\0').Where(p => !string.IsNullOrEmpty(p)).ToList();

--- a/.github/scripts/lint-vb/Program.cs
+++ b/.github/scripts/lint-vb/Program.cs
@@ -33,6 +33,11 @@ var options = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibr
     .WithOptionExplicit(true)
     .WithOptionStrict(OptionStrict.Off);
 
+// `VisualBasic16_9` is the VB compiler version that ships with .NET 6
+// and matches `Vb.language_version` in
+// `src/literalizer/languages/vb.py`; keep them in sync.
+var parseOptions = new VisualBasicParseOptions(LanguageVersion.VisualBasic16_9);
+
 var input = Console.In.ReadToEnd();
 var paths = input.Split('\0').Where(p => !string.IsNullOrEmpty(p)).ToList();
 
@@ -41,7 +46,7 @@ for (var i = 0; i < paths.Count; i++)
 {
     var path = paths[i];
     var source = File.ReadAllText(path);
-    var tree = VisualBasicSyntaxTree.ParseText(source, path: path);
+    var tree = VisualBasicSyntaxTree.ParseText(source, parseOptions, path: path);
     var compilation = VisualBasicCompilation.Create(
         assemblyName: $"fixture_{i}",
         syntaxTrees: new[] { tree },

--- a/.github/scripts/run_ada.py
+++ b/.github/scripts/run_ada.py
@@ -30,6 +30,8 @@ def main() -> None:
         )
         for stub_name in _STUB_SOURCES:
             shutil.copy(src=_REPO_ROOT / stub_name, dst=tmpdir / stub_name)
+        # `-gnat2022` matches `Ada.language_version` in
+        # `src/literalizer/languages/ada.py`; keep them in sync.
         compile_result = subprocess.run(
             args=[gnatmake_path, "-gnat2022", "check.adb"],
             capture_output=True,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -859,9 +859,7 @@ jobs:
             printf 'main :: IO ()\nmain = do\n'
             cat "$calls"
           } > "$workspace/Main.hs"
-          # `-XHaskell2010` matches `Haskell.language_version` in
-          # `src/literalizer/languages/haskell.py`; keep them in sync.
-          (cd "$workspace" && ghc -XHaskell2010 -Wall -Werror -j -outputdir "$tmpdir" -o "$tmpdir/run" Main.hs)
+          (cd "$workspace" && ghc -Wall -Werror -j -outputdir "$tmpdir" -o "$tmpdir/run" Main.hs)
           "$tmpdir/run"
 
       - name: Lint PureScript

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -131,10 +131,8 @@ jobs:
       # current file. Compile each file from inside a private tmpdir so
       # the stale .mod is not on the module search path and parallel
       # runs cannot clobber each other's output.
-      # The Fortran generator emits Fortran 2008 features (e.g. ``int64``
-      # from ``iso_fortran_env``) even though ``Fortran.language_version``
-      # in ``src/literalizer/languages/fortran.py`` is ``V2003``; tracked
-      # in https://github.com/adamtheturtle/literalizer/issues/1919.
+      # ``-std=f2008`` matches ``Fortran.language_version`` in
+      # ``src/literalizer/languages/fortran.py``; keep them in sync.
       - name: Lint Fortran
         run: |-
           find tests/integration/cases -name '*.f90' -print0 > /tmp/files-fortran
@@ -872,7 +870,9 @@ jobs:
             printf 'main :: IO ()\nmain = do\n'
             cat "$calls"
           } > "$workspace/Main.hs"
-          (cd "$workspace" && ghc -Wall -Werror -j -outputdir "$tmpdir" -o "$tmpdir/run" Main.hs)
+          # `-XHaskell2010` matches `Haskell.language_version` in
+          # `src/literalizer/languages/haskell.py`; keep them in sync.
+          (cd "$workspace" && ghc -XHaskell2010 -Wall -Werror -j -outputdir "$tmpdir" -o "$tmpdir/run" Main.hs)
           "$tmpdir/run"
 
       - name: Lint PureScript
@@ -1046,17 +1046,22 @@ jobs:
         uses: SwiftyLab/setup-swift@v1
         with:
           cache-snapshot: true
+      # `-swift-version 5` matches the major version of
+      # `Swift.language_version` in `src/literalizer/languages/swift.py`
+      # (`V5_9`); keep them in sync. `-swift-version` only accepts the
+      # language mode (4/4.2/5/6), not a point release.
       - name: Check Swift syntax
         run: |-
           cat > /tmp/check-swift.sh <<'SCRIPT'
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
           cp "$1" "$tmpdir/check.swift"
-          swiftc -typecheck -warnings-as-errors "$tmpdir/check.swift" || exit 1
+          swiftc -swift-version 5 -typecheck -warnings-as-errors "$tmpdir/check.swift" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/check-swift.sh < /tmp/files-to-lint
       - name: Run Swift files
-        run: xargs -0 -P "$(nproc)" -n1 swift -warnings-as-errors < /tmp/files-to-lint
+        run: xargs -0 -P "$(nproc)" -n1 swift -swift-version 5 -warnings-as-errors
+          < /tmp/files-to-lint
 
   lint-ocaml:
     runs-on: ubuntu-latest
@@ -1221,10 +1226,21 @@ jobs:
         run: find tests/integration/cases -name '*.go' -print0 > /tmp/files-to-lint
       - name: Check Go syntax
         run: xargs -0 gofmt -e < /tmp/files-to-lint
-      - name: Check Go compilation
-        run: xargs -0 -P "$(nproc)" -n1 go vet < /tmp/files-to-lint
-      - name: Run Go files
-        run: xargs -0 -P "$(nproc)" -n1 go run < /tmp/files-to-lint
+      # `go 1.18` in the generated go.mod matches `Go.language_version`
+      # in `src/literalizer/languages/go.py`; keep them in sync. `go vet`
+      # and `go run` honour the module's `go` directive when invoked on
+      # a file inside a module, so wrap each fixture in a tmpdir module.
+      - name: Check Go compilation and run
+        run: |-
+          cat > /tmp/run-go.sh <<'SCRIPT'
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cp "$1" "$tmpdir/main.go"
+          { printf 'module fixture\n\ngo 1.18\n'; } > "$tmpdir/go.mod"
+          (cd "$tmpdir" && go vet ./...) || exit 1
+          (cd "$tmpdir" && go run ./...) || exit 1
+          SCRIPT
+          xargs -0 -P "$(nproc)" -n1 bash /tmp/run-go.sh < /tmp/files-to-lint
 
   lint-rust:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Fortran`'s ``language_version`` default is now
+  ``Fortran.VersionFormats.V2008`` (was ``V2003``) so it matches the
+  Fortran 2008 features the generator actually emits (e.g. ``int64``
+  from ``iso_fortran_env``). ``V2003`` has been removed from
+  ``Fortran.VersionFormats``.
+
 2026.05.14.1
 ------------
 

--- a/CheckJavaSyntax.java
+++ b/CheckJavaSyntax.java
@@ -39,11 +39,13 @@ public class CheckJavaSyntax {
                 final Path classDir = Files.createTempDirectory("javac");
                 final Iterable<? extends JavaFileObject> units =
                         fileManager.getJavaFileObjectsFromStrings(List.of(filename));
+                // `--release 11` matches `Java.language_version` in
+                // `src/literalizer/languages/java.py`; keep them in sync.
                 final JavaCompiler.CompilationTask task = compiler.getTask(
                         null,
                         fileManager,
                         null,
-                        List.of("-d", classDir.toString(), "-proc:none"),
+                        List.of("-d", classDir.toString(), "-proc:none", "--release", "11"),
                         null,
                         units);
                 if (!task.call()) {

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -582,6 +582,8 @@ class Ada(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     call_style: CallStyles = CallStyles.KEYWORD
+    # Keep in sync with the `-gnat2022` flag passed to gnatmake in
+    # `.github/scripts/check_ada_syntax.py` and `.github/scripts/run_ada.py`.
     language_version: VersionFormats = VersionFormats.ADA_2022
     indent: str = "    "
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -582,7 +582,7 @@ class Ada(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     call_style: CallStyles = CallStyles.KEYWORD
-    # Keep in sync with the `-gnat2022` flag passed to gnatmake in
+    # Keep in sync with the `-gnat2022` flag passed to the Ada linter in
     # `.github/scripts/check_ada_syntax.py` and `.github/scripts/run_ada.py`.
     language_version: VersionFormats = VersionFormats.ADA_2022
     indent: str = "    "

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -856,6 +856,8 @@ class CSharp(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `LanguageVersion` passed to the C# lint host
+    # in `.github/scripts/lint-csharp/Program.cs`.
     language_version: VersionFormats = VersionFormats.V10
     indent: str = "    "
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -557,7 +557,7 @@ class Fortran(metaclass=LanguageCls):
     class VersionFormats(enum.Enum):
         """Version options for Fortran."""
 
-        V2003 = enum.auto()
+        V2008 = enum.auto()
 
     version_formats = VersionFormats
 
@@ -679,7 +679,9 @@ class Fortran(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    language_version: VersionFormats = VersionFormats.V2003
+    # Keep in sync with the `-std=` flag passed to gfortran in
+    # `.github/workflows/lint.yml`.
+    language_version: VersionFormats = VersionFormats.V2008
     indent: str = "    "
     null_name: str = "fnull"
     bool_name: str = "fbool"

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -679,7 +679,7 @@ class Fortran(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the `-std=` flag passed to gfortran in
+    # Keep in sync with the `-std=` flag passed to the Fortran linter in
     # `.github/workflows/lint.yml`.
     language_version: VersionFormats = VersionFormats.V2008
     indent: str = "    "

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -643,6 +643,8 @@ class Go(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `go` directive in the generated go.mod in
+    # `.github/workflows/lint.yml`.
     language_version: VersionFormats = VersionFormats.V1_18
     indent: str = "\t"
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1517,8 +1517,6 @@ class Haskell(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the `-XHaskell2010` flag passed to ghc in
-    # `.github/workflows/lint.yml`.
     language_version: VersionFormats = VersionFormats.HASKELL_2010
     indent: str = "    "
     module_name: str = "Check"

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1517,6 +1517,8 @@ class Haskell(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `-XHaskell2010` flag passed to ghc in
+    # `.github/workflows/lint.yml`.
     language_version: VersionFormats = VersionFormats.HASKELL_2010
     indent: str = "    "
     module_name: str = "Check"

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1176,6 +1176,8 @@ class Java(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `--release` flag passed to the JavaCompiler
+    # in `CheckJavaSyntax.java`.
     language_version: VersionFormats = VersionFormats.JDK_11
     indent: str = "    "
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -866,6 +866,9 @@ class Swift(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `-swift-version` flag passed to swiftc/swift
+    # in `.github/workflows/lint.yml` (which only accepts the major
+    # language mode, so `V5_9` maps to `-swift-version 5`).
     language_version: VersionFormats = VersionFormats.V5_9
     indent: str = "    "
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -866,9 +866,9 @@ class Swift(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the `-swift-version` flag passed to swiftc/swift
-    # in `.github/workflows/lint.yml` (which only accepts the major
-    # language mode, so `V5_9` maps to `-swift-version 5`).
+    # Keep in sync with the `-swift-version` flag passed to the Swift
+    # linter in `.github/workflows/lint.yml` (which only accepts the
+    # major language mode, so `V5_9` maps to `-swift-version 5`).
     language_version: VersionFormats = VersionFormats.V5_9
     indent: str = "    "
 

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -647,6 +647,8 @@ class VisualBasic(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `LanguageVersion` passed to the VB lint host
+    # in `.github/scripts/lint-vb/Program.cs`.
     language_version: VersionFormats = VersionFormats.DOTNET_6
     indent: str = "    "
 


### PR DESCRIPTION
## Summary

- Add language-mode flags to remaining linters whose toolchain accepts one: VB (`LanguageVersion.VisualBasic16_9`), Java (`--release 11`), Go (`go 1.18` via generated tmpdir `go.mod`), Haskell (`-XHaskell2010`), Swift (`-swift-version 5`), plus pin C# Roslyn host to `CSharp10` (was `Latest`).
- Add cross-reference \"keep in sync\" comments at both the fixture's \`language_version\` and the linter invocation for C#, VB, Fortran, Ada, Java, Go, Haskell, Swift, matching the pre-existing C/C++/Rust pattern.
- Bump \`Fortran.language_version\` default from \`V2003\` to \`V2008\` so the type matches the Fortran 2008 features the generator already emits (replaces the prior issue #1919 mismatch note).

## Test plan

- [ ] CI green across all touched lint jobs (csharp, vb, fortran, ada, java, go, haskell, swift)
- [ ] Verify Go fixtures still pass under the new tmpdir/go.mod wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI lint/run behavior across multiple languages and makes a small breaking API change by removing `Fortran.VersionFormats.V2003`, which could affect downstream users relying on that enum/value.
> 
> **Overview**
> Aligns fixture linting/tooling with the `Language.language_version` defaults by pinning explicit language modes in CI/helpers (e.g. Ada `-gnat2022`, C# `CSharp10`, VB `VisualBasic16_9`, Swift `-swift-version 5`, Java `--release 11`, and Go via a temporary `go.mod` with `go 1.18`) and adding *“keep in sync”* cross-reference comments on both sides.
> 
> Updates Fortran to default to `V2008` and removes `V2003` from `Fortran.VersionFormats`, and adjusts the Fortran lint step commentary to reflect the now-matching `-std=f2008` setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5297113fcc032617db466c208112943abbd1d13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->