### PR TITLE
Pin Dart lint to Dart.language_version via pubspec SDK constraint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1224,6 +1224,10 @@ jobs:
       - name: Check Dart syntax and run fixtures
         run: |-
           tmpdir=$(mktemp -d)
+          # `sdk: ^3.0.0` matches `Dart.language_version` (`V3`) in
+          # `src/literalizer/languages/dart.py`; keep them in sync. Dart
+          # has no `--langversion`-style flag, so the pubspec SDK
+          # constraint is the only mechanism for pinning the version.
           printf 'name: check\nenvironment:\n  sdk: ^3.0.0\n' > "$tmpdir/pubspec.yaml"
           driver="$tmpdir/main.dart"
           : > "$driver"

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -781,10 +781,10 @@ class Dart(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the `sdk: ^3.0.0` SDK constraint in the
-    # generated `pubspec.yaml` in `.github/workflows/lint.yml`. Dart has
-    # no `--langversion`-style flag, so the pubspec SDK constraint is
-    # the pin mechanism; `V3` maps to `^3.0.0`.
+    # Keep in sync with the `sdk: ^3.0.0` constraint in the generated
+    # `pubspec.yaml` in `.github/workflows/lint.yml`. Dart has no
+    # `--langversion`-style flag, so that `pubspec.yaml` constraint is
+    # the only way to pin the version; `V3` maps to `^3.0.0`.
     language_version: VersionFormats = VersionFormats.V3
     indent: str = "    "
 

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -781,6 +781,10 @@ class Dart(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `sdk: ^3.0.0` SDK constraint in the
+    # generated `pubspec.yaml` in `.github/workflows/lint.yml`. Dart has
+    # no `--langversion`-style flag, so the pubspec SDK constraint is
+    # the pin mechanism; `V3` maps to `^3.0.0`.
     language_version: VersionFormats = VersionFormats.V3
     indent: str = "    "
 


### PR DESCRIPTION
Adds cross-reference sync comments next to the generated `pubspec.yaml` heredoc in `.github/workflows/lint.yml` and next to `Dart.language_version` in `src/literalizer/languages/dart.py`, matching the pattern already used for C#/VB/Swift/Java/Ada/Fortran. The literal `^3.0.0` stays in the workflow because Dart has no `--langversion`-style flag (the pubspec SDK constraint is the only pin mechanism); the comments make future drift visible. This is a comment-only, no-behaviour change, so no CHANGELOG entry is added (matching sibling #2255). Closes #2256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes that just clarify how Dart fixture linting pins the language version; no runtime or build behavior is modified.
> 
> **Overview**
> Adds explicit *sync comments* tying the Dart fixture lint’s generated `pubspec.yaml` SDK constraint (`sdk: ^3.0.0`) to `Dart.language_version` (`VersionFormats.V3`) so future version bumps are reviewed together.
> 
> No functional changes to the lint workflow or Dart literalizer behavior; this only documents that Dart’s SDK constraint is the mechanism used to pin the language version in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edd88243e4cc47027de746118844da30a708bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->