### PR TITLE
Replace C# list_template hack with explicit enable_list_type flag

### DIFF
--- a/src/literalizer/_formatters/collection_openers.py
+++ b/src/literalizer/_formatters/collection_openers.py
@@ -49,6 +49,7 @@ def make_element_to_type(
     datetime_type: str | None,
     time_type: str | None,
     list_template: str,
+    enable_list_type: bool,
     dict_type_template: str | None,
     fallback_value_type: str | None,
     wide_int_type: str | None = None,
@@ -57,7 +58,10 @@ def make_element_to_type(
     template.
 
     The *list_template* must contain ``{inner}`` which will be replaced
-    with the recursively-resolved inner type name.
+    with the recursively-resolved inner type name.  When
+    *enable_list_type* is ``False`` the resolver returns ``None`` for
+    ``ListType`` so the caller can fall back to a generic value type;
+    *list_template* is then ignored.
 
     When *dict_type_template* is given it must contain ``{inner}``
     and is used to resolve ``DictType`` elements.  *fallback_value_type*
@@ -101,6 +105,7 @@ def make_element_to_type(
             element_type=element_type,
             scalar_types=scalar_types,
             list_template=list_template,
+            enable_list_type=enable_list_type,
             dict_type_template=dict_type_template,
             fallback_value_type=fallback_value_type,
         )
@@ -148,6 +153,7 @@ def _resolve_element_to_type(
     element_type: type | ListType | DictType,
     scalar_types: dict[type, str],
     list_template: str,
+    enable_list_type: bool,
     dict_type_template: str | None,
     fallback_value_type: str | None,
 ) -> str | None:
@@ -162,6 +168,7 @@ def _resolve_element_to_type(
                     element_type=element_type.value_type,
                     scalar_types=scalar_types,
                     list_template=list_template,
+                    enable_list_type=enable_list_type,
                     dict_type_template=dict_type_template,
                     fallback_value_type=fallback_value_type,
                 )
@@ -170,12 +177,17 @@ def _resolve_element_to_type(
                 return None
             return dict_type_template.format(inner=inner)
         case ListType():
-            inner = _resolve_element_to_type(
-                element_type=element_type.inner,
-                scalar_types=scalar_types,
-                list_template=list_template,
-                dict_type_template=dict_type_template,
-                fallback_value_type=fallback_value_type,
+            inner = (
+                _resolve_element_to_type(
+                    element_type=element_type.inner,
+                    scalar_types=scalar_types,
+                    list_template=list_template,
+                    enable_list_type=enable_list_type,
+                    dict_type_template=dict_type_template,
+                    fallback_value_type=fallback_value_type,
+                )
+                if enable_list_type
+                else None
             )
             if inner is None:
                 return None
@@ -415,6 +427,7 @@ class TypedOpenerConfig:
         self,
         *,
         list_template: str | None,
+        enable_list_type: bool,
         date_type: str | None,
         datetime_type: str | None,
         enable_dict_type: bool,
@@ -422,7 +435,10 @@ class TypedOpenerConfig:
     ) -> Callable[[type | ListType | DictType], str | None]:
         """Build an element-to-type resolver.
 
-        If *list_template* is given it overrides the default.
+        If *list_template* is given it overrides the default.  When
+        *enable_list_type* is ``False`` the resolver returns ``None``
+        for ``ListType`` so callers can fall back to a generic value
+        type; *list_template* is then ignored.
         If *date_type* or *datetime_type* is given they override the
         base values.  When *enable_dict_type* is ``False`` the
         resolver will not handle ``DictType``.
@@ -459,6 +475,7 @@ class TypedOpenerConfig:
                 if list_template is not None
                 else self._list_template
             ),
+            enable_list_type=enable_list_type,
             dict_type_template=resolved_template,
             fallback_value_type=(
                 self._fallback_value_type if enable_dict_type else None
@@ -496,6 +513,7 @@ class TypedOpenerConfig:
         """
         seq_resolver = self.element_to_type(
             list_template=None,
+            enable_list_type=True,
             date_type=date_type,
             datetime_type=datetime_type,
             enable_dict_type=True,
@@ -503,6 +521,7 @@ class TypedOpenerConfig:
         )
         dict_set_resolver = self.element_to_type(
             list_template=None,
+            enable_list_type=True,
             date_type=date_type,
             datetime_type=datetime_type,
             enable_dict_type=narrow_dict_values,

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -234,6 +234,7 @@ def _make_cpp_element_to_type(
         datetime_type=datetime_type,
         time_type="std::string",
         list_template="std::vector<{inner}>",
+        enable_list_type=True,
         dict_type_template="std::map<std::string, {inner}>",
         fallback_value_type=None,
     )

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -100,6 +100,7 @@ _crystal_narrowed_empty_form = make_narrowed_empty_form(
         datetime_type="String",
         time_type="String",
         list_template="Array({inner})",
+        enable_list_type=True,
         dict_type_template="Hash(String, {inner})",
         fallback_value_type="String",
     ),

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -1094,11 +1094,9 @@ class CSharp(metaclass=LanguageCls):
             dict_open=typed_dict_open(
                 type_to_opener=make_type_to_opener(
                     element_to_type=cfg.element_to_type(
-                        list_template=(
-                            None
-                            if self.sequence_format
-                            is self.sequence_formats.ARRAY
-                            else self.default_dict_value_type
+                        list_template=None,
+                        enable_list_type=(
+                            self.sequence_format is self.sequence_formats.ARRAY
                         ),
                         date_type=cfg.type_name(py_type=self._date_tp),
                         datetime_type=cfg.type_name(py_type=self._dt_tp),

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -122,6 +122,7 @@ _dhall_narrowed_empty_form = make_narrowed_empty_form(
         datetime_type="Text",
         time_type="Text",
         list_template="(List {inner})",
+        enable_list_type=True,
         dict_type_template=None,
         fallback_value_type="Text",
     ),

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -801,6 +801,7 @@ class Go(metaclass=LanguageCls):
             datetime_type=datetime_type,
             time_type="string",
             list_template="[]{inner}",
+            enable_list_type=True,
             dict_type_template=f"map[{self.default_dict_key_type}]{{inner}}",
             fallback_value_type="any",
         )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -147,6 +147,7 @@ def _kotlin_list_sequence_open(
     """
     dict_resolver = cfg.element_to_type(
         list_template="List<{inner}>",
+        enable_list_type=True,
         date_type=date_type,
         datetime_type=datetime_type,
         enable_dict_type=True,
@@ -1193,6 +1194,7 @@ class Kotlin(metaclass=LanguageCls):
                 type_to_opener=make_type_to_opener(
                     element_to_type=self._opener_config.element_to_type(
                         list_template=None,
+                        enable_list_type=True,
                         date_type=self._date_type_name,
                         datetime_type=self._dt_type_name,
                         enable_dict_type=False,

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -95,6 +95,7 @@ _mojo_element_to_type = make_element_to_type(
     datetime_type="String",
     time_type="String",
     list_template="List[{inner}]",
+    enable_list_type=True,
     dict_type_template="Dict[String, {inner}]",
     fallback_value_type="String",
 )
@@ -116,6 +117,7 @@ _mojo_call_arg_element_to_type = make_element_to_type(
     datetime_type="String",
     time_type="String",
     list_template="List[{inner}]",
+    enable_list_type=True,
     dict_type_template="Dict[String, {inner}]",
     fallback_value_type=None,
 )
@@ -1486,6 +1488,7 @@ class Mojo(metaclass=LanguageCls):
                     datetime_type=None,
                     time_type=None,
                     list_template="List[{inner}]",
+                    enable_list_type=True,
                     dict_type_template=None,
                     fallback_value_type=None,
                 ),

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -736,6 +736,7 @@ class Odin(metaclass=LanguageCls):
             datetime_type="string",
             time_type="string",
             list_template="[dynamic]{inner}",
+            enable_list_type=True,
             dict_type_template="map[string]{inner}",
             fallback_value_type="string",
         )

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -122,6 +122,7 @@ def _list_sequence_open(
         type_to_opener=make_type_to_opener(
             element_to_type=cfg.element_to_type(
                 list_template="List[{inner}]",
+                enable_list_type=True,
                 date_type=date_type,
                 datetime_type=datetime_type,
                 enable_dict_type=True,
@@ -861,6 +862,7 @@ class Scala(metaclass=LanguageCls):
                             is self.sequence_formats.LIST
                             else None
                         ),
+                        enable_list_type=True,
                         date_type=self._date_type_name,
                         datetime_type=self._datetime_type_name,
                         enable_dict_type=False,

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -102,6 +102,7 @@ _v_element_to_type = make_element_to_type(
     datetime_type="string",
     time_type="string",
     list_template="[]{inner}",
+    enable_list_type=True,
     dict_type_template=None,
     fallback_value_type=_V_IFACE_NAME,
 )

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -835,6 +835,7 @@ class VisualBasic(metaclass=LanguageCls):
             datetime_type=datetime_type,
             time_type="TimeOnly",
             list_template="{inner}()",
+            enable_list_type=True,
             dict_type_template=None,
             fallback_value_type=None,
         )


### PR DESCRIPTION
## Summary

Follow-up to #2243 addressing the Cursor bugbot comment about `src/literalizer/languages/csharp.py`. The previous patch passed `"object"` as `list_template` for non-ARRAY C# sequence formats, which only worked because `str.format` silently ignores unused placeholders. This adds an explicit `enable_list_type: bool` knob on `make_element_to_type` / `TypedOpenerConfig.element_to_type` (mirroring `enable_dict_type`), so unresolvable list types cleanly fall back via the dict opener's fallback instead of abusing the template API. The other bugbot comment (Gleam `GStr(String)` allegedly missing from the type preamble) is a false positive: Gleam emits its value type via `data_dependent_preamble`/`_collect_gleam_types`, which already includes `datetime.time` in `str_types`, and the existing goldens confirm `GStr(String)` is present.

## Test plan

- [x] `uv run pytest` (3759 passed, 1310 skipped, 20911 subtests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared type-resolution logic used across many language emitters; a mistake could change generated collection type hints (especially for nested lists in dict values), but the change is small and gated behind an explicit flag.
> 
> **Overview**
> Introduces an explicit `enable_list_type` switch in `make_element_to_type` / `TypedOpenerConfig.element_to_type` so callers can opt out of resolving `ListType` (returning `None` to trigger fallback typing) rather than relying on placeholder/formatting behavior.
> 
> Plumbs the new flag through recursive type resolution and updates all language implementations to pass it (notably C# dict typing now disables list-type resolution unless the sequence format is `ARRAY`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b07a18cc2b18cb853c05ddcfea59ea3d947b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->