### PR TITLE
Pin Scala lint to Scala major version via -S 3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1118,6 +1118,10 @@ jobs:
       # per fixture. Each fixture already carries a unique object name
       # derived from its case directory and stem, so a plain copy
       # suffices; no sed rewriting needed.
+      #
+      # `-S 3` matches the major version of `Scala.language_version` in
+      # `src/literalizer/languages/scala.py` (`V3`); keep them in sync.
+      # `-S` only accepts the Scala major version, not a point release.
       - name: Run Scala files
         run: |-
           workspace=$(mktemp -d)
@@ -1132,7 +1136,7 @@ jobs:
             printf '  val _%s = %s\n' "$name" "$name" >> "$main"
           done < /tmp/files-to-lint
           printf '}\n' >> "$main"
-          scala-cli run "$workspace" --main-class __run
+          scala-cli run "$workspace" -S 3 --main-class __run
 
   lint-dart:
     runs-on: ubuntu-latest

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -657,6 +657,9 @@ class Scala(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `-S` flag passed to `scala-cli run` in
+    # `.github/workflows/lint.yml` (which only accepts the Scala major
+    # version, so `V3` maps to `-S 3`).
     language_version: VersionFormats = VersionFormats.V3
     indent: str = "    "
 


### PR DESCRIPTION
## Summary
- Pass `-S 3` to `scala-cli run` in the Scala lint job so fixtures are parsed under the language version declared on `Scala.language_version` (`V3`).
- Add cross-reference sync comments next to both the workflow call site and `language_version` in `src/literalizer/languages/scala.py`, matching the pattern used for Swift/C#/VB/Java/Ada/Fortran.

Closes #2253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: adjusts the Scala fixture lint invocation to explicitly run under Scala 3, reducing version drift without affecting runtime/library code.
> 
> **Overview**
> Pins the Scala lint job to run fixtures with `scala-cli run -S 3`, ensuring CI parses/compiles Scala fixtures under the declared Scala 3 language mode.
> 
> Adds *sync comments* in `.github/workflows/lint.yml` and `src/literalizer/languages/scala.py` to keep the workflow’s `-S` major version aligned with `Scala.language_version` (`V3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7ca0aec1b4eedb82c200175967897923d1f257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->