### PR TITLE
Add RECORD heterogeneous strategy to Kotlin (#2298)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Kotlin` gains the ``RECORD``
+  ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust` and
+  :class:`~literalizer.Go`).  Each record-shaped dict (non-empty,
+  string-keyed) becomes a generated ``data class RecordN(val ...)``
+  declared in the preamble plus a matching ``RecordN(field = value,
+  ...)`` literal, so a dict whose values mix scalars and containers is
+  representable instead of raising.  Field names keep the original
+  dict keys and the data-class-name prefix is configurable via the new
+  ``record_struct_name_prefix`` constructor parameter.  See #2298.
+
 - :class:`~literalizer.Go` gains the ``RECORD`` ``heterogeneous_strategy``
   (already on :class:`~literalizer.Rust`).  Each record-shaped dict
   (non-empty, string-keyed) becomes a generated ``type RecordN struct

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -52,6 +52,13 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import (
     format_string_backslash_dollar,
 )
+from literalizer._formatters.record_strategy import (
+    RecordDeclarationField,
+    RecordLiteralField,
+    RecordRenderer,
+    RecordStrategy,
+    build_record_strategy,
+)
 from literalizer._formatters.type_inference import (
     DictType,
     ListType,
@@ -74,6 +81,7 @@ from literalizer._language import (
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
+    RenderedRecordLiteral,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -87,6 +95,7 @@ from literalizer._language import (
     identity_call_target,
     never_inhibits_consuming_form,
     no_call_stub,
+    no_data_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
@@ -469,6 +478,61 @@ def _kotlin_call_stub(
     lines.append(f"class {root_cls} {{ val {fields[0]} = {prev_cls}() }}")
     lines.append(f"val {root} = {root_cls}()")
     return tuple(lines)
+
+
+# Kotlin collection-constructor call names mapped to the declared type
+# they produce, used to derive a ``RECORD`` field's type from its
+# already-formatted generic literal (e.g. ``linkedMapOf<String, Any?>(``
+# -> ``LinkedHashMap<String, Any?>``).
+_KOTLIN_COLLECTION_TYPE: dict[str, str] = {
+    "listOf": "List",
+    "mapOf": "Map",
+    "hashMapOf": "HashMap",
+    "linkedMapOf": "LinkedHashMap",
+    "setOf": "Set",
+}
+
+
+@beartype
+def _kotlin_record_field_identifier(key: str, /) -> str:
+    """Return the Kotlin record field name for a dict *key*.
+
+    Kotlin allows the original (possibly snake_case) key verbatim as a
+    ``data class`` property name, so the mapping is the identity.
+    """
+    return key
+
+
+@beartype
+def _kotlin_render_declaration(
+    name: str,
+    fields: Sequence[RecordDeclarationField],
+    /,
+) -> str:
+    """Render a Kotlin ``data class Name(val f: T, ...)`` declaration."""
+    params = ", ".join(
+        f"val {field.identifier}: {field.type_name}" for field in fields
+    )
+    return f"data class {name}({params})"
+
+
+@beartype
+def _kotlin_record_literal(
+    name: str,
+    fields: Sequence[RecordLiteralField],
+    /,
+) -> RenderedRecordLiteral:
+    """Render a Kotlin ``Name(field = value, ...)`` literal as
+    structured pieces for the shared compact/multiline layout code.
+    """
+    return RenderedRecordLiteral(
+        head=f"{name}(",
+        entries=tuple(
+            f"{field.identifier} = {field.formatted}" for field in fields
+        ),
+        closer=")",
+        compact_pad="",
+    )
 
 
 @beartype
@@ -901,11 +965,19 @@ class Kotlin(metaclass=LanguageCls):
     modifiers = Modifiers
 
     class HeterogeneousStrategies(enum.Enum):
-        """Heterogeneous-scalar strategy options — this language only
-        supports raising.
+        """Strategy for dicts whose values span more than one Kotlin
+        type.
+
+        ``ERROR`` keeps Kotlin's strict-typing behavior (mixed-value
+        dicts that cannot be represented raise).  ``RECORD`` renders
+        each record-shaped dict (non-empty, string-keyed) as a generated
+        ``data class`` declared in the preamble plus a matching
+        constructor-call literal, so fields may legitimately mix scalars
+        and containers.
         """
 
-        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+        ERROR = enum.auto()
+        RECORD = enum.auto()
 
     heterogeneous_strategies = HeterogeneousStrategies
 
@@ -997,6 +1069,7 @@ class Kotlin(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    record_struct_name_prefix: str = "Record"
     # Keep in sync with the version flags passed to the Kotlin lint host in
     # `.github/scripts/lint-kotlin.main.kts`.
     language_version: VersionFormats = VersionFormats.V1_9
@@ -1036,15 +1109,107 @@ class Kotlin(metaclass=LanguageCls):
         """Format an assignment to an existing variable."""
         return variable_formatter(template="{name} = {value}")
 
+    def _kotlin_record_field_type(self, formatted: str, /) -> str:
+        """Return the Kotlin ``data class`` field type for an
+        already-formatted value.
+
+        The declared type is read off the formatted literal so it
+        always matches what the value formatter emitted.  Scalars and
+        homogeneous typed-array literals have a fixed prefix; richer
+        shapes (string arrays, generic collections, nested records,
+        numbers) are resolved by :meth:`_kotlin_record_composite_type`.
+        """
+        exact = {
+            self.null_literal: "Any?",
+            self.true_literal: "Boolean",
+            self.false_literal: "Boolean",
+        }
+        if formatted in exact:
+            return exact[formatted]
+        prefixes = (
+            ('"', "String"),
+            ("LocalDateTime.of(", "LocalDateTime"),
+            ("LocalDate.of(", "LocalDate"),
+            ("intArrayOf(", "IntArray"),
+        )
+        for prefix, type_name in prefixes:
+            if formatted.startswith(prefix):
+                return type_name
+        return self._kotlin_record_composite_type(formatted=formatted)
+
+    def _kotlin_record_composite_type(self, *, formatted: str) -> str:
+        """Return the field type for a non-scalar formatted value.
+
+        Generic collection literals carry their type in the ``<...>``
+        segment of the constructor call (``linkedMapOf<String, Any?>(``
+        -> ``LinkedHashMap<String, Any?>``); a nested record-shaped dict
+        formats as its own ``RecordN(...)`` literal, whose name is the
+        declared type; everything else is an ``Int``/``Long``/``Double``
+        number.
+        """
+        if formatted.startswith("arrayOf("):
+            body = formatted[len("arrayOf(") :].lstrip()
+            element = body[: body.index('"', 1) + 1]
+            return f"Array<{self._kotlin_record_field_type(element)}>"
+        if "<" in formatted:
+            name = formatted[: formatted.index("<")]
+            generics = formatted[
+                formatted.index("<") : formatted.index(">") + 1
+            ]
+            return f"{_KOTLIN_COLLECTION_TYPE[name]}{generics}"
+        prefix = self.record_struct_name_prefix
+        head = formatted.split(sep="(", maxsplit=1)[0]
+        if head.startswith(prefix) and head[len(prefix) :].isdigit():
+            return head
+        if formatted.lstrip("-").isdigit():
+            value = int(formatted)
+            in_int = _KOTLIN_I32_MIN <= value <= _KOTLIN_I32_MAX
+            return "Int" if in_int else "Long"
+        return "Double"
+
+    @cached_property
+    def _record_renderer(self) -> RecordRenderer:
+        """Kotlin syntax hooks for the ``RECORD`` strategy."""
+        return RecordRenderer(
+            name_prefix=self.record_struct_name_prefix,
+            field_identifier=_kotlin_record_field_identifier,
+            field_type=self._kotlin_record_field_type,
+            render_declaration=_kotlin_render_declaration,
+            render_literal=_kotlin_record_literal,
+        )
+
+    @cached_property
+    def _record_strategy(self) -> RecordStrategy:
+        """Resolve the active strategy to its behavior + preamble."""
+        cls = type(self.heterogeneous_strategy)
+        if self.heterogeneous_strategy is cls.RECORD:
+            return build_record_strategy(renderer=self._record_renderer)
+        return RecordStrategy(
+            behavior=NO_HETEROGENEOUS_BEHAVIOR,
+            preamble=no_data_preamble,
+        )
+
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
-        """Return data-dependent preamble lines."""
-        return _kotlin_biginteger_preamble
+        """Return data-dependent preamble lines.
+
+        Always emits ``import java.math.BigInteger`` when the data
+        carries an out-of-range integer; under
+        ``HeterogeneousStrategies.RECORD`` additionally emits one
+        ``data class`` declaration per record shape present in the data.
+        """
+        record_preamble = self._record_strategy.preamble
+
+        def _preamble(data: Value, /) -> tuple[str, ...]:
+            """Combine the BigInteger import with record declarations."""
+            return _kotlin_biginteger_preamble(data) + record_preamble(data)
+
+        return _preamble
 
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
-        """Return the heterogeneous-behavior config."""
-        return self.heterogeneous_strategy.value
+        """Return the behavior for the chosen heterogeneous strategy."""
+        return self._record_strategy.behavior
 
     @cached_property
     def call_data_dependent_preamble(
@@ -1153,16 +1318,38 @@ class Kotlin(metaclass=LanguageCls):
 
     @cached_property
     def sequence_open(self) -> Callable[[list[Value]], str]:
-        """Callable that returns the opening delimiter for a sequence."""
+        """Callable that returns the opening delimiter for a sequence.
+
+        Under the ``RECORD`` strategy a list whose elements are
+        record-shaped dicts opens as ``listOf<Any?>(`` (the elements
+        format as ``RecordN(...)`` literals, not the ``Map<...>`` the
+        typed opener would otherwise infer).
+        """
         fmt = self.sequence_format.value
         if fmt.typed_opener_fallback is None:
-            return fmt.sequence_open
-        return _kotlin_list_sequence_open(
-            cfg=self._opener_config,
-            date_type=self._date_type_name,
-            datetime_type=self._dt_type_name,
-            dict_key_type=self.default_dict_key_type,
-        )
+            base = fmt.sequence_open
+        else:
+            base = _kotlin_list_sequence_open(
+                cfg=self._opener_config,
+                date_type=self._date_type_name,
+                datetime_type=self._dt_type_name,
+                dict_key_type=self.default_dict_key_type,
+            )
+        record = type(self.heterogeneous_strategy).RECORD
+        if self.heterogeneous_strategy is not record:
+            return base
+        any_open = "listOf<Any?>("
+
+        def _open(items: list[Value], /) -> str:
+            """Use ``listOf<Any?>(`` for lists of record-shaped dicts."""
+            if any(
+                isinstance(item, dict) and not isinstance(item, OrderedMap)
+                for item in items
+            ):
+                return any_open
+            return base(items)
+
+        return _open
 
     @cached_property
     def set_format_config(self) -> SetFormatConfig:

--- a/tests/integration/cases/call_deep_dotted_method/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_deep_dotted_method/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,7 @@
+class _ClientType { fun post(data: Any? = null): Any? = null }
+class _ApiType { val client = _ClientType() }
+class _ObjType { val api = _ApiType() }
+val obj = _ObjType()
+obj.api.client.post(data = "hello")
+obj.api.client.post(data = 42)
+obj.api.client.post(data = true)

--- a/tests/integration/cases/call_deep_dotted_transformed/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_deep_dotted_transformed/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,7 @@
+class _ClientType { fun fetch(payload: Any? = null): Any? = null }
+class _AppType { val client = _ClientType() }
+val app = _AppType()
+fun emit(_arg: Any? = null): Any? = null
+emit(app.client.fetch(payload = "hello"))
+emit(app.client.fetch(payload = 42))
+emit(app.client.fetch(payload = true))

--- a/tests/integration/cases/call_dotted_method/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_dotted_method/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,6 @@
+class _ClientType { fun fetch(payload: Any? = null): Any? = null }
+class _AppType { val client = _ClientType() }
+val app = _AppType()
+app.client.fetch(payload = "hello")
+app.client.fetch(payload = 42)
+app.client.fetch(payload = true)

--- a/tests/integration/cases/call_dotted_transform_stub/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_dotted_transform_stub/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,6 @@
+fun process(value: Any? = null): Any? = null
+class _TracerType { fun emit(_arg: Any? = null): Any? = null }
+val tracer = _TracerType()
+tracer.emit(process(value = "hello"))
+tracer.emit(process(value = 42))
+tracer.emit(process(value = true))

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,14 @@
+fun process(data: Any? = null, count: Any? = null): Any? = null
+val my_ints = intArrayOf(
+    1,
+    2,
+    3,
+)
+val my_strings = arrayOf(
+    "a",
+    "b",
+)
+val my_empty = listOf<Any?>()
+process(data = my_ints, count = 42)
+process(data = my_strings, count = 7)
+process(data = my_empty, count = 99)

--- a/tests/integration/cases/call_ref_args_reused/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_ref_args_reused/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,10 @@
+fun process(data: Any? = null, count: Any? = null): Any? = null
+val single_var = intArrayOf(
+    4,
+    5,
+    6,
+)
+val repeated_var = 1
+process(data = repeated_var, count = 1)
+process(data = single_var, count = 0)
+process(data = repeated_var, count = 8)

--- a/tests/integration/cases/call_ref_args_trivial_register/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_ref_args_trivial_register/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,13 @@
+fun process(value: Any? = null, count: Any? = null): Any? = null
+val my_int = 1
+val my_bool = true
+val my_float = 3.14
+val my_list = intArrayOf(
+    1,
+    2,
+    3,
+)
+process(value = my_int, count = 42)
+process(value = my_bool, count = 7)
+process(value = my_float, count = 9)
+process(value = my_list, count = 1)

--- a/tests/integration/cases/call_scalar_args/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_scalar_args/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,4 @@
+fun process(value: Any? = null): Any? = null
+process(value = "hello")
+process(value = 42)
+process(value = true)

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,4 @@
+fun process(value: Any? = null, label: Any? = null): Any? = null
+process(value = "hello", label = "a")
+process(value = 42, label = "b")
+process(value = true, label = "c")

--- a/tests/integration/cases/call_scalar_args_with_null/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_scalar_args_with_null/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,3 @@
+fun process(value: Any? = null): Any? = null
+process(value = null)
+process(value = "hello")

--- a/tests/integration/cases/call_snake_dotted_method/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_snake_dotted_method/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,6 @@
+class _Http_ClientType { fun fetch(payload: Any? = null): Any? = null }
+class _My_AppType { val http_client = _Http_ClientType() }
+val my_app = _My_AppType()
+my_app.http_client.fetch(payload = "hello")
+my_app.http_client.fetch(payload = 42)
+my_app.http_client.fetch(payload = true)

--- a/tests/integration/cases/call_transform_no_wrapper/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
+++ b/tests/integration/cases/call_transform_no_wrapper/Kotlin_heterogeneous_strategy_record_call@v1_9.kts
@@ -1,0 +1,4 @@
+fun process(value: Any? = null): Any? = null
+process(value = "hello")
+process(value = 42)
+process(value = true)

--- a/tests/integration/cases/dict_all_scalar_types/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/dict_all_scalar_types/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,13 @@
+import java.time.LocalDate
+import java.time.LocalDateTime
+data class Record0(val s: String, val i: Int, val f: Double, val b: Boolean, val n: Any?, val d: LocalDate, val dt: LocalDateTime, val by: String)
+val my_data = Record0(
+    s = "string",
+    i = 1,
+    f = 1.5,
+    b = true,
+    n = null,
+    d = LocalDate.of(2024, 1, 15),
+    dt = LocalDateTime.of(2024, 1, 15, 12, 0, 0),
+    by = "48656c6c6f",
+)

--- a/tests/integration/cases/dict_all_scalar_types/Kotlin_heterogeneous_strategy_record_datetime_epoch@v1_9.kts
+++ b/tests/integration/cases/dict_all_scalar_types/Kotlin_heterogeneous_strategy_record_datetime_epoch@v1_9.kts
@@ -1,0 +1,12 @@
+import java.time.LocalDate
+data class Record0(val s: String, val i: Int, val f: Double, val b: Boolean, val n: Any?, val d: LocalDate, val dt: Int, val by: String)
+val my_data = Record0(
+    s = "string",
+    i = 1,
+    f = 1.5,
+    b = true,
+    n = null,
+    d = LocalDate.of(2024, 1, 15),
+    dt = 1705320000,
+    by = "48656c6c6f",
+)

--- a/tests/integration/cases/dict_all_scalar_types/Kotlin_heterogeneous_strategy_record_datetime_iso@v1_9.kts
+++ b/tests/integration/cases/dict_all_scalar_types/Kotlin_heterogeneous_strategy_record_datetime_iso@v1_9.kts
@@ -1,0 +1,12 @@
+import java.time.LocalDate
+data class Record0(val s: String, val i: Int, val f: Double, val b: Boolean, val n: Any?, val d: LocalDate, val dt: String, val by: String)
+val my_data = Record0(
+    s = "string",
+    i = 1,
+    f = 1.5,
+    b = true,
+    n = null,
+    d = LocalDate.of(2024, 1, 15),
+    dt = "2024-01-15T12:00:00",
+    by = "48656c6c6f",
+)

--- a/tests/integration/cases/dict_mixed_int_widths/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/dict_mixed_int_widths/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,6 @@
+data class Record0(val a: Int, val b: Long, val c: String)
+val my_data = Record0(
+    a = 1,
+    b = 3000000000,
+    c = "x",
+)

--- a/tests/integration/cases/dict_mixed_scalars/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/dict_mixed_scalars/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,5 @@
+data class Record0(val a: Int, val b: String)
+val my_data = Record0(
+    a = 1,
+    b = "x",
+)

--- a/tests/integration/cases/dict_mixed_scalars/Kotlin_heterogeneous_strategy_record_combined@v1_9.kts
+++ b/tests/integration/cases/dict_mixed_scalars/Kotlin_heterogeneous_strategy_record_combined@v1_9.kts
@@ -1,0 +1,9 @@
+data class Record0(val a: Int, val b: String)
+var my_data = Record0(
+    a = 1,
+    b = "x",
+)
+my_data = Record0(
+    a = 1,
+    b = "x",
+)

--- a/tests/integration/cases/dict_with_list_value/Kotlin_heterogeneous_strategy_record_list_val@v1_9.kts
+++ b/tests/integration/cases/dict_with_list_value/Kotlin_heterogeneous_strategy_record_list_val@v1_9.kts
@@ -1,0 +1,9 @@
+data class Record0(val name: String, val scores: IntArray)
+val my_data = Record0(
+    name = "Alice",
+    scores = intArrayOf(
+        10,
+        20,
+        30,
+    ),
+)

--- a/tests/integration/cases/heterogeneous_list_with_string/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/heterogeneous_list_with_string/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,4 @@
+val my_data = listOf<Any?>(
+    "hello",
+    42,
+)

--- a/tests/integration/cases/multiline_sibling_list_widening/Kotlin_heterogeneous_strategy_record_sibling_widening@v1_9.kts
+++ b/tests/integration/cases/multiline_sibling_list_widening/Kotlin_heterogeneous_strategy_record_sibling_widening@v1_9.kts
@@ -1,0 +1,21 @@
+data class Record1(val numbers: IntArray, val strings: Array<String>)
+data class Record0(val omap_value: LinkedHashMap<String, Any?>, val sibling_lists: Record1, val ref_marker_present: Array<String>)
+val my_data = Record0(
+    omap_value = linkedMapOf<String, Any?>(
+        "first" to 1,
+    ),
+    sibling_lists = Record1(
+        numbers = intArrayOf(
+            1,
+            2,
+        ),
+        strings = arrayOf(
+            "x",
+            "y",
+        ),
+    ),
+    ref_marker_present = arrayOf(
+        "\$keep",
+        "z",
+    ),
+)

--- a/tests/integration/cases/nested_mixed_dict/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/nested_mixed_dict/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,9 @@
+data class Record1(val a: Int, val b: String, val c: Any?)
+data class Record0(val outer: Record1)
+val my_data = Record0(
+    outer = Record1(
+        a = 1,
+        b = "x",
+        c = null,
+    ),
+)

--- a/tests/integration/cases/nested_mixed_inner/Kotlin_heterogeneous_strategy_record_inner@v1_9.kts
+++ b/tests/integration/cases/nested_mixed_inner/Kotlin_heterogeneous_strategy_record_inner@v1_9.kts
@@ -1,0 +1,4 @@
+val my_data = listOf<Any?>(
+    listOf<Any?>(1, "a"),
+    listOf<Any?>(2, "b"),
+)

--- a/tests/integration/cases/nested_mixed_types/Kotlin_heterogeneous_strategy_record_sibling@v1_9.kts
+++ b/tests/integration/cases/nested_mixed_types/Kotlin_heterogeneous_strategy_record_sibling@v1_9.kts
@@ -1,0 +1,4 @@
+val my_data = listOf<Any?>(
+    intArrayOf(1, 2),
+    arrayOf("a", "b"),
+)

--- a/tests/integration/cases/nested_sequences/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/nested_sequences/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,4 @@
+val my_data = arrayOf(
+    arrayOf(intArrayOf(1, 2), intArrayOf(3, 4)),
+    arrayOf(intArrayOf(5)),
+)

--- a/tests/integration/cases/ordered_map/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/ordered_map/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,5 @@
+val my_data = linkedMapOf<String, Any?>(
+    "name" to "Alice",
+    "age" to 30,
+    "active" to true,
+)

--- a/tests/integration/cases/record_basic/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/record_basic/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,11 @@
+data class Record0(val id: Int, val description: String, val is_done: Boolean, val blocks: IntArray)
+val my_data = Record0(
+    id = 1,
+    description = "She said \"hello\", then waved",
+    is_done = false,
+    blocks = intArrayOf(
+        1,
+        2,
+        3,
+    ),
+)

--- a/tests/integration/cases/record_nested_container/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/record_nested_container/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,10 @@
+data class Record0(val title: String, val tags: Array<String>, val priority: Int)
+val my_data = Record0(
+    title = "report",
+    tags = arrayOf(
+        "draft",
+        "urgent",
+        "review",
+    ),
+    priority = 2,
+)

--- a/tests/integration/cases/record_nested_record/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/record_nested_record/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,9 @@
+data class Record1(val name: String, val age: Int)
+data class Record0(val id: Int, val owner: Record1)
+val my_data = Record0(
+    id = 1,
+    owner = Record1(
+        name = "Alice",
+        age = 30,
+    ),
+)

--- a/tests/integration/cases/record_pure_scalars/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/record_pure_scalars/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,7 @@
+data class Record0(val name: String, val age: Int, val active: Boolean, val score: Double)
+val my_data = Record0(
+    name = "Alice",
+    age = 30,
+    active = true,
+    score = 4.5,
+)

--- a/tests/integration/cases/record_sequence/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/record_sequence/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,6 @@
+data class Record0(val id: Int, val label: String)
+val my_data = listOf<Any?>(
+    Record0(id = 1, label = "first"),
+    Record0(id = 2, label = "second"),
+    Record0(id = 3, label = "third"),
+)

--- a/tests/integration/cases/record_two_shapes/Kotlin_heterogeneous_strategy_record@v1_9.kts
+++ b/tests/integration/cases/record_two_shapes/Kotlin_heterogeneous_strategy_record@v1_9.kts
@@ -1,0 +1,13 @@
+data class Record1(val count: Int, val rate: Int)
+data class Record2(val retries: Int, val timeout: Int)
+data class Record0(val metrics: Record1, val flags: Record2)
+val my_data = Record0(
+    metrics = Record1(
+        count = 100,
+        rate = 50,
+    ),
+    flags = Record2(
+        retries = 3,
+        timeout = 30,
+    ),
+)


### PR DESCRIPTION
Ports the Rust/Go ``RECORD`` heterogeneous strategy to Kotlin. Sub-issue of #2237; depends on the shared infrastructure landed in #2297 (now merged). Closes #2298.

## Rendering

- Preamble: one ``data class Record0(val id: Int, val description: String, ...)`` per record shape, in dependency order.
- Literal: ``Record0(id = 100, ...)`` (paren-delimited; assembled compact/multiline by the generic expander from #2297, no ``_literalize.py`` change).
- Auto names ``Record0``, ``Record1``, ... (no ``record_shape_names``, no optional-field unification; `RecordShape.optional_keys` always empty).
- Field identifiers keep the original dict keys. Field types are read off the already-formatted literal so they always match what the value formatter emitted (generic collections carry their type in the ``<...>`` segment; nested record dicts format as their own ``RecordN(...)``).

## Implementation (`src/literalizer/languages/kotlin.py` only)

- `HeterogeneousStrategies` upgraded from the simple model to the behavior+preamble config model; adds `RECORD` and the configurable `record_struct_name_prefix` parameter.
- New Kotlin `RecordRenderer` reusing `src/literalizer/_formatters/record_strategy.py`.
- `data_dependent_preamble` composes the existing `BigInteger` import with the record declarations.
- `sequence_open` opens a list of record-shaped dicts as `listOf<Any?>(` so the `RecordN(...)` elements stay assignable.

## Tests / CI gates

- 32 new Kotlin goldens via the `heterogeneous_strategy` variant axis; case-coverage parity with the Go goldens.
- `pytest --cov-fail-under 100`: full suite passes at 100% line + branch coverage.
- Every generated Kotlin fixture compiles under the language/api-version 1.9 lint host (`.github/scripts/lint-kotlin.main.kts`).
- Only expected cross-PR collision with #2299/#2300: the `CHANGELOG.rst` "Next" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Kotlin rendering mode that changes how mixed-type dicts and some list openers are emitted when opted in; while default behavior stays the same, it touches Kotlin preamble/type-inference paths and could affect compilation of generated output.
> 
> **Overview**
> Kotlin gains an opt-in `HeterogeneousStrategies.RECORD` mode that renders record-shaped dicts as generated `data class RecordN(...)` declarations in the preamble and `RecordN(field = value, ...)` constructor literals, with a new `record_struct_name_prefix` option.
> 
> This wires Kotlin into the shared `record_strategy` infrastructure, derives record field types from already-formatted literals (including nested records and generic collection literals), and adjusts `data_dependent_preamble`/`sequence_open` so lists containing record dicts open as `listOf<Any?>(...)`.
> 
> Adds a changelog entry and a broad set of new Kotlin golden integration fixtures covering the `RECORD` strategy across dict/list/call cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e892fa669926a3fcc8f129d8f2acfb76be0ae8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->