### PR TITLE
Cover Rust BTreeSet / BTreeMap type annotations via golden files

### DIFF
--- a/tests/integration/cases/int_key_dict/Rust_dict_btree_map_decl_lazy_static@edition_2021.rs
+++ b/tests/integration/cases/int_key_dict/Rust_dict_btree_map_decl_lazy_static@edition_2021.rs
@@ -1,0 +1,10 @@
+use std::sync::LazyLock;
+use std::collections::BTreeMap;
+fn main() {
+    static my_data: LazyLock<BTreeMap<i32, &str>> = LazyLock::new(|| BTreeMap::from([
+        (1, "one"),
+        (2, "two"),
+        (42, "answer"),
+    ]));
+    let _ = my_data;
+}

--- a/tests/integration/cases/int_key_dict/Rust_dict_btree_map_decl_let_mut@edition_2021.rs
+++ b/tests/integration/cases/int_key_dict/Rust_dict_btree_map_decl_let_mut@edition_2021.rs
@@ -1,0 +1,9 @@
+use std::collections::BTreeMap;
+fn main() {
+    let mut my_data = BTreeMap::from([
+        (1, "one"),
+        (2, "two"),
+        (42, "answer"),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/set_mixed_int_widths/Kotlin_set_sorted_set_decl_var@v1_9.kts
+++ b/tests/integration/cases/set_mixed_int_widths/Kotlin_set_sorted_set_decl_var@v1_9.kts
@@ -1,0 +1,4 @@
+var my_data = sortedSetOf<Long>(
+    1L,
+    1099511627776L,
+)

--- a/tests/integration/cases/set_mixed_int_widths/Rust_set_btree_set_decl_lazy_static@edition_2021.rs
+++ b/tests/integration/cases/set_mixed_int_widths/Rust_set_btree_set_decl_lazy_static@edition_2021.rs
@@ -1,0 +1,9 @@
+use std::sync::LazyLock;
+use std::collections::BTreeSet;
+fn main() {
+    static my_data: LazyLock<BTreeSet<i64>> = LazyLock::new(|| BTreeSet::from([
+        1,
+        1099511627776i64,
+    ]));
+    let _ = my_data;
+}

--- a/tests/integration/cases/set_mixed_int_widths/Rust_set_btree_set_decl_let_mut@edition_2021.rs
+++ b/tests/integration/cases/set_mixed_int_widths/Rust_set_btree_set_decl_let_mut@edition_2021.rs
@@ -1,0 +1,8 @@
+use std::collections::BTreeSet;
+fn main() {
+    let mut my_data = BTreeSet::from([
+        1,
+        1099511627776i64,
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/set_mixed_int_widths/Scala_set_tree_set_decl_var@v3.scala
+++ b/tests/integration/cases/set_mixed_int_widths/Scala_set_tree_set_decl_var@v3.scala
@@ -1,0 +1,7 @@
+import scala.collection.immutable.TreeSet
+object Fixture_set_mixed_int_widths_Scala_set_tree_set_decl_var {
+var my_data = TreeSet[Long](
+    1,
+    1099511627776L,
+)
+}

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -674,6 +674,127 @@ def build_sequence_decl_variants() -> Iterable[Variant]:
 
 
 @beartype
+def _resolve_sequence_format_override(
+    *,
+    lang_cls: literalizer.LanguageCls,
+    declaration_style: enum.Enum,
+) -> enum.Enum | None:
+    """Return the sequence-format override for *declaration_style*, if
+    any.
+
+    Rust ``CONST`` and ``STATIC`` reject the default ``VEC`` sequence
+    format upfront in ``__post_init__``; any cross-product variant that
+    pairs them with a non-default set/dict format still has to apply
+    the same sequence-format override the standalone declaration-style
+    variants use.
+    """
+    overrides = DECLARATION_STYLE_SEQUENCE_FORMAT_OVERRIDES.get(lang_cls, {})
+    seq_format_name = overrides.get(declaration_style.name)
+    if seq_format_name is None:
+        return None
+    spec = make_spec(lang_cls=lang_cls)
+    return next(f for f in spec.sequence_formats if f.name == seq_format_name)
+
+
+@beartype
+def build_set_decl_variants() -> Iterable[Variant]:
+    """Build set format + declaration style cross-option variants.
+
+    For each language with multiple set formats *and* multiple
+    declaration styles, create a variant for every non-default
+    set format paired with every non-default declaration style.
+    """
+    variants: list[Variant] = []
+    for lang_cls in sorted_languages():
+        lang_name = lang_cls.__name__
+        spec = make_spec(lang_cls=lang_cls)
+        default_set_format = spec.set_format
+        default_declaration_style = spec.declaration_style
+        non_default_set_formats = [
+            set_format
+            for set_format in spec.set_formats
+            if set_format is not default_set_format
+        ]
+        non_default_declaration_styles = [
+            declaration_style
+            for declaration_style in spec.declaration_styles
+            if declaration_style is not default_declaration_style
+        ]
+        for set_format in non_default_set_formats:
+            for declaration_style in non_default_declaration_styles:
+                seq_override = _resolve_sequence_format_override(
+                    lang_cls=lang_cls,
+                    declaration_style=declaration_style,
+                )
+                kwargs: dict[str, object] = {
+                    "set_format": set_format,
+                    "declaration_style": declaration_style,
+                }
+                if seq_override is not None:
+                    kwargs["sequence_format"] = seq_override
+                variants.append(
+                    Variant(
+                        name=(
+                            f"{lang_name}_set_{set_format.name.lower()}"
+                            f"_decl_{declaration_style.name.lower()}"
+                        ),
+                        spec=make_spec(lang_cls=lang_cls, **kwargs),
+                        lang_cls=lang_cls,
+                    )
+                )
+    return variants
+
+
+@beartype
+def build_dict_decl_variants() -> Iterable[Variant]:
+    """Build dict format + declaration style cross-option variants.
+
+    For each language with multiple dict formats *and* multiple
+    declaration styles, create a variant for every non-default
+    dict format paired with every non-default declaration style.
+    """
+    variants: list[Variant] = []
+    for lang_cls in sorted_languages():
+        lang_name = lang_cls.__name__
+        spec = make_spec(lang_cls=lang_cls)
+        default_dict_format = spec.dict_format
+        default_declaration_style = spec.declaration_style
+        non_default_dict_formats = [
+            dict_format
+            for dict_format in spec.dict_formats
+            if dict_format is not default_dict_format
+        ]
+        non_default_declaration_styles = [
+            declaration_style
+            for declaration_style in spec.declaration_styles
+            if declaration_style is not default_declaration_style
+        ]
+        for dict_format in non_default_dict_formats:
+            for declaration_style in non_default_declaration_styles:
+                seq_override = _resolve_sequence_format_override(
+                    lang_cls=lang_cls,
+                    declaration_style=declaration_style,
+                )
+                kwargs: dict[str, object] = {
+                    "dict_format": dict_format,
+                    "declaration_style": declaration_style,
+                }
+                if seq_override is not None:
+                    kwargs["sequence_format"] = seq_override
+                variants.append(
+                    Variant(
+                        name=(
+                            f"{lang_name}_dict_{dict_format.name.lower()}"
+                            f"_decl_{declaration_style.name.lower()}"
+                        ),
+                        spec=make_spec(lang_cls=lang_cls, **kwargs),
+                        lang_cls=lang_cls,
+                    )
+                )
+    return variants
+
+
+@beartype
 def build_constructor_name_variants() -> Iterable[Variant]:
     """Build constructor-name variants for languages listed in
     :data:`CONSTRUCTOR_NAME_OVERRIDES` (e.g. Fortran).
@@ -1393,6 +1514,8 @@ _COMPLEX_BUILDERS: dict[str, Callable[[], Iterable[Variant]]] = {
         build_statement_terminator_style_decl_variants
     ),
     "sequence_decl": build_sequence_decl_variants,
+    "set_decl": build_set_decl_variants,
+    "dict_decl": build_dict_decl_variants,
     "type_hints_cross": build_type_hints_cross_variants,
     "string_format_date_cross": lambda: build_string_format_cross_variants(
         other_kwarg="date_format",
@@ -1647,6 +1770,8 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     ),
     "statement_terminator_style_decl": (_ci(case_dir_name="simple_sequence"),),
     "sequence_decl": (_ci(case_dir_name="int_list"),),
+    "set_decl": (_ci(case_dir_name="set_mixed_int_widths"),),
+    "dict_decl": (_ci(case_dir_name="int_key_dict"),),
     "type_name": ADT_INPUTS,
     "constructor_prefix": ADT_INPUTS,
     "numeric_style": (

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -133,25 +133,6 @@ def test_rust_tagged_enum_epoch_datetime_uses_integer_variant() -> None:
     )
 
 
-def test_rust_btree_set_type_annotation() -> None:
-    """``BTREE_SET`` renders a ``BTreeSet`` type annotation."""
-    result = Rust.set_formats.BTREE_SET.format_type_annotation(
-        element_type="i32",
-    )
-
-    assert result == "BTreeSet<i32>"
-
-
-def test_rust_btree_map_type_annotation() -> None:
-    """``BTREE_MAP`` renders a ``BTreeMap`` type annotation."""
-    result = Rust.dict_formats.BTREE_MAP.format_type_annotation(
-        key_type="&str",
-        value_type="i32",
-    )
-
-    assert result == "BTreeMap<&str, i32>"
-
-
 def test_rust_const_vec_raises() -> None:
     """Rust CONST with vector format raises."""
     expected_msg = (


### PR DESCRIPTION
## Summary
- Add `set_decl` and `dict_decl` cross-product variant builders in `tests/integration/variant_cases.py` mirroring the existing `sequence_decl` builder, with a shared `_resolve_sequence_format_override` helper so Rust `CONST`/`STATIC` combos still apply the `VEC` → `ARRAY` override.
- Generate new golden files including `Rust_set_btree_set_decl_lazy_static` and `Rust_dict_btree_map_decl_lazy_static`, which exercise the `BTreeSet<…>` and `BTreeMap<…, …>` type annotations through the public `literalize` API (plus a few incidental Kotlin / Scala / Rust let-mut variants from the same cross product).
- Remove `test_rust_btree_set_type_annotation` and `test_rust_btree_map_type_annotation` from `tests/test_variables.py`, closing #2275.

## Test plan
- [x] `pytest tests/test_variables.py tests/integration/test_orphan_golden_files.py tests/integration/test_variant_cases.py`
- [x] `pytest tests/integration/test_literalize_golden.py::test_format_variant_golden_file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test variant generation and golden fixtures, with minor logic to ensure Rust `CONST`/`STATIC` variants apply the existing sequence-format override.
> 
> **Overview**
> Adds new integration-test variant axes `set_decl` and `dict_decl` to cross non-default set/dict formats with non-default declaration styles, including a shared `_resolve_sequence_format_override` so Rust `CONST`/`STATIC` combinations keep the `VEC` → `ARRAY` workaround.
> 
> Introduces new golden fixtures that exercise typed declarations for ordered set/map formats (notably Rust `BTreeSet<…>`/`BTreeMap<…, …>` under `LAZY_STATIC` and `let mut`, plus incidental Kotlin/Scala sorted-set variants), and removes the unit tests that directly asserted Rust `BTreeSet`/`BTreeMap` type-annotation strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a5adde221cb3a36c5da47a259941cb0df0574a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->