### PR TITLE
Support variable_form on literalize_call for SML

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Sml` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call`, emitting the inference-style
+  binding ``val my_data = make_widget(42)`` without the ``: val_t``
+  annotation or ``datatype`` constructor wrapping used for literal
+  bindings (the call's return type is not known to the renderer, so
+  SML infers it).  See #2248.
+
 - :class:`~literalizer.Java` and :class:`~literalizer.Scala` no longer
   emit output that fails to compile for a post-2038
   :class:`~datetime.datetime`

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -355,7 +355,7 @@ class Sml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -1027,6 +1027,20 @@ class Sml(metaclass=LanguageCls):
     ) -> Callable[[str, str, Value], str]:
         """Callable that formats an assignment to an existing variable."""
         return self._sml_decl
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call expression.
+
+        The literal-binding declaration prepends a ``: val_t`` type
+        annotation and wraps the value in a ``datatype`` constructor
+        derived from the bound value's runtime type; a call expression
+        has no such tag, so both are omitted and SML infers the call's
+        return type instead.
+        """
+        return self.declaration_style.value.formatter
 
     @cached_property
     def scalar_body_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -1034,11 +1034,11 @@ class Sml(metaclass=LanguageCls):
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a declaration binding a call expression.
 
-        The literal-binding declaration prepends a ``: val_t`` type
-        annotation and wraps the value in a ``datatype`` constructor
-        derived from the bound value's runtime type; a call expression
-        has no such tag, so both are omitted and SML infers the call's
-        return type instead.
+        The literal-binding declaration is prepended with a ``: val_t``
+        type annotation and wraps the value in a ``datatype``
+        constructor derived from the bound value's runtime type; a call
+        expression has no such tag, so both are omitted and SML infers
+        the call's return type instead.
         """
         return self.declaration_style.value.formatter
 

--- a/tests/integration/cases/call_variable_form_new/Sml_call@sml_97.sml
+++ b/tests/integration/cases/call_variable_form_new/Sml_call@sml_97.sml
@@ -1,0 +1,5 @@
+fun make_widget _ = ()
+datatype val_t =
+    SInt of LargeInt.int
+val my_data = make_widget(42)
+val _ = my_data


### PR DESCRIPTION
Closes #2248 (sub-issue of #2224, split per language).

SML's literal-binding declaration prepends a `: val_t` annotation and wraps the value in a `datatype` constructor derived from the bound value's runtime type; a call expression has no such tag, so `literalize_call` previously rejected `variable_form` for SML with `UnsupportedCallShapeError`. This flips `supports_call_variable_binding = True` and adds a `format_call_variable_declaration` hook (reusing the shared call-binding plumbing that landed with Haskell in #2261) that emits the inference-style binding `val my_data = make_widget(42)`, omitting both the annotation and constructor wrapper so SML infers the return type. A new golden `Sml_call@sml_97.sml` compiles and runs cleanly under MLton, and existing SML literal-binding output is unchanged (62 SML integration tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to SML call variable binding, plus a new golden fixture and documentation update, with no impact on other languages or data rendering paths.
> 
> **Overview**
> Adds SML support for `literalize_call(..., variable_form=...)` by enabling call-result variable bindings and introducing a call-specific declaration formatter that omits the usual `: val_t` annotation and `datatype` constructor wrapping so SML can infer the call’s return type.
> 
> Updates the changelog and adds an integration golden case verifying the new `val my_data = make_widget(42)` output shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b32effcc54014e39ff35141913ab0e8976178494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->