### PR TITLE
Add RECORD heterogeneous strategy to Go (#2297)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Go` gains the ``RECORD`` ``heterogeneous_strategy``
+  (already on :class:`~literalizer.Rust`).  Each record-shaped dict
+  (non-empty, string-keyed) becomes a generated ``type RecordN struct
+  { ... }`` declared in the preamble plus a matching ``RecordN{Field:
+  value, ...}`` literal, so a dict whose values mix scalars and
+  containers is representable instead of raising.  Field names are
+  exported (PascalCase) and the struct-name prefix is configurable via
+  the new ``record_struct_name_prefix`` constructor parameter.  See
+  #2297.
+
 - :class:`~literalizer.Rust` accepts a ``record_shape_names`` constructor
   parameter — a mapping from each record's key-set
   (:class:`frozenset` [:class:`str`]) to a user-chosen ``struct`` name —

--- a/src/literalizer/_formatters/record_strategy.py
+++ b/src/literalizer/_formatters/record_strategy.py
@@ -1,0 +1,293 @@
+"""Language-agnostic orchestration for the ``RECORD`` heterogeneous
+strategy.
+
+The ``RECORD`` strategy renders record-shaped dicts (non-empty,
+string-keyed) as generated struct/record declarations plus matching
+literals, rather than a homogeneous map.  Shape detection lives in
+:mod:`literalizer._formatters.type_inference`; this module owns the
+parts that are the same for every target language (document-order
+shape naming, post-order declaration emission) and delegates the
+language-specific syntax to a :class:`RecordRenderer`.
+
+Declaration field types are derived from the already-formatted literal
+value (not re-inferred from the raw value) so a field's declared type
+always matches the value the normal formatter emitted, including when
+that value was widened by sibling context.  The behavior caches the
+first-seen formatted fields per shape during literal rendering; the
+preamble (assembled after all literals are formatted) reads that cache.
+
+Rust keeps its own copy of this logic because it additionally supports
+``record_shape_names`` and optional-field unification; this module
+deliberately omits those knobs (out of scope for the non-Rust ports),
+so :attr:`RecordShape.optional_keys` is always empty here.
+"""
+
+import dataclasses
+from collections.abc import Callable, Mapping, Sequence
+
+from beartype import beartype
+
+from literalizer._formatters.type_inference import (
+    RecordShape,
+    collect_record_shapes,
+)
+from literalizer._language import (
+    HeterogeneousBehavior,
+    no_compute_call_slot_wrap_ids,
+    no_compute_wrap_ids,
+)
+from literalizer._types import Scalar, Value
+
+
+@dataclasses.dataclass(frozen=True)
+class RecordDeclarationField:
+    """One resolved field of a generated record declaration."""
+
+    identifier: str
+    type_name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class RecordLiteralField:
+    """One resolved field of a generated record literal.
+
+    ``formatted`` is the already-formatted field value produced by the
+    normal value formatter.
+    """
+
+    identifier: str
+    formatted: str
+
+
+@dataclasses.dataclass(frozen=True)
+class RecordRenderer:
+    """Per-language syntax hooks for the ``RECORD`` strategy.
+
+    ``name_prefix`` is the auto-naming prefix (``Record`` -> ``Record0``,
+    ``Record1``, ...).  ``field_identifier`` maps an original dict key
+    to the language's field identifier (identity for most languages,
+    PascalCase for Go).  ``field_type`` maps a field's already-formatted
+    literal value to its declared type.  ``render_declaration`` builds
+    one declaration block from the resolved fields, and
+    ``render_literal`` builds the single-line literal (the shared
+    multiline expansion in :mod:`literalizer._literalize` re-flows it
+    when the surrounding layout is multiline).
+    """
+
+    name_prefix: str
+    field_identifier: Callable[[str], str]
+    field_type: Callable[[str], str]
+    render_declaration: Callable[
+        [str, Sequence[RecordDeclarationField]],
+        str,
+    ]
+    render_literal: Callable[[str, Sequence[RecordLiteralField]], str]
+
+
+@dataclasses.dataclass(frozen=True)
+class RecordStrategy:
+    """The two pieces a language wires into its strategy config: the
+    :class:`HeterogeneousBehavior` and the data-dependent preamble.
+    """
+
+    behavior: HeterogeneousBehavior
+    preamble: Callable[[Value], tuple[str, ...]]
+
+
+@beartype
+def _ordered_record_shapes(
+    *,
+    data: Value,
+    shapes_by_id: Mapping[int, RecordShape],
+) -> list[RecordShape]:
+    """Return record shapes in document order, one per distinct shape."""
+    ordered: list[RecordShape] = []
+    seen: set[RecordShape] = set()
+    _accumulate_ordered_shapes(
+        data=data,
+        shapes_by_id=shapes_by_id,
+        ordered=ordered,
+        seen=seen,
+    )
+    return ordered
+
+
+@beartype
+def _accumulate_ordered_shapes(
+    *,
+    data: Value,
+    shapes_by_id: Mapping[int, RecordShape],
+    ordered: list[RecordShape],
+    seen: set[RecordShape],
+) -> None:
+    """Walk *data* appending each newly-seen record shape to *ordered*."""
+    match data:
+        case dict():
+            if id(data) in shapes_by_id:
+                shape = shapes_by_id[id(data)]
+                if shape not in seen:
+                    seen.add(shape)
+                    ordered.append(shape)
+            for value in data.values():
+                _accumulate_ordered_shapes(
+                    data=value,
+                    shapes_by_id=shapes_by_id,
+                    ordered=ordered,
+                    seen=seen,
+                )
+        case list():
+            for item in data:
+                _accumulate_ordered_shapes(
+                    data=item,
+                    shapes_by_id=shapes_by_id,
+                    ordered=ordered,
+                    seen=seen,
+                )
+        case _:
+            return
+
+
+@beartype
+def _assign_names(
+    *,
+    shapes: Sequence[RecordShape],
+    prefix: str,
+) -> dict[RecordShape, str]:
+    """Assign ``{prefix}{index}`` names in *shapes* order."""
+    return {
+        shape: f"{prefix}{index}"
+        for index, shape in enumerate(iterable=shapes)
+    }
+
+
+@beartype
+def _accumulate_emit_order(
+    *,
+    data: Value,
+    shapes_by_id: Mapping[int, RecordShape],
+    emit_ordered: list[RecordShape],
+    emit_seen: set[RecordShape],
+) -> None:
+    """Walk *data* post-order so a shape is emitted after its
+    dependencies (nested records declared before their parents).
+    """
+    match data:
+        case dict():
+            for value in data.values():
+                _accumulate_emit_order(
+                    data=value,
+                    shapes_by_id=shapes_by_id,
+                    emit_ordered=emit_ordered,
+                    emit_seen=emit_seen,
+                )
+            if id(data) in shapes_by_id:
+                shape = shapes_by_id[id(data)]
+                if shape not in emit_seen:
+                    emit_seen.add(shape)
+                    emit_ordered.append(shape)
+        case list():
+            for item in data:
+                _accumulate_emit_order(
+                    data=item,
+                    shapes_by_id=shapes_by_id,
+                    emit_ordered=emit_ordered,
+                    emit_seen=emit_seen,
+                )
+        case _:
+            return
+
+
+@beartype
+def build_record_strategy(
+    *,
+    renderer: RecordRenderer,
+) -> RecordStrategy:
+    """Build the behavior + preamble for the ``RECORD`` strategy.
+
+    The two share per-pass caches: ``compute_record_shapes`` (run first,
+    during data checking) assigns the document-order names, and
+    ``render_record_literal`` records the first-seen formatted fields
+    per shape so the preamble can derive each field's declared type
+    from the value the formatter actually emitted.
+    """
+    name_by_shape: dict[RecordShape, str] = {}
+    id_to_shape: dict[int, RecordShape] = {}
+    formatted_by_shape: dict[RecordShape, dict[str, str]] = {}
+
+    def _compute_shapes(data: Value) -> Mapping[int, RecordShape]:
+        """Walk *data*, assign names in document order, and reset the
+        per-pass caches (a cached spec is reused across calls).
+        """
+        shapes_by_id = collect_record_shapes(data=data)
+        name_by_shape.clear()
+        id_to_shape.clear()
+        formatted_by_shape.clear()
+        id_to_shape.update(shapes_by_id)
+        ordered = _ordered_record_shapes(
+            data=data,
+            shapes_by_id=shapes_by_id,
+        )
+        name_by_shape.update(
+            _assign_names(shapes=ordered, prefix=renderer.name_prefix),
+        )
+        return shapes_by_id
+
+    def _render_literal(
+        value: "dict[Scalar, Value]",
+        fields: Mapping[str, str],
+    ) -> str:
+        """Render a record-shape dict as a language-specific literal,
+        caching the first-seen formatted fields for its shape.
+        """
+        shape = id_to_shape[id(value)]
+        formatted_by_shape.setdefault(shape, dict(fields))
+        literal_fields = [
+            RecordLiteralField(
+                identifier=renderer.field_identifier(key),
+                formatted=fields[key],
+            )
+            for key in shape.keys
+        ]
+        return renderer.render_literal(name_by_shape[shape], literal_fields)
+
+    behavior = HeterogeneousBehavior(
+        skip_scalar_checks=False,
+        compute_wrap_ids=no_compute_wrap_ids,
+        wrap_scalar=None,
+        wrap_non_scalar=None,
+        compute_call_slot_wrap_ids=no_compute_call_slot_wrap_ids,
+        render_record_literal=_render_literal,
+        compute_record_shapes=_compute_shapes,
+    )
+
+    def _preamble(data: Value, /) -> tuple[str, ...]:
+        """Build one declaration block per record shape, in dependency
+        order, typing each field from its first-seen formatted value.
+        """
+        shapes_by_id = collect_record_shapes(data=data)
+        if not shapes_by_id:
+            return ()
+        emit_order: list[RecordShape] = []
+        emit_seen: set[RecordShape] = set()
+        _accumulate_emit_order(
+            data=data,
+            shapes_by_id=shapes_by_id,
+            emit_ordered=emit_order,
+            emit_seen=emit_seen,
+        )
+        blocks: list[str] = []
+        for shape in emit_order:
+            formatted = formatted_by_shape[shape]
+            fields = [
+                RecordDeclarationField(
+                    identifier=renderer.field_identifier(key),
+                    type_name=renderer.field_type(formatted[key]),
+                )
+                for key in shape.keys
+            ]
+            blocks.append(
+                renderer.render_declaration(name_by_shape[shape], fields),
+            )
+        return tuple(blocks)
+
+    return RecordStrategy(behavior=behavior, preamble=_preamble)

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -541,18 +541,24 @@ def _expand_record_literal_multiline(
 ) -> str:
     """Expand a single-line record literal into multiline form.
 
-    Splits ``Name { f1: v1, f2: v2 }`` (always produced with at least
-    one field by ``render_record_literal`` because record-eligible
-    dicts are non-empty) into one entry per line indented under
-    *body_prefix* with the closing ``}`` on its own line under
-    *close_prefix*.
+    Splits ``Name { f1: v1, f2: v2 }`` (brace-delimited, e.g. Rust and
+    Go) or ``Name(f1 = v1, f2 = v2)`` (paren-delimited, e.g. Kotlin,
+    Scala, Java) into one entry per line indented under *body_prefix*
+    with the closing delimiter on its own line under *close_prefix*.
+    The opening delimiter is whichever of ``{`` or ``(`` appears first;
+    its matching closer is the literal's final character.  The literal
+    always has at least one field because ``render_record_literal`` is
+    only called for record-eligible (non-empty) dicts.
     """
-    open_idx = rendered.index("{")
+    open_idx = min(
+        index for index, char in enumerate(iterable=rendered) if char in "{("
+    )
+    closer = {"{": "}", "(": ")"}[rendered[open_idx]]
     head = rendered[: open_idx + 1]
     body = rendered[open_idx + 1 : -1].strip()
     entries = _split_record_entries(body=body)
     indented = [f"{body_prefix}{entry.strip()}," for entry in entries]
-    return f"{head}\n" + "\n".join(indented) + f"\n{close_prefix}}}"
+    return f"{head}\n" + "\n".join(indented) + f"\n{close_prefix}{closer}"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from typing import ClassVar
 
 from beartype import beartype
+from ruamel.yaml.compat import ordereddict as _ordereddict
 
 from literalizer._formatters.collection_openers import (
     fixed_open,
@@ -48,6 +49,13 @@ from literalizer._formatters.format_integers import (
     make_unsigned_overflow_fallback,
 )
 from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._formatters.record_strategy import (
+    RecordDeclarationField,
+    RecordLiteralField,
+    RecordRenderer,
+    RecordStrategy,
+    build_record_strategy,
+)
 from literalizer._formatters.type_inference import DictType, ListType
 from literalizer._language import (
     NO_CALL_PARAMETER_LIMIT,
@@ -189,6 +197,25 @@ def _format_go_set_entry(_original: Value, item: str) -> str:
     Example: ``"apple"`` → ``"apple": struct{}{}``.
     """
     return f"{item}: struct{{}}{{}}"
+
+
+@beartype
+def _go_record_field_identifier(key: str, /) -> str:
+    """Return the exported Go struct field name for a dict *key*."""
+    return IdentifierCase.PASCAL.convert(name=key)
+
+
+@beartype
+def _go_record_literal(
+    name: str,
+    fields: Sequence[RecordLiteralField],
+    /,
+) -> str:
+    """Render a single-line Go ``Name{Field: value, ...}`` literal."""
+    body = ", ".join(
+        f"{field.identifier}: {field.formatted}" for field in fields
+    )
+    return f"{name}{{{body}}}"
 
 
 @beartype
@@ -547,11 +574,17 @@ class Go(metaclass=LanguageCls):
     modifiers = Modifiers
 
     class HeterogeneousStrategies(enum.Enum):
-        """Heterogeneous-scalar strategy options — this language only
-        supports raising.
+        """Strategy for dicts whose values span more than one Go type.
+
+        ``ERROR`` keeps Go's strict-typing behavior (mixed-value dicts
+        that cannot be represented raise).  ``RECORD`` renders each
+        record-shaped dict (non-empty, string-keyed) as a generated
+        ``struct`` declared in the preamble plus a matching struct
+        literal, so fields may legitimately mix scalars and containers.
         """
 
-        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+        ERROR = enum.auto()
+        RECORD = enum.auto()
 
     heterogeneous_strategies = HeterogeneousStrategies
 
@@ -644,6 +677,7 @@ class Go(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    record_struct_name_prefix: str = "Record"
     # Keep in sync with the `go` directive in the generated go.mod in
     # `.github/workflows/lint.yml`.
     language_version: VersionFormats = VersionFormats.V1_18
@@ -677,15 +711,78 @@ class Go(metaclass=LanguageCls):
         """Format a set entry."""
         return _format_go_set_entry
 
+    def _go_field_type(self, formatted: str, /) -> str:
+        """Return the Go field type for an already-formatted value.
+
+        The declared type is read off the formatted literal so it
+        always matches what the value formatter emitted, even when a
+        list was widened to ``[]any`` by sibling context.  Composite
+        literals (``[]int{...}``, ``Record1{...}``, ``[][2]any{...}``)
+        carry their type as the text before the first ``{``.
+        """
+        if formatted == self.null_literal:
+            return "any"
+        if formatted in {self.true_literal, self.false_literal}:
+            return "bool"
+        if formatted.startswith('"'):
+            return "string"
+        if formatted.startswith("time.Date("):
+            return "time.Time"
+        if "{" in formatted:
+            return formatted[: formatted.index("{")]
+        return "int" if formatted.lstrip("-").isdigit() else "float64"
+
+    def _go_render_declaration(
+        self,
+        name: str,
+        fields: Sequence[RecordDeclarationField],
+        /,
+    ) -> str:
+        """Render a Go ``type Name struct { ... }`` declaration."""
+        lines = [f"type {name} struct {{"]
+        lines += [
+            f"{self.indent}{field.identifier} {field.type_name}"
+            for field in fields
+        ]
+        lines.append("}")
+        return "\n".join(lines)
+
+    @cached_property
+    def _record_renderer(self) -> RecordRenderer:
+        """Go syntax hooks for the ``RECORD`` strategy."""
+        return RecordRenderer(
+            name_prefix=self.record_struct_name_prefix,
+            field_identifier=_go_record_field_identifier,
+            field_type=self._go_field_type,
+            render_declaration=self._go_render_declaration,
+            render_literal=_go_record_literal,
+        )
+
+    @cached_property
+    def _record_strategy(self) -> RecordStrategy:
+        """Resolve the active strategy to its behavior + preamble."""
+        cls = type(self.heterogeneous_strategy)
+        if self.heterogeneous_strategy is cls.RECORD:
+            return build_record_strategy(renderer=self._record_renderer)
+        return RecordStrategy(
+            behavior=NO_HETEROGENEOUS_BEHAVIOR,
+            preamble=no_data_preamble,
+        )
+
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
-        """Return data-dependent preamble lines."""
-        return no_data_preamble
+        """Return data-dependent preamble lines.
+
+        For ``HeterogeneousStrategies.RECORD`` emits one ``struct``
+        declaration per record shape present in the data; otherwise
+        produces no preamble.
+        """
+        return self._record_strategy.preamble
 
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
-        """Return the heterogeneous-behavior config."""
-        return self.heterogeneous_strategy.value
+        """Return the behavior for the chosen heterogeneous strategy."""
+        return self._record_strategy.behavior
 
     @cached_property
     def call_data_dependent_preamble(
@@ -827,14 +924,35 @@ class Go(metaclass=LanguageCls):
 
     @cached_property
     def sequence_open(self) -> Callable[[list[Value]], str]:
-        """Callable that returns the opening delimiter for a sequence."""
-        return typed_collection_open(
+        """Callable that returns the opening delimiter for a sequence.
+
+        Under the ``RECORD`` strategy a list whose elements are
+        record-shaped dicts is rendered as ``[]any{ RecordN{...}, ... }``
+        (the elements format as struct literals, not as the
+        ``map[string]...`` the typed opener would otherwise infer).
+        """
+        base = typed_collection_open(
             type_to_opener=make_type_to_opener(
                 element_to_type=self._init_element_to_type,
                 opener_template="[]{type_name}{{",
             ),
             fallback=f"[]{self.default_sequence_element_type}{{",
         )
+        record = type(self.heterogeneous_strategy).RECORD
+        if self.heterogeneous_strategy is not record:
+            return base
+        any_open = f"[]{self.default_sequence_element_type}{{"
+
+        def _open(items: list[Value], /) -> str:
+            """Use ``[]any{`` for lists of record-shaped dicts."""
+            if any(
+                isinstance(item, dict) and not isinstance(item, _ordereddict)
+                for item in items
+            ):
+                return any_open
+            return base(items)
+
+        return _open
 
     @cached_property
     def dict_format_config(self) -> DictFormatConfig:

--- a/tests/integration/cases/call_deep_dotted_method/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_deep_dotted_method/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,12 @@
+package main
+type clientType_ struct{}
+func (clientType_) post(args ...any) any { return nil }
+type apiType_ struct{ client clientType_ }
+type objType_ struct{ api apiType_ }
+var obj objType_
+
+func main() {
+obj.api.client.post("hello")
+obj.api.client.post(42)
+obj.api.client.post(true)
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_deep_dotted_transformed/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,12 @@
+package main
+type clientType_ struct{}
+func (clientType_) fetch(args ...any) any { return nil }
+type appType_ struct{ client clientType_ }
+var app appType_
+func emit(args ...any) any { return nil }
+
+func main() {
+emit(app.client.fetch("hello"))
+emit(app.client.fetch(42))
+emit(app.client.fetch(true))
+}

--- a/tests/integration/cases/call_dotted_method/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_dotted_method/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,11 @@
+package main
+type clientType_ struct{}
+func (clientType_) fetch(args ...any) any { return nil }
+type appType_ struct{ client clientType_ }
+var app appType_
+
+func main() {
+app.client.fetch("hello")
+app.client.fetch(42)
+app.client.fetch(true)
+}

--- a/tests/integration/cases/call_dotted_transform_stub/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_dotted_transform_stub/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,11 @@
+package main
+func process(args ...any) any { return nil }
+type tracerType_ struct{}
+func (tracerType_) emit(args ...any) any { return nil }
+var tracer tracerType_
+
+func main() {
+tracer.emit(process("hello"))
+tracer.emit(process(42))
+tracer.emit(process(true))
+}

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,18 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+my_ints := []int{
+	1,
+	2,
+	3,
+}
+my_strings := []string{
+	"a",
+	"b",
+}
+my_empty := []any{}
+process(my_ints, 42)
+process(my_strings, 7)
+process(my_empty, 99)
+}

--- a/tests/integration/cases/call_ref_args_reused/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_ref_args_reused/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,14 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+single_var := []int{
+	4,
+	5,
+	6,
+}
+repeated_var := 1
+process(repeated_var, 1)
+process(single_var, 0)
+process(repeated_var, 8)
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_ref_args_trivial_register/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,17 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+my_int := 1
+my_bool := true
+my_float := 3.14
+my_list := []int{
+	1,
+	2,
+	3,
+}
+process(my_int, 42)
+process(my_bool, 7)
+process(my_float, 9)
+process(my_list, 1)
+}

--- a/tests/integration/cases/call_scalar_args/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_scalar_args/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,8 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+process("hello")
+process(42)
+process(true)
+}

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,8 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+process("hello", "a")
+process(42, "b")
+process(true, "c")
+}

--- a/tests/integration/cases/call_scalar_args_with_null/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_scalar_args_with_null/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,7 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+process(nil)
+process("hello")
+}

--- a/tests/integration/cases/call_snake_dotted_method/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_snake_dotted_method/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,11 @@
+package main
+type http_clientType_ struct{}
+func (http_clientType_) fetch(args ...any) any { return nil }
+type my_appType_ struct{ http_client http_clientType_ }
+var my_app my_appType_
+
+func main() {
+my_app.http_client.fetch("hello")
+my_app.http_client.fetch(42)
+my_app.http_client.fetch(true)
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Go_heterogeneous_strategy_record_call@v1_18.go
+++ b/tests/integration/cases/call_transform_no_wrapper/Go_heterogeneous_strategy_record_call@v1_18.go
@@ -1,0 +1,8 @@
+package main
+func process(args ...any) any { return nil }
+
+func main() {
+process("hello")
+process(42)
+process(true)
+}

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Fortran@v2003.f90
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Fortran@v2003.f90
@@ -1,0 +1,26 @@
+module fval_m
+  implicit none
+  integer, parameter :: int64 = selected_int_kind(18)
+  type :: fval_t
+    integer :: t = 0
+  end type fval_t
+contains
+  function fnull() result(v); type(fval_t) :: v; end function
+  function fbool(b) result(v); logical, intent(in) :: b; type(fval_t) :: v; end function
+  function fint(n) result(v); integer(kind=int64), intent(in) :: n; type(fval_t) :: v; end function
+  function freal(x) result(v); real, intent(in) :: x; type(fval_t) :: v; end function
+  function fstr(s) result(v); character(len=*), intent(in) :: s; type(fval_t) :: v; end function
+  function flist(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fmap(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fset(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fentry(k, u) result(v); character(len=*), intent(in) :: k; type(fval_t), intent(in) :: u; type(fval_t) :: v; end function
+end module fval_m
+program main
+    use fval_m
+    implicit none
+    type(fval_t) :: my_data
+    my_data = fmap([fval_t :: &
+        fentry('host', fstr('it''s here')), &  ! a comment
+        fentry('port', fint(80_int64)) &  ! another
+    ])
+end program main

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Fortran_combined@v2003.f90
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Fortran_combined@v2003.f90
@@ -1,0 +1,41 @@
+module fval_m
+  implicit none
+  integer, parameter :: int64 = selected_int_kind(18)
+  type :: fval_t
+    integer :: t = 0
+  end type fval_t
+contains
+  function fnull() result(v); type(fval_t) :: v; end function
+  function fbool(b) result(v); logical, intent(in) :: b; type(fval_t) :: v; end function
+  function fint(n) result(v); integer(kind=int64), intent(in) :: n; type(fval_t) :: v; end function
+  function freal(x) result(v); real, intent(in) :: x; type(fval_t) :: v; end function
+  function fstr(s) result(v); character(len=*), intent(in) :: s; type(fval_t) :: v; end function
+  function flist(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fmap(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fset(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fentry(k, u) result(v); character(len=*), intent(in) :: k; type(fval_t), intent(in) :: u; type(fval_t) :: v; end function
+end module fval_m
+subroutine main_declaration()
+    use fval_m
+    implicit none
+    type(fval_t) :: my_data
+    my_data = fmap([fval_t :: &
+        fentry('host', fstr('it''s here')), &  ! a comment
+        fentry('port', fint(80_int64)) &  ! another
+    ])
+end subroutine main_declaration
+
+subroutine main_assignment()
+    use fval_m
+    implicit none
+    type(fval_t) :: my_data
+    my_data = fmap([fval_t :: &
+        fentry('host', fstr('it''s here')), &  ! a comment
+        fentry('port', fint(80_int64)) &  ! another
+    ])
+end subroutine main_assignment
+
+program main
+    call main_declaration()
+    call main_assignment()
+end program main

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Fortran_version_v2003@v2003.f90
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Fortran_version_v2003@v2003.f90
@@ -1,0 +1,26 @@
+module fval_m
+  implicit none
+  integer, parameter :: int64 = selected_int_kind(18)
+  type :: fval_t
+    integer :: t = 0
+  end type fval_t
+contains
+  function fnull() result(v); type(fval_t) :: v; end function
+  function fbool(b) result(v); logical, intent(in) :: b; type(fval_t) :: v; end function
+  function fint(n) result(v); integer(kind=int64), intent(in) :: n; type(fval_t) :: v; end function
+  function freal(x) result(v); real, intent(in) :: x; type(fval_t) :: v; end function
+  function fstr(s) result(v); character(len=*), intent(in) :: s; type(fval_t) :: v; end function
+  function flist(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fmap(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fset(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fentry(k, u) result(v); character(len=*), intent(in) :: k; type(fval_t), intent(in) :: u; type(fval_t) :: v; end function
+end module fval_m
+program main
+    use fval_m
+    implicit none
+    type(fval_t) :: my_data
+    my_data = fmap([fval_t :: &
+        fentry('host', fstr('it''s here')), &  ! a comment
+        fentry('port', fint(80_int64)) &  ! another
+    ])
+end program main

--- a/tests/integration/cases/dict_all_scalar_types/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/dict_all_scalar_types/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,26 @@
+package main
+import "time"
+type Record0 struct {
+	S string
+	I int
+	F float64
+	B bool
+	N any
+	D time.Time
+	Dt time.Time
+	By string
+}
+
+func main() {
+my_data := Record0{
+	S: "string",
+	I: 1,
+	F: 1.5,
+	B: true,
+	N: nil,
+	D: time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC),
+	Dt: time.Date(2024, time.January, 15, 12, 0, 0, 0, time.UTC),
+	By: "48656c6c6f",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_all_scalar_types/Go_heterogeneous_strategy_record_datetime_epoch@v1_18.go
+++ b/tests/integration/cases/dict_all_scalar_types/Go_heterogeneous_strategy_record_datetime_epoch@v1_18.go
@@ -1,0 +1,26 @@
+package main
+import "time"
+type Record0 struct {
+	S string
+	I int
+	F float64
+	B bool
+	N any
+	D time.Time
+	Dt int
+	By string
+}
+
+func main() {
+my_data := Record0{
+	S: "string",
+	I: 1,
+	F: 1.5,
+	B: true,
+	N: nil,
+	D: time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC),
+	Dt: 1705320000,
+	By: "48656c6c6f",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_all_scalar_types/Go_heterogeneous_strategy_record_datetime_iso@v1_18.go
+++ b/tests/integration/cases/dict_all_scalar_types/Go_heterogeneous_strategy_record_datetime_iso@v1_18.go
@@ -1,0 +1,26 @@
+package main
+import "time"
+type Record0 struct {
+	S string
+	I int
+	F float64
+	B bool
+	N any
+	D time.Time
+	Dt string
+	By string
+}
+
+func main() {
+my_data := Record0{
+	S: "string",
+	I: 1,
+	F: 1.5,
+	B: true,
+	N: nil,
+	D: time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC),
+	Dt: "2024-01-15T12:00:00",
+	By: "48656c6c6f",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/dict_mixed_int_widths/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,15 @@
+package main
+type Record0 struct {
+	A int
+	B int
+	C string
+}
+
+func main() {
+my_data := Record0{
+	A: 1,
+	B: 3000000000,
+	C: "x",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_mixed_scalars/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/dict_mixed_scalars/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,13 @@
+package main
+type Record0 struct {
+	A int
+	B string
+}
+
+func main() {
+my_data := Record0{
+	A: 1,
+	B: "x",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_mixed_scalars/Go_heterogeneous_strategy_record_combined@v1_18.go
+++ b/tests/integration/cases/dict_mixed_scalars/Go_heterogeneous_strategy_record_combined@v1_18.go
@@ -1,0 +1,17 @@
+package main
+type Record0 struct {
+	A int
+	B string
+}
+
+func main() {
+my_data := Record0{
+	A: 1,
+	B: "x",
+}
+my_data = Record0{
+	A: 1,
+	B: "x",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_with_list_value/Go_heterogeneous_strategy_record_list_val@v1_18.go
+++ b/tests/integration/cases/dict_with_list_value/Go_heterogeneous_strategy_record_list_val@v1_18.go
@@ -1,0 +1,17 @@
+package main
+type Record0 struct {
+	Name string
+	Scores []int
+}
+
+func main() {
+my_data := Record0{
+	Name: "Alice",
+	Scores: []int{
+		10,
+		20,
+		30,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/heterogeneous_list_with_string/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+my_data := []any{
+	"hello",
+	42,
+}
+_ = my_data
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Go_heterogeneous_strategy_record_sibling_widening@v1_18.go
+++ b/tests/integration/cases/multiline_sibling_list_widening/Go_heterogeneous_strategy_record_sibling_widening@v1_18.go
@@ -1,0 +1,33 @@
+package main
+type Record1 struct {
+	Numbers []int
+	Strings []string
+}
+type Record0 struct {
+	OmapValue [][2]any
+	SiblingLists Record1
+	RefMarkerPresent []string
+}
+
+func main() {
+my_data := Record0{
+	OmapValue: [][2]any{
+		{"first", 1},
+	},
+	SiblingLists: Record1{
+		Numbers: []int{
+			1,
+			2,
+		},
+		Strings: []string{
+			"x",
+			"y",
+		},
+	},
+	RefMarkerPresent: []string{
+		"$keep",
+		"z",
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_mixed_dict/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/nested_mixed_dict/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,20 @@
+package main
+type Record1 struct {
+	A int
+	B string
+	C any
+}
+type Record0 struct {
+	Outer Record1
+}
+
+func main() {
+my_data := Record0{
+	Outer: Record1{
+		A: 1,
+		B: "x",
+		C: nil,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_mixed_inner/Go_heterogeneous_strategy_record_inner@v1_18.go
+++ b/tests/integration/cases/nested_mixed_inner/Go_heterogeneous_strategy_record_inner@v1_18.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+my_data := []any{
+	[]any{1, "a"},
+	[]any{2, "b"},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_mixed_types/Go_heterogeneous_strategy_record_sibling@v1_18.go
+++ b/tests/integration/cases/nested_mixed_types/Go_heterogeneous_strategy_record_sibling@v1_18.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+my_data := []any{
+	[]int{1, 2},
+	[]string{"a", "b"},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_sequences/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/nested_sequences/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+my_data := [][][]int{
+	[][]int{[]int{1, 2}, []int{3, 4}},
+	[][]int{[]int{5}},
+}
+_ = my_data
+}

--- a/tests/integration/cases/ordered_map/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/ordered_map/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+my_data := [][2]any{
+	{"name", "Alice"},
+	{"age", 30},
+	{"active", true},
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_basic/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/record_basic/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,21 @@
+package main
+type Record0 struct {
+	Id int
+	Description string
+	IsDone bool
+	Blocks []int
+}
+
+func main() {
+my_data := Record0{
+	Id: 1,
+	Description: "She said \"hello\", then waved",
+	IsDone: false,
+	Blocks: []int{
+		1,
+		2,
+		3,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_nested_container/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/record_nested_container/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,19 @@
+package main
+type Record0 struct {
+	Title string
+	Tags []string
+	Priority int
+}
+
+func main() {
+my_data := Record0{
+	Title: "report",
+	Tags: []string{
+		"draft",
+		"urgent",
+		"review",
+	},
+	Priority: 2,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_nested_record/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/record_nested_record/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,20 @@
+package main
+type Record1 struct {
+	Name string
+	Age int
+}
+type Record0 struct {
+	Id int
+	Owner Record1
+}
+
+func main() {
+my_data := Record0{
+	Id: 1,
+	Owner: Record1{
+		Name: "Alice",
+		Age: 30,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_pure_scalars/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/record_pure_scalars/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,17 @@
+package main
+type Record0 struct {
+	Name string
+	Age int
+	Active bool
+	Score float64
+}
+
+func main() {
+my_data := Record0{
+	Name: "Alice",
+	Age: 30,
+	Active: true,
+	Score: 4.5,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_sequence/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/record_sequence/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,14 @@
+package main
+type Record0 struct {
+	Id int
+	Label string
+}
+
+func main() {
+my_data := []any{
+	Record0{Id: 1, Label: "first"},
+	Record0{Id: 2, Label: "second"},
+	Record0{Id: 3, Label: "third"},
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_two_shapes/Go_heterogeneous_strategy_record@v1_18.go
+++ b/tests/integration/cases/record_two_shapes/Go_heterogeneous_strategy_record@v1_18.go
@@ -1,0 +1,27 @@
+package main
+type Record1 struct {
+	Count int
+	Rate int
+}
+type Record2 struct {
+	Retries int
+	Timeout int
+}
+type Record0 struct {
+	Metrics Record1
+	Flags Record2
+}
+
+func main() {
+my_data := Record0{
+	Metrics: Record1{
+		Count: 100,
+		Rate: 50,
+	},
+	Flags: Record2{
+		Retries: 3,
+		Timeout: 30,
+	},
+}
+_ = my_data
+}


### PR DESCRIPTION
Closes #2297. Foundation PR for #2237 (port the Rust `RECORD` heterogeneous strategy to Go/Kotlin/Scala/Java, one PR per language).

## What

- **Shared `src/literalizer/_formatters/record_strategy.py`** — language-agnostic RECORD orchestration (document-order shape naming, post-order declaration emission, per-pass formatted-field cache) parameterised by a per-language `RecordRenderer`. Kotlin/Scala/Java (#2298/#2299/#2300) reuse this with only their own renderer.
- **`_expand_record_literal_multiline` generalised branch-free** to handle brace (`Record0{...}`, Rust/Go) and paren (`Record0(...)`, Kotlin/Scala/Java) literals. The opener is whichever of `{`/`(` appears first; the closer is read from a table. The `(` path is data, not a branch, so existing brace goldens give full coverage and the change is **byte-identical inert** for Rust and every other language (zero golden modifications).
- **Go**: `HeterogeneousStrategies` upgraded from the simple model to a behavior+preamble model; new `RECORD` member and `record_struct_name_prefix` constructor parameter. Record-shaped dicts render as `type RecordN struct { ... }` in the preamble plus `RecordN{Field: value, ...}` literals with exported PascalCase fields. Field types are derived from the **already-formatted literal value**, so the declared type always matches what the formatter emitted, including when sibling context widens a list to `[]any`. Lists of record dicts open as `[]any{ RecordN{...}, ... }` so struct-literal elements stay assignable.

## Scope

Base RECORD only, per #2237: auto `Record0/1/...` names, no `record_shape_names`, no `record_unify_optional_fields` (both Rust-only), so `RecordShape.optional_keys` is always empty here.

## Verification

- Full suite: **4081 passed, 100.00% coverage** (`record_strategy.py` and all new Go code fully exercised by the auto-generated `Go_heterogeneous_strategy_record*` variant goldens; no `# pragma: no cover`).
- All 32 generated Go fixtures pass `gofmt -e`, `go vet ./...` and `go run ./...` (the `lint-go` job).
- pylint 10/10, ruff check/format clean, mypy/pyright/ty/pyrefly/vulture/deptry/interrogate green.
- No existing golden file modified (only new `Go_heterogeneous_strategy_record*` files added), confirming the shared change is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new heterogeneous rendering mode for Go that changes how mixed-type dicts and some lists are emitted (new generated `struct` preambles and `[]any` openers), which could affect type inference and output compatibility for affected inputs.
> 
> **Overview**
> **Go now supports `HeterogeneousStrategies.RECORD`** for mixed-type, record-shaped dicts, emitting generated `type RecordN struct { ... }` declarations in a data-dependent preamble and using `RecordN{Field: value, ...}` literals with exported PascalCase fields (plus configurable `record_struct_name_prefix`). Field types are derived from the *already-formatted* literal values, and lists containing record dicts fall back to `[]any{...}` so struct-literal elements remain type-correct.
> 
> Adds a new shared formatter module `src/literalizer/_formatters/record_strategy.py` to orchestrate RECORD shape naming and declaration emission across languages, and generalizes `_expand_record_literal_multiline` to handle both `{...}` and `(...)` record-literal delimiters. Integration goldens are expanded with many new `Go_heterogeneous_strategy_record*` fixtures (and a few new Fortran comment-escaping fixtures) to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7c3450219886f410af64ee7f1b0bcbdbf56d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->