### PR TITLE
Remove two pragma: no cover; cover via int_key_dict variant

### DIFF
--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -204,14 +204,16 @@ def record_shape_for_dict(
     ``str``.  Callers must filter out ordered maps before
     calling this helper.
     """
-    # Defensive branches: every Rust RECORD fixture passes non-empty
-    # string-keyed dicts here, but the walker also calls this helper
-    # on nested dicts of arbitrary shape that may not be record-eligible.
+    # The walker calls this helper on dicts of arbitrary shape that may
+    # not be record-eligible.  An empty dict has no fields to infer; a
+    # non-string-keyed dict is a plain map, not a record (the
+    # ``int_key_dict`` heterogeneous-strategy variant exercises the
+    # latter).
     if not value:  # pragma: no cover
         return None
     str_keys: list[str] = []
     for key in value:
-        if not isinstance(key, str):  # pragma: no cover
+        if not isinstance(key, str):
             return None
         str_keys.append(key)
     return RecordShape(keys=tuple(str_keys))

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -526,7 +526,7 @@ def _maybe_format_record_literal(
     render_record_literal = behavior.render_record_literal
     if render_record_literal is None:
         return None
-    if record_shape_for_dict(value=value) is None:  # pragma: no cover
+    if record_shape_for_dict(value=value) is None:
         return None
     is_multiline = collection_layout is CollectionLayout.MULTILINE
     body_prefix = multiline_prefix + spec.indent if is_multiline else ""

--- a/tests/integration/cases/int_key_dict/Java_heterogeneous_strategy_record@jdk_16.java
+++ b/tests/integration/cases/int_key_dict/Java_heterogeneous_strategy_record@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+class Main {
+    public static void main() {
+var my_data = Map.ofEntries(
+    Map.entry(1, "one"),
+    Map.entry(2, "two"),
+    Map.entry(42, "answer")
+);
+    }
+}

--- a/tests/integration/cases/int_key_dict/Mojo_heterogeneous_strategy_variant@v24_5.mojo
+++ b/tests/integration/cases/int_key_dict/Mojo_heterogeneous_strategy_variant@v24_5.mojo
@@ -1,0 +1,7 @@
+def main():
+    var my_data = {
+        1: "one",
+        2: "two",
+        42: "answer",
+    }
+    _ = my_data

--- a/tests/integration/cases/int_key_dict/Rust_heterogeneous_strategy_record@edition_2021.rs
+++ b/tests/integration/cases/int_key_dict/Rust_heterogeneous_strategy_record@edition_2021.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+fn main() {
+    let my_data = HashMap::from([
+        (1, "one"),
+        (2, "two"),
+        (42, "answer"),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/int_key_dict/Rust_heterogeneous_strategy_tagged_enum@edition_2021.rs
+++ b/tests/integration/cases/int_key_dict/Rust_heterogeneous_strategy_tagged_enum@edition_2021.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+fn main() {
+    let my_data = HashMap::from([
+        (1, "one"),
+        (2, "two"),
+        (42, "answer"),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/record_sequence/Scala_heterogeneous_strategy_record@v3.scala
+++ b/tests/integration/cases/record_sequence/Scala_heterogeneous_strategy_record@v3.scala
@@ -1,8 +1,8 @@
 object Fixture_record_sequence_Scala_heterogeneous_strategy_record {
-case class Record0(id: Int, label: String)
+case class Record0(id: Int, label: String, tags: List[Any])
 val my_data = List(
-    Record0(id = 1, label = "first"),
-    Record0(id = 2, label = "second"),
-    Record0(id = 3, label = "third"),
+    Record0(id = 1, label = "first", tags = List()),
+    Record0(id = 2, label = "second", tags = List()),
+    Record0(id = 3, label = "third", tags = List()),
 )
 }

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -1694,6 +1694,17 @@ HETEROGENEOUS_INPUTS: tuple[CaseInput, ...] = tuple(
     )
 )
 
+# The ``heterogeneous_strategy`` axis additionally covers
+# ``int_key_dict`` so the RECORD strategy walks a non-string-keyed
+# (non-record-eligible) dict through ``record_shape_for_dict`` /
+# ``_maybe_format_record_literal``.  Languages that cannot represent
+# integer keys raise ``UnrepresentableInputError`` and are skipped; the
+# rest render it as a plain map, identical to the default output.
+HETEROGENEOUS_STRATEGY_INPUTS: tuple[CaseInput, ...] = (
+    *HETEROGENEOUS_INPUTS,
+    _ci(case_dir_name="int_key_dict"),
+)
+
 DICT_FORMAT_INPUTS: tuple[CaseInput, ...] = (
     _ci(case_dir_name="simple_dict"),
     _ci(case_dir_name="dict_with_list_value", suffix="_list_val"),
@@ -1871,7 +1882,7 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
         _ci(case_dir_name="simple_sequence"),
     ),
     "constructor_name": (_ci(case_dir_name="simple_dict"),),
-    "heterogeneous_strategy": HETEROGENEOUS_INPUTS,
+    "heterogeneous_strategy": HETEROGENEOUS_STRATEGY_INPUTS,
     "heterogeneous_strategy_datetime_cross": (
         _ci(case_dir_name="dict_all_scalar_types"),
     ),


### PR DESCRIPTION
Two `# pragma: no cover` directives are removed: the non-string-key branch of `record_shape_for_dict` in `type_inference.py` and the `record_shape_for_dict(...) is None` guard in `_maybe_format_record_literal` in `_literalize.py`. Both are now exercised by adding `int_key_dict` to the `heterogeneous_strategy` variant axis (via a dedicated `HETEROGENEOUS_STRATEGY_INPUTS` tuple so the value-name axes sharing `HETEROGENEOUS_INPUTS` are untouched), so a non-record dict walks through both branches under the RECORD strategy. Languages that cannot represent integer keys raise `UnrepresentableInputError` and skip, so only three compiling goldens are added (Rust RECORD/TAGGED_ENUM, Mojo VARIANT), byte-identical to their existing default goldens. This also regenerates the pre-existing stale `record_sequence/Scala_heterogeneous_strategy_record@v3.scala` golden, which was failing on the base branch because an earlier `tags: []` change did not regenerate it. Verified: full suite passes (4417 passed, 26885 subtests), `type_inference.py` at 100% branch coverage, and ruff/ty/orphan-golden checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily test coverage improvements and comment/pragma adjustments; core literalization behavior for record detection is unchanged aside from removing coverage exclusions.
> 
> **Overview**
> Adds an `int_key_dict` integration case to the `heterogeneous_strategy` variant axis so the RECORD strategy exercises non-record-eligible dicts (non-string keys) through `record_shape_for_dict`/`_maybe_format_record_literal`.
> 
> Removes two `# pragma: no cover` exclusions (and updates inline rationale) and adds new goldens for the `int_key_dict` case where supported, ensuring those branches are now covered by integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38392548f367851be2a1589034460e53dcf0888b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->