### PR TITLE
Remove dead _no_compute_record_shapes pragma (#2318)

### DIFF
--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -609,9 +609,10 @@ def check_data(  # noqa: C901  # pylint: disable=too-complex
     dict_supports_het = spec.dict_supports_heterogeneous_values
     set_supports_het = spec.set_format_config.supports_heterogeneity
     behavior = spec.heterogeneous_behavior
+    compute_record_shapes = behavior.compute_record_shapes
     record_shapes_by_id: Mapping[int, RecordShape] = (
-        behavior.compute_record_shapes(data)
-        if behavior.render_record_literal is not None
+        compute_record_shapes(data)
+        if compute_record_shapes is not None
         else {}
     )
     record_dict_ids: frozenset[int] = frozenset(record_shapes_by_id)

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -501,8 +501,10 @@ class HeterogeneousBehavior:
     mapping from ``id(dict)`` to :class:`RecordShape` for every dict
     the strategy will render as a record literal.  Used by
     :func:`~literalizer._checks.check_data` to carve record-eligible
-    dicts out of the heterogeneous-values checks.  Defaults to a
-    callable returning an empty mapping for non-RECORD strategies.
+    dicts out of the heterogeneous-values checks.  Defaults to
+    ``None`` for non-RECORD strategies, paired with
+    ``render_record_literal``: a behavior either sets both (RECORD)
+    or neither.
 
     Languages that do not wrap expose
     :data:`NO_HETEROGENEOUS_BEHAVIOR`.
@@ -520,25 +522,14 @@ class HeterogeneousBehavior:
         ]
         | None
     ) = None
-    compute_record_shapes: Callable[[Value], Mapping[int, RecordShape]] = (
-        dataclasses.field(default_factory=lambda: _no_compute_record_shapes)
-    )
+    compute_record_shapes: (
+        Callable[[Value], Mapping[int, RecordShape]] | None
+    ) = None
 
 
 def no_compute_wrap_ids(_data: Value, /) -> frozenset[int]:
     """Return an empty wrap-id set — used by non-wrapping languages."""
     return frozenset()
-
-
-def _no_compute_record_shapes(_data: Value, /) -> Mapping[int, RecordShape]:
-    """Return an empty record-shape mapping — default for non-RECORD
-    strategies.
-
-    ``check_data`` skips this call when ``render_record_literal`` is
-    ``None`` so the body never runs in practice; it exists to keep the
-    behavior's API uniform.
-    """
-    return {}  # pragma: no cover
 
 
 def _no_compute_call_slot_wrap_ids(


### PR DESCRIPTION
Part of #2318 (drive `# pragma: no cover` / `# pragma: no branch` to zero).

## What

`HeterogeneousBehavior.compute_record_shapes` defaulted to a
`_no_compute_record_shapes` helper carrying `# pragma: no cover` on its
`return {}`. `_checks.check_data` only invokes `compute_record_shapes`
when the behavior also sets `render_record_literal`, and the two are
paired by construction: the two RECORD behaviors (`rust.py`,
`record_strategy.py`) set both; every other behavior sets neither. So
the default helper was provably unreachable dead code.

- `compute_record_shapes` now defaults to `None` (typed
  `Callable[...] | None`).
- The call site guards on `compute_record_shapes is not None` directly
  (behaviourally identical to the old `render_record_literal is not
  None` guard given the pairing invariant), so the type checker is
  satisfied without the helper.
- `_no_compute_record_shapes` and its pragma are deleted.

## Scope

This addresses the single genuinely-dead, #2317-independent entry. The
other 10 inventory sites in #2318 are all the out-of-MVP set /
non-record-dict / empty / non-string-keyed record-field shapes whose
cross-language behaviour is the open design decision in #2317; #2318's
own notes defer them there (and lint requires every fixture to compile
in all languages, so they cannot be golden-covered until #2317 picks a
behaviour). Those are intentionally left for #2317.

## Verification

- `pytest --cov-fail-under 100 --cov=src/ --cov=tests`: 4282 passed,
  100.00% coverage retained, no new pragmas.
- mypy / ruff / pre-commit (incl. vulture dead-code) clean on the
  changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal cleanup: changes `HeterogeneousBehavior.compute_record_shapes` defaulting/guarding, but behavior should be unchanged because non-RECORD strategies never use record-shape computation.
> 
> **Overview**
> Simplifies RECORD-strategy plumbing by making `HeterogeneousBehavior.compute_record_shapes` optional (defaults to `None`) instead of a default no-op helper.
> 
> Updates `check_data` to call `compute_record_shapes` only when it is set, and deletes the unreachable `_no_compute_record_shapes` implementation and its coverage pragma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc559158e473f628959664087dc7d52b0efe093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->