### PR TITLE
Remove redundant Rust type annotation unit tests

### DIFF
--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -87,15 +87,6 @@ def test_rust_tuple_format_type_annotation_raises() -> None:
         )
 
 
-def test_rust_vec_format_type_annotation() -> None:
-    """``format_type_annotation`` returns ``Vec<T>`` for vector format."""
-    result = Rust.sequence_formats.VEC.format_type_annotation(
-        element_type="i32",
-        length=3,
-    )
-    assert result == "Vec<i32>"
-
-
 def test_rust_static_single_element_tuple_annotation_has_comma() -> None:
     """Single-element tuple annotations include the required comma."""
     rust = Rust(
@@ -140,15 +131,6 @@ def test_rust_tagged_enum_epoch_datetime_uses_integer_variant() -> None:
     assert result.code == (
         "vec![\n    Value::I64(1704067200),\n    Value::I32(1),\n]"
     )
-
-
-def test_rust_hash_set_type_annotation() -> None:
-    """``HASH_SET`` renders a ``HashSet`` type annotation."""
-    result = Rust.set_formats.HASH_SET.format_type_annotation(
-        element_type="i32",
-    )
-
-    assert result == "HashSet<i32>"
 
 
 def test_rust_btree_set_type_annotation() -> None:


### PR DESCRIPTION
## Summary
- Remove `test_rust_hash_set_type_annotation` and `test_rust_vec_format_type_annotation`, which directly invoked the private `format_type_annotation` helper.
- The `HashSet<...>` and `Vec<...>` annotations they asserted are already exercised by existing golden files under `tests/integration/cases/`.
- Filed #2275 for the analogous `BTREE_SET` / `BTREE_MAP` tests, which currently lack golden coverage.

## Test plan
- [ ] `pytest tests/integration/test_literalize_golden.py::test_golden_file[Rust]` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that deletes redundant unit tests without modifying runtime code. Risk is limited to potentially reduced regression detection if golden coverage is incomplete.
> 
> **Overview**
> Removes the `test_rust_vec_format_type_annotation` and `test_rust_hash_set_type_annotation` unit tests from `tests/test_variables.py`, reducing direct test coverage of `format_type_annotation` for `Vec<T>` and `HashSet<T>`.
> 
> Other Rust-specific tests (e.g., tuple incompatibility and single-element tuple annotation) remain unchanged, so this PR is a *test suite cleanup* rather than a behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afe89e0306c3e27d8634e05c25b27988270265b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->