### PR TITLE
Add JDK 16 support for Java (#2313)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,6 +98,16 @@ jobs:
           # under the declared minimum interpreter.
           python-version: '3.12'
 
+      # The fixture set spans every `Java.VersionFormats` member in
+      # `src/literalizer/languages/java.py`; the installed JDK must be at
+      # least the highest member (`JDK_16`) so `--release 16` is accepted.
+      # 21 is the current LTS and also accepts `--release 11`.
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: Lint Bash
         run: |-
           find tests/integration/cases -name '*.sh' -print0 > /tmp/files-bash && test -s /tmp/files-bash
@@ -117,14 +127,19 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 node < /tmp/files-js
 
       # The host compiles each fixture into an in-memory assembly, then
-      # reflectively constructs `Check` and invokes its `check()` method
+      # reflectively constructs `Main` and invokes its `main()` method
       # (or runs field initializers on field-only fixtures), so javac
       # emit-success and runtime errors (e.g. bad `Instant.parse` input)
-      # both fail here.
+      # both fail here. Each `@jdk_<release>` golden is compiled at the
+      # matching `--release`; the `11` / `16` literals match
+      # `Java.VersionFormats.JDK_11` / `JDK_16` in
+      # `src/literalizer/languages/java.py`. Keep them in sync.
       - name: Lint Java
         run: |-
-          find tests/integration/cases -name '*.java' -print0 > /tmp/files-java && test -s /tmp/files-java
-          xargs -0 java CheckJavaSyntax.java < /tmp/files-java
+          find tests/integration/cases -name '*@jdk_11.java' -print0 > /tmp/files-java-11 && test -s /tmp/files-java-11
+          xargs -0 java CheckJavaSyntax.java 11 < /tmp/files-java-11
+          find tests/integration/cases -name '*@jdk_16.java' -print0 > /tmp/files-java-16 && test -s /tmp/files-java-16
+          xargs -0 java CheckJavaSyntax.java 16 < /tmp/files-java-16
 
       - name: Lint Php
         run: |-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Next
   dict keys and the data-class-name prefix is configurable via the new
   ``record_struct_name_prefix`` constructor parameter.  See #2298.
 
+- :class:`~literalizer.Java` now offers ``VersionFormats.JDK_16``
+  alongside ``VersionFormats.JDK_11`` (still the default), selectable
+  via ``language_version``.  Generated code is currently identical for
+  both targets; the member exists so a future Java ``RECORD``
+  ``heterogeneous_strategy`` (whose ``record`` declarations require
+  Java 16) can gate on it.  The golden harness emits a parallel
+  ``@jdk_16`` fixture set.  See #2313.
+
 2026.05.15
 ----------
 

--- a/CheckJavaSyntax.java
+++ b/CheckJavaSyntax.java
@@ -30,22 +30,31 @@ public class CheckJavaSyntax {
             System.err.println("No JDK Java compiler available.");
             System.exit(2);
         }
+        if (args.length < 2) {
+            System.err.println("Usage: CheckJavaSyntax <release> <file>...");
+            System.exit(2);
+        }
+        // The `--release` value is supplied as the first argument by the
+        // `Lint Java` step in `.github/workflows/lint.yml`, which passes
+        // the literal matching each fixture's `@jdk_<release>` golden tag
+        // (`11` for `JDK_11`, `16` for `JDK_16` in `Java.VersionFormats`
+        // in `src/literalizer/languages/java.py`). Keep them in sync.
+        final String release = args[0];
         boolean failed = false;
         try (final StandardJavaFileManager fileManager =
                 compiler.getStandardFileManager(null, null, null)) {
-            for (final String filename : args) {
+            for (int i = 1; i < args.length; i++) {
+                final String filename = args[i];
                 // Each fixture declares `class Main`, so give every file
                 // its own output directory to avoid class-name collisions.
                 final Path classDir = Files.createTempDirectory("javac");
                 final Iterable<? extends JavaFileObject> units =
                         fileManager.getJavaFileObjectsFromStrings(List.of(filename));
-                // `--release 11` matches `Java.language_version` in
-                // `src/literalizer/languages/java.py`; keep them in sync.
                 final JavaCompiler.CompilationTask task = compiler.getTask(
                         null,
                         fileManager,
                         null,
-                        List.of("-d", classDir.toString(), "-proc:none", "--release", "11"),
+                        List.of("-d", classDir.toString(), "-proc:none", "--release", release),
                         null,
                         units);
                 if (!task.call()) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -458,6 +458,7 @@ ignore_names = [
     "call_styles",
     "heterogeneous_strategies",
     "INTERFACE",
+    "JDK_16",
     "OBJECT_VARIANT",
     "RECORD",
     "TAGGED_ENUM",

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -930,9 +930,14 @@ class Java(metaclass=LanguageCls):
     heterogeneous_strategies = HeterogeneousStrategies
 
     class VersionFormats(enum.Enum):
-        """Version options for Java."""
+        """Version options for Java.
+
+        * ``VersionFormats.JDK_11``: target Java 11.
+        * ``VersionFormats.JDK_16``: target Java 16.
+        """
 
         JDK_11 = enum.auto()
+        JDK_16 = enum.auto()
 
     version_formats = VersionFormats
 
@@ -1175,8 +1180,10 @@ class Java(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the `--release` flag passed to the JavaCompiler
-    # in `CheckJavaSyntax.java`.
+    # The `Lint Java` step in `.github/workflows/lint.yml` compiles each
+    # `@jdk_<release>` golden with the `--release` literal matching its
+    # `VersionFormats` member (`11` for `JDK_11`, `16` for `JDK_16`).
+    # Keep those literals in sync with `VersionFormats` above.
     language_version: VersionFormats = VersionFormats.JDK_11
     indent: str = "    "
 

--- a/tests/integration/cases/binary/Java@jdk_16.java
+++ b/tests/integration/cases/binary/Java@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "48656c6c6f"
+};
+    }
+}

--- a/tests/integration/cases/binary/Java_combined@jdk_16.java
+++ b/tests/integration/cases/binary/Java_combined@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "48656c6c6f"
+};
+my_data = new String[]{
+    "48656c6c6f"
+};
+    }
+}

--- a/tests/integration/cases/binary/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/binary/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "48656c6c6f"
+};
+    }
+}

--- a/tests/integration/cases/binary_list/Java@jdk_16.java
+++ b/tests/integration/cases/binary_list/Java@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "48656c6c6f"
+};
+    }
+}

--- a/tests/integration/cases/binary_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/binary_list/Java_combined@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "48656c6c6f"
+};
+my_data = new String[]{
+    "48656c6c6f"
+};
+    }
+}

--- a/tests/integration/cases/binary_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/binary_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "48656c6c6f"
+};
+    }
+}

--- a/tests/integration/cases/binary_with_empty_sibling/Java@jdk_16.java
+++ b/tests/integration/cases/binary_with_empty_sibling/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    "48656c6c6f",
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/binary_with_empty_sibling/Java_combined@jdk_16.java
+++ b/tests/integration/cases/binary_with_empty_sibling/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    "48656c6c6f",
+    new Object[]{}
+};
+my_data = new Object[]{
+    "48656c6c6f",
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/binary_with_empty_sibling/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/binary_with_empty_sibling/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    "48656c6c6f",
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/bool_key_dict/Java@jdk_16.java
+++ b/tests/integration/cases/bool_key_dict/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(true, "yes"),
+    Map.entry(false, "no")
+);
+    }
+}

--- a/tests/integration/cases/bool_key_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/bool_key_dict/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(true, "yes"),
+    Map.entry(false, "no")
+);
+my_data = Map.ofEntries(
+    Map.entry(true, "yes"),
+    Map.entry(false, "no")
+);
+    }
+}

--- a/tests/integration/cases/bool_key_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/bool_key_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(true, "yes"),
+    Map.entry(false, "no")
+);
+    }
+}

--- a/tests/integration/cases/bool_list/Java@jdk_16.java
+++ b/tests/integration/cases/bool_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new boolean[]{
+    true,
+    false,
+    true
+};
+    }
+}

--- a/tests/integration/cases/bool_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/bool_list/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new boolean[]{
+    true,
+    false,
+    true
+};
+my_data = new boolean[]{
+    true,
+    false,
+    true
+};
+    }
+}

--- a/tests/integration/cases/bool_list/Java_indent_three_space@jdk_16.java
+++ b/tests/integration/cases/bool_list/Java_indent_three_space@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+   public static void main() {
+var my_data = new boolean[]{
+   true,
+   false,
+   true
+};
+   }
+}

--- a/tests/integration/cases/bool_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/bool_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new boolean[]{
+    true,
+    false,
+    true
+};
+    }
+}

--- a/tests/integration/cases/call_27_parameters/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_27_parameters/Java_call@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
+    }
+}

--- a/tests/integration/cases/call_comments/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_comments/Java_call@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+// Test cases
+process("hello");  // single word
+process("hello world");  // two words
+// trailing comment
+    }
+}

--- a/tests/integration/cases/call_comments_dict_args/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_comments_dict_args/Java_call@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+// Test cases
+process(Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_1")));  // first case
+process(Map.ofEntries(Map.entry("type", "update"), Map.entry("pr_id", "pr_2")));  // second case
+// third case
+process(Map.ofEntries(Map.entry("type", "delete"), Map.entry("pr_id", "pr_3")));
+    }
+}

--- a/tests/integration/cases/call_deep_dotted_method/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_deep_dotted_method/Java_call@jdk_16.java
@@ -1,0 +1,11 @@
+class Main {
+static class ClientType_ { Object post(Object... args) { return null; } }
+static class ApiType_ { ClientType_ client = new ClientType_(); }
+static class ObjType_ { ApiType_ api = new ApiType_(); }
+static ObjType_ obj = new ObjType_();
+    public static void main() {
+obj.api.client.post("hello");
+obj.api.client.post(42);
+obj.api.client.post(true);
+    }
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_deep_dotted_transformed/Java_call@jdk_16.java
@@ -1,0 +1,11 @@
+class Main {
+static class ClientType_ { Object fetch(Object... args) { return null; } }
+static class AppType_ { ClientType_ client = new ClientType_(); }
+static AppType_ app = new AppType_();
+static Object emit(Object... args) { return null; }
+    public static void main() {
+emit(app.client.fetch("hello"));
+emit(app.client.fetch(42));
+emit(app.client.fetch(true));
+    }
+}

--- a/tests/integration/cases/call_dotted_method/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_dotted_method/Java_call@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+static class ClientType_ { Object fetch(Object... args) { return null; } }
+static class AppType_ { ClientType_ client = new ClientType_(); }
+static AppType_ app = new AppType_();
+    public static void main() {
+app.client.fetch("hello");
+app.client.fetch(42);
+app.client.fetch(true);
+    }
+}

--- a/tests/integration/cases/call_dotted_transform_stub/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_dotted_transform_stub/Java_call@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+static Object process(Object... args) { return null; }
+static class TracerType_ { Object emit(Object... args) { return null; } }
+static TracerType_ tracer = new TracerType_();
+    public static void main() {
+tracer.emit(process("hello"));
+tracer.emit(process(42));
+tracer.emit(process(true));
+    }
+}

--- a/tests/integration/cases/call_existing_ref_arg/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_existing_ref_arg/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var existing = 42;
+process(existing);
+    }
+}

--- a/tests/integration/cases/call_homogeneous_dotted_method/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_homogeneous_dotted_method/Java_call@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+static class ClientType_ { Object fetch(Object... args) { return null; } }
+static class AppType_ { ClientType_ client = new ClientType_(); }
+static AppType_ app = new AppType_();
+    public static void main() {
+app.client.fetch("hello");
+app.client.fetch("world");
+    }
+}

--- a/tests/integration/cases/call_homogeneous_value_dict_arg/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_homogeneous_value_dict_arg/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+import java.util.Map;
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(Map.ofEntries(Map.entry("a", 1), Map.entry("b", 2)));
+    }
+}

--- a/tests/integration/cases/call_keyword_args/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_keyword_args/Java_call@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+static class ThrottlerType_ { Object check(Object... args) { return null; } }
+static ThrottlerType_ throttler = new ThrottlerType_();
+static Object emit(Object... args) { return null; }
+    public static void main() {
+emit(throttler.check("user_1", 1000.0));
+emit(throttler.check("user_2", 2000.5));
+    }
+}

--- a/tests/integration/cases/call_mixed_type_dicts/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_mixed_type_dicts/Java_call@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+static class MgrType_ { Object run(Object... args) { return null; } }
+static class AppType_ { MgrType_ mgr = new MgrType_(); }
+static AppType_ app = new AppType_();
+    public static void main() {
+app.mgr.run(Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_1"), Map.entry("draft", true)));
+app.mgr.run(Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_2")));
+    }
+}

--- a/tests/integration/cases/call_multi_args/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_multi_args/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(1, 42);
+process(2, 100);
+    }
+}

--- a/tests/integration/cases/call_negative_int/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_negative_int/Java_call@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(-1);
+process(-2);
+process(-3);
+    }
+}

--- a/tests/integration/cases/call_no_params/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_no_params/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process();
+process();
+    }
+}

--- a/tests/integration/cases/call_no_params_dotted/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_no_params_dotted/Java_call@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+static class ThrottlerType_ { Object check(Object... args) { return null; } }
+static ThrottlerType_ throttler = new ThrottlerType_();
+    public static void main() {
+throttler.check();
+throttler.check();
+    }
+}

--- a/tests/integration/cases/call_no_params_transform/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_no_params_transform/Java_call@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+static Object process(Object... args) { return null; }
+static Object emit(Object... args) { return null; }
+    public static void main() {
+emit(process());
+emit(process());
+    }
+}

--- a/tests/integration/cases/call_per_element_false/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_per_element_false/Java_call@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(1);
+    }
+}

--- a/tests/integration/cases/call_per_element_false_dict_arg/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_per_element_false_dict_arg/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+import java.util.Map;
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(Map.ofEntries(Map.entry("a", 1), Map.entry("b", "x")));
+    }
+}

--- a/tests/integration/cases/call_quad_args/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_quad_args/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(1, 2, 3, 4);
+process(5, 6, 7, 8);
+    }
+}

--- a/tests/integration/cases/call_ref_args/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args/Java_call@jdk_16.java
@@ -1,0 +1,17 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var my_var = new int[]{
+    1,
+    2,
+    3
+};
+var my_other = new int[]{
+    4,
+    5,
+    6
+};
+process(my_var, 42);
+process(my_other, 7);
+    }
+}

--- a/tests/integration/cases/call_ref_args_converted/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args_converted/Java_call@jdk_16.java
@@ -1,0 +1,17 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var myVar = new int[]{
+    1,
+    2,
+    3
+};
+var myOther = new int[]{
+    4,
+    5,
+    6
+};
+process(myVar, 42);
+process(myOther, 7);
+    }
+}

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Java_call@jdk_16.java
@@ -1,0 +1,17 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var myVar = new int[]{
+    1,
+    2,
+    3
+};
+var myOther = new int[]{
+    4,
+    5,
+    6
+};
+process(myVar, 42);
+process(myOther, 7);
+    }
+}

--- a/tests/integration/cases/call_ref_args_converted_whole/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args_converted_whole/Java_call@jdk_16.java
@@ -1,0 +1,11 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var myVar = new int[]{
+    1,
+    2,
+    3
+};
+process(myVar);
+    }
+}

--- a/tests/integration/cases/call_ref_args_escaped_quote/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var my_str = "a\"b";
+process(my_str);
+    }
+}

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Java_call@jdk_16.java
@@ -1,0 +1,18 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var my_ints = new int[]{
+    1,
+    2,
+    3
+};
+var my_strings = new String[]{
+    "a",
+    "b"
+};
+var my_empty = new Object[]{};
+process(my_ints, 42);
+process(my_strings, 7);
+process(my_empty, 99);
+    }
+}

--- a/tests/integration/cases/call_ref_args_reused/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args_reused/Java_call@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var single_var = new int[]{
+    4,
+    5,
+    6
+};
+var repeated_var = 1;
+process(repeated_var, 1);
+process(single_var, 0);
+process(repeated_var, 8);
+    }
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_args_trivial_register/Java_call@jdk_16.java
@@ -1,0 +1,17 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var my_int = 1;
+var my_bool = true;
+var my_float = 3.14;
+var my_list = new int[]{
+    1,
+    2,
+    3
+};
+process(my_int, 42);
+process(my_bool, 7);
+process(my_float, 9);
+process(my_list, 1);
+    }
+}

--- a/tests/integration/cases/call_ref_nested_converted/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_nested_converted/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var myVar = 42;
+process(new Object[]{myVar, 42, "static"});
+    }
+}

--- a/tests/integration/cases/call_ref_nested_in_dict/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_nested_in_dict/Java_call@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var my_var = 42;
+process(Map.ofEntries(Map.entry("key", my_var), Map.entry("count", 42)));
+    }
+}

--- a/tests/integration/cases/call_ref_nested_in_list/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_ref_nested_in_list/Java_call@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+var my_var = 42;
+var my_other = 7;
+process(new Object[]{my_var, 42, "static"});
+process(new Object[]{my_other, 7, "label"});
+    }
+}

--- a/tests/integration/cases/call_reserved_target/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_reserved_target/Java_call@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+static Object op(Object... args) { return null; }
+    public static void main() {
+op("hello");
+    }
+}

--- a/tests/integration/cases/call_scalar_args/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_scalar_args/Java_call@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process("hello");
+process(42);
+process(true);
+    }
+}

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Java_call@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process("hello", "a");
+process(42, "b");
+process(true, "c");
+    }
+}

--- a/tests/integration/cases/call_scalar_args_with_null/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_scalar_args_with_null/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(null);
+process("hello");
+    }
+}

--- a/tests/integration/cases/call_snake_dotted_method/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_snake_dotted_method/Java_call@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+static class Http_ClientType_ { Object fetch(Object... args) { return null; } }
+static class My_AppType_ { Http_ClientType_ http_client = new Http_ClientType_(); }
+static My_AppType_ my_app = new My_AppType_();
+    public static void main() {
+my_app.http_client.fetch("hello");
+my_app.http_client.fetch(42);
+my_app.http_client.fetch(true);
+    }
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_transform_no_wrapper/Java_call@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process("hello");
+process(42);
+process(true);
+    }
+}

--- a/tests/integration/cases/call_variable_form_new/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_variable_form_new/Java_call@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+static Object make_widget(Object... args) { return null; }
+    public static void main() {
+var my_data = make_widget(42);
+    }
+}

--- a/tests/integration/cases/call_wrap_in_file/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_wrap_in_file/Java_call@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process(1, 2);
+process(3, 4);
+    }
+}

--- a/tests/integration/cases/call_wrap_in_file_escaped_quote/Java_call@jdk_16.java
+++ b/tests/integration/cases/call_wrap_in_file_escaped_quote/Java_call@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() {
+process("a\"b");
+    }
+}

--- a/tests/integration/cases/comment_block_scalar_not_comment/Java@jdk_16.java
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("description", "# not a comment\n"),
+    Map.entry("name", "foo")
+);
+    }
+}

--- a/tests/integration/cases/comment_block_scalar_not_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("description", "# not a comment\n"),
+    Map.entry("name", "foo")
+);
+my_data = Map.ofEntries(
+    Map.entry("description", "# not a comment\n"),
+    Map.entry("name", "foo")
+);
+    }
+}

--- a/tests/integration/cases/comment_block_scalar_not_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("description", "# not a comment\n"),
+    Map.entry("name", "foo")
+);
+    }
+}

--- a/tests/integration/cases/comment_scalar/Java@jdk_16.java
+++ b/tests/integration/cases/comment_scalar/Java@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comment_scalar/Java_combined@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+// note
+my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comment_scalar/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_before_and_inline/Java@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_before_and_inline/Java@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+// before
+// inline
+var my_data = "plain";
+    }
+}

--- a/tests/integration/cases/comment_scalar_before_and_inline/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_before_and_inline/Java_combined@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+// before
+// inline
+var my_data = "plain";
+// before
+// inline
+my_data = "plain";
+    }
+}

--- a/tests/integration/cases/comment_scalar_before_and_inline/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_before_and_inline/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+// before
+// inline
+var my_data = "plain";
+    }
+}

--- a/tests/integration/cases/comment_scalar_document_markers/Java@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_document_markers/Java@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_document_markers/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_document_markers/Java_combined@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+// note
+my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_document_markers/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_document_markers/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_inline/Java@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_inline/Java@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_inline/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_inline/Java_combined@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+// note
+my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_inline/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_inline/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Java@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Java@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Java_combined@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+// note
+var my_data = "hello # world";
+// note
+my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+var my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/comments/Java@jdk_16.java
+++ b/tests/integration/cases/comments/Java@jdk_16.java
@@ -1,0 +1,12 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // Server configuration
+    Map.entry("host", "localhost"),  // default host
+    Map.entry("port", 8080),
+    // Enable debug mode
+    Map.entry("debug", true)
+);
+    }
+}

--- a/tests/integration/cases/comments/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments/Java_combined@jdk_16.java
@@ -1,0 +1,19 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // Server configuration
+    Map.entry("host", "localhost"),  // default host
+    Map.entry("port", 8080),
+    // Enable debug mode
+    Map.entry("debug", true)
+);
+my_data = Map.ofEntries(
+    // Server configuration
+    Map.entry("host", "localhost"),  // default host
+    Map.entry("port", 8080),
+    // Enable debug mode
+    Map.entry("debug", true)
+);
+    }
+}

--- a/tests/integration/cases/comments/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,12 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // Server configuration
+    Map.entry("host", "localhost"),  // default host
+    Map.entry("port", 8080),
+    // Enable debug mode
+    Map.entry("debug", true)
+);
+    }
+}

--- a/tests/integration/cases/comments_bang_in_double_quote/Java@jdk_16.java
+++ b/tests/integration/cases/comments_bang_in_double_quote/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "\"bang!\"")  // real
+);
+    }
+}

--- a/tests/integration/cases/comments_bang_in_double_quote/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_bang_in_double_quote/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "\"bang!\"")  // real
+);
+my_data = Map.ofEntries(
+    Map.entry("key", "\"bang!\"")  // real
+);
+    }
+}

--- a/tests/integration/cases/comments_bang_in_double_quote/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_bang_in_double_quote/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "\"bang!\"")  // real
+);
+    }
+}

--- a/tests/integration/cases/comments_double_hash/Java@jdk_16.java
+++ b/tests/integration/cases/comments_double_hash/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // # section
+    "a"
+};
+    }
+}

--- a/tests/integration/cases/comments_double_hash/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_double_hash/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // # section
+    "a"
+};
+my_data = new String[]{
+    // # section
+    "a"
+};
+    }
+}

--- a/tests/integration/cases/comments_double_hash/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_double_hash/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // # section
+    "a"
+};
+    }
+}

--- a/tests/integration/cases/comments_empty_line/Java@jdk_16.java
+++ b/tests/integration/cases/comments_empty_line/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a",
+    //
+    "b"
+};
+    }
+}

--- a/tests/integration/cases/comments_empty_line/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_empty_line/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a",
+    //
+    "b"
+};
+my_data = new String[]{
+    "a",
+    //
+    "b"
+};
+    }
+}

--- a/tests/integration/cases/comments_empty_line/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_empty_line/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a",
+    //
+    "b"
+};
+    }
+}

--- a/tests/integration/cases/comments_escaped_quote/Java@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_quote/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "value \" # not a comment")  // real
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_quote/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_quote/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "value \" # not a comment")  // real
+);
+my_data = Map.ofEntries(
+    Map.entry("key", "value \" # not a comment")  // real
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_quote/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_quote/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "value \" # not a comment")  // real
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote/Java@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_single_quote/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "it's here")  // a comment
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_single_quote/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "it's here")  // a comment
+);
+my_data = Map.ofEntries(
+    Map.entry("key", "it's here")  // a comment
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_single_quote/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key", "it's here")  // a comment
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Java@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "it's here"),  // a comment
+    Map.entry("port", 80)  // another
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "it's here"),  // a comment
+    Map.entry("port", 80)  // another
+);
+my_data = Map.ofEntries(
+    Map.entry("host", "it's here"),  // a comment
+    Map.entry("port", 80)  // another
+);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "it's here"),  // a comment
+    Map.entry("port", 80)  // another
+);
+    }
+}

--- a/tests/integration/cases/comments_multi_line/Java@jdk_16.java
+++ b/tests/integration/cases/comments_multi_line/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // line 1
+    // line 2
+    "a"
+};
+    }
+}

--- a/tests/integration/cases/comments_multi_line/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_multi_line/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // line 1
+    // line 2
+    "a"
+};
+my_data = new String[]{
+    // line 1
+    // line 2
+    "a"
+};
+    }
+}

--- a/tests/integration/cases/comments_multi_line/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_multi_line/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // line 1
+    // line 2
+    "a"
+};
+    }
+}

--- a/tests/integration/cases/comments_nested_mapping/Java@jdk_16.java
+++ b/tests/integration/cases/comments_nested_mapping/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", Map.ofEntries(Map.entry("x", 1))),
+    Map.entry("b", 2)
+);
+    }
+}

--- a/tests/integration/cases/comments_nested_mapping/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_nested_mapping/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", Map.ofEntries(Map.entry("x", 1))),
+    Map.entry("b", 2)
+);
+my_data = Map.ofEntries(
+    Map.entry("a", Map.ofEntries(Map.entry("x", 1))),
+    Map.entry("b", 2)
+);
+    }
+}

--- a/tests/integration/cases/comments_nested_mapping/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_nested_mapping/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", Map.ofEntries(Map.entry("x", 1))),
+    Map.entry("b", 2)
+);
+    }
+}

--- a/tests/integration/cases/comments_nested_sequence_scalar/Java@jdk_16.java
+++ b/tests/integration/cases/comments_nested_sequence_scalar/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[][]{
+    new String[]{"ADD", "alice", "hello"},
+    new String[]{"DEL", "bob", "5"}  // removes "world"
+};
+    }
+}

--- a/tests/integration/cases/comments_nested_sequence_scalar/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_nested_sequence_scalar/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[][]{
+    new String[]{"ADD", "alice", "hello"},
+    new String[]{"DEL", "bob", "5"}  // removes "world"
+};
+my_data = new String[][]{
+    new String[]{"ADD", "alice", "hello"},
+    new String[]{"DEL", "bob", "5"}  // removes "world"
+};
+    }
+}

--- a/tests/integration/cases/comments_nested_sequence_scalar/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_nested_sequence_scalar/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[][]{
+    new String[]{"ADD", "alice", "hello"},
+    new String[]{"DEL", "bob", "5"}  // removes "world"
+};
+    }
+}

--- a/tests/integration/cases/comments_sequence_before/Java@jdk_16.java
+++ b/tests/integration/cases/comments_sequence_before/Java@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // first
+    "a",
+    // second
+    "b"
+};
+    }
+}

--- a/tests/integration/cases/comments_sequence_before/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_sequence_before/Java_combined@jdk_16.java
@@ -1,0 +1,16 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // first
+    "a",
+    // second
+    "b"
+};
+my_data = new String[]{
+    // first
+    "a",
+    // second
+    "b"
+};
+    }
+}

--- a/tests/integration/cases/comments_sequence_before/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_sequence_before/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    // first
+    "a",
+    // second
+    "b"
+};
+    }
+}

--- a/tests/integration/cases/comments_sequence_inline/Java@jdk_16.java
+++ b/tests/integration/cases/comments_sequence_inline/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a",  // note a
+    "b"  // note b
+};
+    }
+}

--- a/tests/integration/cases/comments_sequence_inline/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_sequence_inline/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a",  // note a
+    "b"  // note b
+};
+my_data = new String[]{
+    "a",  // note a
+    "b"  // note b
+};
+    }
+}

--- a/tests/integration/cases/comments_sequence_inline/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_sequence_inline/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a",  // note a
+    "b"  // note b
+};
+    }
+}

--- a/tests/integration/cases/comments_trailing/Java@jdk_16.java
+++ b/tests/integration/cases/comments_trailing/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a"
+    // trailing
+};
+    }
+}

--- a/tests/integration/cases/comments_trailing/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_trailing/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a"
+    // trailing
+};
+my_data = new String[]{
+    "a"
+    // trailing
+};
+    }
+}

--- a/tests/integration/cases/comments_trailing/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_trailing/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "a"
+    // trailing
+};
+    }
+}

--- a/tests/integration/cases/comments_vb_before_dim/Java@jdk_16.java
+++ b/tests/integration/cases/comments_vb_before_dim/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // Configuration
+    Map.entry("name", "app"),
+    // Port setting
+    Map.entry("port", 3000)
+);
+    }
+}

--- a/tests/integration/cases/comments_vb_before_dim/Java_combined@jdk_16.java
+++ b/tests/integration/cases/comments_vb_before_dim/Java_combined@jdk_16.java
@@ -1,0 +1,17 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // Configuration
+    Map.entry("name", "app"),
+    // Port setting
+    Map.entry("port", 3000)
+);
+my_data = Map.ofEntries(
+    // Configuration
+    Map.entry("name", "app"),
+    // Port setting
+    Map.entry("port", 3000)
+);
+    }
+}

--- a/tests/integration/cases/comments_vb_before_dim/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/comments_vb_before_dim/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // Configuration
+    Map.entry("name", "app"),
+    // Port setting
+    Map.entry("port", 3000)
+);
+    }
+}

--- a/tests/integration/cases/date_key_dict/Java@jdk_16.java
+++ b/tests/integration/cases/date_key_dict/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.time.LocalDate;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(LocalDate.of(2024, 1, 1), "new_year"),
+    Map.entry(LocalDate.of(2024, 7, 4), "independence_day"),
+    Map.entry(LocalDate.of(2024, 12, 25), "christmas")
+);
+    }
+}

--- a/tests/integration/cases/date_key_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/date_key_dict/Java_combined@jdk_16.java
@@ -1,0 +1,16 @@
+import java.time.LocalDate;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(LocalDate.of(2024, 1, 1), "new_year"),
+    Map.entry(LocalDate.of(2024, 7, 4), "independence_day"),
+    Map.entry(LocalDate.of(2024, 12, 25), "christmas")
+);
+my_data = Map.ofEntries(
+    Map.entry(LocalDate.of(2024, 1, 1), "new_year"),
+    Map.entry(LocalDate.of(2024, 7, 4), "independence_day"),
+    Map.entry(LocalDate.of(2024, 12, 25), "christmas")
+);
+    }
+}

--- a/tests/integration/cases/date_key_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/date_key_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.time.LocalDate;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(LocalDate.of(2024, 1, 1), "new_year"),
+    Map.entry(LocalDate.of(2024, 7, 4), "independence_day"),
+    Map.entry(LocalDate.of(2024, 12, 25), "christmas")
+);
+    }
+}

--- a/tests/integration/cases/date_list/Java@jdk_16.java
+++ b/tests/integration/cases/date_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.time.LocalDate;
+class Main {
+    public static void main() {
+var my_data = new LocalDate[]{
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 2, 20)
+};
+    }
+}

--- a/tests/integration/cases/date_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/date_list/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.time.LocalDate;
+class Main {
+    public static void main() {
+var my_data = new LocalDate[]{
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 2, 20)
+};
+my_data = new LocalDate[]{
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 2, 20)
+};
+    }
+}

--- a/tests/integration/cases/date_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/date_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.time.LocalDate;
+class Main {
+    public static void main() {
+var my_data = new LocalDate[]{
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 2, 20)
+};
+    }
+}

--- a/tests/integration/cases/date_set/Java@jdk_16.java
+++ b/tests/integration/cases/date_set/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.time.LocalDate;
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 6, 1)
+);
+    }
+}

--- a/tests/integration/cases/date_set/Java_combined@jdk_16.java
+++ b/tests/integration/cases/date_set/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+import java.time.LocalDate;
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 6, 1)
+);
+my_data = Set.of(
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 6, 1)
+);
+    }
+}

--- a/tests/integration/cases/date_set/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/date_set/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.time.LocalDate;
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    LocalDate.of(2024, 1, 15),
+    LocalDate.of(2024, 6, 1)
+);
+    }
+}

--- a/tests/integration/cases/dates/Java@jdk_16.java
+++ b/tests/integration/cases/dates/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("date", LocalDate.of(2024, 1, 15)),
+    Map.entry("datetime", Instant.parse("2024-01-15T12:30:00+00:00"))
+);
+    }
+}

--- a/tests/integration/cases/dates/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dates/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("date", LocalDate.of(2024, 1, 15)),
+    Map.entry("datetime", Instant.parse("2024-01-15T12:30:00+00:00"))
+);
+my_data = Map.ofEntries(
+    Map.entry("date", LocalDate.of(2024, 1, 15)),
+    Map.entry("datetime", Instant.parse("2024-01-15T12:30:00+00:00"))
+);
+    }
+}

--- a/tests/integration/cases/dates/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dates/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("date", LocalDate.of(2024, 1, 15)),
+    Map.entry("datetime", Instant.parse("2024-01-15T12:30:00+00:00"))
+);
+    }
+}

--- a/tests/integration/cases/datetime_list/Java@jdk_16.java
+++ b/tests/integration/cases/datetime_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Instant.parse("2024-01-15T12:30:00.123456+00:00"),
+    Instant.parse("2024-06-01T08:00:00+00:00")
+};
+    }
+}

--- a/tests/integration/cases/datetime_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/datetime_list/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Instant.parse("2024-01-15T12:30:00.123456+00:00"),
+    Instant.parse("2024-06-01T08:00:00+00:00")
+};
+my_data = new Object[]{
+    Instant.parse("2024-01-15T12:30:00.123456+00:00"),
+    Instant.parse("2024-06-01T08:00:00+00:00")
+};
+    }
+}

--- a/tests/integration/cases/datetime_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/datetime_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Instant.parse("2024-01-15T12:30:00.123456+00:00"),
+    Instant.parse("2024-06-01T08:00:00+00:00")
+};
+    }
+}

--- a/tests/integration/cases/deep_nesting/Java@jdk_16.java
+++ b/tests/integration/cases/deep_nesting/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("level1", Map.ofEntries(Map.entry("level2", Map.ofEntries(Map.entry("level3", Map.ofEntries(Map.entry("level4", Map.ofEntries(Map.entry("value", "deep"), Map.entry("items", new String[]{"a", "b"}))))), Map.entry("sibling", 42))), Map.entry("tags", new Object[]{Map.ofEntries(Map.entry("name", "tag1"), Map.entry("meta", Map.ofEntries(Map.entry("priority", 1), Map.entry("labels", new String[]{"x", "y"}))))})))
+);
+    }
+}

--- a/tests/integration/cases/deep_nesting/Java_combined@jdk_16.java
+++ b/tests/integration/cases/deep_nesting/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("level1", Map.ofEntries(Map.entry("level2", Map.ofEntries(Map.entry("level3", Map.ofEntries(Map.entry("level4", Map.ofEntries(Map.entry("value", "deep"), Map.entry("items", new String[]{"a", "b"}))))), Map.entry("sibling", 42))), Map.entry("tags", new Object[]{Map.ofEntries(Map.entry("name", "tag1"), Map.entry("meta", Map.ofEntries(Map.entry("priority", 1), Map.entry("labels", new String[]{"x", "y"}))))})))
+);
+my_data = Map.ofEntries(
+    Map.entry("level1", Map.ofEntries(Map.entry("level2", Map.ofEntries(Map.entry("level3", Map.ofEntries(Map.entry("level4", Map.ofEntries(Map.entry("value", "deep"), Map.entry("items", new String[]{"a", "b"}))))), Map.entry("sibling", 42))), Map.entry("tags", new Object[]{Map.ofEntries(Map.entry("name", "tag1"), Map.entry("meta", Map.ofEntries(Map.entry("priority", 1), Map.entry("labels", new String[]{"x", "y"}))))})))
+);
+    }
+}

--- a/tests/integration/cases/deep_nesting/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/deep_nesting/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("level1", Map.ofEntries(Map.entry("level2", Map.ofEntries(Map.entry("level3", Map.ofEntries(Map.entry("level4", Map.ofEntries(Map.entry("value", "deep"), Map.entry("items", new String[]{"a", "b"}))))), Map.entry("sibling", 42))), Map.entry("tags", new Object[]{Map.ofEntries(Map.entry("name", "tag1"), Map.entry("meta", Map.ofEntries(Map.entry("priority", 1), Map.entry("labels", new String[]{"x", "y"}))))})))
+);
+    }
+}

--- a/tests/integration/cases/dict_all_null_trailing_comment/Java@jdk_16.java
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Java@jdk_16.java
@@ -1,0 +1,7 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries();
+    // trailing
+    }
+}

--- a/tests/integration/cases/dict_all_null_trailing_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Java_combined@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries();
+    // trailing
+my_data = Map.ofEntries();
+    // trailing
+    }
+}

--- a/tests/integration/cases/dict_all_null_trailing_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,7 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries();
+    // trailing
+    }
+}

--- a/tests/integration/cases/dict_all_scalar_types/Java@jdk_16.java
+++ b/tests/integration/cases/dict_all_scalar_types/Java@jdk_16.java
@@ -1,0 +1,16 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("s", "string"),
+    Map.entry("i", 1),
+    Map.entry("f", 1.5),
+    Map.entry("b", true),
+    Map.entry("d", LocalDate.of(2024, 1, 15)),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
+    Map.entry("by", "48656c6c6f")
+);
+    }
+}

--- a/tests/integration/cases/dict_all_scalar_types/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_all_scalar_types/Java_combined@jdk_16.java
@@ -1,0 +1,25 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("s", "string"),
+    Map.entry("i", 1),
+    Map.entry("f", 1.5),
+    Map.entry("b", true),
+    Map.entry("d", LocalDate.of(2024, 1, 15)),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
+    Map.entry("by", "48656c6c6f")
+);
+my_data = Map.ofEntries(
+    Map.entry("s", "string"),
+    Map.entry("i", 1),
+    Map.entry("f", 1.5),
+    Map.entry("b", true),
+    Map.entry("d", LocalDate.of(2024, 1, 15)),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
+    Map.entry("by", "48656c6c6f")
+);
+    }
+}

--- a/tests/integration/cases/dict_all_scalar_types/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_all_scalar_types/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,16 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("s", "string"),
+    Map.entry("i", 1),
+    Map.entry("f", 1.5),
+    Map.entry("b", true),
+    Map.entry("d", LocalDate.of(2024, 1, 15)),
+    Map.entry("dt", Instant.parse("2024-01-15T12:00:00Z")),
+    Map.entry("by", "48656c6c6f")
+);
+    }
+}

--- a/tests/integration/cases/dict_in_sequence_with_empty_sibling/Java@jdk_16.java
+++ b/tests/integration/cases/dict_in_sequence_with_empty_sibling/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("a", 1)),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/dict_in_sequence_with_empty_sibling/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_in_sequence_with_empty_sibling/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("a", 1)),
+    new Object[]{}
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("a", 1)),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/dict_in_sequence_with_empty_sibling/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_in_sequence_with_empty_sibling/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("a", 1)),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Java@jdk_16.java
+++ b/tests/integration/cases/dict_mixed_int_widths/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 3000000000L),
+    Map.entry("c", "x")
+);
+    }
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_mixed_int_widths/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 3000000000L),
+    Map.entry("c", "x")
+);
+my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 3000000000L),
+    Map.entry("c", "x")
+);
+    }
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_mixed_int_widths/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 3000000000L),
+    Map.entry("c", "x")
+);
+    }
+}

--- a/tests/integration/cases/dict_mixed_scalars/Java@jdk_16.java
+++ b/tests/integration/cases/dict_mixed_scalars/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", "x")
+);
+    }
+}

--- a/tests/integration/cases/dict_mixed_scalars/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_mixed_scalars/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", "x")
+);
+my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", "x")
+);
+    }
+}

--- a/tests/integration/cases/dict_mixed_scalars/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_mixed_scalars/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", "x")
+);
+    }
+}

--- a/tests/integration/cases/dict_null_leading_comment/Java@jdk_16.java
+++ b/tests/integration/cases/dict_null_leading_comment/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // comment
+    Map.entry("name", "Alice")
+);
+    }
+}

--- a/tests/integration/cases/dict_null_leading_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_null_leading_comment/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // comment
+    Map.entry("name", "Alice")
+);
+my_data = Map.ofEntries(
+    // comment
+    Map.entry("name", "Alice")
+);
+    }
+}

--- a/tests/integration/cases/dict_null_leading_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_null_leading_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // comment
+    Map.entry("name", "Alice")
+);
+    }
+}

--- a/tests/integration/cases/dict_null_middle_inline_comment/Java@jdk_16.java
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "localhost"),
+    // not configured yet
+    Map.entry("debug", true)
+);
+    }
+}

--- a/tests/integration/cases/dict_null_middle_inline_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "localhost"),
+    // not configured yet
+    Map.entry("debug", true)
+);
+my_data = Map.ofEntries(
+    Map.entry("host", "localhost"),
+    // not configured yet
+    Map.entry("debug", true)
+);
+    }
+}

--- a/tests/integration/cases/dict_null_middle_inline_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "localhost"),
+    // not configured yet
+    Map.entry("debug", true)
+);
+    }
+}

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Java@jdk_16.java
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "localhost")
+    // not configured yet
+);
+    }
+}

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "localhost")
+    // not configured yet
+);
+my_data = Map.ofEntries(
+    Map.entry("host", "localhost")
+    // not configured yet
+);
+    }
+}

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("host", "localhost")
+    // not configured yet
+);
+    }
+}

--- a/tests/integration/cases/dict_with_control_char_keys/Java@jdk_16.java
+++ b/tests/integration/cases/dict_with_control_char_keys/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key\nwith\nnewlines", "value1"),
+    Map.entry("key\twith\ttabs", "value2"),
+    Map.entry("", "value3")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_control_char_keys/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_with_control_char_keys/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key\nwith\nnewlines", "value1"),
+    Map.entry("key\twith\ttabs", "value2"),
+    Map.entry("", "value3")
+);
+my_data = Map.ofEntries(
+    Map.entry("key\nwith\nnewlines", "value1"),
+    Map.entry("key\twith\ttabs", "value2"),
+    Map.entry("", "value3")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_control_char_keys/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_with_control_char_keys/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("key\nwith\nnewlines", "value1"),
+    Map.entry("key\twith\ttabs", "value2"),
+    Map.entry("", "value3")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_homogeneous_annotated_values/Java@jdk_16.java
+++ b/tests/integration/cases/dict_with_homogeneous_annotated_values/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", new Object[]{})
+);
+    }
+}

--- a/tests/integration/cases/dict_with_homogeneous_annotated_values/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_with_homogeneous_annotated_values/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", new Object[]{})
+);
+my_data = Map.ofEntries(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", new Object[]{})
+);
+    }
+}

--- a/tests/integration/cases/dict_with_homogeneous_annotated_values/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_with_homogeneous_annotated_values/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", new Object[]{})
+);
+    }
+}

--- a/tests/integration/cases/dict_with_hyphen_keys/Java@jdk_16.java
+++ b/tests/integration/cases/dict_with_hyphen_keys/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("my-key", "value1"),
+    Map.entry("another-key", "value2"),
+    Map.entry("normal_key", "value3")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_hyphen_keys/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_with_hyphen_keys/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("my-key", "value1"),
+    Map.entry("another-key", "value2"),
+    Map.entry("normal_key", "value3")
+);
+my_data = Map.ofEntries(
+    Map.entry("my-key", "value1"),
+    Map.entry("another-key", "value2"),
+    Map.entry("normal_key", "value3")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_hyphen_keys/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_with_hyphen_keys/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("my-key", "value1"),
+    Map.entry("another-key", "value2"),
+    Map.entry("normal_key", "value3")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Java@jdk_16.java
+++ b/tests/integration/cases/dict_with_list_value/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", new int[]{10, 20, 30})
+);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_with_list_value/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", new int[]{10, 20, 30})
+);
+my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", new int[]{10, 20, 30})
+);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_with_list_value/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", new int[]{10, 20, 30})
+);
+    }
+}

--- a/tests/integration/cases/dict_with_nulls/Java@jdk_16.java
+++ b/tests/integration/cases/dict_with_nulls/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30)
+);
+    }
+}

--- a/tests/integration/cases/dict_with_nulls/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_with_nulls/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30)
+);
+my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30)
+);
+    }
+}

--- a/tests/integration/cases/dict_with_nulls/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_with_nulls/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30)
+);
+    }
+}

--- a/tests/integration/cases/dict_with_quoted_digit_keys/Java@jdk_16.java
+++ b/tests/integration/cases/dict_with_quoted_digit_keys/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("0a", "first"),
+    Map.entry("1b", "second")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_quoted_digit_keys/Java_combined@jdk_16.java
+++ b/tests/integration/cases/dict_with_quoted_digit_keys/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("0a", "first"),
+    Map.entry("1b", "second")
+);
+my_data = Map.ofEntries(
+    Map.entry("0a", "first"),
+    Map.entry("1b", "second")
+);
+    }
+}

--- a/tests/integration/cases/dict_with_quoted_digit_keys/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/dict_with_quoted_digit_keys/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("0a", "first"),
+    Map.entry("1b", "second")
+);
+    }
+}

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Java@jdk_16.java
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}},
+    new int[][]{},
+    new int[][]{new int[]{3, 4}}
+};
+    }
+}

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Java_combined@jdk_16.java
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}},
+    new int[][]{},
+    new int[][]{new int[]{3, 4}}
+};
+my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}},
+    new int[][]{},
+    new int[][]{new int[]{3, 4}}
+};
+    }
+}

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}},
+    new int[][]{},
+    new int[][]{new int[]{3, 4}}
+};
+    }
+}

--- a/tests/integration/cases/empty_dict/Java@jdk_16.java
+++ b/tests/integration/cases/empty_dict/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries();
+    }
+}

--- a/tests/integration/cases/empty_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_dict/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries();
+my_data = Map.ofEntries();
+    }
+}

--- a/tests/integration/cases/empty_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries();
+    }
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/empty_dicts_in_sequence/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(),
+    Map.ofEntries()
+};
+    }
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_dicts_in_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(),
+    Map.ofEntries()
+};
+my_data = new Object[]{
+    Map.ofEntries(),
+    Map.ofEntries()
+};
+    }
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_dicts_in_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(),
+    Map.ofEntries()
+};
+    }
+}

--- a/tests/integration/cases/empty_list/Java@jdk_16.java
+++ b/tests/integration/cases/empty_list/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{};
+    }
+}

--- a/tests/integration/cases/empty_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_list/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{};
+my_data = new Object[]{};
+    }
+}

--- a/tests/integration/cases/empty_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{};
+    }
+}

--- a/tests/integration/cases/empty_ordered_map/Java@jdk_16.java
+++ b/tests/integration/cases/empty_ordered_map/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList());
+    }
+}

--- a/tests/integration/cases/empty_ordered_map/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_ordered_map/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList());
+my_data = new java.util.ArrayList<>(java.util.Arrays.asList());
+    }
+}

--- a/tests/integration/cases/empty_ordered_map/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_ordered_map/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList());
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_value_in_dict/Java@jdk_16.java
+++ b/tests/integration/cases/empty_orderedmap_value_in_dict/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", new java.util.ArrayList<>(java.util.Arrays.asList())),
+    Map.entry("b", 1)
+);
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_value_in_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_orderedmap_value_in_dict/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", new java.util.ArrayList<>(java.util.Arrays.asList())),
+    Map.entry("b", 1)
+);
+my_data = Map.ofEntries(
+    Map.entry("a", new java.util.ArrayList<>(java.util.Arrays.asList())),
+    Map.entry("b", 1)
+);
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_value_in_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_orderedmap_value_in_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", new java.util.ArrayList<>(java.util.Arrays.asList())),
+    Map.entry("b", 1)
+);
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_with_sibling/Java@jdk_16.java
+++ b/tests/integration/cases/empty_orderedmap_with_sibling/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList()),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_with_sibling/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_orderedmap_with_sibling/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList()),
+    new Object[]{}
+};
+my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList()),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_with_sibling/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_orderedmap_with_sibling/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList()),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/empty_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/empty_sequence/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{},
+    Map.ofEntries()
+};
+    }
+}

--- a/tests/integration/cases/empty_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{},
+    Map.ofEntries()
+};
+my_data = new Object[]{
+    new Object[]{},
+    Map.ofEntries()
+};
+    }
+}

--- a/tests/integration/cases/empty_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{},
+    Map.ofEntries()
+};
+    }
+}

--- a/tests/integration/cases/empty_set/Java@jdk_16.java
+++ b/tests/integration/cases/empty_set/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of();
+    }
+}

--- a/tests/integration/cases/empty_set/Java_combined@jdk_16.java
+++ b/tests/integration/cases/empty_set/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of();
+my_data = Set.of();
+    }
+}

--- a/tests/integration/cases/empty_set/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/empty_set/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of();
+    }
+}

--- a/tests/integration/cases/float_list/Java@jdk_16.java
+++ b/tests/integration/cases/float_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    1.1,
+    -2.2,
+    3.3
+};
+    }
+}

--- a/tests/integration/cases/float_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/float_list/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    1.1,
+    -2.2,
+    3.3
+};
+my_data = new double[]{
+    1.1,
+    -2.2,
+    3.3
+};
+    }
+}

--- a/tests/integration/cases/float_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/float_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    1.1,
+    -2.2,
+    3.3
+};
+    }
+}

--- a/tests/integration/cases/float_negative_zero/Java@jdk_16.java
+++ b/tests/integration/cases/float_negative_zero/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    -0.0,
+    1.5
+};
+    }
+}

--- a/tests/integration/cases/float_negative_zero/Java_combined@jdk_16.java
+++ b/tests/integration/cases/float_negative_zero/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    -0.0,
+    1.5
+};
+my_data = new double[]{
+    -0.0,
+    1.5
+};
+    }
+}

--- a/tests/integration/cases/float_negative_zero/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/float_negative_zero/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    -0.0,
+    1.5
+};
+    }
+}

--- a/tests/integration/cases/float_scientific_notation/Java@jdk_16.java
+++ b/tests/integration/cases/float_scientific_notation/Java@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    0.0,
+    1.0,
+    1500.0,
+    0.001
+};
+    }
+}

--- a/tests/integration/cases/float_scientific_notation/Java_combined@jdk_16.java
+++ b/tests/integration/cases/float_scientific_notation/Java_combined@jdk_16.java
@@ -1,0 +1,16 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    0.0,
+    1.0,
+    1500.0,
+    0.001
+};
+my_data = new double[]{
+    0.0,
+    1.0,
+    1500.0,
+    0.001
+};
+    }
+}

--- a/tests/integration/cases/float_scientific_notation/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/float_scientific_notation/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    0.0,
+    1.0,
+    1500.0,
+    0.001
+};
+    }
+}

--- a/tests/integration/cases/float_special_values/Java@jdk_16.java
+++ b/tests/integration/cases/float_special_values/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    Double.POSITIVE_INFINITY,
+    Double.NEGATIVE_INFINITY,
+    Double.NaN
+};
+    }
+}

--- a/tests/integration/cases/float_special_values/Java_combined@jdk_16.java
+++ b/tests/integration/cases/float_special_values/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    Double.POSITIVE_INFINITY,
+    Double.NEGATIVE_INFINITY,
+    Double.NaN
+};
+my_data = new double[]{
+    Double.POSITIVE_INFINITY,
+    Double.NEGATIVE_INFINITY,
+    Double.NaN
+};
+    }
+}

--- a/tests/integration/cases/float_special_values/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/float_special_values/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    Double.POSITIVE_INFINITY,
+    Double.NEGATIVE_INFINITY,
+    Double.NaN
+};
+    }
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Java@jdk_16.java
+++ b/tests/integration/cases/heterogeneous_list_with_string/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    "hello",
+    42
+};
+    }
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Java_combined@jdk_16.java
+++ b/tests/integration/cases/heterogeneous_list_with_string/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    "hello",
+    42
+};
+my_data = new Object[]{
+    "hello",
+    42
+};
+    }
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/heterogeneous_list_with_string/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    "hello",
+    42
+};
+    }
+}

--- a/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Java@jdk_16.java
@@ -1,0 +1,14 @@
+import java.time.LocalDate;
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    true,
+    1.5,
+    null,
+    LocalDate.of(2020, 1, 1),
+    Instant.parse("2020-01-01T00:00:00+00:00"),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,22 @@
+import java.time.LocalDate;
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    true,
+    1.5,
+    null,
+    LocalDate.of(2020, 1, 1),
+    Instant.parse("2020-01-01T00:00:00+00:00"),
+    new Object[]{}
+};
+my_data = new Object[]{
+    true,
+    1.5,
+    null,
+    LocalDate.of(2020, 1, 1),
+    Instant.parse("2020-01-01T00:00:00+00:00"),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,14 @@
+import java.time.LocalDate;
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    true,
+    1.5,
+    null,
+    LocalDate.of(2020, 1, 1),
+    Instant.parse("2020-01-01T00:00:00+00:00"),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/int_key_dict/Java@jdk_16.java
+++ b/tests/integration/cases/int_key_dict/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+);
+    }
+}

--- a/tests/integration/cases/int_key_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/int_key_dict/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+);
+my_data = Map.ofEntries(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+);
+    }
+}

--- a/tests/integration/cases/int_key_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/int_key_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+);
+    }
+}

--- a/tests/integration/cases/int_list/Java@jdk_16.java
+++ b/tests/integration/cases/int_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    1,
+    2,
+    3
+};
+    }
+}

--- a/tests/integration/cases/int_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/int_list/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    1,
+    2,
+    3
+};
+my_data = new int[]{
+    1,
+    2,
+    3
+};
+    }
+}

--- a/tests/integration/cases/int_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/int_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    1,
+    2,
+    3
+};
+    }
+}

--- a/tests/integration/cases/int_list_large/Java@jdk_16.java
+++ b/tests/integration/cases/int_list_large/Java@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    1000000,
+    -1234,
+    255,
+    -10
+};
+    }
+}

--- a/tests/integration/cases/int_list_large/Java_combined@jdk_16.java
+++ b/tests/integration/cases/int_list_large/Java_combined@jdk_16.java
@@ -1,0 +1,16 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    1000000,
+    -1234,
+    255,
+    -10
+};
+my_data = new int[]{
+    1000000,
+    -1234,
+    255,
+    -10
+};
+    }
+}

--- a/tests/integration/cases/int_list_large/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/int_list_large/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    1000000,
+    -1234,
+    255,
+    -10
+};
+    }
+}

--- a/tests/integration/cases/int_list_with_zero/Java@jdk_16.java
+++ b/tests/integration/cases/int_list_with_zero/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    0,
+    1,
+    -1
+};
+    }
+}

--- a/tests/integration/cases/int_list_with_zero/Java_combined@jdk_16.java
+++ b/tests/integration/cases/int_list_with_zero/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    0,
+    1,
+    -1
+};
+my_data = new int[]{
+    0,
+    1,
+    -1
+};
+    }
+}

--- a/tests/integration/cases/int_list_with_zero/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/int_list_with_zero/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[]{
+    0,
+    1,
+    -1
+};
+    }
+}

--- a/tests/integration/cases/int_set/Java@jdk_16.java
+++ b/tests/integration/cases/int_set/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    1,
+    2,
+    3
+);
+    }
+}

--- a/tests/integration/cases/int_set/Java_combined@jdk_16.java
+++ b/tests/integration/cases/int_set/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    1,
+    2,
+    3
+);
+my_data = Set.of(
+    1,
+    2,
+    3
+);
+    }
+}

--- a/tests/integration/cases/int_set/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/int_set/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    1,
+    2,
+    3
+);
+    }
+}

--- a/tests/integration/cases/literalize_ref_camel_name/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_camel_name/Java_ref@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var myVar = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = myVar;
+    }
+}

--- a/tests/integration/cases/literalize_ref_deep_nesting/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_deep_nesting/Java_ref@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var deep = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = Map.ofEntries(
+    Map.entry("a", Map.ofEntries(Map.entry("b", Map.ofEntries(Map.entry("c", deep)))))
+);
+    }
+}

--- a/tests/integration/cases/literalize_ref_default_nested/Java_ref_default@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_default_nested/Java_ref_default@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var item_var = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = Map.ofEntries(
+    Map.entry("items", new Object[]{item_var, Map.ofEntries(Map.entry("fallback", "value"))})
+);
+    }
+}

--- a/tests/integration/cases/literalize_ref_default_whole/Java_ref_default@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_default_whole/Java_ref_default@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_var = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = my_var;
+    }
+}

--- a/tests/integration/cases/literalize_ref_heterogeneous/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_heterogeneous/Java_ref@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", "hello")
+);
+    }
+}

--- a/tests/integration/cases/literalize_ref_in_dict/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_in_dict/Java_ref@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var myVar = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = Map.ofEntries(
+    Map.entry("key", myVar)
+);
+    }
+}

--- a/tests/integration/cases/literalize_ref_in_list/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_in_list/Java_ref@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var valX = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var valY = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = new Object[]{
+    valX,
+    valY
+};
+    }
+}

--- a/tests/integration/cases/literalize_ref_in_mixed_list/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_in_mixed_list/Java_ref@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var refX = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = new Object[]{
+    refX,
+    1,
+    2
+};
+    }
+}

--- a/tests/integration/cases/literalize_ref_json5_unquoted_key/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_json5_unquoted_key/Java_ref@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var myVar = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = myVar;
+    }
+}

--- a/tests/integration/cases/literalize_ref_json_escaped_key/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_json_escaped_key/Java_ref@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var myVar = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = myVar;
+    }
+}

--- a/tests/integration/cases/literalize_ref_scalar/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_scalar/Java_ref@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var myInt = 42;
+var my_data = myInt;
+    }
+}

--- a/tests/integration/cases/literalize_ref_toml_table/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_toml_table/Java_ref@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var myVar = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = Map.ofEntries(
+    Map.entry("key", myVar)
+);
+    }
+}

--- a/tests/integration/cases/literalize_ref_whole/Java_ref@jdk_16.java
+++ b/tests/integration/cases/literalize_ref_whole/Java_ref@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var myVar = Map.ofEntries(
+    Map.entry("_", "_")
+);
+var my_data = myVar;
+    }
+}

--- a/tests/integration/cases/mixed_number_dict/Java@jdk_16.java
+++ b/tests/integration/cases/mixed_number_dict/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 2.5),
+    Map.entry("c", 3)
+);
+    }
+}

--- a/tests/integration/cases/mixed_number_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/mixed_number_dict/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 2.5),
+    Map.entry("c", 3)
+);
+my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 2.5),
+    Map.entry("c", 3)
+);
+    }
+}

--- a/tests/integration/cases/mixed_number_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/mixed_number_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("a", 1),
+    Map.entry("b", 2.5),
+    Map.entry("c", 3)
+);
+    }
+}

--- a/tests/integration/cases/mixed_number_list/Java@jdk_16.java
+++ b/tests/integration/cases/mixed_number_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    1,
+    2.5,
+    3
+};
+    }
+}

--- a/tests/integration/cases/mixed_number_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/mixed_number_list/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    1,
+    2.5,
+    3
+};
+my_data = new double[]{
+    1,
+    2.5,
+    3
+};
+    }
+}

--- a/tests/integration/cases/mixed_number_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/mixed_number_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new double[]{
+    1,
+    2.5,
+    3
+};
+    }
+}

--- a/tests/integration/cases/mixed_set/Java@jdk_16.java
+++ b/tests/integration/cases/mixed_set/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    true,
+    42,
+    "apple"
+);
+    }
+}

--- a/tests/integration/cases/mixed_set/Java_combined@jdk_16.java
+++ b/tests/integration/cases/mixed_set/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    true,
+    42,
+    "apple"
+);
+my_data = Set.of(
+    true,
+    42,
+    "apple"
+);
+    }
+}

--- a/tests/integration/cases/mixed_set/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/mixed_set/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    true,
+    42,
+    "apple"
+);
+    }
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_1"), Map.entry("draft", true)),
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_2"))
+};
+    }
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_1"), Map.entry("draft", true)),
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_2"))
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_1"), Map.entry("draft", true)),
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_2"))
+};
+    }
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_1"), Map.entry("draft", true)),
+    Map.ofEntries(Map.entry("type", "create"), Map.entry("pr_id", "pr_2"))
+};
+    }
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Java@jdk_16.java
+++ b/tests/integration/cases/multiline_sibling_list_widening/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("omap_value", new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("first", 1)))),
+    Map.entry("sibling_lists", Map.ofEntries(Map.entry("numbers", new Object[]{1, 2}), Map.entry("strings", new Object[]{"x", "y"}))),
+    Map.entry("ref_marker_present", new String[]{"$keep", "z"})
+);
+    }
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Java_combined@jdk_16.java
+++ b/tests/integration/cases/multiline_sibling_list_widening/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("omap_value", new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("first", 1)))),
+    Map.entry("sibling_lists", Map.ofEntries(Map.entry("numbers", new Object[]{1, 2}), Map.entry("strings", new Object[]{"x", "y"}))),
+    Map.entry("ref_marker_present", new String[]{"$keep", "z"})
+);
+my_data = Map.ofEntries(
+    Map.entry("omap_value", new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("first", 1)))),
+    Map.entry("sibling_lists", Map.ofEntries(Map.entry("numbers", new Object[]{1, 2}), Map.entry("strings", new Object[]{"x", "y"}))),
+    Map.entry("ref_marker_present", new String[]{"$keep", "z"})
+);
+    }
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/multiline_sibling_list_widening/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("omap_value", new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("first", 1)))),
+    Map.entry("sibling_lists", Map.ofEntries(Map.entry("numbers", new Object[]{1, 2}), Map.entry("strings", new Object[]{"x", "y"}))),
+    Map.entry("ref_marker_present", new String[]{"$keep", "z"})
+);
+    }
+}

--- a/tests/integration/cases/nested/Java@jdk_16.java
+++ b/tests/integration/cases/nested/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("users", new Object[]{Map.ofEntries(Map.entry("name", "Bob"), Map.entry("tags", new String[]{"admin", "user"})), Map.ofEntries(Map.entry("name", "Carol"), Map.entry("tags", new String[]{"guest"}))})
+);
+    }
+}

--- a/tests/integration/cases/nested/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("users", new Object[]{Map.ofEntries(Map.entry("name", "Bob"), Map.entry("tags", new String[]{"admin", "user"})), Map.ofEntries(Map.entry("name", "Carol"), Map.entry("tags", new String[]{"guest"}))})
+);
+my_data = Map.ofEntries(
+    Map.entry("users", new Object[]{Map.ofEntries(Map.entry("name", "Bob"), Map.entry("tags", new String[]{"admin", "user"})), Map.ofEntries(Map.entry("name", "Carol"), Map.entry("tags", new String[]{"guest"}))})
+);
+    }
+}

--- a/tests/integration/cases/nested/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("users", new Object[]{Map.ofEntries(Map.entry("name", "Bob"), Map.entry("tags", new String[]{"admin", "user"})), Map.ofEntries(Map.entry("name", "Carol"), Map.entry("tags", new String[]{"guest"}))})
+);
+    }
+}

--- a/tests/integration/cases/nested_bool_list/Java@jdk_16.java
+++ b/tests/integration/cases/nested_bool_list/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new boolean[][]{
+    new boolean[]{true, false},
+    new boolean[]{true, true}
+};
+    }
+}

--- a/tests/integration/cases/nested_bool_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_bool_list/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new boolean[][]{
+    new boolean[]{true, false},
+    new boolean[]{true, true}
+};
+my_data = new boolean[][]{
+    new boolean[]{true, false},
+    new boolean[]{true, true}
+};
+    }
+}

--- a/tests/integration/cases/nested_bool_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_bool_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new boolean[][]{
+    new boolean[]{true, false},
+    new boolean[]{true, true}
+};
+    }
+}

--- a/tests/integration/cases/nested_collection_multi_space_string/Java@jdk_16.java
+++ b/tests/integration/cases/nested_collection_multi_space_string/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("key", "hello   world"), Map.entry("value", 1))
+};
+    }
+}

--- a/tests/integration/cases/nested_collection_multi_space_string/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_collection_multi_space_string/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("key", "hello   world"), Map.entry("value", 1))
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("key", "hello   world"), Map.entry("value", 1))
+};
+    }
+}

--- a/tests/integration/cases/nested_collection_multi_space_string/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_collection_multi_space_string/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("key", "hello   world"), Map.entry("value", 1))
+};
+    }
+}

--- a/tests/integration/cases/nested_deep_empty/Java@jdk_16.java
+++ b/tests/integration/cases/nested_deep_empty/Java@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{new Object[]{}, new Object[]{}}
+};
+    }
+}

--- a/tests/integration/cases/nested_deep_empty/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_deep_empty/Java_combined@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{new Object[]{}, new Object[]{}}
+};
+my_data = new Object[]{
+    new Object[]{new Object[]{}, new Object[]{}}
+};
+    }
+}

--- a/tests/integration/cases/nested_deep_empty/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_deep_empty/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{new Object[]{}, new Object[]{}}
+};
+    }
+}

--- a/tests/integration/cases/nested_deep_mixed/Java@jdk_16.java
+++ b/tests/integration/cases/nested_deep_mixed/Java@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{new int[]{1, 2}, new String[]{"a", "b"}}
+};
+    }
+}

--- a/tests/integration/cases/nested_deep_mixed/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_deep_mixed/Java_combined@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{new int[]{1, 2}, new String[]{"a", "b"}}
+};
+my_data = new Object[]{
+    new Object[]{new int[]{1, 2}, new String[]{"a", "b"}}
+};
+    }
+}

--- a/tests/integration/cases/nested_deep_mixed/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_deep_mixed/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,7 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{new int[]{1, 2}, new String[]{"a", "b"}}
+};
+    }
+}

--- a/tests/integration/cases/nested_empty_inner/Java@jdk_16.java
+++ b/tests/integration/cases/nested_empty_inner/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{},
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/nested_empty_inner/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_empty_inner/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{},
+    new Object[]{}
+};
+my_data = new Object[]{
+    new Object[]{},
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/nested_empty_inner/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_empty_inner/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{},
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/nested_float_list/Java@jdk_16.java
+++ b/tests/integration/cases/nested_float_list/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new double[][]{
+    new double[]{1.5, 2.5},
+    new double[]{3.5, 4.5}
+};
+    }
+}

--- a/tests/integration/cases/nested_float_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_float_list/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new double[][]{
+    new double[]{1.5, 2.5},
+    new double[]{3.5, 4.5}
+};
+my_data = new double[][]{
+    new double[]{1.5, 2.5},
+    new double[]{3.5, 4.5}
+};
+    }
+}

--- a/tests/integration/cases/nested_float_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_float_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new double[][]{
+    new double[]{1.5, 2.5},
+    new double[]{3.5, 4.5}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Java@jdk_16.java
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new int[]{1, 2},
+    new Object[]{},
+    new String[]{"a", "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new int[]{1, 2},
+    new Object[]{},
+    new String[]{"a", "b"}
+};
+my_data = new Object[]{
+    new int[]{1, 2},
+    new Object[]{},
+    new String[]{"a", "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new int[]{1, 2},
+    new Object[]{},
+    new String[]{"a", "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_of_dicts/Java@jdk_16.java
+++ b/tests/integration/cases/nested_list_of_dicts/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{Map.ofEntries(Map.entry("name", "Alice")), Map.ofEntries(Map.entry("name", "Bob"))},
+    new Object[]{Map.ofEntries(Map.entry("name", "Charlie")), Map.ofEntries(Map.entry("name", "Dave"))}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_of_dicts/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_list_of_dicts/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{Map.ofEntries(Map.entry("name", "Alice")), Map.ofEntries(Map.entry("name", "Bob"))},
+    new Object[]{Map.ofEntries(Map.entry("name", "Charlie")), Map.ofEntries(Map.entry("name", "Dave"))}
+};
+my_data = new Object[]{
+    new Object[]{Map.ofEntries(Map.entry("name", "Alice")), Map.ofEntries(Map.entry("name", "Bob"))},
+    new Object[]{Map.ofEntries(Map.entry("name", "Charlie")), Map.ofEntries(Map.entry("name", "Dave"))}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_of_dicts/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_list_of_dicts/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{Map.ofEntries(Map.entry("name", "Alice")), Map.ofEntries(Map.entry("name", "Bob"))},
+    new Object[]{Map.ofEntries(Map.entry("name", "Charlie")), Map.ofEntries(Map.entry("name", "Dave"))}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_with_empty_sibling/Java@jdk_16.java
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[][]{
+    new int[]{1, 2},
+    new int[]{},
+    new int[]{3, 4}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_with_empty_sibling/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new int[][]{
+    new int[]{1, 2},
+    new int[]{},
+    new int[]{3, 4}
+};
+my_data = new int[][]{
+    new int[]{1, 2},
+    new int[]{},
+    new int[]{3, 4}
+};
+    }
+}

--- a/tests/integration/cases/nested_list_with_empty_sibling/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new int[][]{
+    new int[]{1, 2},
+    new int[]{},
+    new int[]{3, 4}
+};
+    }
+}

--- a/tests/integration/cases/nested_mixed_dict/Java@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_dict/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("outer", Map.ofEntries(Map.entry("a", 1), Map.entry("b", "x")))
+);
+    }
+}

--- a/tests/integration/cases/nested_mixed_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_dict/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("outer", Map.ofEntries(Map.entry("a", 1), Map.entry("b", "x")))
+);
+my_data = Map.ofEntries(
+    Map.entry("outer", Map.ofEntries(Map.entry("a", 1), Map.entry("b", "x")))
+);
+    }
+}

--- a/tests/integration/cases/nested_mixed_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("outer", Map.ofEntries(Map.entry("a", 1), Map.entry("b", "x")))
+);
+    }
+}

--- a/tests/integration/cases/nested_mixed_inner/Java@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_inner/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{1, "a"},
+    new Object[]{2, "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_mixed_inner/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_inner/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{1, "a"},
+    new Object[]{2, "b"}
+};
+my_data = new Object[]{
+    new Object[]{1, "a"},
+    new Object[]{2, "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_mixed_inner/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_inner/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new Object[]{1, "a"},
+    new Object[]{2, "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_mixed_set/Java@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_set/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("tags", Set.of(true, 42, "apple"))
+);
+    }
+}

--- a/tests/integration/cases/nested_mixed_set/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_set/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+import java.util.Map;
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("tags", Set.of(true, 42, "apple"))
+);
+my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("tags", Set.of(true, 42, "apple"))
+);
+    }
+}

--- a/tests/integration/cases/nested_mixed_set/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_set/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("tags", Set.of(true, 42, "apple"))
+);
+    }
+}

--- a/tests/integration/cases/nested_mixed_types/Java@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_types/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new int[]{1, 2},
+    new String[]{"a", "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_mixed_types/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_types/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new int[]{1, 2},
+    new String[]{"a", "b"}
+};
+my_data = new Object[]{
+    new int[]{1, 2},
+    new String[]{"a", "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_mixed_types/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_mixed_types/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new int[]{1, 2},
+    new String[]{"a", "b"}
+};
+    }
+}

--- a/tests/integration/cases/nested_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/nested_sequence/Java@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    true,
+    "hi",
+    new int[]{1, 2},
+    null
+};
+    }
+}

--- a/tests/integration/cases/nested_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,16 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    true,
+    "hi",
+    new int[]{1, 2},
+    null
+};
+my_data = new Object[]{
+    true,
+    "hi",
+    new int[]{1, 2},
+    null
+};
+    }
+}

--- a/tests/integration/cases/nested_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    true,
+    "hi",
+    new int[]{1, 2},
+    null
+};
+    }
+}

--- a/tests/integration/cases/nested_sequences/Java@jdk_16.java
+++ b/tests/integration/cases/nested_sequences/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}, new int[]{3, 4}},
+    new int[][]{new int[]{5}}
+};
+    }
+}

--- a/tests/integration/cases/nested_sequences/Java_combined@jdk_16.java
+++ b/tests/integration/cases/nested_sequences/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}, new int[]{3, 4}},
+    new int[][]{new int[]{5}}
+};
+my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}, new int[]{3, 4}},
+    new int[][]{new int[]{5}}
+};
+    }
+}

--- a/tests/integration/cases/nested_sequences/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/nested_sequences/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new int[][][]{
+    new int[][]{new int[]{1, 2}, new int[]{3, 4}},
+    new int[][]{new int[]{5}}
+};
+    }
+}

--- a/tests/integration/cases/no_comment/Java@jdk_16.java
+++ b/tests/integration/cases/no_comment/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("message", "no comment here")
+);
+    }
+}

--- a/tests/integration/cases/no_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/no_comment/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("message", "no comment here")
+);
+my_data = Map.ofEntries(
+    Map.entry("message", "no comment here")
+);
+    }
+}

--- a/tests/integration/cases/no_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/no_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("message", "no comment here")
+);
+    }
+}

--- a/tests/integration/cases/null_list/Java@jdk_16.java
+++ b/tests/integration/cases/null_list/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    null,
+    null
+};
+    }
+}

--- a/tests/integration/cases/null_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/null_list/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    null,
+    null
+};
+my_data = new Object[]{
+    null,
+    null
+};
+    }
+}

--- a/tests/integration/cases/null_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/null_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    null,
+    null
+};
+    }
+}

--- a/tests/integration/cases/ordered_map/Java@jdk_16.java
+++ b/tests/integration/cases/ordered_map/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+));
+    }
+}

--- a/tests/integration/cases/ordered_map/Java_combined@jdk_16.java
+++ b/tests/integration/cases/ordered_map/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+));
+my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+));
+    }
+}

--- a/tests/integration/cases/ordered_map/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/ordered_map/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/ordered_map_in_sequence/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    "hello"
+};
+    }
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/ordered_map_in_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    "hello"
+};
+my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    "hello"
+};
+    }
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/ordered_map_in_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    "hello"
+};
+    }
+}

--- a/tests/integration/cases/ordered_map_int_keys/Java@jdk_16.java
+++ b/tests/integration/cases/ordered_map_int_keys/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_int_keys/Java_combined@jdk_16.java
+++ b/tests/integration/cases/ordered_map_int_keys/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+));
+my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_int_keys/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/ordered_map_int_keys/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_nested_values/Java@jdk_16.java
+++ b/tests/integration/cases/ordered_map_nested_values/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", Map.ofEntries(Map.entry(1, "first"), Map.entry(2, "second")))
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_nested_values/Java_combined@jdk_16.java
+++ b/tests/integration/cases/ordered_map_nested_values/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", Map.ofEntries(Map.entry(1, "first"), Map.entry(2, "second")))
+));
+my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", Map.ofEntries(Map.entry(1, "first"), Map.entry(2, "second")))
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_nested_values/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/ordered_map_nested_values/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("name", "Alice"),
+    Map.entry("scores", Map.ofEntries(Map.entry(1, "first"), Map.entry(2, "second")))
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_string_values/Java@jdk_16.java
+++ b/tests/integration/cases/ordered_map_string_values/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("first", "one"),
+    Map.entry("second", "two"),
+    Map.entry("third", "three")
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_string_values/Java_combined@jdk_16.java
+++ b/tests/integration/cases/ordered_map_string_values/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("first", "one"),
+    Map.entry("second", "two"),
+    Map.entry("third", "three")
+));
+my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("first", "one"),
+    Map.entry("second", "two"),
+    Map.entry("third", "three")
+));
+    }
+}

--- a/tests/integration/cases/ordered_map_string_values/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/ordered_map_string_values/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("first", "one"),
+    Map.entry("second", "two"),
+    Map.entry("third", "three")
+));
+    }
+}

--- a/tests/integration/cases/orderedmap_with_annotated_value/Java@jdk_16.java
+++ b/tests/integration/cases/orderedmap_with_annotated_value/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", 1)
+));
+    }
+}

--- a/tests/integration/cases/orderedmap_with_annotated_value/Java_combined@jdk_16.java
+++ b/tests/integration/cases/orderedmap_with_annotated_value/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", 1)
+));
+my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", 1)
+));
+    }
+}

--- a/tests/integration/cases/orderedmap_with_annotated_value/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/orderedmap_with_annotated_value/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new java.util.ArrayList<>(java.util.Arrays.asList(
+    Map.entry("a", new Object[]{}),
+    Map.entry("b", 1)
+));
+    }
+}

--- a/tests/integration/cases/orderedmap_with_empty_sibling/Java@jdk_16.java
+++ b/tests/integration/cases/orderedmap_with_empty_sibling/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/orderedmap_with_empty_sibling/Java_combined@jdk_16.java
+++ b/tests/integration/cases/orderedmap_with_empty_sibling/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    new Object[]{}
+};
+my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/orderedmap_with_empty_sibling/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/orderedmap_with_empty_sibling/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    new java.util.ArrayList<>(java.util.Arrays.asList(Map.entry("a", 1))),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/pair_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/pair_sequence/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello"
+};
+    }
+}

--- a/tests/integration/cases/pair_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/pair_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello"
+};
+my_data = new Object[]{
+    1,
+    "hello"
+};
+    }
+}

--- a/tests/integration/cases/pair_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/pair_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello"
+};
+    }
+}

--- a/tests/integration/cases/record_basic/Java@jdk_16.java
+++ b/tests/integration/cases/record_basic/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("description", "She said \"hello\", then waved"),
+    Map.entry("is_done", false),
+    Map.entry("blocks", new int[]{1, 2, 3})
+);
+    }
+}

--- a/tests/integration/cases/record_basic/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_basic/Java_combined@jdk_16.java
@@ -1,0 +1,17 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("description", "She said \"hello\", then waved"),
+    Map.entry("is_done", false),
+    Map.entry("blocks", new int[]{1, 2, 3})
+);
+my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("description", "She said \"hello\", then waved"),
+    Map.entry("is_done", false),
+    Map.entry("blocks", new int[]{1, 2, 3})
+);
+    }
+}

--- a/tests/integration/cases/record_basic/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_basic/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("description", "She said \"hello\", then waved"),
+    Map.entry("is_done", false),
+    Map.entry("blocks", new int[]{1, 2, 3})
+);
+    }
+}

--- a/tests/integration/cases/record_named_shape/Java@jdk_16.java
+++ b/tests/integration/cases/record_named_shape/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 100), Map.entry("description", "first task"), Map.entry("is_done", false), Map.entry("blocks", new int[]{102, 103})),
+    Map.ofEntries(Map.entry("id", 101), Map.entry("description", "second task"), Map.entry("is_done", true), Map.entry("blocks", new int[]{100}))
+};
+    }
+}

--- a/tests/integration/cases/record_named_shape/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_named_shape/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 100), Map.entry("description", "first task"), Map.entry("is_done", false), Map.entry("blocks", new int[]{102, 103})),
+    Map.ofEntries(Map.entry("id", 101), Map.entry("description", "second task"), Map.entry("is_done", true), Map.entry("blocks", new int[]{100}))
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 100), Map.entry("description", "first task"), Map.entry("is_done", false), Map.entry("blocks", new int[]{102, 103})),
+    Map.ofEntries(Map.entry("id", 101), Map.entry("description", "second task"), Map.entry("is_done", true), Map.entry("blocks", new int[]{100}))
+};
+    }
+}

--- a/tests/integration/cases/record_named_shape/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_named_shape/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 100), Map.entry("description", "first task"), Map.entry("is_done", false), Map.entry("blocks", new int[]{102, 103})),
+    Map.ofEntries(Map.entry("id", 101), Map.entry("description", "second task"), Map.entry("is_done", true), Map.entry("blocks", new int[]{100}))
+};
+    }
+}

--- a/tests/integration/cases/record_nested_container/Java@jdk_16.java
+++ b/tests/integration/cases/record_nested_container/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("title", "report"),
+    Map.entry("tags", new String[]{"draft", "urgent", "review"}),
+    Map.entry("priority", 2)
+);
+    }
+}

--- a/tests/integration/cases/record_nested_container/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_nested_container/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("title", "report"),
+    Map.entry("tags", new String[]{"draft", "urgent", "review"}),
+    Map.entry("priority", 2)
+);
+my_data = Map.ofEntries(
+    Map.entry("title", "report"),
+    Map.entry("tags", new String[]{"draft", "urgent", "review"}),
+    Map.entry("priority", 2)
+);
+    }
+}

--- a/tests/integration/cases/record_nested_container/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_nested_container/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("title", "report"),
+    Map.entry("tags", new String[]{"draft", "urgent", "review"}),
+    Map.entry("priority", 2)
+);
+    }
+}

--- a/tests/integration/cases/record_nested_record/Java@jdk_16.java
+++ b/tests/integration/cases/record_nested_record/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("owner", Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)))
+);
+    }
+}

--- a/tests/integration/cases/record_nested_record/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_nested_record/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("owner", Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)))
+);
+my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("owner", Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)))
+);
+    }
+}

--- a/tests/integration/cases/record_nested_record/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_nested_record/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("id", 1),
+    Map.entry("owner", Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)))
+);
+    }
+}

--- a/tests/integration/cases/record_optional_unify/Java@jdk_16.java
+++ b/tests/integration/cases/record_optional_unify/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("items", new Object[]{Map.ofEntries(Map.entry("id", 1)), Map.ofEntries(Map.entry("id", 2), Map.entry("count", 10)), Map.ofEntries(Map.entry("id", 3), Map.entry("count", 20))})
+);
+    }
+}

--- a/tests/integration/cases/record_optional_unify/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_optional_unify/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("items", new Object[]{Map.ofEntries(Map.entry("id", 1)), Map.ofEntries(Map.entry("id", 2), Map.entry("count", 10)), Map.ofEntries(Map.entry("id", 3), Map.entry("count", 20))})
+);
+my_data = Map.ofEntries(
+    Map.entry("items", new Object[]{Map.ofEntries(Map.entry("id", 1)), Map.ofEntries(Map.entry("id", 2), Map.entry("count", 10)), Map.ofEntries(Map.entry("id", 3), Map.entry("count", 20))})
+);
+    }
+}

--- a/tests/integration/cases/record_optional_unify/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_optional_unify/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("items", new Object[]{Map.ofEntries(Map.entry("id", 1)), Map.ofEntries(Map.entry("id", 2), Map.entry("count", 10)), Map.ofEntries(Map.entry("id", 3), Map.entry("count", 20))})
+);
+    }
+}

--- a/tests/integration/cases/record_pure_scalars/Java@jdk_16.java
+++ b/tests/integration/cases/record_pure_scalars/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("score", 4.5)
+);
+    }
+}

--- a/tests/integration/cases/record_pure_scalars/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_pure_scalars/Java_combined@jdk_16.java
@@ -1,0 +1,17 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("score", 4.5)
+);
+my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("score", 4.5)
+);
+    }
+}

--- a/tests/integration/cases/record_pure_scalars/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_pure_scalars/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("score", 4.5)
+);
+    }
+}

--- a/tests/integration/cases/record_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/record_sequence/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 1), Map.entry("label", "first")),
+    Map.ofEntries(Map.entry("id", 2), Map.entry("label", "second")),
+    Map.ofEntries(Map.entry("id", 3), Map.entry("label", "third"))
+};
+    }
+}

--- a/tests/integration/cases/record_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 1), Map.entry("label", "first")),
+    Map.ofEntries(Map.entry("id", 2), Map.entry("label", "second")),
+    Map.ofEntries(Map.entry("id", 3), Map.entry("label", "third"))
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 1), Map.entry("label", "first")),
+    Map.ofEntries(Map.entry("id", 2), Map.entry("label", "second")),
+    Map.ofEntries(Map.entry("id", 3), Map.entry("label", "third"))
+};
+    }
+}

--- a/tests/integration/cases/record_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("id", 1), Map.entry("label", "first")),
+    Map.ofEntries(Map.entry("id", 2), Map.entry("label", "second")),
+    Map.ofEntries(Map.entry("id", 3), Map.entry("label", "third"))
+};
+    }
+}

--- a/tests/integration/cases/record_two_shapes/Java@jdk_16.java
+++ b/tests/integration/cases/record_two_shapes/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("metrics", Map.ofEntries(Map.entry("count", 100), Map.entry("rate", 50))),
+    Map.entry("flags", Map.ofEntries(Map.entry("retries", 3), Map.entry("timeout", 30)))
+);
+    }
+}

--- a/tests/integration/cases/record_two_shapes/Java_combined@jdk_16.java
+++ b/tests/integration/cases/record_two_shapes/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("metrics", Map.ofEntries(Map.entry("count", 100), Map.entry("rate", 50))),
+    Map.entry("flags", Map.ofEntries(Map.entry("retries", 3), Map.entry("timeout", 30)))
+);
+my_data = Map.ofEntries(
+    Map.entry("metrics", Map.ofEntries(Map.entry("count", 100), Map.entry("rate", 50))),
+    Map.entry("flags", Map.ofEntries(Map.entry("retries", 3), Map.entry("timeout", 30)))
+);
+    }
+}

--- a/tests/integration/cases/record_two_shapes/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/record_two_shapes/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("metrics", Map.ofEntries(Map.entry("count", 100), Map.entry("rate", 50))),
+    Map.entry("flags", Map.ofEntries(Map.entry("retries", 3), Map.entry("timeout", 30)))
+);
+    }
+}

--- a/tests/integration/cases/scalar_bool/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_bool/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = true;
+    }
+}

--- a/tests/integration/cases/scalar_bool/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_bool/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = true;
+my_data = true;
+    }
+}

--- a/tests/integration/cases/scalar_bool/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_bool/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = true;
+    }
+}

--- a/tests/integration/cases/scalar_date/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_date/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.LocalDate;
+class Main {
+    public static void main() {
+var my_data = LocalDate.of(2024, 1, 15);
+    }
+}

--- a/tests/integration/cases/scalar_date/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_date/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.time.LocalDate;
+class Main {
+    public static void main() {
+var my_data = LocalDate.of(2024, 1, 15);
+my_data = LocalDate.of(2024, 1, 15);
+    }
+}

--- a/tests/integration/cases/scalar_date/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_date/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.LocalDate;
+class Main {
+    public static void main() {
+var my_data = LocalDate.of(2024, 1, 15);
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00+00:00");
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00+00:00");
+my_data = Instant.parse("2024-01-15T12:30:00+00:00");
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00+00:00");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_microsecond/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_microsecond/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00.123456+00:00");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_microsecond/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_microsecond/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00.123456+00:00");
+my_data = Instant.parse("2024-01-15T12:30:00.123456+00:00");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_microsecond/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_microsecond/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00.123456+00:00");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_midnight/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_midnight/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T00:00:00Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_midnight/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_midnight/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T00:00:00Z");
+my_data = Instant.parse("2024-01-15T00:00:00Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_midnight/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_midnight/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T00:00:00Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_naive/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_naive/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00Z");
+my_data = Instant.parse("2024-01-15T12:30:00Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_naive/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:00Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_non_utc/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T18:00:00+05:30");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_non_utc/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T18:00:00+05:30");
+my_data = Instant.parse("2024-01-15T18:00:00+05:30");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_non_utc/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T18:00:00+05:30");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
+my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.time.Instant;
+class Main {
+    public static void main() {
+var my_data = Instant.parse("2024-01-15T12:30:45.123456Z");
+    }
+}

--- a/tests/integration/cases/scalar_float/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_float/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = 3.14;
+    }
+}

--- a/tests/integration/cases/scalar_float/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_float/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = 3.14;
+my_data = 3.14;
+    }
+}

--- a/tests/integration/cases/scalar_float/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_float/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = 3.14;
+    }
+}

--- a/tests/integration/cases/scalar_int/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_int/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/scalar_int/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_int/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = 42;
+my_data = 42;
+    }
+}

--- a/tests/integration/cases/scalar_int/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_int/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = 42;
+    }
+}

--- a/tests/integration/cases/scalar_int_large/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_int_large/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = 2147483648L;
+    }
+}

--- a/tests/integration/cases/scalar_int_large/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_int_large/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = 2147483648L;
+my_data = 2147483648L;
+    }
+}

--- a/tests/integration/cases/scalar_int_large/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_int_large/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = 2147483648L;
+    }
+}

--- a/tests/integration/cases/scalar_int_negative_large/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_int_negative_large/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = -2147483649L;
+    }
+}

--- a/tests/integration/cases/scalar_int_negative_large/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_int_negative_large/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = -2147483649L;
+my_data = -2147483649L;
+    }
+}

--- a/tests/integration/cases/scalar_int_negative_large/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_int_negative_large/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = -2147483649L;
+    }
+}

--- a/tests/integration/cases/scalar_int_very_large/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_int_very_large/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.math.BigInteger;
+class Main {
+    public static void main() {
+var my_data = new BigInteger("9223372036854775808");
+    }
+}

--- a/tests/integration/cases/scalar_int_very_large/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_int_very_large/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.math.BigInteger;
+class Main {
+    public static void main() {
+var my_data = new BigInteger("9223372036854775808");
+my_data = new BigInteger("9223372036854775808");
+    }
+}

--- a/tests/integration/cases/scalar_int_very_large/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_int_very_large/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.math.BigInteger;
+class Main {
+    public static void main() {
+var my_data = new BigInteger("9223372036854775808");
+    }
+}

--- a/tests/integration/cases/scalar_int_very_negative_large/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_int_very_negative_large/Java@jdk_16.java
@@ -1,0 +1,6 @@
+import java.math.BigInteger;
+class Main {
+    public static void main() {
+var my_data = new BigInteger("-9223372036854775809");
+    }
+}

--- a/tests/integration/cases/scalar_int_very_negative_large/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_int_very_negative_large/Java_combined@jdk_16.java
@@ -1,0 +1,7 @@
+import java.math.BigInteger;
+class Main {
+    public static void main() {
+var my_data = new BigInteger("-9223372036854775809");
+my_data = new BigInteger("-9223372036854775809");
+    }
+}

--- a/tests/integration/cases/scalar_int_very_negative_large/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_int_very_negative_large/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+import java.math.BigInteger;
+class Main {
+    public static void main() {
+var my_data = new BigInteger("-9223372036854775809");
+    }
+}

--- a/tests/integration/cases/scalar_null/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_null/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+Object my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_null/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_null/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+Object my_data = null;
+my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_null/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_null/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+Object my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_null_with_comment/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_null_with_comment/Java@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+Object my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_null_with_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_null_with_comment/Java_combined@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+// note
+Object my_data = null;
+// note
+my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_null_with_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_null_with_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+// note
+Object my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_quoted_with_hash_no_comment/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_quoted_with_hash_no_comment/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/scalar_quoted_with_hash_no_comment/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_quoted_with_hash_no_comment/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = "hello # world";
+my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/scalar_quoted_with_hash_no_comment/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_quoted_with_hash_no_comment/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/scalar_string/Java@jdk_16.java
+++ b/tests/integration/cases/scalar_string/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = "hello";
+    }
+}

--- a/tests/integration/cases/scalar_string/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalar_string/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = "hello";
+my_data = "hello";
+    }
+}

--- a/tests/integration/cases/scalar_string/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalar_string/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = "hello";
+    }
+}

--- a/tests/integration/cases/scalars/Java@jdk_16.java
+++ b/tests/integration/cases/scalars/Java@jdk_16.java
@@ -1,0 +1,11 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    42,
+    3.14,
+    true,
+    false,
+    "hello \"world\""
+};
+    }
+}

--- a/tests/integration/cases/scalars/Java_combined@jdk_16.java
+++ b/tests/integration/cases/scalars/Java_combined@jdk_16.java
@@ -1,0 +1,18 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    42,
+    3.14,
+    true,
+    false,
+    "hello \"world\""
+};
+my_data = new Object[]{
+    42,
+    3.14,
+    true,
+    false,
+    "hello \"world\""
+};
+    }
+}

--- a/tests/integration/cases/scalars/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/scalars/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    42,
+    3.14,
+    true,
+    false,
+    "hello \"world\""
+};
+    }
+}

--- a/tests/integration/cases/sequence_of_dicts/Java@jdk_16.java
+++ b/tests/integration/cases/sequence_of_dicts/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)),
+    Map.ofEntries(Map.entry("name", "Bob"), Map.entry("age", 25))
+};
+    }
+}

--- a/tests/integration/cases/sequence_of_dicts/Java_combined@jdk_16.java
+++ b/tests/integration/cases/sequence_of_dicts/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)),
+    Map.ofEntries(Map.entry("name", "Bob"), Map.entry("age", 25))
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)),
+    Map.ofEntries(Map.entry("name", "Bob"), Map.entry("age", 25))
+};
+    }
+}

--- a/tests/integration/cases/sequence_of_dicts/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/sequence_of_dicts/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("name", "Alice"), Map.entry("age", 30)),
+    Map.ofEntries(Map.entry("name", "Bob"), Map.entry("age", 25))
+};
+    }
+}

--- a/tests/integration/cases/set/Java@jdk_16.java
+++ b/tests/integration/cases/set/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    "apple",
+    "banana",
+    "cherry"
+);
+    }
+}

--- a/tests/integration/cases/set/Java_combined@jdk_16.java
+++ b/tests/integration/cases/set/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    "apple",
+    "banana",
+    "cherry"
+);
+my_data = Set.of(
+    "apple",
+    "banana",
+    "cherry"
+);
+    }
+}

--- a/tests/integration/cases/set/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/set/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    "apple",
+    "banana",
+    "cherry"
+);
+    }
+}

--- a/tests/integration/cases/set_comments/Java@jdk_16.java
+++ b/tests/integration/cases/set_comments/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    "apple",  // inline comment
+    // before banana
+    "banana"
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_comments/Java_combined@jdk_16.java
+++ b/tests/integration/cases/set_comments/Java_combined@jdk_16.java
@@ -1,0 +1,17 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    "apple",  // inline comment
+    // before banana
+    "banana"
+    // trailing
+);
+my_data = Set.of(
+    "apple",  // inline comment
+    // before banana
+    "banana"
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_comments/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/set_comments/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    "apple",  // inline comment
+    // before banana
+    "banana"
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_comments_unsorted_order/Java@jdk_16.java
+++ b/tests/integration/cases/set_comments_unsorted_order/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_comments_unsorted_order/Java_combined@jdk_16.java
+++ b/tests/integration/cases/set_comments_unsorted_order/Java_combined@jdk_16.java
@@ -1,0 +1,17 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+my_data = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_comments_unsorted_order/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/set_comments_unsorted_order/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    // before apple
+    "apple",
+    "banana"  // banana inline
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/set_in_annotated_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/set_in_annotated_sequence/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Set.of(),
+    Set.of(1, 2),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/set_in_annotated_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/set_in_annotated_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Set.of(),
+    Set.of(1, 2),
+    new Object[]{}
+};
+my_data = new Object[]{
+    Set.of(),
+    Set.of(1, 2),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/set_in_annotated_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/set_in_annotated_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Set.of(),
+    Set.of(1, 2),
+    new Object[]{}
+};
+    }
+}

--- a/tests/integration/cases/set_in_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/set_in_sequence/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Set.of("a", "b")
+};
+    }
+}

--- a/tests/integration/cases/set_in_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/set_in_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Set.of("a", "b")
+};
+my_data = new Object[]{
+    Set.of("a", "b")
+};
+    }
+}

--- a/tests/integration/cases/set_in_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/set_in_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Set.of("a", "b")
+};
+    }
+}

--- a/tests/integration/cases/set_mixed_int_widths/Java@jdk_16.java
+++ b/tests/integration/cases/set_mixed_int_widths/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    1L,
+    1099511627776L
+);
+    }
+}

--- a/tests/integration/cases/set_mixed_int_widths/Java_combined@jdk_16.java
+++ b/tests/integration/cases/set_mixed_int_widths/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    1L,
+    1099511627776L
+);
+my_data = Set.of(
+    1L,
+    1099511627776L
+);
+    }
+}

--- a/tests/integration/cases/set_mixed_int_widths/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/set_mixed_int_widths/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Set;
+class Main {
+    public static void main() {
+var my_data = Set.of(
+    1L,
+    1099511627776L
+);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_nested/Java@jdk_16.java
+++ b/tests/integration/cases/sibling_list_values_nested/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new Object[]{}}),
+    Map.entry("test", new Object[]{5, new Object[]{"compile"}})
+);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_nested/Java_combined@jdk_16.java
+++ b/tests/integration/cases/sibling_list_values_nested/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new Object[]{}}),
+    Map.entry("test", new Object[]{5, new Object[]{"compile"}})
+);
+my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new Object[]{}}),
+    Map.entry("test", new Object[]{5, new Object[]{"compile"}})
+);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_nested/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/sibling_list_values_nested/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new Object[]{}}),
+    Map.entry("test", new Object[]{5, new Object[]{"compile"}})
+);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Java@jdk_16.java
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new int[]{1}}),
+    Map.entry("test", new Object[]{5, new int[]{7}})
+);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Java_combined@jdk_16.java
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new int[]{1}}),
+    Map.entry("test", new Object[]{5, new int[]{7}})
+);
+my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new int[]{1}}),
+    Map.entry("test", new Object[]{5, new int[]{7}})
+);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("lint", new Object[]{2, new int[]{1}}),
+    Map.entry("test", new Object[]{5, new int[]{7}})
+);
+    }
+}

--- a/tests/integration/cases/simple_dict/Java@jdk_16.java
+++ b/tests/integration/cases/simple_dict/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+);
+    }
+}

--- a/tests/integration/cases/simple_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/simple_dict/Java_combined@jdk_16.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+);
+my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+);
+    }
+}

--- a/tests/integration/cases/simple_dict/Java_pre_indent_1_public_static_final@jdk_16.java
+++ b/tests/integration/cases/simple_dict/Java_pre_indent_1_public_static_final@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static final Map<String, Object> my_data = Map.ofEntries(
+        Map.entry("name", "Alice"),
+        Map.entry("age", 30),
+        Map.entry("active", true)
+    );
+}

--- a/tests/integration/cases/simple_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/simple_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true)
+);
+    }
+}

--- a/tests/integration/cases/simple_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/simple_sequence/Java@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello",
+    true,
+    null
+};
+    }
+}

--- a/tests/integration/cases/simple_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/simple_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,16 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello",
+    true,
+    null
+};
+my_data = new Object[]{
+    1,
+    "hello",
+    true,
+    null
+};
+    }
+}

--- a/tests/integration/cases/simple_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/simple_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello",
+    true,
+    null
+};
+    }
+}

--- a/tests/integration/cases/string_control_chars/Java@jdk_16.java
+++ b/tests/integration/cases/string_control_chars/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "line1\r\nline2",
+    "line1\rline2",
+    ""
+};
+    }
+}

--- a/tests/integration/cases/string_control_chars/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_control_chars/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "line1\r\nline2",
+    "line1\rline2",
+    ""
+};
+my_data = new String[]{
+    "line1\r\nline2",
+    "line1\rline2",
+    ""
+};
+    }
+}

--- a/tests/integration/cases/string_control_chars/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_control_chars/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "line1\r\nline2",
+    "line1\rline2",
+    ""
+};
+    }
+}

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Java@jdk_16.java
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Java@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = "hello \"world\" -- not a comment";
+    }
+}

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Java_combined@jdk_16.java
@@ -1,0 +1,6 @@
+class Main {
+    public static void main() {
+var my_data = "hello \"world\" -- not a comment";
+my_data = "hello \"world\" -- not a comment";
+    }
+}

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main() {
+var my_data = "hello \"world\" -- not a comment";
+    }
+}

--- a/tests/integration/cases/string_list/Java@jdk_16.java
+++ b/tests/integration/cases/string_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "foo",
+    "bar",
+    "baz"
+};
+    }
+}

--- a/tests/integration/cases/string_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_list/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "foo",
+    "bar",
+    "baz"
+};
+my_data = new String[]{
+    "foo",
+    "bar",
+    "baz"
+};
+    }
+}

--- a/tests/integration/cases/string_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "foo",
+    "bar",
+    "baz"
+};
+    }
+}

--- a/tests/integration/cases/string_with_backslash/Java@jdk_16.java
+++ b/tests/integration/cases/string_with_backslash/Java@jdk_16.java
@@ -1,0 +1,13 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "C:\\path\\to\\file",
+    "back\\\\slash",
+    "hello \\\"world\\\"",
+    "path\\to \"# file",
+    "trailing\\",
+    "both \"quotes''' here",
+    "line1\\nline2\nwith newline"
+};
+    }
+}

--- a/tests/integration/cases/string_with_backslash/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_with_backslash/Java_combined@jdk_16.java
@@ -1,0 +1,22 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "C:\\path\\to\\file",
+    "back\\\\slash",
+    "hello \\\"world\\\"",
+    "path\\to \"# file",
+    "trailing\\",
+    "both \"quotes''' here",
+    "line1\\nline2\nwith newline"
+};
+my_data = new String[]{
+    "C:\\path\\to\\file",
+    "back\\\\slash",
+    "hello \\\"world\\\"",
+    "path\\to \"# file",
+    "trailing\\",
+    "both \"quotes''' here",
+    "line1\\nline2\nwith newline"
+};
+    }
+}

--- a/tests/integration/cases/string_with_backslash/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_with_backslash/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,13 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "C:\\path\\to\\file",
+    "back\\\\slash",
+    "hello \\\"world\\\"",
+    "path\\to \"# file",
+    "trailing\\",
+    "both \"quotes''' here",
+    "line1\\nline2\nwith newline"
+};
+    }
+}

--- a/tests/integration/cases/string_with_dollar/Java@jdk_16.java
+++ b/tests/integration/cases/string_with_dollar/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "price $10",
+    "$HOME"
+};
+    }
+}

--- a/tests/integration/cases/string_with_dollar/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_with_dollar/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "price $10",
+    "$HOME"
+};
+my_data = new String[]{
+    "price $10",
+    "$HOME"
+};
+    }
+}

--- a/tests/integration/cases/string_with_dollar/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_with_dollar/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "price $10",
+    "$HOME"
+};
+    }
+}

--- a/tests/integration/cases/string_with_dollar_brace/Java@jdk_16.java
+++ b/tests/integration/cases/string_with_dollar_brace/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "prefix ${HOME} suffix",
+    "${interpolated}"
+};
+    }
+}

--- a/tests/integration/cases/string_with_dollar_brace/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_with_dollar_brace/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "prefix ${HOME} suffix",
+    "${interpolated}"
+};
+my_data = new String[]{
+    "prefix ${HOME} suffix",
+    "${interpolated}"
+};
+    }
+}

--- a/tests/integration/cases/string_with_dollar_brace/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_with_dollar_brace/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "prefix ${HOME} suffix",
+    "${interpolated}"
+};
+    }
+}

--- a/tests/integration/cases/string_with_hash/Java@jdk_16.java
+++ b/tests/integration/cases/string_with_hash/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "issue #{42}",
+    "color #red"
+};
+    }
+}

--- a/tests/integration/cases/string_with_hash/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_with_hash/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "issue #{42}",
+    "color #red"
+};
+my_data = new String[]{
+    "issue #{42}",
+    "color #red"
+};
+    }
+}

--- a/tests/integration/cases/string_with_hash/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_with_hash/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "issue #{42}",
+    "color #red"
+};
+    }
+}

--- a/tests/integration/cases/string_with_percent/Java@jdk_16.java
+++ b/tests/integration/cases/string_with_percent/Java@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "100% done",
+    "%(name) is here"
+};
+    }
+}

--- a/tests/integration/cases/string_with_percent/Java_combined@jdk_16.java
+++ b/tests/integration/cases/string_with_percent/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "100% done",
+    "%(name) is here"
+};
+my_data = new String[]{
+    "100% done",
+    "%(name) is here"
+};
+    }
+}

--- a/tests/integration/cases/string_with_percent/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/string_with_percent/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+class Main {
+    public static void main() {
+var my_data = new String[]{
+    "100% done",
+    "%(name) is here"
+};
+    }
+}

--- a/tests/integration/cases/time_dict/Java@jdk_16.java
+++ b/tests/integration/cases/time_dict/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.time.LocalTime;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("morning", LocalTime.of(9, 30)),
+    Map.entry("afternoon", LocalTime.of(14, 15)),
+    Map.entry("evening", LocalTime.of(23, 59, 59))
+);
+    }
+}

--- a/tests/integration/cases/time_dict/Java_combined@jdk_16.java
+++ b/tests/integration/cases/time_dict/Java_combined@jdk_16.java
@@ -1,0 +1,16 @@
+import java.time.LocalTime;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("morning", LocalTime.of(9, 30)),
+    Map.entry("afternoon", LocalTime.of(14, 15)),
+    Map.entry("evening", LocalTime.of(23, 59, 59))
+);
+my_data = Map.ofEntries(
+    Map.entry("morning", LocalTime.of(9, 30)),
+    Map.entry("afternoon", LocalTime.of(14, 15)),
+    Map.entry("evening", LocalTime.of(23, 59, 59))
+);
+    }
+}

--- a/tests/integration/cases/time_dict/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/time_dict/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.time.LocalTime;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("morning", LocalTime.of(9, 30)),
+    Map.entry("afternoon", LocalTime.of(14, 15)),
+    Map.entry("evening", LocalTime.of(23, 59, 59))
+);
+    }
+}

--- a/tests/integration/cases/time_list/Java@jdk_16.java
+++ b/tests/integration/cases/time_list/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.time.LocalTime;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("times", new LocalTime[]{LocalTime.of(9, 30), LocalTime.of(17, 45), LocalTime.of(23, 59, 59)})
+);
+    }
+}

--- a/tests/integration/cases/time_list/Java_combined@jdk_16.java
+++ b/tests/integration/cases/time_list/Java_combined@jdk_16.java
@@ -1,0 +1,12 @@
+import java.time.LocalTime;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("times", new LocalTime[]{LocalTime.of(9, 30), LocalTime.of(17, 45), LocalTime.of(23, 59, 59)})
+);
+my_data = Map.ofEntries(
+    Map.entry("times", new LocalTime[]{LocalTime.of(9, 30), LocalTime.of(17, 45), LocalTime.of(23, 59, 59)})
+);
+    }
+}

--- a/tests/integration/cases/time_list/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/time_list/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.time.LocalTime;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("times", new LocalTime[]{LocalTime.of(9, 30), LocalTime.of(17, 45), LocalTime.of(23, 59, 59)})
+);
+    }
+}

--- a/tests/integration/cases/times_heterogeneous_with_dates/Java@jdk_16.java
+++ b/tests/integration/cases/times_heterogeneous_with_dates/Java@jdk_16.java
@@ -1,0 +1,10 @@
+import java.time.LocalTime;
+import java.time.LocalDate;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("vals", new Object[]{LocalDate.of(2024, 1, 15), LocalTime.of(9, 30)})
+);
+    }
+}

--- a/tests/integration/cases/times_heterogeneous_with_dates/Java_combined@jdk_16.java
+++ b/tests/integration/cases/times_heterogeneous_with_dates/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.time.LocalTime;
+import java.time.LocalDate;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("vals", new Object[]{LocalDate.of(2024, 1, 15), LocalTime.of(9, 30)})
+);
+my_data = Map.ofEntries(
+    Map.entry("vals", new Object[]{LocalDate.of(2024, 1, 15), LocalTime.of(9, 30)})
+);
+    }
+}

--- a/tests/integration/cases/times_heterogeneous_with_dates/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/times_heterogeneous_with_dates/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,10 @@
+import java.time.LocalTime;
+import java.time.LocalDate;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("vals", new Object[]{LocalDate.of(2024, 1, 15), LocalTime.of(9, 30)})
+);
+    }
+}

--- a/tests/integration/cases/toml_comments/Java@jdk_16.java
+++ b/tests/integration/cases/toml_comments/Java@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // before
+    Map.entry("answer", 42),  // inline
+    Map.entry("plain", "ok")
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/toml_comments/Java_combined@jdk_16.java
+++ b/tests/integration/cases/toml_comments/Java_combined@jdk_16.java
@@ -1,0 +1,17 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // before
+    Map.entry("answer", 42),  // inline
+    Map.entry("plain", "ok")
+    // trailing
+);
+my_data = Map.ofEntries(
+    // before
+    Map.entry("answer", 42),  // inline
+    Map.entry("plain", "ok")
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/toml_comments/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/toml_comments/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    // before
+    Map.entry("answer", 42),  // inline
+    Map.entry("plain", "ok")
+    // trailing
+);
+    }
+}

--- a/tests/integration/cases/toml_table/Java@jdk_16.java
+++ b/tests/integration/cases/toml_table/Java@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("section", Map.ofEntries(Map.entry("value", 1)))
+);
+    }
+}

--- a/tests/integration/cases/toml_table/Java_combined@jdk_16.java
+++ b/tests/integration/cases/toml_table/Java_combined@jdk_16.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("section", Map.ofEntries(Map.entry("value", 1)))
+);
+my_data = Map.ofEntries(
+    Map.entry("section", Map.ofEntries(Map.entry("value", 1)))
+);
+    }
+}

--- a/tests/integration/cases/toml_table/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/toml_table/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,8 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("section", Map.ofEntries(Map.entry("value", 1)))
+);
+    }
+}

--- a/tests/integration/cases/triple_sequence/Java@jdk_16.java
+++ b/tests/integration/cases/triple_sequence/Java@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello",
+    true
+};
+    }
+}

--- a/tests/integration/cases/triple_sequence/Java_combined@jdk_16.java
+++ b/tests/integration/cases/triple_sequence/Java_combined@jdk_16.java
@@ -1,0 +1,14 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello",
+    true
+};
+my_data = new Object[]{
+    1,
+    "hello",
+    true
+};
+    }
+}

--- a/tests/integration/cases/triple_sequence/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/triple_sequence/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    1,
+    "hello",
+    true
+};
+    }
+}

--- a/tests/integration/cases/type_hints/Java@jdk_16.java
+++ b/tests/integration/cases/type_hints/Java@jdk_16.java
@@ -1,0 +1,15 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("joined", LocalDate.of(2024, 1, 15)),
+    Map.entry("last_login", Instant.parse("2024-01-15T12:30:00+00:00")),
+    Map.entry("avatar", "48656c6c6f")
+);
+    }
+}

--- a/tests/integration/cases/type_hints/Java_combined@jdk_16.java
+++ b/tests/integration/cases/type_hints/Java_combined@jdk_16.java
@@ -1,0 +1,23 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("joined", LocalDate.of(2024, 1, 15)),
+    Map.entry("last_login", Instant.parse("2024-01-15T12:30:00+00:00")),
+    Map.entry("avatar", "48656c6c6f")
+);
+my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("joined", LocalDate.of(2024, 1, 15)),
+    Map.entry("last_login", Instant.parse("2024-01-15T12:30:00+00:00")),
+    Map.entry("avatar", "48656c6c6f")
+);
+    }
+}

--- a/tests/integration/cases/type_hints/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/type_hints/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,15 @@
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry("name", "Alice"),
+    Map.entry("age", 30),
+    Map.entry("active", true),
+    Map.entry("joined", LocalDate.of(2024, 1, 15)),
+    Map.entry("last_login", Instant.parse("2024-01-15T12:30:00+00:00")),
+    Map.entry("avatar", "48656c6c6f")
+);
+    }
+}

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Java@jdk_16.java
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("x", 1), Map.entry("y", 2.5)),
+    Map.ofEntries(Map.entry("x", 3), Map.entry("y", 4.0))
+};
+    }
+}

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Java_combined@jdk_16.java
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("x", 1), Map.entry("y", 2.5)),
+    Map.ofEntries(Map.entry("x", 3), Map.entry("y", 4.0))
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("x", 1), Map.entry("y", 2.5)),
+    Map.ofEntries(Map.entry("x", 3), Map.entry("y", 4.0))
+};
+    }
+}

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("x", 1), Map.entry("y", 2.5)),
+    Map.ofEntries(Map.entry("x", 3), Map.entry("y", 4.0))
+};
+    }
+}

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Java@jdk_16.java
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Java@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("first", "Alice"), Map.entry("last", "Smith")),
+    Map.ofEntries(Map.entry("first", "Bob"), Map.entry("last", "Jones"))
+};
+    }
+}

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Java_combined@jdk_16.java
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Java_combined@jdk_16.java
@@ -1,0 +1,13 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("first", "Alice"), Map.entry("last", "Smith")),
+    Map.ofEntries(Map.entry("first", "Bob"), Map.entry("last", "Jones"))
+};
+my_data = new Object[]{
+    Map.ofEntries(Map.entry("first", "Alice"), Map.entry("last", "Smith")),
+    Map.ofEntries(Map.entry("first", "Bob"), Map.entry("last", "Jones"))
+};
+    }
+}

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Java_version_jdk_16@jdk_16.java
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Java_version_jdk_16@jdk_16.java
@@ -1,0 +1,9 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = new Object[]{
+    Map.ofEntries(Map.entry("first", "Alice"), Map.entry("last", "Smith")),
+    Map.ofEntries(Map.entry("first", "Bob"), Map.entry("last", "Jones"))
+};
+    }
+}


### PR DESCRIPTION
Adds `JDK_16` to `Java.VersionFormats` alongside the existing `JDK_11` (still the default); generated code is currently identical for both targets, but the member exists so a future Java `RECORD` `heterogeneous_strategy` (whose `record` declarations require Java 16) can gate on it. The version-variant golden harness automatically emits a parallel `@jdk_16` fixture set (508 new files, byte-identical to `@jdk_11`), and Vulture's `ignore_names` gains `JDK_16` since, unlike `JDK_11`, it has no static reference. The `Lint Java` CI step now compiles each fixture at the `--release` matching its `@jdk_<release>` tag: `CheckJavaSyntax.java` takes the release as its first argument, the workflow passes explicit `11`/`16` literals over the partitioned fixture sets, and a pinned Temurin 21 JDK (accepts both `--release 11` and `16`) is set up explicitly. Sync comments are kept bidirectional between `java.py`, `lint.yml`, and `CheckJavaSyntax.java`. Closes #2313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive (new `JDK_16` enum option and parallel golden fixtures), but it also changes CI linting to compile Java fixtures with explicit `--release` values and pins a JDK in GitHub Actions, which could affect build stability.
> 
> **Overview**
> Adds `Java.VersionFormats.JDK_16` (alongside default `JDK_11`) and documents it in the changelog, enabling users to select a Java 16 target via `language_version`.
> 
> Updates the fixture/golden + CI harness to support multiple Java releases: the Java lint workflow now installs Temurin JDK 21, splits fixtures by `@jdk_11`/`@jdk_16`, and passes the desired `--release` into `CheckJavaSyntax.java` (which now requires `<release> <file>...`). Also expands integration fixtures with a new `@jdk_16` set and adds `JDK_16` to Vulture ignore names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a141af8e3d0666c2b0087e3df152cfab3f27db57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->