### PR TITLE
Remove rust.py:1031 pragma: no branch (cover via .get idiom)

### DIFF
--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1028,11 +1028,10 @@ def _accumulate_emit_order(
                     emit_ordered=emit_ordered,
                     emit_seen=emit_seen,
                 )
-            if id(data) in shapes_by_id:  # pragma: no branch
-                shape = shapes_by_id[id(data)]
-                if shape not in emit_seen:
-                    emit_seen.add(shape)
-                    emit_ordered.append(shape)
+            shape = shapes_by_id.get(id(data))
+            if shape is not None and shape not in emit_seen:
+                emit_seen.add(shape)
+                emit_ordered.append(shape)
         case list():
             for item in data:
                 _accumulate_emit_order(


### PR DESCRIPTION
Addresses one site from #2318: the `# pragma: no branch` on
`_accumulate_emit_order`'s `if id(data) in shapes_by_id:` in
`src/literalizer/languages/rust.py`.

## Why it was pragma'd

The false arc (a dict *absent* from `shapes_by_id`) is the
out-of-MVP non-record-dict shape, unreachable within MVP, so the
guard was always taken and never branch-covered.

## Fix

Restructure to the idiom already used pragma-free two functions
away in `_ordered_unique_shapes.walk` (`type_inference.py`): look
up via `shapes_by_id.get(id(data))` and fold the membership test
into the existing `shape not in emit_seen` condition:

```python
shape = shapes_by_id.get(id(data))
if shape is not None and shape not in emit_seen:
    ...
```

A repeated record shape (e.g. a record array, exercised by the
existing `record_sequence` golden cases) drives the combined `if`
both ways, so the branch is genuinely covered and no pragma is
needed. This is a structural cleanup, not a moved pragma.

## Verification

- No behaviour change (pure refactor).
- Full CI coverage command green: **100.00%**, gate unchanged, no
  new `# pragma: no cover` / `no branch`.
- `ruff`, `ty`, `vulture`, and all pre-commit hooks pass.

Refs #2318 (`# pragma: no branch` checklist: now 1/2 done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to Rust record preamble generation; behavior should be unchanged aside from slightly different branching/coverage characteristics in `_accumulate_emit_order`.
> 
> **Overview**
> Removes a `# pragma: no branch` in `src/literalizer/languages/rust.py` by restructuring `_accumulate_emit_order` to use `shapes_by_id.get(id(data))` and a single conditional (`shape is not None and shape not in emit_seen`) when appending record shapes to the emit order.
> 
> This keeps the emit-ordering logic the same while making the “no shape present” path explicit and naturally branch-coverable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e50bdd3a98c667b7340eaff1f00bf5778fce11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->