### PR TITLE
Add cancel-in-progress concurrency to CI and Deploy documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: deploy-docs-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `concurrency` with `cancel-in-progress: true` to the CI and Deploy documentation workflows, mirroring the existing `lint.yml` pattern. A new push to a PR now cancels that PR's superseded in-progress CI (8 jobs per run) and docs-build runs, freeing runners and reducing queue starvation. The `head_ref || run_id` group keeps `main` push and scheduled runs uncancelled, so every main commit is still validated and its docs still published. This was prompted by a large queue backlog; it mitigates wasted work on future backlogs but does not address GitHub-side runner capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just cancels in-progress runs for the same PR/branch; main and scheduled runs remain isolated via the `head_ref || run_id` grouping.
> 
> **Overview**
> Adds `concurrency` with `cancel-in-progress: true` to the `CI` and `Deploy documentation` GitHub Actions workflows, matching the existing pattern in `lint.yml`.
> 
> New pushes to the same PR/branch will now cancel superseded test matrices and docs builds, reducing wasted runner time and queue backlog while keeping `main`/scheduled runs from cancelling each other via `github.head_ref || github.run_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 734c8baa3c4d6170826bf67ddc44a011860847f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->