### PR TITLE
Remove redundant test_python_dotted_target_function_renders

### DIFF
--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -401,20 +401,6 @@ def test_dhall_quoted_dict_key() -> None:
     assert result.code == '{\n  `a"b` = +1,\n}'
 
 
-def test_python_dotted_target_function_renders() -> None:
-    """Dotted ``target_function`` succeeds when the language supports
-    it.
-    """
-    result = literalize_call(
-        source="[[1]]",
-        input_format=InputFormat.JSON,
-        language=Python(),
-        target_function="module.fn",
-        parameter_names=["a"],
-    )
-    assert result.code == "module.fn(a=1)"
-
-
 def test_python_accepts_syntactic_non_idiomatic_ref_case() -> None:
     """Cases legal in the language but absent from the idiomatic
     preference list are accepted and rendered.


### PR DESCRIPTION
Removes `test_python_dotted_target_function_renders` from `tests/test_languages.py`. The dotted `target_function` rendering it asserted (`module.fn(a=1)`) is already covered by the `call_dotted_method` golden-file case and its siblings (`call_homogeneous_dotted_method`, `call_deep_dotted_method`, `call_snake_dotted_method`, `call_no_params_dotted`) across all ~80 languages, including Python, where the golden is compiled by per-language lint CI. This aligns with the project preference for golden-file integration coverage over Python-specific pytest string assertions for non-error behavior. No imports become unused since `literalize_call` is still used by other tests, and `test_call_golden_file[call_dotted_method/Python]` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single redundant test without changing any production code or behavior.
> 
> **Overview**
> Removes the `test_python_dotted_target_function_renders` assertion from `tests/test_languages.py`, relying on existing golden-file integration coverage for dotted `target_function` call rendering (including Python).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3a69c59e66d642fae0e708a09ec82654b89042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->