### PR TITLE
Drop redundant F# bigint suffix test in favour of golden file

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -29,7 +29,6 @@ from literalizer.languages import (
     Dart,
     Dhall,
     Fortran,
-    FSharp,
     Gleam,
     Go,
     Haskell,
@@ -65,7 +64,6 @@ FORTRAN = Fortran(
     sequence_format=Fortran.sequence_formats.LIST,
     module_name="check",
 )
-FSHARP = FSharp(module_name="check")
 
 
 def test_python_datetime_whole_hour_offset_omits_minutes() -> None:
@@ -386,22 +384,6 @@ def test_fortran_continuation_with_escaped_quote_and_comment() -> None:
         "    fentry('host', fstr('it''s here')), &  ! a comment\n"
         "    fentry('port', fint(80_int64)) &  ! another\n"
         "])"
-    )
-
-
-def test_fsharp_scalar_very_large_int_uses_bigint_suffix() -> None:
-    """Bare F# scalar integers above i64 range use the ``I`` suffix."""
-    result = literalize(
-        source="9223372036854775808",
-        input_format=InputFormat.JSON,
-        language=FSHARP,
-        pre_indent_level=0,
-        include_delimiters=False,
-        variable_form=None,
-    )
-
-    assert result.code == (
-        "type Val =\n    | FInt of bigint\n9223372036854775808I"
     )
 
 


### PR DESCRIPTION
## Summary
- Removed `test_fsharp_scalar_very_large_int_uses_bigint_suffix` and the now-unused `FSHARP`/`FSharp` references from `tests/test_languages.py`.
- The `scalar_int_very_large` golden case already covers F# emitting the `I` suffix for values above the i64 range.

## Test plan
- [x] Pre-commit hooks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only deletes test code and an unused F# test fixture, with behavior still covered by an existing golden-file integration case.
> 
> **Overview**
> Removes the standalone F# unit test that asserted very-large integers render with the `I` bigint suffix, along with the now-unused `FSharp` import and `FSHARP` test spec in `tests/test_languages.py`.
> 
> Coverage for this behavior is left to the existing `tests/integration/cases/scalar_int_very_large` golden case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6b1ab4f736db82f4fea288a31aa8f9f4c6fd88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->