### PR TITLE
Remove redundant test_python_no_any_import_when_all_defaults_overridden

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -448,28 +448,6 @@ def test_java_list_rejects_null_elements() -> None:
         )
 
 
-def test_python_no_any_import_when_all_defaults_overridden() -> None:
-    """When all Python default collection types are non-Any, the
-    ``from typing import Any`` import is not emitted.
-    """
-    spec = Python(
-        default_set_element_type="str",
-        default_sequence_element_type="str",
-        default_dict_value_type="str",
-        default_dict_key_type="str",
-    )
-    result = literalize(
-        source="{}\n",
-        input_format=InputFormat.YAML,
-        language=spec,
-        pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name="my_data"),
-    )
-    assert result.code == "my_data: dict[str, str] = {}"
-    assert result.preamble == ("from __future__ import annotations",)
-
-
 def test_literalize_call_wrap_in_file_emits_stubs() -> None:
     """``wrap_in_file=True`` produces a self-contained file that
     defines the ``target_function`` so the output compiles on its own.


### PR DESCRIPTION
## Summary
- Delete `test_python_no_any_import_when_all_defaults_overridden` from `tests/test_languages.py`. The no-`Any`-import behavior on an empty-dict input is already covered by the golden file `tests/integration/cases/empty_dict/Python_default_dict_value_type_string@py39.py`, which emits `dict[str, int] = {}` with no `from typing import Any`. The other three default-type overrides in the deleted test were inert for an empty-dict input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that reduces duplication without affecting runtime behavior.
> 
> **Overview**
> Removes `test_python_no_any_import_when_all_defaults_overridden` from `tests/test_languages.py`, relying on the existing `tests/integration/cases/empty_dict/Python_default_dict_value_type_string@py39.py` golden case to cover the “no `from typing import Any` import” behavior for empty dict output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a462fd9b645f5122c0305253c8e580597412f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->