### PR TITLE
Add Python fixture lint gate to lint-fast CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,6 +74,14 @@ jobs:
           luaVersion: '5.4'
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          # Pinned to ``Python.language_version`` (``PY_3_12``) in
+          # ``src/literalizer/languages/python.py``; keep this version
+          # in sync with that default so the Python fixture gate runs
+          # under the declared minimum interpreter.
+          python-version: '3.12'
 
       - name: Lint Bash
         run: |-
@@ -114,6 +122,12 @@ jobs:
       # The run step reuses the same trick: one pwsh process iterates
       # every fixture, executing its script block in a child scope so
       # `$my_data` (and anything else) does not leak between fixtures.
+      - name: Lint Python
+        run: |-
+          find tests/integration/cases -name '*.py' -print0 > /tmp/files-python
+          xargs -0 -P "$(nproc)" -n1 uv run --no-project python -m py_compile < /tmp/files-python
+          xargs -0 -P "$(nproc)" -n1 uv run --no-project python < /tmp/files-python
+
       - name: Lint PowerShell
         run: |-
           find tests/integration/cases -name '*.ps1' -print0 > /tmp/files-ps1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- ``lint-fast`` CI job now syntax-checks and runs the Python fixtures
+  under ``tests/integration/cases``, matching the per-language gate
+  already in place for Bash, Ruby, JavaScript, and other fixture
+  languages.  See #1921.
+
 - ``lint-odin`` CI job now uses ``odin run .`` again to catch runtime
   errors that ``odin build .`` cannot detect (e.g. nil-proc calls).
   The ``laytan/setup-odin`` action is pinned to ``dev-2026-04``, the

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1065,6 +1065,10 @@ class Python(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep this in sync with the ``python-version`` pinned on the
+    # ``Install uv`` step of the ``lint-fast`` job in
+    # ``.github/workflows/lint.yml``; the CI gate must run under an
+    # interpreter at least as new as this default.
     language_version: VersionFormats = VersionFormats.PY_3_12
     indent: str = "    "
 


### PR DESCRIPTION
## Summary
- Adds a `Lint Python` step to the `lint-fast` job that `py_compile`s and runs every `tests/integration/cases/*.py` fixture, mirroring the existing per-language gates (Bash, Ruby, JavaScript, etc.).
- Pins the interpreter via `astral-sh/setup-uv`'s `python-version: '3.12'` so the gate matches `Python.language_version` (`PY_3_12`); cross-references the pin from `python.py` to keep the two in sync.
- Adds a CHANGELOG entry under `Next`. Closes #1921.

## Test plan
- [ ] CI: `lint-fast` job's new `Lint Python` step passes on push.
- [x] Local: ran both the `py_compile` and run passes against all 528 fixtures via `uv run --no-project python` with the pinned 3.12 interpreter — both passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a new Python fixture gate; main impact is potential new CI failures if fixtures or runner Python assumptions change.
> 
> **Overview**
> `lint-fast` CI now includes a Python fixture gate: it installs `uv` with Python `3.12`, then `py_compile`s and executes every `tests/integration/cases/*.py` fixture in parallel.
> 
> This also documents the Python 3.12 pin in both `.github/workflows/lint.yml` and `src/literalizer/languages/python.py` (to keep CI in sync with `Python.language_version`), and adds a corresponding `CHANGELOG.rst` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a7266ecc5345e6c110c17736735e70da82045e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->