### PR TITLE
Replace ruamel ordereddict marker with domain-owned OrderedMap

### DIFF
--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -7,10 +7,9 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._language import Language
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import (
     HeterogeneousScalarCollectionError,
     HeterogeneousSetError,
@@ -94,7 +93,7 @@ def _value_type_family(*, value: Value) -> str:
         (datetime.date, "date"),
         (datetime.time, "time"),
         (list, "list"),
-        (ordereddict, "dict"),
+        (OrderedMap, "dict"),
         (dict, "dict"),
     ):
         if isinstance(value, check_type):

--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -4,9 +4,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict as _ordereddict
 
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 
 
 @dataclass(frozen=True)
@@ -102,7 +101,7 @@ def _collect_element_types(
                 if inner is None:
                     return _INFER_FAILED
                 element_types.add(ListType(inner=inner))
-            case dict() if not isinstance(item, _ordereddict):
+            case dict() if not isinstance(item, OrderedMap):
                 dict_values.extend(item.values())
                 element_types.add(dict)
             case _:
@@ -198,7 +197,7 @@ def record_shape_for_dict(
     dict is not record-eligible.
 
     A dict is record-eligible when it is non-empty and every key is a
-    ``str``.  Callers must filter out ruamel ordered maps before
+    ``str``.  Callers must filter out ordered maps before
     calling this helper.
     """
     # Defensive branches: every Rust RECORD fixture passes non-empty
@@ -386,7 +385,7 @@ def _accumulate_record_shapes(
     # ``Value``-typed sets only contain scalars (see ``literalizer._types``)
     # so there's no need to walk into them.
     match data:
-        case dict() if not isinstance(data, _ordereddict):
+        case dict() if not isinstance(data, OrderedMap):
             shape = record_shape_for_dict(value=data)
             if shape is not None:  # pragma: no branch
                 out[id(data)] = shape

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -3593,20 +3593,12 @@ def _materialize_value_input(*, value: ValueInput) -> Value:
     """Convert a user-supplied ``ValueInput`` into the internal ``Value``
     form, replacing any non-``list`` ``Sequence`` and non-``dict``
     ``Mapping`` with concrete ``list`` / ``dict`` instances.
-
-    An :class:`OrderedMap` is rebuilt as an ``OrderedMap`` rather than a
-    plain ``dict`` so callers can opt into ordered-map rendering by
-    passing one as a ref value; without this the nominal tag would be
-    lost when the mapping is reconstructed.
     """
     if _is_value_mapping(value):
-        materialized = {
+        return {
             key: _materialize_value_input(value=item)
             for key, item in value.items()
         }
-        if isinstance(value, OrderedMap):
-            return OrderedMap(materialized)
-        return materialized
     if _is_value_sequence(value):
         return [_materialize_value_input(value=item) for item in value]
     return value

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -8,7 +8,6 @@ from typing import Final, assert_never
 
 from beartype import BeartypeConf, beartype
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
-from ruamel.yaml.compat import ordereddict
 from typing_extensions import TypeIs
 
 from literalizer._checks import check_data
@@ -54,7 +53,7 @@ from literalizer._preamble import (
     compute_preamble,
     deduplicate_preamble_entries,
 )
-from literalizer._types import Scalar, Value, ValueInput
+from literalizer._types import OrderedMap, Scalar, Value, ValueInput
 from literalizer.exceptions import (
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
@@ -391,7 +390,7 @@ def _guard_dict_keys_supported(
 @beartype
 def _format_ordered_map_value(
     *,
-    value: ordereddict,
+    value: OrderedMap,
     spec: Language,
     wrap_ids: frozenset[int],
     ref_case: IdentifierCase | None,
@@ -405,9 +404,9 @@ def _format_ordered_map_value(
     _guard_dict_keys_supported(value=value, spec=spec)
     ordered_map_cfg = spec.ordered_map_format_config
 
-    ordered_map_items: list[tuple[str, Value]] = [
+    ordered_map_items: list[tuple[Scalar, Value]] = [
         (k, v)
-        for k, v in value.items()  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
+        for k, v in value.items()
         if not (spec.skip_null_dict_values and v is None)
     ]
     if (
@@ -487,7 +486,7 @@ def _maybe_format_record_literal(
 
     Returns ``None`` when the language's heterogeneous behavior is not
     RECORD-enabled or when *value* is not record-shaped (empty,
-    non-string keys, or a ruamel ordered map).
+    non-string keys, or an ordered map).
     """
     behavior = spec.heterogeneous_behavior
     render_record_literal = behavior.render_record_literal
@@ -803,7 +802,7 @@ def _compute_dict_open_override(
     dicts: list[dict[Scalar, Value]] = [
         item
         for item in items
-        if isinstance(item, dict) and not isinstance(item, ordereddict)
+        if isinstance(item, dict) and not isinstance(item, OrderedMap)
     ]
     # Widening compares openers across dicts, so we need at least two
     # to have anything to compare.
@@ -1334,7 +1333,7 @@ def _format_value(  # pylint: disable=too-complex
                 if expand_refs
                 else spec.format_call_ref_identifier(ref_name, ref_value)
             )
-    if isinstance(value, dict) and not isinstance(value, ordereddict):
+    if isinstance(value, dict) and not isinstance(value, OrderedMap):
         record_literal = _maybe_format_record_literal(
             value=value,
             spec=spec,
@@ -1350,7 +1349,7 @@ def _format_value(  # pylint: disable=too-complex
             return record_literal
     if (
         collection_layout is CollectionLayout.MULTILINE
-        and isinstance(value, (dict, list, set, ordereddict))
+        and isinstance(value, (dict, list, set, OrderedMap))
         and value
     ):
         return _format_multiline_collection_value(
@@ -1366,7 +1365,7 @@ def _format_value(  # pylint: disable=too-complex
             sequence_open_override=sequence_open_override,
         )
     match value:
-        case ordereddict():
+        case OrderedMap():
             result = _format_ordered_map_value(
                 value=value,
                 spec=spec,
@@ -1527,7 +1526,7 @@ def _format_multiline_collection_value(
     lines and the closing delimiter are prefixed here so nested layouts align
     under that entry.
     """
-    is_ordered_map = isinstance(value, ordereddict)
+    is_ordered_map = isinstance(value, OrderedMap)
     trailing_comma = spec.trailing_comma_config.multiline_trailing_comma
     body_prefix = line_prefix + spec.indent
     lines = _format_collection_lines(
@@ -1897,9 +1896,9 @@ def _literalize(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
         and language.skip_null_dict_values
         and all(v is None for v in data.values())
     ):
-        is_ordered_map = isinstance(data, ordereddict)
-        empty_value: ordereddict | dict[Scalar, Value] = (
-            ordereddict() if is_ordered_map else {}
+        is_ordered_map = isinstance(data, OrderedMap)
+        empty_value: OrderedMap | dict[Scalar, Value] = (
+            OrderedMap() if is_ordered_map else {}
         )
         formatted = _format_value(
             value=empty_value,
@@ -1919,7 +1918,7 @@ def _literalize(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
     if (
         include_delimiters
         and isinstance(data, dict)
-        and not isinstance(data, ordereddict)
+        and not isinstance(data, OrderedMap)
     ):
         record_literal = _maybe_format_record_literal(
             value=data,
@@ -1939,7 +1938,7 @@ def _literalize(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
         line_prefix + language.indent if include_delimiters else line_prefix
     )
 
-    is_ordered_map = isinstance(data, ordereddict)
+    is_ordered_map = isinstance(data, OrderedMap)
     trailing_comma = language.trailing_comma_config.multiline_trailing_comma
     lines: list[str] = _format_collection_lines(
         data=data,
@@ -3594,12 +3593,20 @@ def _materialize_value_input(*, value: ValueInput) -> Value:
     """Convert a user-supplied ``ValueInput`` into the internal ``Value``
     form, replacing any non-``list`` ``Sequence`` and non-``dict``
     ``Mapping`` with concrete ``list`` / ``dict`` instances.
+
+    An :class:`OrderedMap` is rebuilt as an ``OrderedMap`` rather than a
+    plain ``dict`` so callers can opt into ordered-map rendering by
+    passing one as a ref value; without this the nominal tag would be
+    lost when the mapping is reconstructed.
     """
     if _is_value_mapping(value):
-        return {
+        materialized = {
             key: _materialize_value_input(value=item)
             for key, item in value.items()
         }
+        if isinstance(value, OrderedMap):
+            return OrderedMap(materialized)
+        return materialized
     if _is_value_sequence(value):
         return [_materialize_value_input(value=item) for item in value]
     return value

--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -15,12 +15,11 @@ from ruamel.yaml.comments import (
     CommentedOrderedMap,
     CommentedSet,
 )
-from ruamel.yaml.compat import ordereddict
 from ruamel.yaml.error import YAMLError
 from tomlkit.exceptions import TOMLKitError
 from tomlkit.toml_document import TOMLDocument
 
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 from literalizer.exceptions import (
     JSON5ParseError,
     JSONParseError,
@@ -129,10 +128,11 @@ def _unwrap_yaml_data(*, data: YamlCoercible) -> Value:
     """Recursively unwrap ruamel YAML wrappers to plain Python types.
 
     The round-trip loader returns ``CommentedOrderedMap`` for YAML
-    ``!!omap`` nodes; those are demoted to plain ``ordereddict`` so
-    ordered-map detection in :func:`_literalize` still works.  Other
-    mappings come through as ``CommentedMap`` and are demoted to plain
-    ``dict``.  :class:`CommentedSet` does not subclass :class:`set`, so
+    ``!!omap`` nodes; those are converted to literalizer's own
+    :class:`OrderedMap` so ordered-map detection in :func:`_literalize`
+    does not depend on ruamel's class hierarchy.  Other mappings come
+    through as ``CommentedMap`` and are demoted to plain ``dict``.
+    :class:`CommentedSet` does not subclass :class:`set`, so
     it is converted as well.  Scalar leaves (including dict keys) are
     unwrapped to plain Python types so type-based dispatch sees
     ``int`` rather than ``ScalarInt`` and friends.
@@ -146,11 +146,11 @@ def _unwrap_yaml_data(*, data: YamlCoercible) -> Value:
     # and ``list`` respectively, so their cases collapse into the plain
     # ``dict()`` / ``list()`` arms below.  ``CommentedOrderedMap`` must
     # stay on its own arm because it is *also* a ``dict`` subclass but
-    # represents ``!!omap`` and must be demoted to ``ordereddict``.
+    # represents ``!!omap`` and must become an ``OrderedMap``.
     match data:
         case CommentedOrderedMap():
             omap_src: dict[Scalar, YamlCoercible] = dict(data)
-            return ordereddict(
+            return OrderedMap(
                 [
                     (
                         _unwrap_yaml_scalar(value=k),

--- a/src/literalizer/_parsing.py
+++ b/src/literalizer/_parsing.py
@@ -130,7 +130,7 @@ def _unwrap_yaml_data(*, data: YamlCoercible) -> Value:
     The round-trip loader returns ``CommentedOrderedMap`` for YAML
     ``!!omap`` nodes; those are converted to literalizer's own
     :class:`OrderedMap` so ordered-map detection in :func:`_literalize`
-    does not depend on ruamel's class hierarchy.  Other mappings come
+    does not depend on the ruamel class hierarchy.  Other mappings come
     through as ``CommentedMap`` and are demoted to plain ``dict``.
     :class:`CommentedSet` does not subclass :class:`set`, so
     it is converted as well.  Scalar leaves (including dict keys) are

--- a/src/literalizer/_preamble.py
+++ b/src/literalizer/_preamble.py
@@ -3,15 +3,13 @@
 import dataclasses
 import datetime
 import math
-from collections import OrderedDict
 from typing import assert_never
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._checks import scalar_type_bucket
 from literalizer._language import Language
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 
 
 class HeterogeneousElements:
@@ -36,7 +34,7 @@ def _collect_value_types(*, data: Value) -> frozenset[type]:
                 child_types = child_types | _collect_value_types(data=k)
                 child_types = child_types | _collect_value_types(data=v)
             container_type = (
-                ordereddict if isinstance(data, ordereddict) else dict
+                OrderedMap if isinstance(data, OrderedMap) else dict
             )
             # ``str`` is included unconditionally because typed-map
             # languages whose dict opener hard-codes the default key
@@ -91,11 +89,11 @@ def _walk_annotated_collections(  # noqa: C901, PLR0912  # pylint: disable=too-c
 ) -> None:
     """Walk *val* and add collection types that appear in type annotations."""
     match val:
-        case ordereddict():
+        case OrderedMap():
             if _needs_annotation(val=val):
-                result.add(ordereddict)
-                for v in val.values():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-                    _walk_annotated_collections(val=v, result=result)  # pyright: ignore[reportUnknownArgumentType]
+                result.add(OrderedMap)
+                for v in val.values():
+                    _walk_annotated_collections(val=v, result=result)
         case dict():
             if _needs_annotation(val=val):
                 result.add(dict)
@@ -110,8 +108,8 @@ def _walk_annotated_collections(  # noqa: C901, PLR0912  # pylint: disable=too-c
                 for v in val:
                     _walk_annotated_collections(val=v, result=result)
                     match v:
-                        case ordereddict():
-                            result.add(ordereddict)
+                        case OrderedMap():
+                            result.add(OrderedMap)
                         case dict():
                             result.add(dict)
                         case set():
@@ -167,7 +165,7 @@ def _collection_preamble(
         lines.extend(language.set_format_config.preamble_lines)
     if list in types:
         lines.extend(language.sequence_format_config.preamble_lines)
-    if ordereddict in types:
+    if OrderedMap in types:
         lines.extend(language.ordered_map_format_config.preamble_lines)
     return tuple(lines)
 
@@ -223,11 +221,9 @@ def _list_merge_dicts(*, elements: list[Value]) -> list[Value]:
     has_ordered = False
     for elem in elements:
         match elem:
-            case ordereddict() | OrderedDict():
+            case OrderedMap():
                 has_ordered = True
-                ordered_vals.extend(
-                    elem.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-                )
+                ordered_vals.extend(elem.values())
             case dict():
                 has_plain = True
                 plain_vals.extend(elem.values())
@@ -240,10 +236,10 @@ def _list_merge_dicts(*, elements: list[Value]) -> list[Value]:
         }
         merged.append(merged_plain)
     if has_ordered:
-        merged_ordered: dict[Scalar, Value] = ordereddict(
-            {str(object=i): v for i, v in enumerate(iterable=ordered_vals)}
-        )
-        merged.append(merged_ordered)
+        ordered_src: dict[Scalar, Value] = {
+            str(object=i): v for i, v in enumerate(iterable=ordered_vals)
+        }
+        merged.append(OrderedMap(ordered_src))
     return merged
 
 
@@ -294,14 +290,12 @@ def _structural_type_id(  # noqa: C901, PLR0911, PLR0912  # pylint: disable=too-
         case set():
             elem_ids = sorted({_structural_type_id(value=e) for e in value})
             return f"set({','.join(elem_ids)})"
-        case ordereddict() | OrderedDict() if not value:
+        case OrderedMap() if not value:
             return "empty_odict"
-        case ordereddict() | OrderedDict():
+        case OrderedMap():
             val_set: set[str] = set()
-            for ov in value.values():  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-                val_set.add(
-                    _structural_type_id(value=ov)  # pyright: ignore[reportUnknownArgumentType]
-                )
+            for ov in value.values():
+                val_set.add(_structural_type_id(value=ov))
             val_ids = sorted(val_set)
             return f"odict({','.join(val_ids)})"
         case dict() if not value:
@@ -381,7 +375,7 @@ def compute_preamble(
     collection = _collection_preamble(types=types, language=language)
     annotated_collection_types: frozenset[type] = (
         _collect_annotated_collection_types(data=data)
-        if has_variable_declaration and types & {dict, list, set, ordereddict}
+        if has_variable_declaration and types & {dict, list, set, OrderedMap}
         else frozenset()
     )
     if annotated_collection_types and _has_union_in_type_hints(data=data):

--- a/src/literalizer/_types.py
+++ b/src/literalizer/_types.py
@@ -28,8 +28,8 @@ class OrderedMap(dict[Scalar, Value]):
     positionally and never collapsed into a record. This is the only
     distinction the type carries: it is a bare :class:`dict` subclass
     (every ``dict`` is insertion-ordered since Python 3.7) used purely
-    as a nominal tag, so it remains a valid ``Value``/``ValueInput`` and
-    keeps plain-``dict`` equality semantics.
+    as a nominal tag, so it stays a valid ``Value`` and ``ValueInput``
+    while keeping plain ``dict`` equality semantics.
 
     This type is owned by literalizer so that ordered-map detection does
     not depend on a third-party YAML library's class hierarchy. The YAML

--- a/src/literalizer/_types.py
+++ b/src/literalizer/_types.py
@@ -18,3 +18,21 @@ type Value = Scalar | list[Value] | dict[Scalar, Value] | set[Scalar]
 type ValueInput = (
     Scalar | Sequence[ValueInput] | Mapping[Scalar, ValueInput] | set[Scalar]
 )
+
+
+class OrderedMap(dict[Scalar, Value]):
+    """An order-significant mapping (a YAML ``!!omap``).
+
+    Literalizer treats a plain :class:`dict` as unordered and therefore
+    record-eligible, while an ``OrderedMap`` is always rendered
+    positionally and never collapsed into a record. This is the only
+    distinction the type carries: it is a bare :class:`dict` subclass
+    (every ``dict`` is insertion-ordered since Python 3.7) used purely
+    as a nominal tag, so it remains a valid ``Value``/``ValueInput`` and
+    keeps plain-``dict`` equality semantics.
+
+    This type is owned by literalizer so that ordered-map detection does
+    not depend on a third-party YAML library's class hierarchy. The YAML
+    parser (the only ruamel boundary) converts ``!!omap`` nodes into
+    ``OrderedMap``; everything downstream dispatches on this type alone.
+    """

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -9,7 +9,6 @@ from types import MappingProxyType
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     make_element_to_type,
@@ -82,7 +81,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 
 
 class _CppModifiers(enum.Enum):
@@ -402,9 +401,9 @@ def _compute_cpp_type(
     *type_ctx*.
     """
     match item:
-        case ordereddict():
-            omap_values = item.values()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-            values: list[Value] = list(omap_values)  # pyright: ignore[reportUnknownArgumentType]
+        case OrderedMap():
+            omap_values = item.values()
+            values: list[Value] = list(omap_values)
             value_type = _compute_element_type_for_items(
                 items=values,
                 type_ctx=type_ctx,
@@ -585,7 +584,7 @@ def _has_empty_collection(data: Value) -> bool:
     require ``#include <cstddef>``.
     """
     match data:
-        case list() | set() | dict() | ordereddict() if not data:
+        case list() | set() | dict() if not data:
             return True
         case list():
             return any(_has_empty_collection(data=v) for v in data)

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -9,7 +9,6 @@ from functools import cached_property
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -67,7 +66,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
@@ -363,7 +362,7 @@ def _build_elm_body_preamble(
                 (frozenset(str_types), f"{p}Str String"),
                 (frozenset({list}), f"{p}List (List {type_name})"),
                 (
-                    frozenset({dict, ordereddict}),
+                    frozenset({dict, OrderedMap}),
                     f"{p}Dict (List ( String, {type_name} ))",
                 ),
                 (frozenset({set}), f"{p}Set (List {type_name})"),

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -9,7 +9,6 @@ from functools import cached_property
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -81,7 +80,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 
 
 @beartype
@@ -1028,7 +1027,7 @@ class FSharp(metaclass=LanguageCls):
                 header,
                 f"    | {p}Map of (string * {self.type_name}) list",
             ),
-            ordereddict: (
+            OrderedMap: (
                 header,
                 f"    | {p}Map of (string * {self.type_name}) list",
             ),

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -11,7 +11,6 @@ from types import MappingProxyType
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -75,7 +74,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import UnrepresentableSpecialFloatError
 
 
@@ -485,7 +484,7 @@ def _build_gleam_data_dependent_preamble(
                 (frozenset(str_types), f"{p}Str(String)"),
                 (frozenset({list}), f"{p}List(List({type_name}))"),
                 (
-                    frozenset({dict, ordereddict}),
+                    frozenset({dict, OrderedMap}),
                     f"{p}Dict(List(#(String, {type_name})))",
                 ),
                 (frozenset({set}), f"{p}Set(List({type_name}))"),

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -8,7 +8,6 @@ from functools import cached_property
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -76,7 +75,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
@@ -623,7 +622,7 @@ def _haskell_base_constructors(
             (frozenset({str, bytes}), f"{p}Str String"),
             (frozenset({list}), f"{p}List [{type_name}]"),
             (
-                frozenset({dict, ordereddict}),
+                frozenset({dict, OrderedMap}),
                 f"{p}Map [(String, {type_name})]",
             ),
             (frozenset({set}), f"{p}Set [{type_name}]"),

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -4,14 +4,12 @@ import dataclasses
 import datetime
 import enum
 import functools
-from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import Any, ClassVar, assert_never
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
@@ -83,7 +81,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 from literalizer.exceptions import NullInCollectionError
 
 
@@ -351,11 +349,7 @@ def _java_type_hint(
     match data:
         case dict():
             val_type = common(elements=list(data.values()), boxed=True)
-            outer = (
-                "Map"
-                if isinstance(data, (ordereddict, OrderedDict))
-                else dict_outer
-            )
+            outer = "Map" if isinstance(data, OrderedMap) else dict_outer
             hint = f"{outer}<String, {val_type}>"
         case set():
             elem_type = common(elements=list(data), boxed=True)

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -4,14 +4,12 @@ import dataclasses
 import datetime
 import enum
 import functools
-from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar, assert_never
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     TypedOpenerConfig,
@@ -95,7 +93,7 @@ from literalizer._language import (
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 
 
 @beartype
@@ -370,7 +368,7 @@ def _kotlin_type_hint(
         case dict():
             hint = _kotlin_dict_hint(
                 is_empty=not data,
-                is_ordered=isinstance(data, (ordereddict, OrderedDict)),
+                is_ordered=isinstance(data, OrderedMap),
                 val_types=[recurse(data=v) for v in data.values()],
                 default_dict_key_type=default_dict_key_type,
                 default_dict_value_type=default_dict_value_type,

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -9,7 +9,6 @@ from types import MappingProxyType
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -78,7 +77,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
@@ -1007,7 +1006,7 @@ class OCaml(metaclass=LanguageCls):
             datetime.datetime: (_h, _datetime_constructor),
             list: (_h, f"  | {p}List of {self.type_name} list"),
             dict: (_h, f"  | {p}Map of (string * {self.type_name}) list"),
-            ordereddict: (
+            OrderedMap: (
                 _h,
                 f"  | {p}Map of (string * {self.type_name}) list",
             ),

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -9,7 +9,6 @@ from functools import cached_property
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -72,7 +71,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import (
     UnrepresentableIntegerError,
     WrapCombinedInFileNotSupportedError,
@@ -437,7 +436,7 @@ def _build_purescript_body_preamble(
     def _compute(types: frozenset[type], data: Value, /) -> tuple[str, ...]:
         """Return body-preamble lines for the given *types*."""
         p = constructor_prefix
-        needs_tuple = bool(types & {dict, ordereddict})
+        needs_tuple = bool(types & {dict, OrderedMap})
         has_large_int = int in types and _purescript_has_large_int(val=data)
         int_types: set[type] = {int}
         str_types: set[type] = {str, bytes, datetime.date, datetime.time}
@@ -455,7 +454,7 @@ def _build_purescript_body_preamble(
                 (frozenset(str_types), f"{p}Str String"),
                 (frozenset({list}), f"{p}List (Array {type_name})"),
                 (
-                    frozenset({dict, ordereddict}),
+                    frozenset({dict, OrderedMap}),
                     f"{p}Dict (Array (Tuple String {type_name}))",
                 ),
                 (frozenset({set}), f"{p}Set (Array {type_name})"),

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -4,14 +4,12 @@ import dataclasses
 import datetime
 import enum
 import functools
-from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar, assert_never
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -85,7 +83,7 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._preamble import HeterogeneousElements
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 
 
 @beartype
@@ -320,7 +318,7 @@ def _merge_dict_elements(*, elements: list[Value]) -> list[Value]:
     for elem in elements:
         match elem:
             case dict():
-                is_ordered = isinstance(elem, (ordereddict, OrderedDict))
+                is_ordered = isinstance(elem, OrderedMap)
                 target = ordered_vals if is_ordered else plain_vals
                 target.extend(elem.values())
                 if is_ordered:
@@ -339,7 +337,7 @@ def _merge_dict_elements(*, elements: list[Value]) -> list[Value]:
         ordered_repr: dict[Scalar, Value] = {
             str(object=i): v for i, v in enumerate(iterable=ordered_vals)
         }
-        merged.append(OrderedDict(ordered_repr))
+        merged.append(OrderedMap(ordered_repr))
     return merged
 
 
@@ -418,13 +416,11 @@ def _python_type_hint(
     match data:
         case dict():
             outer = (
-                "OrderedDict"
-                if isinstance(data, (ordereddict, OrderedDict))
-                else dict_hint
+                "OrderedDict" if isinstance(data, OrderedMap) else dict_hint
             )
             key_hint = default_dict_key_type if not data else "str"
             val_union = _collection_element_union(
-                elements=list(data.values()),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                elements=list(data.values()),
                 recurse=recurse,
                 sort=False,
                 merge_dicts=False,
@@ -491,7 +487,7 @@ def _build_type_hint_preamble(
                 or default_dict_key_type == "Any",
             ),
             (
-                ordereddict,
+                OrderedMap,
                 default_dict_value_type == "Any"
                 or default_dict_key_type == "Any",
             ),
@@ -586,7 +582,7 @@ def _build_type_hint_preamble_py38(
                 or default_dict_key_type == "Any",
             ),
             (
-                ordereddict,
+                OrderedMap,
                 default_dict_value_type == "Any"
                 or default_dict_key_type == "Any",
             ),

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -9,7 +9,6 @@ from functools import cached_property
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -71,7 +70,7 @@ from literalizer._language import (
     no_validate_call_arg,
     no_validate_spec_for_data,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
@@ -418,7 +417,7 @@ def _build_roc_body_preamble(
                 (frozenset(str_types), f"{p}Str Str"),
                 (frozenset({list}), f"{p}List (List {type_name})"),
                 (
-                    frozenset({dict, ordereddict}),
+                    frozenset({dict, OrderedMap}),
                     f"{p}Dict (List (Str, {type_name}))",
                 ),
                 (frozenset({set}), f"{p}Set (List {type_name})"),

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -9,7 +9,6 @@ from types import MappingProxyType
 from typing import ClassVar
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -78,7 +77,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
 
@@ -1058,7 +1057,7 @@ class Sml(metaclass=LanguageCls):
             datetime.datetime: (_h, _datetime_constructor),
             list: (_h, f"{p}List of {self.type_name} list"),
             dict: (_h, f"{p}Map of (string * {self.type_name}) list"),
-            ordereddict: (
+            OrderedMap: (
                 _h,
                 f"{p}Map of (string * {self.type_name}) list",
             ),

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -4,14 +4,12 @@ import dataclasses
 import datetime
 import enum
 import functools
-from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar, assert_never
 
 from beartype import beartype
-from ruamel.yaml.compat import ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -85,7 +83,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Scalar, Value
+from literalizer._types import OrderedMap, Scalar, Value
 
 
 def _ts_call_stub(
@@ -217,7 +215,7 @@ def _ts_type_hint(
     match data:
         case dict():
             hint = _ts_dict_hint(
-                is_ordered=isinstance(data, (ordereddict, OrderedDict)),
+                is_ordered=isinstance(data, OrderedMap),
                 is_empty=not data,
                 val_types=[recurse(data=v) for v in data.values()],
                 dict_hint_template=dict_hint_template,


### PR DESCRIPTION
Introduces `literalizer._types.OrderedMap`, a bare `dict` subclass used as the single "this is a YAML `!!omap`" tag, replacing `ruamel.yaml.compat.ordereddict` (and `python.py`'s `collections.OrderedDict` marker) across `_literalize.py`, `_preamble.py`, `_checks.py`, `_formatters/type_inference.py`, and 13 language backends. ruamel is now confined to the YAML-parser/comment boundary, so no `src/literalizer/languages/` module imports it. The stronger typing let me fix a wrong `Scalar`-key annotation and drop ~8 now-redundant `# pyright: ignore` comments. Behavior is unchanged: all golden files identical, full suite green with 100% coverage, and mypy/pyright/pyrefly/ty/ruff all clean. `OrderedMap` is intentionally kept internal (not in `literalizer.__all__`), consistent with `Value`/`Scalar`/`ValueInput`. Closes #2301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor touching parsing, core formatting, preamble, type inference, and many language backends to change how ordered maps are identified; behavior should be identical but any missed `ordereddict`/`OrderedDict` check could alter rendering or type hints for YAML `!!omap`.
> 
> **Overview**
> Introduces `literalizer._types.OrderedMap` as a domain-owned nominal tag for YAML `!!omap`, and updates core logic to dispatch on this type instead of `ruamel.yaml.compat.ordereddict` (and `collections.OrderedDict`).
> 
> Moves the ruamel dependency boundary into YAML parsing by converting `CommentedOrderedMap` into `OrderedMap`, and propagates this through checks, record-shape/type inference, preamble/type-hint generation, and ordered-map rendering across the language backends so ordered maps stay positional and never become record literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c068ab6d832d7ed889358f8f1aab58e5a9ef536b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->