### PR TITLE
Remove stale type_inference pragma: no branch

### DIFF
--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -393,7 +393,7 @@ def _accumulate_record_shapes(
     match data:
         case dict() if not isinstance(data, OrderedMap):
             shape = record_shape_for_dict(value=data)
-            if shape is not None:  # pragma: no branch
+            if shape is not None:
                 out[id(data)] = shape
             for v in data.values():
                 _accumulate_record_shapes(data=v, out=out)


### PR DESCRIPTION
Removes the `# pragma: no branch` on the `if shape is not None:` guard in `_accumulate_record_shapes` (`src/literalizer/_formatters/type_inference.py`). The pragma was stale: the False arm is already exercised whenever a non-`OrderedMap` dict has a non-string key (so `record_shape_for_dict` returns `None`), which the `int_key_dict` fixture hits via Rust's RECORD and TUPLE heterogeneous-strategy variants. With the pragma removed, `type_inference.py` stays at 100% branch coverage, verified by running the golden suite. No fixtures or golden files needed to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Coverage-only change that removes a stale branch-coverage suppression without altering runtime behavior.
> 
> **Overview**
> Removes the stale `# pragma: no branch` from the `if shape is not None:` guard in `_accumulate_record_shapes` (`type_inference.py`), relying on existing tests to exercise both paths and keep branch coverage accurate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74230d1f46039aafd743bb711f307fa9fd54cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->