### PR TITLE
Add supports_record_struct_name_prefix capability flag to LanguageCls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ Next
   representable instead of raising.  Field names keep the original
   dict keys and the data-class-name prefix is configurable via the new
   ``record_struct_name_prefix`` constructor parameter.  See #2298.
+- :class:`~literalizer._language.LanguageCls` now exposes a
+  ``supports_record_struct_name_prefix`` flag alongside the existing
+  ``supports_*`` family.  Runtime-dispatched callers that look up a
+  language by name can use it to decide whether to pass the
+  ``record_struct_name_prefix`` constructor keyword argument without
+  inspecting dataclass fields or the ``__init__`` signature.  It is
+  ``True`` on :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,
+  and :class:`~literalizer.Rust`, and ``False`` on every other language.
 
 2026.05.15
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -517,6 +517,7 @@ ignore_names = [
     "supports_default_sequence_element_type",
     "supports_default_set_element_type",
     "supports_default_ordered_map_value_type",
+    "supports_record_struct_name_prefix",
     # Used in documentation code examples
     "custom",
     "result",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -696,6 +696,7 @@ class LanguageCls(type):
     supports_default_sequence_element_type: bool
     supports_default_set_element_type: bool
     supports_default_ordered_map_value_type: bool
+    supports_record_struct_name_prefix: bool
     dict_supports_heterogeneous_values: bool
     format_call_arg: FormatCallArg
     validate_call_arg: Callable[[Value], None]

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -238,6 +238,7 @@ class Ada(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -216,6 +216,7 @@ class Bash(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -263,6 +263,7 @@ class C(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -128,6 +128,7 @@ class Clojure(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -354,6 +354,7 @@ class Cobol(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -137,6 +137,7 @@ class CommonLisp(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -945,6 +945,7 @@ class Cpp(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -200,6 +200,7 @@ class Crystal(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -382,6 +382,7 @@ class CSharp(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -184,6 +184,7 @@ class D(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -361,6 +361,7 @@ class Dart(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -575,6 +575,7 @@ class Dhall(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -226,6 +226,7 @@ class Elixir(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -559,6 +559,7 @@ class Elm(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -221,6 +221,7 @@ class Erlang(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -230,6 +230,7 @@ class Forth(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -351,6 +351,7 @@ class Fortran(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -341,6 +341,7 @@ class FSharp(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -565,6 +565,7 @@ class Gleam(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -318,6 +318,7 @@ class Go(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = True
+    supports_record_struct_name_prefix = True
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -164,6 +164,7 @@ class Groovy(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1142,6 +1142,7 @@ class Haskell(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -176,6 +176,7 @@ class Hcl(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -613,6 +613,7 @@ class Java(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -148,6 +148,7 @@ class JavaScript(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -140,6 +140,7 @@ class Json5(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -158,6 +158,7 @@ class Jsonnet(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -176,6 +176,7 @@ class Julia(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -591,6 +591,7 @@ class Kotlin(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = True
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -162,6 +162,7 @@ class Lua(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -229,6 +229,7 @@ class Matlab(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -937,6 +937,7 @@ class Mojo(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -565,6 +565,7 @@ class Nim(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -208,6 +208,7 @@ class Nix(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -112,6 +112,7 @@ class Norg(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -317,6 +317,7 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -301,6 +301,7 @@ class OCaml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -155,6 +155,7 @@ class Occam(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -234,6 +234,7 @@ class Odin(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -174,6 +174,7 @@ class Perl(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -171,6 +171,7 @@ class Php(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -187,6 +187,7 @@ class PowerShell(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -711,6 +711,7 @@ class PureScript(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -714,6 +714,7 @@ class Python(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -186,6 +186,7 @@ class R(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -129,6 +129,7 @@ class Racket(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -206,6 +206,7 @@ class Raku(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -567,6 +567,7 @@ class Roc(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
     supports_special_floats = True
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -208,6 +208,7 @@ class Ruby(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1139,6 +1139,7 @@ class Rust(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = True
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -249,6 +249,7 @@ class Scala(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -125,6 +125,7 @@ class Scheme(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -375,6 +375,7 @@ class Sml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -425,6 +425,7 @@ class Swift(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -259,6 +259,7 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -170,6 +170,7 @@ class Tcl(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -145,6 +145,7 @@ class Toml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -332,6 +332,7 @@ class TypeScript(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -405,6 +405,7 @@ class V(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -290,6 +290,7 @@ class VisualBasic(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -189,6 +189,7 @@ class Wren(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -114,6 +114,7 @@ class Yaml(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -250,6 +250,7 @@ class Zig(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/tests/metadata/test_language_metadata.py
+++ b/tests/metadata/test_language_metadata.py
@@ -1,6 +1,7 @@
 """Language-wide metadata and protocol checks."""
 
 import enum
+from typing import Protocol, runtime_checkable
 
 import pytest
 from pygments.lexers import find_lexer_class_by_name
@@ -143,6 +144,40 @@ def test_wrap_combined_in_file_unsupported_raises(
             variable_name="x",
             body_preamble=(),
         )
+
+
+@runtime_checkable
+class _HasRecordStructNamePrefix(Protocol):
+    """Structural type for languages that expose a
+    ``record_struct_name_prefix`` constructor field.
+
+    Used to narrow a generic :class:`literalizer.Language` to one with
+    the field without introspecting ``__dataclass_fields__`` or casting
+    to ``Any``.
+    """
+
+    record_struct_name_prefix: str
+
+
+@pytest.mark.parametrize(
+    argnames="language_cls",
+    argvalues=_SORTED_LANGUAGES,
+    ids=[c.__name__ for c in _SORTED_LANGUAGES],
+)
+def test_supports_record_struct_name_prefix_matches_constructor(
+    *,
+    language_cls: LanguageCls,
+) -> None:
+    """The flag is ``True`` exactly when the constructor accepts
+    ``record_struct_name_prefix``.
+
+    Runtime-dispatched callers rely on this flag instead of inspecting
+    dataclass fields, so it must stay in lock-step with the actual
+    constructor keyword arguments.
+    """
+    spec = language_cls()
+    accepts_kwarg = isinstance(spec, _HasRecordStructNamePrefix)
+    assert language_cls.supports_record_struct_name_prefix == accepts_kwarg
 
 
 def test_supported_ref_cases_independent_of_identifier_cases() -> None:


### PR DESCRIPTION
Adds a `supports_record_struct_name_prefix: bool` class variable to `LanguageCls` so runtime-dispatched callers can decide whether to pass the `record_struct_name_prefix` constructor keyword argument without inspecting dataclass fields or the `__init__` signature, matching the existing `supports_*` family. It is set `True` on the three languages whose constructor accepts that kwarg (Go, Kotlin, Rust) and `False` on every other language; note the originating issue predates the Kotlin RECORD port (#2298), so Kotlin is included for correctness. A parametrized metadata test asserts the flag stays in lock-step with the actual constructor field via a `runtime_checkable` Protocol (mirroring the repo's existing typed-narrowing pattern), and `pyproject.toml` and `CHANGELOG.rst` are updated accordingly. The remaining 63 one-line language-file edits just declare the new flag.

Closes #2315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new metadata flag and a test to keep it aligned with constructor support; no rendering logic changes, but touches many language class declarations.
> 
> **Overview**
> Adds a new `LanguageCls.supports_record_struct_name_prefix` capability flag so runtime language selection can safely decide whether to pass the `record_struct_name_prefix` constructor kwarg.
> 
> Sets the flag to `True` for `Go`, `Kotlin`, and `Rust` and `False` for all other built-in languages, and adds a parametrized metadata test (via a runtime-checkable `Protocol`) to assert the flag matches actual constructor support. Updates the changelog and `pyproject.toml`’s tooling ignore list accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8893d252a9c7ac99f635a40407d6c7bdf7da453c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->