### PR TITLE
Port record_shape_names to Kotlin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,18 @@ Next
   ``supports_record_shape_names`` language-class flag mirrors the
   constructor.  See #2324.
 
+- :class:`~literalizer.Kotlin` gains the same ``record_shape_names``
+  constructor parameter, a ``Mapping[frozenset[str], str]`` from a
+  record shape's key-set to a custom ``data class`` name.  A mapped
+  shape is declared and rendered with the given name instead of the
+  auto-generated ``RecordN``; the ``record_struct_name_prefix`` counter
+  advances only for the shapes with no custom name.  Names are
+  validated as PascalCase Kotlin identifiers that do not collide with
+  the auto ``{prefix}{N}`` pattern or each other, raising
+  :class:`~literalizer.exceptions.InvalidRecordNameError`.  Its
+  ``supports_record_shape_names`` language-class flag is now ``True``.
+  See #2324.
+
 2026.05.15.1
 ------------
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -4,7 +4,8 @@ import dataclasses
 import datetime
 import enum
 import functools
-from collections.abc import Callable, Sequence
+import re
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar, assert_never
@@ -104,6 +105,9 @@ from literalizer._language import (
     wrap_in_file_noop,
 )
 from literalizer._types import OrderedMap, Scalar, Value
+from literalizer.exceptions import InvalidRecordNameError
+
+_PASCAL_CASE_IDENTIFIER = re.compile(pattern=r"^[A-Z][A-Za-z0-9_]*$")
 
 
 @beartype
@@ -593,7 +597,7 @@ class Kotlin(metaclass=LanguageCls):
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = True
-    supports_record_shape_names = False
+    supports_record_shape_names = True
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
@@ -1073,6 +1077,10 @@ class Kotlin(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     record_struct_name_prefix: str = "Record"
+    record_shape_names: Mapping[frozenset[str], str] = dataclasses.field(
+        default_factory=lambda: MappingProxyType(mapping={}),
+        hash=False,
+    )
     # Keep in sync with the version flags passed to the Kotlin lint host in
     # `.github/scripts/lint-kotlin.main.kts`.
     language_version: VersionFormats = VersionFormats.V1_9
@@ -1091,6 +1099,51 @@ class Kotlin(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
+
+    def __post_init__(self) -> None:
+        """Validate ``record_shape_names`` after construction."""
+        self._validate_record_naming()
+
+    def _validate_record_naming(self) -> None:
+        """Validate ``record_shape_names`` for PascalCase identifier
+        shape, collisions with the auto-generated ``{prefix}{N}``
+        struct names, and duplicate target names.
+
+        Ported from
+        :meth:`literalizer.languages.Rust._validate_record_naming`.
+        Kotlin has no ``heterogeneous_value_enum_name`` so that
+        collision check does not apply, and Rust's reserved-keyword
+        check is unnecessary here: every Kotlin keyword is lowercase,
+        so the PascalCase requirement already rejects every one of
+        them.
+        """
+        prefix = self.record_struct_name_prefix
+        auto_name_pattern = re.compile(
+            pattern=rf"^{re.escape(pattern=prefix)}\d+$",
+        )
+        seen_names: set[str] = set()
+        for keys, name in self.record_shape_names.items():
+            if not _PASCAL_CASE_IDENTIFIER.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which is not a PascalCase Kotlin "
+                    f"identifier."
+                )
+                raise InvalidRecordNameError(msg)
+            if auto_name_pattern.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which collides with the "
+                    f"auto-generated {prefix!r}-prefixed struct names."
+                )
+                raise InvalidRecordNameError(msg)
+            if name in seen_names:
+                msg = (
+                    f"record_shape_names maps multiple key-sets to "
+                    f"{name!r}; struct names must be unique."
+                )
+                raise InvalidRecordNameError(msg)
+            seen_names.add(name)
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -1191,10 +1244,7 @@ class Kotlin(metaclass=LanguageCls):
         """Kotlin syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
-            # Kotlin does not yet expose a ``record_shape_names``
-            # constructor field (ported separately); an empty mapping
-            # keeps every shape on the auto ``{prefix}{N}`` names.
-            record_shape_names=MappingProxyType(mapping={}),
+            record_shape_names=self.record_shape_names,
             field_identifier=_kotlin_record_field_identifier,
             field_type=self._kotlin_record_field_type_request,
             render_declaration=_kotlin_render_declaration,

--- a/tests/integration/cases/record_named_shape/Kotlin_record_shape_names_Task@v1_9.kts
+++ b/tests/integration/cases/record_named_shape/Kotlin_record_shape_names_Task@v1_9.kts
@@ -1,0 +1,5 @@
+data class Task(val id: Int, val description: String, val is_done: Boolean, val blocks: IntArray)
+val my_data = listOf<Any?>(
+    Task(id = 100, description = "first task", is_done = false, blocks = intArrayOf(102, 103)),
+    Task(id = 101, description = "second task", is_done = true, blocks = intArrayOf(100)),
+)

--- a/tests/test_record_naming.py
+++ b/tests/test_record_naming.py
@@ -5,7 +5,7 @@
 import pytest
 
 from literalizer.exceptions import InvalidRecordNameError
-from literalizer.languages import Go, Rust
+from literalizer.languages import Go, Kotlin, Rust
 
 
 @pytest.mark.parametrize(
@@ -92,6 +92,43 @@ def test_go_duplicate_shape_names_raises() -> None:
     """Two distinct key-sets cannot map to the same Go struct name."""
     with pytest.raises(expected_exception=InvalidRecordNameError):
         Go(
+            record_shape_names={
+                frozenset({"id", "name"}): "Task",
+                frozenset({"id", "title"}): "Task",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    argnames="name",
+    argvalues=["task", "My-Task", "9Task"],
+)
+def test_kotlin_invalid_shape_name_raises(name: str) -> None:
+    """Values in Kotlin's ``record_shape_names`` must be PascalCase
+    identifiers.
+
+    Kotlin has no PascalCase reserved keyword (every Kotlin keyword is
+    lowercase), so the PascalCase check is the only name-shape gate.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Kotlin(record_shape_names={frozenset({"id", "name"}): name})
+
+
+def test_kotlin_shape_name_collides_with_auto_generated_raises() -> None:
+    """A mapped struct name that matches the auto-generated
+    ``{prefix}{N}`` pattern is rejected because the user-named record
+    would clash with an index-named record at render time.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Kotlin(record_shape_names={frozenset({"id", "name"}): "Record0"})
+
+
+def test_kotlin_duplicate_shape_names_raises() -> None:
+    """Two distinct key-sets cannot map to the same Kotlin struct
+    name.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Kotlin(
             record_shape_names={
                 frozenset({"id", "name"}): "Task",
                 frozenset({"id", "title"}): "Task",


### PR DESCRIPTION
PR2 of #2324: ports Rust's `record_shape_names` knob to **Kotlin**. (PR1 #2342 landed Go + the shared `_formatters/record_strategy.py` change.)

## Changes

- **`src/literalizer/languages/kotlin.py`**
  - New `record_shape_names: Mapping[frozenset[str], str]` constructor field (default empty `MappingProxyType`, `hash=False`), threaded into the `RecordRenderer` (replacing the previous hard-coded empty mapping).
  - `__post_init__` / `_validate_record_naming` ported from `Rust._validate_record_naming`: PascalCase identifier, no collision with the auto `{prefix}{N}` pattern, no duplicate targets, raising `InvalidRecordNameError`. No reserved-keyword check (every Kotlin keyword is lowercase, so PascalCase already excludes them, and an empty-keyword-set branch would be uncovered under `--cov-fail-under 100`).
  - `supports_record_shape_names` flag flipped to `True` (flag + parametrized parity test landed in PR1).
- **`tests/test_record_naming.py`** — Kotlin validation tests mirroring the Go cases (invalid name, auto-generated collision, duplicate target).
- **`tests/integration/cases/record_named_shape/Kotlin_record_shape_names_Task@v1_9.kts`** — auto-discovered golden (`Task` data class instead of `Record0`).
- **`CHANGELOG.rst`** — Kotlin entry.

## Verification

- `tests/test_record_naming.py`, `test_format_variant_golden_file[Kotlin]`, `test_supports_record_shape_names_matches_constructor`, and all Kotlin golden integration tests pass.
- ruff (check + format) and ty clean on changed files; all pre-commit hooks pass.
- New validation code is fully branch-covered by the new tests + the golden happy path; default behavior (empty mapping) unchanged.
- Branch is at `origin/main` (5abb0bfef); no merge needed.

Scala/Java will pick up `record_shape_names` with their own #2237 RECORD ports (#2299/#2300).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Kotlin constructor parameter and validation that can raise `InvalidRecordNameError` for previously accepted inputs, and changes generated Kotlin record declarations/literals when the option is used.
> 
> **Overview**
> Adds Kotlin support for `record_shape_names`, letting callers map record-shaped dict key-sets to custom `data class` names instead of auto `RecordN` names.
> 
> Kotlin now validates these names on construction (PascalCase, no collision with `{prefix}{N}`, no duplicates) and threads the mapping into the shared `RecordRenderer`; a new Kotlin golden fixture and unit tests cover the new validation behavior, and the changelog is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50e3a7ddaf412307d570df4030d802b22953976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->