### PR TITLE
Drop Rust LazyLock preamble unit tests covered by goldens

### DIFF
--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -186,28 +186,6 @@ def test_rust_static_vec_raises() -> None:
         )
 
 
-RUST_LAZY_STATIC = Rust(
-    date_format=Rust.date_formats.ISO,
-    datetime_format=Rust.datetime_formats.ISO,
-    bytes_format=Rust.bytes_formats.HEX,
-    declaration_style=Rust.declaration_styles.LAZY_STATIC,
-)
-
-
-def test_rust_lazy_static_preamble_includes_lazy_lock() -> None:
-    """``LAZY_STATIC`` adds ``use std::sync::LazyLock;`` to the
-    preamble.
-    """
-    assert RUST_LAZY_STATIC.static_preamble == ("use std::sync::LazyLock;",)
-
-
-def test_rust_static_preamble_excludes_lazy_lock() -> None:
-    """Non-``LAZY_STATIC`` declaration styles emit no ``LazyLock``
-    import.
-    """
-    assert RUST_CONST.static_preamble == ()
-
-
 def test_rust_lazy_static_config_formatter_raises_if_called_directly() -> None:
     """The LAZY_STATIC ``DeclarationStyleConfig`` formatter is a
     placeholder.


### PR DESCRIPTION
## Summary
- Remove `test_rust_lazy_static_preamble_includes_lazy_lock` and `test_rust_static_preamble_excludes_lazy_lock` along with the now-unused `RUST_LAZY_STATIC` fixture. The `use std::sync::LazyLock;` preamble behaviour is already exercised by every `*_lazy_static@edition_2021.rs` golden file.

## Test plan
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a small set of redundant Rust `LAZY_STATIC` preamble unit tests/fixture without changing runtime code; coverage is expected to remain via existing golden integration cases.
> 
> **Overview**
> Removes the `RUST_LAZY_STATIC` test fixture and two unit tests that asserted `LAZY_STATIC` adds a `use std::sync::LazyLock;` preamble (and that non-`LAZY_STATIC` styles do not).
> 
> Keeps the guard test ensuring the stored `LAZY_STATIC` formatter raises if called directly, relying on existing `*_lazy_static@edition_2021.rs` golden integration files to cover the preamble behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f27c31b3d5d3556bebc08cc5e35578910aa08741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->