### PR TITLE
Pin Kotlin lint to language version 1.9

### DIFF
--- a/.github/scripts/lint-kotlin.main.kts
+++ b/.github/scripts/lint-kotlin.main.kts
@@ -15,7 +15,17 @@ var allOk = true
 for (path in files) {
     val out = java.nio.file.Files.createTempDirectory("kotlin-lint-").toFile()
     try {
-        val exit = compiler.exec(System.err, "-script", "-d", out.absolutePath, path)
+        // `-language-version 1.9` and `-api-version 1.9` match
+        // `Kotlin.language_version` in `src/literalizer/languages/kotlin.py`;
+        // keep them in sync.
+        val exit = compiler.exec(
+            System.err,
+            "-script",
+            "-language-version", "1.9",
+            "-api-version", "1.9",
+            "-d", out.absolutePath,
+            path,
+        )
         if (exit != ExitCode.OK) {
             System.err.println("Failed: $path")
             allOk = false

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -997,8 +997,8 @@ class Kotlin(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the `-language-version`/`-api-version` flags passed
-    # to the Kotlin lint host in `.github/scripts/lint-kotlin.main.kts`.
+    # Keep in sync with the version flags passed to the Kotlin lint host in
+    # `.github/scripts/lint-kotlin.main.kts`.
     language_version: VersionFormats = VersionFormats.V1_9
     indent: str = "    "
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -997,6 +997,8 @@ class Kotlin(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `-language-version`/`-api-version` flags passed
+    # to the Kotlin lint host in `.github/scripts/lint-kotlin.main.kts`.
     language_version: VersionFormats = VersionFormats.V1_9
     indent: str = "    "
 


### PR DESCRIPTION
Closes #2251.

The Kotlin lint host now passes explicit `-language-version 1.9` and `-api-version 1.9` to `K2JVMCompiler.exec(...)`, matching `Kotlin.language_version` (`VersionFormats.V1_9`). Cross-reference sync comments on both `.github/scripts/lint-kotlin.main.kts` and `src/literalizer/languages/kotlin.py` flag future drift, matching the pattern used for C#/VB/Ada.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI linting only, with a small argument change to the Kotlin compiler invocation and no runtime code-path impact beyond syntax checking.
> 
> **Overview**
> Pins the Kotlin lint script (`.github/scripts/lint-kotlin.main.kts`) to compile scripts with explicit `-language-version 1.9` and `-api-version 1.9` flags.
> 
> Adds cross-reference comments in both the lint script and `src/literalizer/languages/kotlin.py` to keep the CI lint version aligned with `Kotlin.language_version` (`VersionFormats.V1_9`) and prevent future drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f353f2de5f78d969d75f75d066a213c5c8bc5508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->