### PR TITLE
Remove unreachable pragma: no cover in _maybe_format_record_literal

### DIFF
--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -526,19 +526,18 @@ def _maybe_format_record_literal(
     render_record_literal = behavior.render_record_literal
     if render_record_literal is None:
         return None
-    if record_shape_for_dict(value=value) is None:
+    record_shape = record_shape_for_dict(value=value)
+    if record_shape is None:
         return None
     is_multiline = collection_layout is CollectionLayout.MULTILINE
     body_prefix = multiline_prefix + spec.indent if is_multiline else ""
     field_multiline_prefix = body_prefix if is_multiline else multiline_prefix
-    # Iterate over *value*'s own keys; missing-from-this-dict keys are
-    # filled in by the strategy's render callable using whatever
-    # unified shape it has cached.
-    str_keys: list[str] = []
-    for key in value:
-        if not isinstance(key, str):  # pragma: no cover
-            return None
-        str_keys.append(key)
+    # ``record_shape.keys`` holds *value*'s own keys in insertion order
+    # (``record_shape_for_dict`` already guaranteed they are all
+    # strings); missing-from-this-dict keys are filled in by the
+    # strategy's render callable using whatever unified shape it has
+    # cached.
+    str_keys = list(record_shape.keys)
     formatted_fields: dict[str, str] = {
         key: _format_value(
             value=value[key],


### PR DESCRIPTION
`_maybe_format_record_literal` called `record_shape_for_dict(value=value)` purely as an eligibility check, then re-iterated `value`'s keys with an `isinstance(key, str)` guard marked `# pragma: no cover`. That guard was genuinely unreachable dead code, since `record_shape_for_dict` already returns `None` for any non-`str` key, so no test could ever cover it. This change captures the returned `RecordShape` and derives `str_keys` from `record_shape.keys`, removing both the duplicate iteration and the coverage-bypass pragma with no behavior change. Verified by the full test suite (4503 passed, 26920 subtests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in record-literal rendering logic that removes dead code and a coverage pragma without changing output behavior.
> 
> **Overview**
> Simplifies `_maybe_format_record_literal` by capturing the `RecordShape` from `record_shape_for_dict` and using `record_shape.keys` to derive `str_keys`, eliminating a redundant key-iteration and an unreachable `# pragma: no cover` `isinstance(key, str)` guard.
> 
> No functional behavior is intended to change; this is a small cleanup in the record-literal formatting path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca0cc1d71b9ad1f8aed855849448cee3a445d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->