### PR TITLE
RECORD literal: emit structured parts (no flatten-then-reparse)

### DIFF
--- a/src/literalizer/_formatters/record_strategy.py
+++ b/src/literalizer/_formatters/record_strategy.py
@@ -33,6 +33,7 @@ from literalizer._formatters.type_inference import (
 )
 from literalizer._language import (
     HeterogeneousBehavior,
+    RenderedRecordLiteral,
     no_compute_call_slot_wrap_ids,
     no_compute_wrap_ids,
 )
@@ -69,9 +70,10 @@ class RecordRenderer:
     PascalCase for Go).  ``field_type`` maps a field's already-formatted
     literal value to its declared type.  ``render_declaration`` builds
     one declaration block from the resolved fields, and
-    ``render_literal`` builds the single-line literal (the shared
-    multiline expansion in :mod:`literalizer._literalize` re-flows it
-    when the surrounding layout is multiline).
+    ``render_literal`` builds the literal as a
+    :class:`RenderedRecordLiteral` (structured pieces; the shared code
+    in :mod:`literalizer._literalize` assembles the compact or multiline
+    form from them, so no language flattens then re-parses).
     """
 
     name_prefix: str
@@ -81,7 +83,10 @@ class RecordRenderer:
         [str, Sequence[RecordDeclarationField]],
         str,
     ]
-    render_literal: Callable[[str, Sequence[RecordLiteralField]], str]
+    render_literal: Callable[
+        [str, Sequence[RecordLiteralField]],
+        RenderedRecordLiteral,
+    ]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -235,7 +240,7 @@ def build_record_strategy(
     def _render_literal(
         value: "dict[Scalar, Value]",
         fields: Mapping[str, str],
-    ) -> str:
+    ) -> RenderedRecordLiteral:
         """Render a record-shape dict as a language-specific literal,
         caching the first-seen formatted fields for its shape.
         """

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -435,6 +435,27 @@ class CollectionLayout(enum.Enum):
 
 
 @dataclasses.dataclass(frozen=True)
+class RenderedRecordLiteral:
+    """A record literal as structured pieces, assembled into compact or
+    multiline form by the shared record-layout code without re-parsing.
+
+    ``head`` is the literal up to and including its opening delimiter
+    (``Record0 {`` for Rust, ``Record0{`` for Go).  ``entries`` is one
+    already-formatted field per element (``id: 1``); an entry whose
+    value is itself multiline arrives already expanded.  ``closer`` is
+    the closing delimiter (``}``).  ``compact_pad`` is inserted just
+    inside the delimiters in compact form (a space for Rust's
+    ``Name { a }``, empty for Go's ``Name{a}``) and is unused in the
+    multiline form.
+    """
+
+    head: str
+    entries: tuple[str, ...]
+    closer: str
+    compact_pad: str
+
+
+@dataclasses.dataclass(frozen=True)
 class HeterogeneousBehavior:
     """Per-language hook describing how heterogeneous scalar
     collections are rendered.
@@ -470,8 +491,11 @@ class HeterogeneousBehavior:
 
     ``render_record_literal`` renders a record-shaped dict as a
     generated struct literal given its :class:`RecordShape` and a
-    mapping of pre-formatted field values.  Defaults to ``None`` for
-    strategies that do not opt into the ``RECORD`` style.
+    mapping of pre-formatted field values, returning a
+    :class:`RenderedRecordLiteral` (structured pieces the shared
+    record-layout code assembles into compact or multiline form).
+    Defaults to ``None`` for strategies that do not opt into the
+    ``RECORD`` style.
 
     ``compute_record_shapes`` walks the data once and returns a
     mapping from ``id(dict)`` to :class:`RecordShape` for every dict
@@ -490,7 +514,11 @@ class HeterogeneousBehavior:
     wrap_non_scalar: Callable[[Value, str], str] | None
     compute_call_slot_wrap_ids: Callable[[Sequence[Value]], frozenset[int]]
     render_record_literal: (
-        Callable[[dict[Scalar, Value], Mapping[str, str]], str] | None
+        Callable[
+            [dict[Scalar, Value], Mapping[str, str]],
+            RenderedRecordLiteral,
+        ]
+        | None
     ) = None
     compute_record_shapes: Callable[[Value], Mapping[int, RecordShape]] = (
         dataclasses.field(default_factory=lambda: _no_compute_record_shapes)

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Final, assert_never
 
 from beartype import BeartypeConf, beartype
@@ -524,118 +524,13 @@ def _maybe_format_record_literal(
     }
     rendered = render_record_literal(value, formatted_fields)
     if not is_multiline:
-        return rendered
-    return _expand_record_literal_multiline(
-        rendered=rendered,
-        body_prefix=body_prefix,
-        close_prefix=multiline_prefix,
-    )
-
-
-@beartype
-def _expand_record_literal_multiline(
-    *,
-    rendered: str,
-    body_prefix: str,
-    close_prefix: str,
-) -> str:
-    """Expand a single-line record literal into multiline form.
-
-    Splits ``Name { f1: v1, f2: v2 }`` (brace-delimited, e.g. Rust and
-    Go) or ``Name(f1 = v1, f2 = v2)`` (paren-delimited, e.g. Kotlin,
-    Scala, Java) into one entry per line indented under *body_prefix*
-    with the closing delimiter on its own line under *close_prefix*.
-    The opening delimiter is whichever of ``{`` or ``(`` appears first;
-    its matching closer is the literal's final character.  The literal
-    always has at least one field because ``render_record_literal`` is
-    only called for record-eligible (non-empty) dicts.
-    """
-    open_idx = min(
-        index for index, char in enumerate(iterable=rendered) if char in "{("
-    )
-    closer = {"{": "}", "(": ")"}[rendered[open_idx]]
-    head = rendered[: open_idx + 1]
-    body = rendered[open_idx + 1 : -1].strip()
-    entries = _split_record_entries(body=body)
-    indented = [f"{body_prefix}{entry.strip()}," for entry in entries]
-    return f"{head}\n" + "\n".join(indented) + f"\n{close_prefix}{closer}"
-
-
-@dataclasses.dataclass(frozen=True)
-class _StringScanStep:
-    r"""One step of scanning inside a string literal.
-
-    *in_string* is the currently-open quote character (or ``None`` if
-    the literal just closed).  *skip_next* is ``True`` when the next
-    char must be skipped because it is the second half of a ``\X``
-    escape sequence.
-    """
-
-    in_string: str | None
-    skip_next: bool
-
-
-@beartype
-def _split_record_entries(*, body: str) -> list[str]:
-    """Split a record-literal body on commas that are not inside
-    brackets or quotes.
-
-    *body* is the inner text of ``Name { ... }`` for a record with at
-    least one field, so the loop always produces a non-empty trailing
-    entry after the last comma (or the whole body when there are no
-    top-level commas).
-    """
-    entries: list[str] = []
-    last = 0
-    for index in _depth_zero_comma_indices(body=body):
-        entries.append(body[last:index])
-        last = index + 1
-    entries.append(body[last:].strip().rstrip(","))
-    return [e for e in entries if e.strip()]
-
-
-@beartype
-def _depth_zero_comma_indices(*, body: str) -> Iterator[int]:
-    r"""Yield indices of commas in *body* that are at bracket depth zero
-    and outside any string literal.
-
-    Treats ``\\`` inside a string literal as an escape so embedded
-    escaped quotes do not prematurely close string tracking.
-    """
-    depth = 0
-    in_string: str | None = None
-    skip_next = False
-    for index, char in enumerate(iterable=body):
-        if skip_next:
-            skip_next = False
-        elif in_string is not None:
-            step = _advance_string_state(char=char, quote=in_string)
-            in_string = step.in_string
-            skip_next = step.skip_next
-        elif char in {'"', "'"}:
-            in_string = char
-        elif char in {"(", "[", "{"}:
-            depth += 1
-        elif char in {")", "]", "}"}:
-            depth -= 1
-        elif char == "," and depth == 0:
-            yield index
-
-
-@beartype
-def _advance_string_state(
-    *,
-    char: str,
-    quote: str,
-) -> _StringScanStep:
-    """Return the next ``(in_string, skip_next)`` state inside a string
-    literal, given the current quote and next char.
-    """
-    if char == "\\":
-        return _StringScanStep(in_string=quote, skip_next=True)
-    if char == quote:
-        return _StringScanStep(in_string=None, skip_next=False)
-    return _StringScanStep(in_string=quote, skip_next=False)
+        joined = ", ".join(rendered.entries)
+        return (
+            f"{rendered.head}{rendered.compact_pad}{joined}"
+            f"{rendered.compact_pad}{rendered.closer}"
+        )
+    body = "\n".join(f"{body_prefix}{entry}," for entry in rendered.entries)
+    return f"{rendered.head}\n{body}\n{multiline_prefix}{rendered.closer}"
 
 
 @beartype

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -74,6 +74,7 @@ from literalizer._language import (
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
+    RenderedRecordLiteral,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -210,12 +211,18 @@ def _go_record_literal(
     name: str,
     fields: Sequence[RecordLiteralField],
     /,
-) -> str:
-    """Render a single-line Go ``Name{Field: value, ...}`` literal."""
-    body = ", ".join(
-        f"{field.identifier}: {field.formatted}" for field in fields
+) -> RenderedRecordLiteral:
+    """Render a Go ``Name{Field: value, ...}`` literal as structured
+    pieces for the shared compact/multiline layout code.
+    """
+    return RenderedRecordLiteral(
+        head=f"{name}{{",
+        entries=tuple(
+            f"{field.identifier}: {field.formatted}" for field in fields
+        ),
+        closer="}",
+        compact_pad="",
     )
-    return f"{name}{{{body}}}"
 
 
 @beartype

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -74,6 +74,7 @@ from literalizer._language import (
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
+    RenderedRecordLiteral,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -742,7 +743,7 @@ def _build_record_behavior(
     def _render_literal(
         value: "dict[Scalar, Value]",
         fields: Mapping[str, str],
-    ) -> str:
+    ) -> RenderedRecordLiteral:
         """Render a record-shape dict as a Rust struct literal.
 
         Looks up *value*'s (possibly unified) shape from the
@@ -750,6 +751,9 @@ def _build_record_behavior(
         ``check_data``.  Iterates the unified shape's keys: keys
         missing from this instance render as ``None``; keys marked
         optional render as ``Some(value)``; required keys render bare.
+        Returns the structured pieces (``Name {``, one entry per
+        field, ``}``, single-space compact padding) the shared
+        record-layout code assembles into compact or multiline form.
         """
         shape = id_to_shape[id(value)]
         parts: list[str] = []
@@ -762,8 +766,12 @@ def _build_record_behavior(
                     parts.append(f"{key}: {formatted}")
             else:
                 parts.append(f"{key}: None")
-        body = ", ".join(parts)
-        return f"{name_cache[shape]} {{ {body} }}"
+        return RenderedRecordLiteral(
+            head=f"{name_cache[shape]} {{",
+            entries=tuple(parts),
+            closer="}",
+            compact_pad=" ",
+        )
 
     return HeterogeneousBehavior(
         skip_scalar_checks=False,


### PR DESCRIPTION
Part A of #2305 (closes #2307). The RECORD renderer flattened its structured fields into one single-line string that `_expand_record_literal_multiline` then re-lexed (bracket-depth + string/escape scanning) just to recover the field boundaries it had discarded. This adds `RenderedRecordLiteral(head, entries, closer, compact_pad)` in `_language.py` (where the `HeterogeneousBehavior` contract lives, avoiding a `record_strategy`/`_language` import cycle): `render_record_literal` / `RecordRenderer.render_literal` now return structured pieces and `_maybe_format_record_literal` does the uniform compact/multiline assembly off `collection_layout`, deleting `_expand_record_literal_multiline`, `_split_record_entries`, `_depth_zero_comma_indices`, `_StringScanStep`, and `_advance_string_state` (no other callers). Rust + Go record goldens are byte-identical and 100% coverage is retained (ruff/mypy/ty/pyright/pyrefly/pylint clean). The Go `_go_field_type` structured-type-info change is the separate Part B, tracked as #2308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `RECORD` literal rendering and changes the `render_record_literal` contract across languages, so any missed implementation detail could alter formatting or multiline layout. Output is intended to be byte-identical, but regressions would affect codegen for record-shaped dicts (not general dict rendering).
> 
> **Overview**
> **Reworks `RECORD` literal rendering to avoid flatten-then-reparse.** `render_record_literal` / `RecordRenderer.render_literal` now return a new `RenderedRecordLiteral` (`head`, `entries`, `closer`, `compact_pad`) instead of a single flattened string.
> 
> `_maybe_format_record_literal` now assembles compact vs multiline output directly from these structured pieces, deleting the previous multiline expansion logic that scanned strings for delimiters/commas/quotes. Go and Rust record literal renderers were updated to emit the structured form (preserving their spacing rules via `compact_pad`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e826488a6a89eb66f35bf4922cd893fc737d3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->