### PR TITLE
type_inference: replace OrderedMap isinstance guards with ordered match arms

### DIFF
--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -105,7 +105,9 @@ def _collect_element_types(
                 if inner is None:
                     return _INFER_FAILED
                 element_types.add(ListType(inner=inner))
-            case dict() if not isinstance(item, OrderedMap):
+            case OrderedMap():
+                element_types.add(type(item))
+            case dict():
                 dict_values.extend(item.values())
                 element_types.add(dict)
             case _:
@@ -391,13 +393,13 @@ def _accumulate_record_shapes(
     # ``Value``-typed sets only contain scalars (see ``literalizer._types``)
     # so there's no need to walk into them.
     match data:
-        case dict() if not isinstance(data, OrderedMap):
-            shape = record_shape_for_dict(value=data)
-            if shape is not None:
-                out[id(data)] = shape
+        case OrderedMap():
             for v in data.values():
                 _accumulate_record_shapes(data=v, out=out)
         case dict():
+            shape = record_shape_for_dict(value=data)
+            if shape is not None:
+                out[id(data)] = shape
             for v in data.values():
                 _accumulate_record_shapes(data=v, out=out)
         case list():


### PR DESCRIPTION
Since `OrderedMap` is a `dict` subclass, the two `match` blocks in `type_inference.py` used a `case dict() if not isinstance(item, OrderedMap)` guard to keep ordered maps out of the record-eligible path. This places an explicit `case OrderedMap()` arm before `case dict()` so the discrimination happens by arm order instead, removing the double-negative guard. The change is purely internal with no behavior change, verified by the full test suite passing with all golden files byte-identical (4581 passed, 27771 subtests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal refactor that only changes match-arm ordering in type inference/record-shape walking; behavior should remain the same aside from any subtle pattern-matching edge cases.
> 
> **Overview**
> Updates `type_inference.py` to treat `OrderedMap` explicitly in structural pattern matches by adding a `case OrderedMap()` arm before `case dict()`.
> 
> This removes the prior double-negative `dict() if not isinstance(..., OrderedMap)` guards in both element-type collection and record-shape accumulation, keeping ordered maps on the non-record/non-plain-dict path via match ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfcc1a8c84afca31e9531479411d36efad792254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->