### PR TITLE
Java RECORD: reject non-ARRAY sequence_format; structural field typing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,14 +20,6 @@ Next
   ``record`` declarations require Java 16, so a ``RECORD`` spec pins
   ``language_version`` to ``JDK_16``.  See #2300.
 
-- :class:`~literalizer.Java` now rejects ``heterogeneous_strategy=RECORD``
-  combined with a non-ARRAY ``sequence_format`` (e.g. ``LIST``) with
-  :class:`~literalizer.exceptions.IncompatibleFormatsError`.  A
-  list-valued record component is typed from the array opener the value
-  formatter emits, which only ``sequence_format=ARRAY`` produces; other
-  sequence formats carry no element type and previously rendered an
-  uncompilable ``record``.  See #2337.
-
 - :func:`~literalizer.literalize_call`'s ``call_transform`` now receives
   a :class:`~literalizer.CallContext` instead of the bare call string.
   The context exposes ``call`` (the rendered call expression, formerly

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Next
   ``record`` declarations require Java 16, so a ``RECORD`` spec pins
   ``language_version`` to ``JDK_16``.  See #2300.
 
+- :class:`~literalizer.Java` now rejects ``heterogeneous_strategy=RECORD``
+  combined with a non-ARRAY ``sequence_format`` (e.g. ``LIST``) with
+  :class:`~literalizer.exceptions.IncompatibleFormatsError`.  A
+  list-valued record component is typed from the array opener the value
+  formatter emits, which only ``sequence_format=ARRAY`` produces; other
+  sequence formats carry no element type and previously rendered an
+  uncompilable ``record``.  See #2337.
+
 - :func:`~literalizer.literalize_call`'s ``call_transform`` now receives
   a :class:`~literalizer.CallContext` instead of the bare call string.
   The context exposes ``call`` (the rendered call expression, formerly

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -89,11 +89,13 @@ from literalizer._language import (
     no_data_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
-    no_validate_spec_for_data,
     prepend_body_preamble,
 )
 from literalizer._types import OrderedMap, Scalar, Value
-from literalizer.exceptions import NullInCollectionError
+from literalizer.exceptions import (
+    IncompatibleFormatsError,
+    NullInCollectionError,
+)
 
 
 class _JavaModifiers(enum.Enum):
@@ -577,25 +579,6 @@ def _java_record_field_identifier(key: str, /) -> str:
 
 
 @beartype
-def _java_opener_field_type(opener: str, /) -> str:
-    """Return the Java component type for a container field from the
-    very collection opener the value formatter uses.
-
-    A record field is formatted with no sibling override, so the opener
-    a language returns for the field's value is exactly the one it
-    emitted.  Every Java container opener starts ``new <type>`` and the
-    type ends at the first ``{`` (array initializer), ``(`` (factory
-    call) or ``<`` (a diamond, which is illegal in a type position):
-    ``new int[]{`` -> ``int[]``, ``new Object[]{`` -> ``Object[]``,
-    ``new java.util.ArrayList<>(java.util.Arrays.asList(`` ->
-    ``java.util.ArrayList``.
-    """
-    rest = opener[len("new ") :]
-    ends = [pos for pos in (rest.find(c) for c in "{(<") if pos != -1]
-    return rest[: min(ends)]
-
-
-@beartype
 def _java_record_literal(
     name: str,
     fields: Sequence[RecordLiteralField],
@@ -1068,7 +1051,37 @@ class Java(metaclass=LanguageCls):
         ):
             object.__setattr__(self, "language_version", jdk_16)
 
-    validate_spec_for_data = no_validate_spec_for_data
+    def validate_spec_for_data(self, data: Value) -> None:
+        """Raise if the spec cannot produce valid code for *data*.
+
+        Under the ``RECORD`` heterogeneous strategy a list-valued
+        record component is typed from the array opener
+        (``new <type>[]{``) the value formatter emits, so its declared
+        type matches the rendered literal.  Only
+        ``sequence_format=ARRAY`` produces that opener; every other
+        sequence format (e.g. ``LIST`` -> ``List.of(...)``) carries no
+        element type in its opener and is outside the ``RECORD``
+        strategy's MVP (cf. the set / non-record-dict boundary in
+        #2317), so the combination is rejected here rather than
+        emitting an uncompilable ``record`` declaration.  This check is
+        spec-only; *data* is unused.
+        """
+        del data
+        strategies = type(self.heterogeneous_strategy)
+        formats = type(self.sequence_format)
+        if (
+            self.heterogeneous_strategy is strategies.RECORD
+            and self.sequence_format is not formats.ARRAY
+        ):
+            msg = (
+                "Java heterogeneous_strategy=RECORD requires "
+                "sequence_format=ARRAY: a list-valued record component "
+                "is typed from the array opener the value formatter "
+                "emits, and other sequence formats (e.g. LIST -> "
+                "List.of(...)) carry no element type. "
+                "Use sequence_format=ARRAY."
+            )
+            raise IncompatibleFormatsError(msg)
 
     @cached_property
     def validate_call_arg(self) -> Callable[[Value], None]:
@@ -1371,21 +1384,27 @@ class Java(metaclass=LanguageCls):
 
         Derives the type from the raw value (and any resolved
         nested-record name), mirroring Go's structural port rather than
-        re-parsing the formatted literal.  A list or ordered-map field
-        is typed from the very collection opener the value formatter
-        uses for it (a record field is formatted with no sibling
-        override, so the opener equals the one emitted).  ``int``
-        magnitude (``int`` vs ``long``) and the format-dependent
-        ``datetime`` type (``Instant`` / ``ZonedDateTime`` /
-        ``String`` / epoch ``int``) are value- and spec-driven, so
-        they are resolved explicitly; every other scalar (including
-        ``date`` -> ``LocalDate``) goes through the shared type-only
-        resolver.
+        re-parsing the formatted literal.  ``int`` magnitude (``int``
+        vs ``long``) and the format-dependent ``datetime`` type
+        (``Instant`` / ``ZonedDateTime`` / ``String`` / epoch ``int``)
+        are value- and spec-driven, so they are resolved explicitly;
+        every other scalar (including ``date`` -> ``LocalDate``) goes
+        through the shared type-only resolver.
+
+        An ordered-map field is the concrete ``java.util.ArrayList``
+        the ordered-map opener constructs.  A list field is typed from
+        the array opener ``self.sequence_open`` emits for it (no
+        sibling override, so the opener equals the one rendered):
+        ``new int[]{`` -> ``int[]``, ``new Object[]{`` -> ``Object[]``.
+        Only ``sequence_format=ARRAY`` produces that opener;
+        :meth:`validate_spec_for_data` rejects ``RECORD`` with any
+        other sequence format up front, so no opener without an
+        encoded element type (e.g. ``List.of(``) reaches this branch.
 
         A set or a non-record dict (an empty or non-string-keyed dict)
         as a record field is outside the ``RECORD`` strategy's MVP --
         the same shapes Rust's ``_rust_record_field_type`` is imprecise
-        for (#2234) -- so it folds into the ``Object`` top type, which
+        for (#2317) -- so it folds into the ``Object`` top type, which
         the rendered literal still assigns into.
         """
         if request.record_name is not None:
@@ -1401,16 +1420,15 @@ class Java(metaclass=LanguageCls):
             case datetime.datetime():
                 return self._java_record_datetime_hint
             case OrderedMap():
-                opener = self.ordered_map_format_config.ordered_map_open(
-                    value,
-                )
+                field_type = "java.util.ArrayList"
             case list():
                 opener = self.sequence_open(value)
+                field_type = opener.removeprefix("new ").removesuffix("{")
             case _:
                 return self._java_record_scalar_resolver(type(value)) or (
                     "Object"
                 )
-        return _java_opener_field_type(opener)
+        return field_type
 
     @cached_property
     def _record_renderer(self) -> RecordRenderer:

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1063,8 +1063,8 @@ class Java(metaclass=LanguageCls):
         element type in its opener and is outside the ``RECORD``
         strategy's MVP (cf. the set / non-record-dict boundary in
         #2317), so the combination is rejected here rather than
-        emitting an uncompilable ``record`` declaration.  This check is
-        spec-only; *data* is unused.
+        emitting a ``record`` declaration that fails to compile.  This
+        check is spec-only; *data* is unused.
         """
         del data
         strategies = type(self.heterogeneous_strategy)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -15,7 +15,7 @@ from literalizer import (
 from literalizer.exceptions import (
     IncompatibleFormatsError,
 )
-from literalizer.languages import CSharp, Nim, Rust
+from literalizer.languages import CSharp, Java, Nim, Rust
 
 RUST_CONST = Rust(
     date_format=Rust.date_formats.ISO,
@@ -243,4 +243,38 @@ def test_nim_object_variant_const_raises() -> None:
                 Nim.heterogeneous_strategies.OBJECT_VARIANT
             ),
             declaration_style=Nim.declaration_styles.CONST,
+        )
+
+
+def test_java_record_non_array_sequence_raises() -> None:
+    """Java ``RECORD`` rejects a non-ARRAY ``sequence_format``.
+
+    A list-valued record component is typed from the array opener
+    (``new <type>[]{``) the value formatter emits; ``LIST`` renders
+    ``List.of(...)``, whose opener carries no element type, so the
+    combination would emit an uncompilable ``record`` and is rejected.
+    """
+    expected_msg = (
+        "Java heterogeneous_strategy=RECORD requires "
+        "sequence_format=ARRAY: a list-valued record component "
+        "is typed from the array opener the value formatter "
+        "emits, and other sequence formats (e.g. LIST -> "
+        "List.of(...)) carry no element type. "
+        "Use sequence_format=ARRAY."
+    )
+    java_record_list = Java(
+        heterogeneous_strategy=Java.heterogeneous_strategies.RECORD,
+        sequence_format=Java.sequence_formats.LIST,
+    )
+    with pytest.raises(
+        expected_exception=IncompatibleFormatsError,
+        match=f"^{re.escape(pattern=expected_msg)}$",
+    ):
+        literalize(
+            source='{"name": "Alice", "scores": [1, 2, 3]}',
+            input_format=InputFormat.JSON,
+            language=java_record_list,
+            pre_indent_level=0,
+            include_delimiters=True,
+            variable_form=NewVariable(name="my_var"),
         )

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -252,7 +252,8 @@ def test_java_record_non_array_sequence_raises() -> None:
     A list-valued record component is typed from the array opener
     (``new <type>[]{``) the value formatter emits; ``LIST`` renders
     ``List.of(...)``, whose opener carries no element type, so the
-    combination would emit an uncompilable ``record`` and is rejected.
+    combination would emit a ``record`` that fails to compile and is
+    rejected.
     """
     expected_msg = (
         "Java heterogeneous_strategy=RECORD requires "


### PR DESCRIPTION
Fixes #2337.

`_java_opener_field_type` stripped a `new ` prefix and ran `min()` over a possibly-empty list, mis-typing list-valued record components under any non-ARRAY `sequence_format` (e.g. `LIST` -> `List.of(` produced a bogus component type and an uncompilable `record`), with no validation guarding the combination. Java only supports `RECORD` with `sequence_format=ARRAY`, so `Java.validate_spec_for_data` now rejects any other combination with `IncompatibleFormatsError`, the brittle opener reparser is deleted, and the ordered-map / array field types are derived structurally (the concrete `java.util.ArrayList`; the array opener with prefix/suffix removed). Added `test_java_record_non_array_sequence_raises` to lock down the failure mode and repointed a stale #2234 doc cross-ref to #2317. All goldens stay byte-identical, full suite passes with `--cov-fail-under 100` and no `# pragma: no cover`, and `origin/main` was merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens spec validation and changes how Java `RECORD` field types are derived, which can introduce new `IncompatibleFormatsError` failures and alter generated record declarations for list/ordered-map fields.
> 
> **Overview**
> Prevents Java `heterogeneous_strategy=RECORD` from being used with non-`ARRAY` `sequence_format` by adding `Java.validate_spec_for_data` validation that raises `IncompatibleFormatsError` (avoiding generation of uncompilable `record` declarations when lists render as `List.of(...)`).
> 
> Simplifies Java record component typing by deleting the brittle `_java_opener_field_type` re-parser and deriving container field types structurally (`java.util.ArrayList` for ordered maps; array type extracted from the array opener for lists). Adds a regression test asserting the new validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44572e0a7ed7c46cb238639d30dac2e0a4cba265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->