### PR TITLE
RECORD: derive Go field type structurally instead of reparsing rendered output

### DIFF
--- a/src/literalizer/_formatters/record_strategy.py
+++ b/src/literalizer/_formatters/record_strategy.py
@@ -9,12 +9,16 @@ parts that are the same for every target language (document-order
 shape naming, post-order declaration emission) and delegates the
 language-specific syntax to a :class:`RecordRenderer`.
 
-Declaration field types are derived from the already-formatted literal
-value (not re-inferred from the raw value) so a field's declared type
-always matches the value the normal formatter emitted, including when
-that value was widened by sibling context.  The behavior caches the
-first-seen formatted fields per shape during literal rendering; the
-preamble (assembled after all literals are formatted) reads that cache.
+Declaration field types are derived from the raw field value through
+the language's own collection openers (the same opener functions the
+value formatter uses), not by re-parsing the formatted literal.
+Because a record field is formatted with no sibling override, the
+opener a language returns for the field's value is exactly the one it
+emitted (including a widening to an ``any``-typed container), so the
+declared type still matches the rendered literal.  The behavior caches
+the first-seen :class:`RecordFieldType` request per shape during
+literal rendering; the preamble (assembled after all literals are
+formatted) reads that cache.
 
 Rust keeps its own copy of this logic because it additionally supports
 ``record_shape_names`` and optional-field unification; this module
@@ -61,14 +65,33 @@ class RecordLiteralField:
 
 
 @dataclasses.dataclass(frozen=True)
+class RecordFieldType:
+    """The structured input to :attr:`RecordRenderer.field_type`.
+
+    ``value`` is the raw field value (first-seen for its shape); the
+    language maps it to a declared type through its own collection
+    openers / scalar mapping rather than prefix-matching a formatted
+    literal.  ``record_name`` is the generated declaration name when
+    ``value`` is itself a nested record-shaped dict (resolved here, the
+    one piece a language cannot recover from the value alone), and
+    ``None`` otherwise.
+    """
+
+    value: Value
+    record_name: str | None
+
+
+@dataclasses.dataclass(frozen=True)
 class RecordRenderer:
     """Per-language syntax hooks for the ``RECORD`` strategy.
 
     ``name_prefix`` is the auto-naming prefix (``Record`` -> ``Record0``,
     ``Record1``, ...).  ``field_identifier`` maps an original dict key
     to the language's field identifier (identity for most languages,
-    PascalCase for Go).  ``field_type`` maps a field's already-formatted
-    literal value to its declared type.  ``render_declaration`` builds
+    PascalCase for Go).  ``field_type`` maps a :class:`RecordFieldType`
+    (raw field value plus any resolved nested-record name) to its
+    declared type, using the language's own collection openers rather
+    than re-parsing the formatted literal.  ``render_declaration`` builds
     one declaration block from the resolved fields, and
     ``render_literal`` builds the literal as a
     :class:`RenderedRecordLiteral` (structured pieces; the shared code
@@ -78,7 +101,7 @@ class RecordRenderer:
 
     name_prefix: str
     field_identifier: Callable[[str], str]
-    field_type: Callable[[str], str]
+    field_type: Callable[[RecordFieldType], str]
     render_declaration: Callable[
         [str, Sequence[RecordDeclarationField]],
         str,
@@ -211,13 +234,14 @@ def build_record_strategy(
 
     The two share per-pass caches: ``compute_record_shapes`` (run first,
     during data checking) assigns the document-order names, and
-    ``render_record_literal`` records the first-seen formatted fields
-    per shape so the preamble can derive each field's declared type
-    from the value the formatter actually emitted.
+    ``render_record_literal`` records the first-seen
+    :class:`RecordFieldType` request per shape so the preamble can
+    derive each field's declared type from the raw value through the
+    language's own collection openers.
     """
     name_by_shape: dict[RecordShape, str] = {}
     id_to_shape: dict[int, RecordShape] = {}
-    formatted_by_shape: dict[RecordShape, dict[str, str]] = {}
+    request_by_shape: dict[RecordShape, dict[str, RecordFieldType]] = {}
 
     def _compute_shapes(data: Value) -> Mapping[int, RecordShape]:
         """Walk *data*, assign names in document order, and reset the
@@ -226,7 +250,7 @@ def build_record_strategy(
         shapes_by_id = collect_record_shapes(data=data)
         name_by_shape.clear()
         id_to_shape.clear()
-        formatted_by_shape.clear()
+        request_by_shape.clear()
         id_to_shape.update(shapes_by_id)
         ordered = _ordered_record_shapes(
             data=data,
@@ -237,15 +261,35 @@ def build_record_strategy(
         )
         return shapes_by_id
 
+    def _field_type_request(field_value: Value) -> RecordFieldType:
+        """Build the structured field-type request for *field_value*.
+
+        ``record_name`` is set only when *field_value* is itself a
+        nested record-shaped dict (the one piece a language cannot
+        recover from the raw value); every other value, including a
+        list of record-shaped dicts, is typed by the language from the
+        value via its own collection openers.
+        """
+        nested_name = (
+            name_by_shape.get(id_to_shape[id(field_value)])
+            if isinstance(field_value, dict) and id(field_value) in id_to_shape
+            else None
+        )
+        return RecordFieldType(value=field_value, record_name=nested_name)
+
     def _render_literal(
         value: "dict[Scalar, Value]",
         fields: Mapping[str, str],
     ) -> RenderedRecordLiteral:
         """Render a record-shape dict as a language-specific literal,
-        caching the first-seen formatted fields for its shape.
+        caching the first-seen field-type requests for its shape.
         """
         shape = id_to_shape[id(value)]
-        formatted_by_shape.setdefault(shape, dict(fields))
+        if shape not in request_by_shape:
+            request_by_shape[shape] = {
+                key: _field_type_request(field_value=value[key])
+                for key in shape.keys
+            }
         literal_fields = [
             RecordLiteralField(
                 identifier=renderer.field_identifier(key),
@@ -267,7 +311,8 @@ def build_record_strategy(
 
     def _preamble(data: Value, /) -> tuple[str, ...]:
         """Build one declaration block per record shape, in dependency
-        order, typing each field from its first-seen formatted value.
+        order, typing each field from its first-seen
+        :class:`RecordFieldType` request.
         """
         shapes_by_id = collect_record_shapes(data=data)
         if not shapes_by_id:
@@ -282,11 +327,11 @@ def build_record_strategy(
         )
         blocks: list[str] = []
         for shape in emit_order:
-            formatted = formatted_by_shape[shape]
+            requests = request_by_shape[shape]
             fields = [
                 RecordDeclarationField(
                     identifier=renderer.field_identifier(key),
-                    type_name=renderer.field_type(formatted[key]),
+                    type_name=renderer.field_type(requests[key]),
                 )
                 for key in shape.keys
             ]

--- a/src/literalizer/_formatters/record_strategy.py
+++ b/src/literalizer/_formatters/record_strategy.py
@@ -68,17 +68,22 @@ class RecordLiteralField:
 class RecordFieldType:
     """The structured input to :attr:`RecordRenderer.field_type`.
 
-    ``value`` is the raw field value (first-seen for its shape); the
-    language maps it to a declared type through its own collection
-    openers / scalar mapping rather than prefix-matching a formatted
-    literal.  ``record_name`` is the generated declaration name when
-    ``value`` is itself a nested record-shaped dict (resolved here, the
-    one piece a language cannot recover from the value alone), and
-    ``None`` otherwise.
+    ``value`` is the raw field value (first-seen for its shape); a
+    ported language maps it to a declared type through its own
+    collection openers / scalar mapping rather than prefix-matching a
+    formatted literal.  ``record_name`` is the generated declaration
+    name when ``value`` is itself a nested record-shaped dict (resolved
+    here, the one piece a language cannot recover from the value
+    alone), and ``None`` otherwise.  ``formatted`` is the
+    already-formatted field literal, retained for languages whose
+    ``field_type`` hook has not yet been ported off the
+    formatted-string contract (Kotlin); ported languages (Go) ignore
+    it.
     """
 
     value: Value
     record_name: str | None
+    formatted: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -261,21 +266,29 @@ def build_record_strategy(
         )
         return shapes_by_id
 
-    def _field_type_request(field_value: Value) -> RecordFieldType:
+    def _field_type_request(
+        field_value: Value,
+        formatted: str,
+    ) -> RecordFieldType:
         """Build the structured field-type request for *field_value*.
 
         ``record_name`` is set only when *field_value* is itself a
         nested record-shaped dict (the one piece a language cannot
         recover from the raw value); every other value, including a
         list of record-shaped dicts, is typed by the language from the
-        value via its own collection openers.
+        value via its own collection openers.  *formatted* is carried
+        through for not-yet-ported languages.
         """
         nested_name = (
             name_by_shape.get(id_to_shape[id(field_value)])
             if isinstance(field_value, dict) and id(field_value) in id_to_shape
             else None
         )
-        return RecordFieldType(value=field_value, record_name=nested_name)
+        return RecordFieldType(
+            value=field_value,
+            record_name=nested_name,
+            formatted=formatted,
+        )
 
     def _render_literal(
         value: "dict[Scalar, Value]",
@@ -287,7 +300,10 @@ def build_record_strategy(
         shape = id_to_shape[id(value)]
         if shape not in request_by_shape:
             request_by_shape[shape] = {
-                key: _field_type_request(field_value=value[key])
+                key: _field_type_request(
+                    field_value=value[key],
+                    formatted=fields[key],
+                )
                 for key in shape.keys
             }
         literal_fields = [

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -51,6 +51,7 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import format_string_backslash
 from literalizer._formatters.record_strategy import (
     RecordDeclarationField,
+    RecordFieldType,
     RecordLiteralField,
     RecordRenderer,
     RecordStrategy,
@@ -94,7 +95,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 
 
 @beartype
@@ -718,26 +719,41 @@ class Go(metaclass=LanguageCls):
         """Format a set entry."""
         return _format_go_set_entry
 
-    def _go_field_type(self, formatted: str, /) -> str:
-        """Return the Go field type for an already-formatted value.
+    def _go_record_field_type(self, request: RecordFieldType, /) -> str:
+        """Return the Go struct field type for a record field.
 
-        The declared type is read off the formatted literal so it
-        always matches what the value formatter emitted, even when a
-        list was widened to ``[]any`` by sibling context.  Composite
-        literals (``[]int{...}``, ``Record1{...}``, ``[][2]any{...}``)
-        carry their type as the text before the first ``{``.
+        A field whose value is itself a nested record-shaped dict uses
+        that record's generated struct name.  A list or ordered-map
+        field derives its type from the very collection opener the
+        value formatter uses for that value (a record field is
+        formatted with no sibling override, so the opener equals the
+        one emitted, including a widening to ``[]any``); the opener's
+        trailing ``{`` is dropped to leave the bare type, e.g.
+        ``[]int{`` -> ``[]int``, ``[][2]any{`` -> ``[][2]any``.  A
+        scalar field uses the same scalar mapping the openers are
+        built on.
+
+        A set or a non-record dict (an empty or non-string-keyed dict)
+        as a record field is outside the ``RECORD`` strategy's MVP --
+        Rust's ``_rust_record_field_type`` is imprecise for the same
+        shapes (#2234) -- so it is declared as Go's top type ``any``,
+        which the rendered literal still assigns into.
         """
-        if formatted == self.null_literal:
-            return "any"
-        if formatted in {self.true_literal, self.false_literal}:
-            return "bool"
-        if formatted.startswith('"'):
-            return "string"
-        if formatted.startswith("time.Date("):
-            return "time.Time"
-        if "{" in formatted:
-            return formatted[: formatted.index("{")]
-        return "int" if formatted.lstrip("-").isdigit() else "float64"
+        if request.record_name is not None:
+            return request.record_name
+        value = request.value
+        match value:
+            case None:
+                return "any"
+            case OrderedMap():
+                opener = self.ordered_map_format_config.ordered_map_open(
+                    value,
+                )
+            case list():
+                opener = self.sequence_open(value)
+            case _:
+                return self._init_element_to_type(type(value)) or "any"
+        return opener[: -len("{")]
 
     def _go_render_declaration(
         self,
@@ -760,7 +776,7 @@ class Go(metaclass=LanguageCls):
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
             field_identifier=_go_record_field_identifier,
-            field_type=self._go_field_type,
+            field_type=self._go_record_field_type,
             render_declaration=self._go_render_declaration,
             render_literal=_go_record_literal,
         )

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -54,6 +54,7 @@ from literalizer._formatters.format_strings import (
 )
 from literalizer._formatters.record_strategy import (
     RecordDeclarationField,
+    RecordFieldType,
     RecordLiteralField,
     RecordRenderer,
     RecordStrategy,
@@ -1167,13 +1168,29 @@ class Kotlin(metaclass=LanguageCls):
             return "Int" if in_int else "Long"
         return "Double"
 
+    def _kotlin_record_field_type_request(
+        self,
+        request: RecordFieldType,
+        /,
+    ) -> str:
+        """Adapt the structured :class:`RecordFieldType` hook to
+        Kotlin's still-formatted-string field typing.
+
+        Kotlin's ``field_type`` has not yet been ported off the
+        formatted-string contract (unlike Go), so it reads
+        ``request.formatted``.  Porting it to derive the type from
+        ``request.value`` via Kotlin's own openers is tracked
+        separately.
+        """
+        return self._kotlin_record_field_type(request.formatted)
+
     @cached_property
     def _record_renderer(self) -> RecordRenderer:
         """Kotlin syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
             field_identifier=_kotlin_record_field_identifier,
-            field_type=self._kotlin_record_field_type,
+            field_type=self._kotlin_record_field_type_request,
             render_declaration=_kotlin_render_declaration,
             render_literal=_kotlin_record_literal,
         )


### PR DESCRIPTION
Closes #2308.

`Go._go_field_type`'s formatted-string prefix matching is replaced with a structured `RecordFieldType` (raw field value plus any resolved nested-record name); the shared `record_strategy` now caches these requests per shape instead of formatted strings. `Go._go_record_field_type` derives each struct field type from the same collection openers the value formatter uses (or the scalar mapping they are built on), so the declared type still matches the emitted literal without re-parsing rendered output. A set or non-record dict as a record field is outside the RECORD MVP (Rust's `_rust_record_field_type` is imprecise for the identical shapes, #2234) and folds into the covered fallback as Go's top type `any`, which the rendered literal still assigns into. Go and Rust record goldens are byte-identical, the full suite passes with 100% branch coverage retained, and no `# pragma: no cover` or new fixtures were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `RECORD` preambles compute declared field types and updates Go’s typing logic, which could subtly affect generated struct types for nested/collection fields. Kotlin is adapted via a compatibility shim, but mismatches between declared and rendered types are still the main risk area.
> 
> **Overview**
> Refactors the shared `RECORD` strategy to stop inferring declaration field types by re-parsing formatted literals; it now caches a per-field `RecordFieldType` (raw value + optional nested record name + formatted fallback) and passes that into `RecordRenderer.field_type` when emitting preamble declarations.
> 
> Updates Go’s `RECORD` implementation to derive struct field types structurally from the raw value using the same collection openers/scalar type mapping (with a fallback to `any` for sets and non-record dicts), and wires Kotlin to the new API via a small adapter that continues using the existing formatted-string typing logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d556ca1b51296846a5981c7abd088beb8819ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->