### PR TITLE
Port record_shape_names to Go (+ shared RecordRenderer change)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Go` gains the ``record_shape_names`` constructor
+  parameter (already on :class:`~literalizer.Rust`), a
+  ``Mapping[frozenset[str], str]`` from a record shape's key-set to a
+  custom struct name.  A mapped shape is declared and rendered with the
+  given name instead of the auto-generated ``RecordN``; the
+  ``record_struct_name_prefix`` counter advances only for the shapes
+  with no custom name.  Names are validated as PascalCase Go
+  identifiers that do not
+  collide with the auto ``{prefix}{N}`` pattern or each other, raising
+  :class:`~literalizer.exceptions.InvalidRecordNameError`.  A new
+  ``supports_record_shape_names`` language-class flag mirrors the
+  constructor.  See #2324.
+
 2026.05.15.1
 ------------
 

--- a/src/literalizer/_formatters/record_strategy.py
+++ b/src/literalizer/_formatters/record_strategy.py
@@ -20,10 +20,12 @@ the first-seen :class:`RecordFieldType` request per shape during
 literal rendering; the preamble (assembled after all literals are
 formatted) reads that cache.
 
-Rust keeps its own copy of this logic because it additionally supports
-``record_shape_names`` and optional-field unification; this module
-deliberately omits those knobs (out of scope for the non-Rust ports),
-so :attr:`RecordShape.optional_keys` is always empty here.
+Rust keeps its own copy of this logic because it additionally
+supports optional-field unification; this module supports
+``record_shape_names`` (custom per-shape struct names, keyed by the
+shape's key-set) but deliberately omits unification (out of scope
+for the non-Rust ports), so :attr:`RecordShape.optional_keys` is
+always empty here.
 """
 
 import dataclasses
@@ -91,9 +93,13 @@ class RecordRenderer:
     """Per-language syntax hooks for the ``RECORD`` strategy.
 
     ``name_prefix`` is the auto-naming prefix (``Record`` -> ``Record0``,
-    ``Record1``, ...).  ``field_identifier`` maps an original dict key
-    to the language's field identifier (identity for most languages,
-    PascalCase for Go).  ``field_type`` maps a :class:`RecordFieldType`
+    ``Record1``, ...).  ``record_shape_names`` maps a shape's key-set
+    (``frozenset`` of its keys) to a custom struct name; a mapped shape
+    uses that name and the auto ``{prefix}{index}`` counter advances
+    only for the shapes with no custom name (mirrors Rust).
+    ``field_identifier`` maps an original dict key to the language's
+    field identifier (identity for most languages, PascalCase for Go).
+    ``field_type`` maps a :class:`RecordFieldType`
     (raw field value plus any resolved nested-record name) to its
     declared type, using the language's own collection openers rather
     than re-parsing the formatted literal.  ``render_declaration`` builds
@@ -105,6 +111,7 @@ class RecordRenderer:
     """
 
     name_prefix: str
+    record_shape_names: Mapping[frozenset[str], str]
     field_identifier: Callable[[str], str]
     field_type: Callable[[RecordFieldType], str]
     render_declaration: Callable[
@@ -185,12 +192,25 @@ def _assign_names(
     *,
     shapes: Sequence[RecordShape],
     prefix: str,
+    record_shape_names: Mapping[frozenset[str], str],
 ) -> dict[RecordShape, str]:
-    """Assign ``{prefix}{index}`` names in *shapes* order."""
-    return {
-        shape: f"{prefix}{index}"
-        for index, shape in enumerate(iterable=shapes)
-    }
+    """Assign struct names in *shapes* order.
+
+    A shape whose key-set is mapped in *record_shape_names* takes the
+    custom name; every other shape gets ``{prefix}{index}`` where
+    *index* advances only for the auto-named shapes (mirrors Rust's
+    ``_compute_shapes``/``_build_record_preamble``).
+    """
+    names: dict[RecordShape, str] = {}
+    prefix_index = 0
+    for shape in shapes:
+        custom = record_shape_names.get(frozenset(shape.keys))
+        if custom is None:
+            names[shape] = f"{prefix}{prefix_index}"
+            prefix_index += 1
+        else:
+            names[shape] = custom
+    return names
 
 
 @beartype
@@ -262,7 +282,11 @@ def build_record_strategy(
             shapes_by_id=shapes_by_id,
         )
         name_by_shape.update(
-            _assign_names(shapes=ordered, prefix=renderer.name_prefix),
+            _assign_names(
+                shapes=ordered,
+                prefix=renderer.name_prefix,
+                record_shape_names=renderer.record_shape_names,
+            ),
         )
         return shapes_by_id
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -682,6 +682,7 @@ class LanguageCls(type):
     supports_default_set_element_type: bool
     supports_default_ordered_map_value_type: bool
     supports_record_struct_name_prefix: bool
+    supports_record_shape_names: bool
     dict_supports_heterogeneous_values: bool
     format_call_arg: FormatCallArg
     validate_call_arg: Callable[[Value], None]

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -239,6 +239,7 @@ class Ada(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -217,6 +217,7 @@ class Bash(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -264,6 +264,7 @@ class C(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -129,6 +129,7 @@ class Clojure(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -355,6 +355,7 @@ class Cobol(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -138,6 +138,7 @@ class CommonLisp(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -946,6 +946,7 @@ class Cpp(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -201,6 +201,7 @@ class Crystal(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -383,6 +383,7 @@ class CSharp(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -185,6 +185,7 @@ class D(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -362,6 +362,7 @@ class Dart(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -576,6 +576,7 @@ class Dhall(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -227,6 +227,7 @@ class Elixir(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -560,6 +560,7 @@ class Elm(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -222,6 +222,7 @@ class Erlang(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -231,6 +231,7 @@ class Forth(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -352,6 +352,7 @@ class Fortran(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -342,6 +342,7 @@ class FSharp(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -566,6 +566,7 @@ class Gleam(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -3,7 +3,8 @@
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+import re
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar
@@ -96,6 +97,9 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import OrderedMap, Value
+from literalizer.exceptions import InvalidRecordNameError
+
+_PASCAL_CASE_IDENTIFIER = re.compile(pattern=r"^[A-Z][A-Za-z0-9_]*$")
 
 
 @beartype
@@ -320,6 +324,7 @@ class Go(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = True
     supports_record_struct_name_prefix = True
+    supports_record_shape_names = True
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
@@ -687,6 +692,10 @@ class Go(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     record_struct_name_prefix: str = "Record"
+    record_shape_names: Mapping[frozenset[str], str] = dataclasses.field(
+        default_factory=lambda: MappingProxyType(mapping={}),
+        hash=False,
+    )
     # Keep in sync with the `go` directive in the generated go.mod in
     # `.github/workflows/lint.yml`.
     language_version: VersionFormats = VersionFormats.V1_18
@@ -704,6 +713,51 @@ class Go(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ("package main",)
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ('import "math"',)
+
+    def __post_init__(self) -> None:
+        """Validate ``record_shape_names`` after construction."""
+        self._validate_record_naming()
+
+    def _validate_record_naming(self) -> None:
+        """Validate ``record_shape_names`` for PascalCase identifier
+        shape, collisions with the auto-generated ``{prefix}{N}``
+        struct names, and duplicate target names.
+
+        Ported from
+        :meth:`literalizer.languages.Rust._validate_record_naming`.  Go
+        has no ``heterogeneous_value_enum_name`` so that collision
+        check does not apply, and Rust's reserved-keyword check is
+        unnecessary here: every Go keyword and built-in identifier is
+        lowercase, so the PascalCase requirement already rejects every
+        one of them.
+        """
+        prefix = self.record_struct_name_prefix
+        auto_name_pattern = re.compile(
+            pattern=rf"^{re.escape(pattern=prefix)}\d+$",
+        )
+        seen_names: set[str] = set()
+        for keys, name in self.record_shape_names.items():
+            if not _PASCAL_CASE_IDENTIFIER.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which is not a PascalCase Go "
+                    f"identifier."
+                )
+                raise InvalidRecordNameError(msg)
+            if auto_name_pattern.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which collides with the "
+                    f"auto-generated {prefix!r}-prefixed struct names."
+                )
+                raise InvalidRecordNameError(msg)
+            if name in seen_names:
+                msg = (
+                    f"record_shape_names maps multiple key-sets to "
+                    f"{name!r}; struct names must be unique."
+                )
+                raise InvalidRecordNameError(msg)
+            seen_names.add(name)
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -776,6 +830,7 @@ class Go(metaclass=LanguageCls):
         """Go syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
+            record_shape_names=self.record_shape_names,
             field_identifier=_go_record_field_identifier,
             field_type=self._go_record_field_type,
             render_declaration=self._go_render_declaration,

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -165,6 +165,7 @@ class Groovy(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1143,6 +1143,7 @@ class Haskell(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -177,6 +177,7 @@ class Hcl(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -688,6 +688,7 @@ class Java(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = True
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
@@ -1417,6 +1418,11 @@ class Java(metaclass=LanguageCls):
         """Java syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
+            # Java does not yet expose a ``record_shape_names``
+            # constructor field (ported with its own RECORD work); an
+            # empty mapping keeps every shape on the auto
+            # ``{prefix}{N}`` names.
+            record_shape_names=MappingProxyType(mapping={}),
             field_identifier=_java_record_field_identifier,
             field_type=self._java_record_field_type,
             render_declaration=_java_render_declaration,

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -149,6 +149,7 @@ class JavaScript(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -141,6 +141,7 @@ class Json5(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -159,6 +159,7 @@ class Jsonnet(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -177,6 +177,7 @@ class Julia(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -593,6 +593,7 @@ class Kotlin(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = True
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
@@ -1190,6 +1191,10 @@ class Kotlin(metaclass=LanguageCls):
         """Kotlin syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
+            # Kotlin does not yet expose a ``record_shape_names``
+            # constructor field (ported separately); an empty mapping
+            # keeps every shape on the auto ``{prefix}{N}`` names.
+            record_shape_names=MappingProxyType(mapping={}),
             field_identifier=_kotlin_record_field_identifier,
             field_type=self._kotlin_record_field_type_request,
             render_declaration=_kotlin_render_declaration,

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -163,6 +163,7 @@ class Lua(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -230,6 +230,7 @@ class Matlab(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -938,6 +938,7 @@ class Mojo(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -566,6 +566,7 @@ class Nim(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -209,6 +209,7 @@ class Nix(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -113,6 +113,7 @@ class Norg(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -318,6 +318,7 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -302,6 +302,7 @@ class OCaml(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -156,6 +156,7 @@ class Occam(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -235,6 +235,7 @@ class Odin(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -175,6 +175,7 @@ class Perl(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -172,6 +172,7 @@ class Php(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -188,6 +188,7 @@ class PowerShell(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -698,6 +698,7 @@ class PureScript(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -715,6 +715,7 @@ class Python(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -187,6 +187,7 @@ class R(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -130,6 +130,7 @@ class Racket(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -207,6 +207,7 @@ class Raku(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -568,6 +568,7 @@ class Roc(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
     supports_special_floats = True
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -209,6 +209,7 @@ class Ruby(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1141,6 +1141,7 @@ class Rust(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = True
+    supports_record_shape_names = True
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -344,6 +344,7 @@ class Scala(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = True
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
@@ -876,6 +877,11 @@ class Scala(metaclass=LanguageCls):
         """Scala syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
+            # Scala does not yet expose a ``record_shape_names``
+            # constructor field (ported with its own RECORD work); an
+            # empty mapping keeps every shape on the auto
+            # ``{prefix}{N}`` names.
+            record_shape_names=MappingProxyType(mapping={}),
             field_identifier=_scala_record_field_identifier,
             field_type=self._scala_record_field_type,
             render_declaration=_scala_render_declaration,

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -126,6 +126,7 @@ class Scheme(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -376,6 +376,7 @@ class Sml(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -426,6 +426,7 @@ class Swift(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -260,6 +260,7 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -171,6 +171,7 @@ class Tcl(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -146,6 +146,7 @@ class Toml(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -333,6 +333,7 @@ class TypeScript(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -406,6 +406,7 @@ class V(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -291,6 +291,7 @@ class VisualBasic(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -190,6 +190,7 @@ class Wren(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -115,6 +115,7 @@ class Yaml(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -251,6 +251,7 @@ class Zig(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
     class DateFormats(enum.Enum):

--- a/tests/integration/cases/record_named_shape/Go_record_shape_names_Task@v1_18.go
+++ b/tests/integration/cases/record_named_shape/Go_record_shape_names_Task@v1_18.go
@@ -1,0 +1,15 @@
+package main
+type Task struct {
+	Id int
+	Description string
+	IsDone bool
+	Blocks []int
+}
+
+func main() {
+my_data := []any{
+	Task{Id: 100, Description: "first task", IsDone: false, Blocks: []int{102, 103}},
+	Task{Id: 101, Description: "second task", IsDone: true, Blocks: []int{100}},
+}
+_ = my_data
+}

--- a/tests/metadata/test_language_metadata.py
+++ b/tests/metadata/test_language_metadata.py
@@ -1,6 +1,7 @@
 """Language-wide metadata and protocol checks."""
 
 import enum
+from collections.abc import Mapping
 from typing import Protocol, runtime_checkable
 
 import pytest
@@ -178,6 +179,40 @@ def test_supports_record_struct_name_prefix_matches_constructor(
     spec = language_cls()
     accepts_kwarg = isinstance(spec, _HasRecordStructNamePrefix)
     assert language_cls.supports_record_struct_name_prefix == accepts_kwarg
+
+
+@runtime_checkable
+class _HasRecordShapeNames(Protocol):
+    """Structural type for languages that expose a
+    ``record_shape_names`` constructor field.
+
+    Used to narrow a generic :class:`literalizer.Language` to one with
+    the field without introspecting ``__dataclass_fields__`` or casting
+    to ``Any``.
+    """
+
+    record_shape_names: Mapping[frozenset[str], str]
+
+
+@pytest.mark.parametrize(
+    argnames="language_cls",
+    argvalues=_SORTED_LANGUAGES,
+    ids=[c.__name__ for c in _SORTED_LANGUAGES],
+)
+def test_supports_record_shape_names_matches_constructor(
+    *,
+    language_cls: LanguageCls,
+) -> None:
+    """The flag is ``True`` exactly when the constructor accepts
+    ``record_shape_names``.
+
+    Runtime-dispatched callers rely on this flag instead of inspecting
+    dataclass fields, so it must stay in lock-step with the actual
+    constructor keyword arguments.
+    """
+    spec = language_cls()
+    accepts_kwarg = isinstance(spec, _HasRecordShapeNames)
+    assert language_cls.supports_record_shape_names == accepts_kwarg
 
 
 def test_supported_ref_cases_independent_of_identifier_cases() -> None:

--- a/tests/test_record_naming.py
+++ b/tests/test_record_naming.py
@@ -1,11 +1,11 @@
-"""Validation tests for Rust ``record_struct_name_prefix`` and
+"""Validation tests for the ``record_struct_name_prefix`` and
 ``record_shape_names`` constructor parameters.
 """
 
 import pytest
 
 from literalizer.exceptions import InvalidRecordNameError
-from literalizer.languages import Rust
+from literalizer.languages import Go, Rust
 
 
 @pytest.mark.parametrize(
@@ -57,6 +57,41 @@ def test_duplicate_shape_names_raises() -> None:
     """Two distinct key-sets cannot map to the same struct name."""
     with pytest.raises(expected_exception=InvalidRecordNameError):
         Rust(
+            record_shape_names={
+                frozenset({"id", "name"}): "Task",
+                frozenset({"id", "title"}): "Task",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    argnames="name",
+    argvalues=["task", "My-Task", "9Task"],
+)
+def test_go_invalid_shape_name_raises(name: str) -> None:
+    """Values in Go's ``record_shape_names`` must be PascalCase
+    identifiers.
+
+    Go has no PascalCase reserved keyword (every Go keyword is
+    lowercase), so the PascalCase check is the only name-shape gate.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Go(record_shape_names={frozenset({"id", "name"}): name})
+
+
+def test_go_shape_name_collides_with_auto_generated_raises() -> None:
+    """A mapped struct name that matches the auto-generated
+    ``{prefix}{N}`` pattern is rejected because the user-named record
+    would clash with an index-named record at render time.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Go(record_shape_names={frozenset({"id", "name"}): "Record0"})
+
+
+def test_go_duplicate_shape_names_raises() -> None:
+    """Two distinct key-sets cannot map to the same Go struct name."""
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Go(
             record_shape_names={
                 frozenset({"id", "name"}): "Task",
                 frozenset({"id", "title"}): "Task",


### PR DESCRIPTION
Adds the `record_shape_names: Mapping[frozenset[str], str]` constructor parameter to `Go` (already on `Rust`), mapping a record shape's key-set to a custom struct name; the shared `_formatters/record_strategy.py` now carries `record_shape_names` on `RecordRenderer` and `_assign_names` mirrors Rust so a mapped shape uses its custom name while the `{prefix}{index}` counter advances only for unmapped shapes. Go validates names in `__post_init__` (PascalCase, no `{prefix}{N}` collision, no duplicates) raising `InvalidRecordNameError`, with no reserved-keyword check because every Go keyword/built-in is lowercase and the PascalCase rule already excludes them. A new `supports_record_shape_names` `LanguageCls` flag (True on Go and Rust, False elsewhere) mirrors the constructor with a parametrized parity test, and Kotlin/Scala/Java now pass an empty mapping through the shared module (unchanged behavior; their own field lands with their port). Includes Go validation tests, the auto-discovered `record_named_shape` Go golden, and a CHANGELOG entry. Per the issue's one-PR-per-language convention this is the Go PR (carrying the shared change); Kotlin is a separate follow-up PR. See #2324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the shared `RECORD` naming logic and language metadata, so regressions could affect record declaration/literal generation across multiple languages even though behavior is intended to be unchanged when the mapping is empty.
> 
> **Overview**
> Adds Go support for custom per-record-shape struct names via a new `record_shape_names: Mapping[frozenset[str], str]` constructor arg, including validation (PascalCase identifier, no collisions with auto `RecordN` pattern, no duplicate target names) that raises `InvalidRecordNameError`.
> 
> Updates the shared `RECORD` strategy (`RecordRenderer` + name assignment) to carry `record_shape_names` and to skip advancing the auto `RecordN` counter for shapes that are explicitly named; non-Go languages wire an empty mapping to preserve existing behavior. Also introduces a `supports_record_shape_names` capability flag on `LanguageCls` (enabled for Go/Rust, disabled elsewhere), adds metadata parity tests, new Go golden integration fixture, and expands record-naming tests to cover Go.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a7836e93e07d665338a0fa7e78e807944ed2b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->