### PR TITLE
Replace Raku kebab unit test with kebab ref golden case

### DIFF
--- a/tests/integration/case_discovery.py
+++ b/tests/integration/case_discovery.py
@@ -36,46 +36,74 @@ class LiteralizeRefCaseConfig:
     matching ref stub.  Without it the harness keeps its historical
     behavior: refs render with no value-type knowledge and stubs are
     dict shaped.
+
+    When *ref_case_override* is set, the case forces that identifier
+    case for the ``ref_case`` argument of :func:`literalize` instead of
+    using the language's default (``identifier_cases[0]``).  Discovery
+    skips any language whose ``supported_ref_cases`` does not include
+    the override.
     """
 
     case_dir_name: str
     ref_key: str
-    ref_value_sources: tuple[tuple[str, str], ...] = ()
+    ref_value_sources: tuple[tuple[str, str], ...]
+    ref_case_override: literalizer.IdentifierCase | None
 
 
 LITERALIZE_REF_CASE_CONFIGS: list[LiteralizeRefCaseConfig] = [
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_whole",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_in_dict",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_in_list",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_heterogeneous",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_in_mixed_list",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_camel_name",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_deep_nesting",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_scalar",
         ref_key="$ref",
         ref_value_sources=(("my_int", "42"),),
+        ref_case_override=None,
+    ),
+    LiteralizeRefCaseConfig(
+        case_dir_name="literalize_ref_kebab_name",
+        ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=literalizer.IdentifierCase.KEBAB,
     ),
 ]
 
@@ -83,10 +111,14 @@ LITERALIZE_DEFAULT_REF_CASE_CONFIGS: list[LiteralizeRefCaseConfig] = [
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_default_nested",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
     LiteralizeRefCaseConfig(
         case_dir_name="literalize_ref_default_whole",
         ref_key="$ref",
+        ref_value_sources=(),
+        ref_case_override=None,
     ),
 ]
 

--- a/tests/integration/cases/literalize_ref_kebab_name/Nix_ref@v2.nix
+++ b/tests/integration/cases/literalize_ref_kebab_name/Nix_ref@v2.nix
@@ -1,4 +1,4 @@
 let user-obj = {
   _ = "_";
-}; in user-obj
+}; in
 let my_data = user-obj; in my_data

--- a/tests/integration/cases/literalize_ref_kebab_name/Nix_ref@v2.nix
+++ b/tests/integration/cases/literalize_ref_kebab_name/Nix_ref@v2.nix
@@ -1,0 +1,4 @@
+let user-obj = {
+  _ = "_";
+}; in user-obj
+let my_data = user-obj; in my_data

--- a/tests/integration/cases/literalize_ref_kebab_name/Raku_ref@v6d.raku
+++ b/tests/integration/cases/literalize_ref_kebab_name/Raku_ref@v6d.raku
@@ -1,0 +1,4 @@
+my $user-obj = {
+    '_' => '_',
+};
+my $my_data = $user-obj;

--- a/tests/integration/cases/literalize_ref_kebab_name/input.yaml
+++ b/tests/integration/cases/literalize_ref_kebab_name/input.yaml
@@ -1,0 +1,1 @@
+$ref: user-obj

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -72,11 +72,20 @@ class LiteralizeRefCase:
 @functools.cache
 @beartype
 def discover_literalize_ref_cases() -> list[LiteralizeRefCase]:
-    """Return literalize-ref test cases for all languages."""
+    """Return literalize-ref test cases for all languages.
+
+    Configs with a ``ref_case_override`` are filtered to languages whose
+    ``supported_ref_cases`` includes that override; the remaining
+    languages cannot produce a golden file for the forced ref case and
+    are excluded from discovery so the orphan-files check stays
+    accurate.
+    """
     return [
         LiteralizeRefCase(config=config, lang_cls=lang_cls)
         for config in LITERALIZE_REF_CASE_CONFIGS
         for lang_cls in sorted_languages()
+        if config.ref_case_override is None
+        or config.ref_case_override in lang_cls.supported_ref_cases
     ]
 
 

--- a/tests/integration/literalize_ref_cases.py
+++ b/tests/integration/literalize_ref_cases.py
@@ -74,8 +74,8 @@ class LiteralizeRefCase:
 def discover_literalize_ref_cases() -> list[LiteralizeRefCase]:
     """Return literalize-ref test cases for all languages.
 
-    Configs with a ``ref_case_override`` are filtered to languages whose
-    ``supported_ref_cases`` includes that override; the remaining
+    A case carrying a ``ref_case_override`` is filtered to languages
+    whose ``supported_ref_cases`` includes that override; the remaining
     languages cannot produce a golden file for the forced ref case and
     are excluded from discovery so the orphan-files check stays
     accurate.
@@ -129,7 +129,10 @@ def _collect_ref_names(data: _RefData, *, ref_key: str) -> list[str]:
 
 
 _STUB_ASSIGN_LINE_RE = re.compile(pattern=r"^\w+\s*=(?!=)")
-_NIX_STUB_IN_RE = re.compile(pattern=r"^(.*;\s+in)\s+\w+\s*$")
+# The trailing identifier may be a kebab-case ref name (Nix permits
+# ``-`` in identifiers), so the name class allows hyphens, not just
+# ``\w``.
+_NIX_STUB_IN_RE = re.compile(pattern=r"^(.*;\s+in)\s+[\w-]+\s*$")
 
 
 def _split_stub(stub_code: str) -> tuple[list[str], list[str]]:

--- a/tests/integration/test_literalize_ref_golden.py
+++ b/tests/integration/test_literalize_ref_golden.py
@@ -39,6 +39,11 @@ def test_literalize_ref_golden_file(
                 lang_cls=lang_cls,
                 language_version=version_format,
             )
+            effective_ref_case = (
+                ref_case.config.ref_case_override
+                if ref_case.config.ref_case_override is not None
+                else spec.identifier_cases[0]
+            )
             run_literalize_ref_golden_case(
                 config=ref_case.config,
                 lang_cls=lang_cls,
@@ -46,6 +51,6 @@ def test_literalize_ref_golden_file(
                 golden_name=f"{lang_cls.__name__}_ref",
                 cases_dir=cases_dir,
                 file_regression=file_regression,
-                ref_case=spec.identifier_cases[0],
+                ref_case=effective_ref_case,
                 version=version_format,
             )

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -40,7 +40,6 @@ from literalizer.languages import (
     Nim,
     Python,
     R,
-    Raku,
     Rust,
     Sml,
     Swift,
@@ -717,30 +716,6 @@ def test_python_accepts_syntactic_non_idiomatic_ref_case() -> None:
     )
 
     assert result.declaration_code == "userObj"
-
-
-def test_raku_kebab_ref_case_renders() -> None:
-    """Kebab-friendly languages render kebab-form refs as legal
-    symbols.
-    """
-    assert Raku().supported_ref_cases == frozenset(
-        {
-            IdentifierCase.SNAKE,
-            IdentifierCase.UPPER_SNAKE,
-            IdentifierCase.PASCAL,
-            IdentifierCase.CAMEL,
-            IdentifierCase.KEBAB,
-        },
-    )
-
-    result = literalize(
-        source='{"$ref": "user_obj"}',
-        input_format=InputFormat.JSON,
-        language=Raku(),
-        ref_case=IdentifierCase.KEBAB,
-    )
-
-    assert result.declaration_code == "$user-obj"
 
 
 def test_haskell_unknown_ref_values_keep_strip_behavior() -> None:


### PR DESCRIPTION
## Summary
- Add `ref_case_override` to `LiteralizeRefCaseConfig` so a ref-golden case can force a specific `IdentifierCase` instead of using `spec.identifier_cases[0]`.
- Introduce a new `literalize_ref_kebab_name` case (`$ref: user-obj`) that forces `IdentifierCase.KEBAB`; goldens are emitted for Raku and Nix, while Clojure, Common Lisp, Racket, Scheme, and Cobol document the skip path via `CallArgNotSupportedError`.
- Drop the Raku-specific `test_raku_kebab_ref_case_renders` unit test now that kebab ref rendering is covered end-to-end by goldens.

## Test plan
- [x] `pytest tests/integration/test_literalize_ref_golden.py tests/integration/test_literalize_ref_default.py tests/integration/test_orphan_golden_files.py tests/test_languages.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test harness/discovery and golden fixtures, with a small regex tweak for Nix stub parsing.
> 
> **Overview**
> Adds `ref_case_override` to `LiteralizeRefCaseConfig` so `$ref` golden cases can force a specific `IdentifierCase`, and updates discovery to skip languages that don’t support the forced case.
> 
> Introduces a new `literalize_ref_kebab_name` fixture (`$ref: user-obj`) with Nix and Raku goldens, updates the Nix stub `; in <ident>` regex to accept hyphenated identifiers, and removes the now-redundant Raku-only kebab ref unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c3cacbed93fcac6d68e8d93d058fce839b195d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->