### PR TITLE
Make CI matrix fail-fast explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fail-fast: true
       matrix:
         python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
Adds an explicit `fail-fast: true` to the `build` matrix in `.github/workflows/ci.yml`. This cancels the remaining Python/platform matrix combinations as soon as one of them fails. It documents the intended behaviour (this was already the implicit default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just makes the CI matrix cancel remaining runs on first failure; no production code or runtime behavior is affected.
> 
> **Overview**
> Makes the `build` job’s GitHub Actions matrix explicitly `fail-fast: true`, so remaining Python/platform combinations are cancelled as soon as one fails (documenting the intended behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25484e93281b4d14c1a3df1f407c0f00a3b44d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->