### PR TITLE
Width-aware RECORD field type for Kotlin/Java/Scala (#2376)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,14 @@ Next
   non-default ``integer_format``, ``numeric_separator`` or
   ``numeric_literal_suffix`` keep their value-derived field type.
   In-range integers are unaffected.  See #2306.
+- :class:`~literalizer.Kotlin`, :class:`~literalizer.Java` and
+  :class:`~literalizer.Scala` no longer emit output that fails to
+  compile for a record field holding an integer beyond the signed
+  64-bit range under the ``RECORD`` ``heterogeneous_strategy``.  The
+  generated ``data class`` / ``record`` / ``case class`` field is now
+  typed ``BigInteger`` / ``BigInteger`` / ``BigInt`` to match the
+  arbitrary-precision overflow-fallback literal instead of
+  ``Long`` / ``long``.  In-range integers are unaffected.  See #2376.
 - Internal: the ``RECORD`` ``heterogeneous_strategy`` no longer threads
   the already-formatted field literal into the field-type hook.
   :class:`~literalizer.Kotlin` now derives each generated ``data class``

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -38,6 +38,8 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_integers import (
+    I64_MAX,
+    I64_MIN,
     data_has_out_of_range_int,
     format_integer_binary,
     format_integer_hex,
@@ -1391,7 +1393,11 @@ class Java(metaclass=LanguageCls):
             enable_dict_type=False,
         )
 
-    def _java_record_field_type(self, request: RecordFieldType, /) -> str:
+    def _java_record_field_type(  # noqa: PLR0911
+        self,
+        request: RecordFieldType,
+        /,
+    ) -> str:
         """Return the Java record-component type for a field.
 
         Derives the type from the raw value (and any resolved
@@ -1427,6 +1433,8 @@ class Java(metaclass=LanguageCls):
         match value:
             case bool():
                 return "boolean"
+            case int() if not I64_MIN <= value <= I64_MAX:
+                return "BigInteger"
             case int():
                 in_i32 = _JAVA_I32_MIN <= value <= _JAVA_I32_MAX
                 return "long" if int_type == "int" and not in_i32 else int_type

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -44,6 +44,8 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_integers import (
+    I64_MAX,
+    I64_MIN,
     data_has_out_of_range_int,
     format_integer_binary,
     format_integer_hex,
@@ -1265,6 +1267,8 @@ class Kotlin(metaclass=LanguageCls):
                 return "Any?"
             case bool():
                 return "Boolean"
+            case int() if not I64_MIN <= value <= I64_MAX:
+                return "BigInteger"
             case int():
                 in_i32 = _KOTLIN_I32_MIN <= value <= _KOTLIN_I32_MAX
                 return "Int" if in_i32 else "Long"

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -42,6 +42,8 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_integers import (
+    I64_MAX,
+    I64_MIN,
     format_integer_hex,
     format_integer_underscore,
     make_overflow_fallback_formatter,
@@ -844,7 +846,11 @@ class Scala(metaclass=LanguageCls):
         )
         return self._scalar_field_type_resolver(element_type) or "Any"
 
-    def _scala_record_field_type(self, request: RecordFieldType, /) -> str:
+    def _scala_record_field_type(  # noqa: PLR0911
+        self,
+        request: RecordFieldType,
+        /,
+    ) -> str:
         """Return the Scala ``case class`` field type for a record
         field, derived structurally from the raw value.
 
@@ -893,6 +899,8 @@ class Scala(metaclass=LanguageCls):
                 opener = self.sequence_open(value)
             case bool():
                 return self._scalar_field_type_resolver(bool) or "Any"
+            case int() if not I64_MIN <= value <= I64_MAX:
+                return "BigInt"
             case int():
                 return self._scala_int_magnitude_field_type(value)
             case _:

--- a/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_integer_binary@jdk_16.java
+++ b/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_integer_binary@jdk_16.java
@@ -1,0 +1,14 @@
+import java.util.Map;
+import java.math.BigInteger;
+record Record0(int quantity, BigInteger big, double ratio, String label, boolean ok) {}
+class Main {
+    public static void main() {
+var my_data = new Record0(
+    0b11110100001001000000,
+    new BigInteger("18446744073709551615"),
+    2.5,
+    "tag",
+    true
+);
+    }
+}

--- a/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_integer_hex@jdk_16.java
+++ b/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_integer_hex@jdk_16.java
@@ -1,0 +1,14 @@
+import java.util.Map;
+import java.math.BigInteger;
+record Record0(int quantity, BigInteger big, double ratio, String label, boolean ok) {}
+class Main {
+    public static void main() {
+var my_data = new Record0(
+    0xf4240,
+    new BigInteger("18446744073709551615"),
+    2.5,
+    "tag",
+    true
+);
+    }
+}

--- a/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_integer_octal@jdk_16.java
+++ b/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_integer_octal@jdk_16.java
@@ -1,0 +1,14 @@
+import java.util.Map;
+import java.math.BigInteger;
+record Record0(int quantity, BigInteger big, double ratio, String label, boolean ok) {}
+class Main {
+    public static void main() {
+var my_data = new Record0(
+    03641100,
+    new BigInteger("18446744073709551615"),
+    2.5,
+    "tag",
+    true
+);
+    }
+}

--- a/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_separator_underscore@jdk_16.java
+++ b/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_separator_underscore@jdk_16.java
@@ -1,0 +1,14 @@
+import java.util.Map;
+import java.math.BigInteger;
+record Record0(int quantity, BigInteger big, double ratio, String label, boolean ok) {}
+class Main {
+    public static void main() {
+var my_data = new Record0(
+    1_000_000,
+    new BigInteger("18446744073709551615"),
+    2.5,
+    "tag",
+    true
+);
+    }
+}

--- a/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_suffix_auto@jdk_16.java
+++ b/tests/integration/cases/record_wide_int/Java_heterogeneous_strategy_record_suffix_auto@jdk_16.java
@@ -1,0 +1,14 @@
+import java.util.Map;
+import java.math.BigInteger;
+record Record0(long quantity, BigInteger big, double ratio, String label, boolean ok) {}
+class Main {
+    public static void main() {
+var my_data = new Record0(
+    1000000L,
+    new BigInteger("18446744073709551615"),
+    2.5,
+    "tag",
+    true
+);
+    }
+}

--- a/tests/integration/cases/record_wide_int/Kotlin_heterogeneous_strategy_record_integer_binary@v1_9.kts
+++ b/tests/integration/cases/record_wide_int/Kotlin_heterogeneous_strategy_record_integer_binary@v1_9.kts
@@ -1,0 +1,9 @@
+import java.math.BigInteger
+data class Record0(val quantity: Int, val big: BigInteger, val ratio: Double, val label: String, val ok: Boolean)
+val my_data = Record0(
+    quantity = 0b11110100001001000000,
+    big = BigInteger("18446744073709551615"),
+    ratio = 2.5,
+    label = "tag",
+    ok = true,
+)

--- a/tests/integration/cases/record_wide_int/Kotlin_heterogeneous_strategy_record_integer_hex@v1_9.kts
+++ b/tests/integration/cases/record_wide_int/Kotlin_heterogeneous_strategy_record_integer_hex@v1_9.kts
@@ -1,0 +1,9 @@
+import java.math.BigInteger
+data class Record0(val quantity: Int, val big: BigInteger, val ratio: Double, val label: String, val ok: Boolean)
+val my_data = Record0(
+    quantity = 0xf4240,
+    big = BigInteger("18446744073709551615"),
+    ratio = 2.5,
+    label = "tag",
+    ok = true,
+)

--- a/tests/integration/cases/record_wide_int/Kotlin_heterogeneous_strategy_record_separator_underscore@v1_9.kts
+++ b/tests/integration/cases/record_wide_int/Kotlin_heterogeneous_strategy_record_separator_underscore@v1_9.kts
@@ -1,0 +1,9 @@
+import java.math.BigInteger
+data class Record0(val quantity: Int, val big: BigInteger, val ratio: Double, val label: String, val ok: Boolean)
+val my_data = Record0(
+    quantity = 1_000_000,
+    big = BigInteger("18446744073709551615"),
+    ratio = 2.5,
+    label = "tag",
+    ok = true,
+)

--- a/tests/integration/cases/record_wide_int/Scala_heterogeneous_strategy_record_integer_hex@v3.scala
+++ b/tests/integration/cases/record_wide_int/Scala_heterogeneous_strategy_record_integer_hex@v3.scala
@@ -1,0 +1,10 @@
+object Fixture_record_wide_int_Scala_heterogeneous_strategy_record_integer_hex {
+case class Record0(quantity: Int, big: BigInt, ratio: Double, label: String, ok: Boolean)
+val my_data = Record0(
+    quantity = 0xf4240,
+    big = BigInt("18446744073709551615"),
+    ratio = 2.5,
+    label = "tag",
+    ok = true,
+)
+}

--- a/tests/integration/cases/record_wide_int/Scala_heterogeneous_strategy_record_separator_underscore@v3.scala
+++ b/tests/integration/cases/record_wide_int/Scala_heterogeneous_strategy_record_separator_underscore@v3.scala
@@ -1,0 +1,10 @@
+object Fixture_record_wide_int_Scala_heterogeneous_strategy_record_separator_underscore {
+case class Record0(quantity: Int, big: BigInt, ratio: Double, label: String, ok: Boolean)
+val my_data = Record0(
+    quantity = 1_000_000,
+    big = BigInt("18446744073709551615"),
+    ratio = 2.5,
+    label = "tag",
+    ok = true,
+)
+}

--- a/tests/integration/language_specs.py
+++ b/tests/integration/language_specs.py
@@ -19,24 +19,8 @@ from literalizer.languages import (
     Crystal,
     Erlang,
     Gleam,
-    Go,
     Haskell,
-    Rust,
     Scala,
-)
-
-# Languages whose ``RECORD`` heterogeneous strategy gives each generated
-# struct field a type that matches the rendered literal under any
-# non-default ``integer_format`` / ``numeric_separator`` /
-# ``numeric_literal_suffix`` and for a positive integer outside the
-# signed 64-bit range (whose literal comes from a wide-integer overflow
-# fallback).  Kotlin, Java and Scala derive the field type structurally
-# (#2305) but still pick a fixed-width integer type that the
-# out-of-range fallback literal overflows, so that combination does not
-# compile; the remaining width gap is tracked by #2376 and each
-# language joins this set once fixed.
-RECORD_FIELD_TYPE_FROM_VALUE_LANGUAGES: frozenset[literalizer.LanguageCls] = (
-    frozenset({Go, Rust})
 )
 
 

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -44,11 +44,7 @@ from literalizer.languages import (
 )
 
 from .case_discovery import cases_with_special_floats, discover_cases
-from .language_specs import (
-    RECORD_FIELD_TYPE_FROM_VALUE_LANGUAGES,
-    make_spec,
-    sorted_languages,
-)
+from .language_specs import make_spec, sorted_languages
 
 _CASES_DIR = Path(__file__).parent / "cases"
 
@@ -994,23 +990,16 @@ def build_record_epoch_i32_overflow_variants() -> Iterable[Variant]:
 def build_record_numeric_cross_variants() -> Iterable[Variant]:
     """Build ``RECORD`` x non-default numeric-formatter variants.
 
-    For every language whose ``RECORD`` strategy chooses each struct
-    field's type from the value
-    (:data:`RECORD_FIELD_TYPE_FROM_VALUE_LANGUAGES`), cross ``RECORD``
-    with every non-default ``integer_format``, ``numeric_separator`` and
-    ``numeric_literal_suffix``.  Run against the ``record_wide_int``
-    input these lock in that the declared field type follows the value,
-    not the formatted literal (issue #2306, follow-up to #2297): an
+    For every language exposing a ``RECORD`` heterogeneous strategy,
+    cross ``RECORD`` with every non-default ``integer_format``,
+    ``numeric_separator`` and ``numeric_literal_suffix``.  Run against
+    the ``record_wide_int`` input these lock in that the declared field
+    type follows the value, not the formatted literal (issue #2306,
+    follow-up to #2297; extended to Kotlin/Java/Scala by #2376): an
     integer field keeps its value-derived type however the literal is
-    written, and a positive integer beyond the signed 64-bit range is
-    typed to match its wide-integer overflow-fallback literal instead of
-    the type a formatted-string inspection would infer.
-
-    Languages whose ``RECORD`` strategy does not yet widen a record
-    field's integer type to match its out-of-range overflow-fallback
-    literal would emit golden files that do not compile for this cross;
-    that width gap is tracked by #2376 and each language joins the set
-    once fixed.
+    written, and an integer beyond the signed 64-bit range is typed to
+    match its wide-integer overflow-fallback literal instead of the
+    type a formatted-string inspection would infer.
     """
     axes: list[
         tuple[
@@ -1041,14 +1030,17 @@ def build_record_numeric_cross_variants() -> Iterable[Variant]:
     ]
     variants: list[Variant] = []
     for lang_cls in sorted_languages():
-        if lang_cls not in RECORD_FIELD_TYPE_FROM_VALUE_LANGUAGES:
-            continue
         spec = make_spec(lang_cls=lang_cls)
         record_strategy = next(
-            strategy
-            for strategy in spec.heterogeneous_strategies
-            if strategy.name == "RECORD"
+            (
+                strategy
+                for strategy in spec.heterogeneous_strategies
+                if strategy.name == "RECORD"
+            ),
+            None,
         )
+        if record_strategy is None:
+            continue
         lang_name = lang_cls.__name__
         for tag, kwarg, get_default, get_formats in axes:
             default = get_default(spec)


### PR DESCRIPTION
Closes #2376. **Stacked on #2361 (#2306)** — base is `adamtheturtle/issue-2306` so the diff is only this issue's changes; retarget to `main` once #2361 merges.

## Summary

Kotlin/Java/Scala sized a RECORD integer field by 32/64-bit magnitude only, so a value beyond signed 64-bit range was declared `Long`/`long` while its literal rendered through the arbitrary-precision overflow fallback (`BigInteger`/`BigInteger`/`BigInt`) — non-compiling, the #2306 class for those languages. `_kotlin_value_field_type` / `_java_record_field_type` / `_scala_record_field_type` now return `BigInteger`/`BigInteger`/`BigInt` for an integer outside `[I64_MIN, I64_MAX]`, mirroring each language's scalar overflow fallback so the declared field type matches the rendered literal. The `import java.math.BigInteger` preamble already fires via `data_has_out_of_range_int`; Scala `BigInt` is built in.

With every RECORD-strategy language now width-correct, the test-side `RECORD_FIELD_TYPE_FROM_VALUE_LANGUAGES` allowlist (added by #2361 as a temporary scope guard) is **deleted**: `build_record_numeric_cross_variants` iterates all RECORD-strategy languages unconditionally, so `record_wide_int` now also generates Kotlin/Java/Scala cross goldens.

## Verification

- New Kotlin/Java/Scala `record_wide_int` goldens compile/run locally via `kotlinc -script`, `javac` (JDK 26, records), `scalac` (3.8); existing Go/Rust goldens unchanged.
- `pytest --cov-fail-under 100` green (4577 passed, 100.00% coverage); `ruff`/`ty`/pylint-spelling clean. `record_wide_int` stays `VARIANT_ONLY` (its non-RECORD base representation still can't hold `>2^63` for C++/others — out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RECORD field-type inference for Kotlin/Java/Scala, affecting generated source signatures and potentially downstream compilation/type expectations for wide integers. Risk is contained to out-of-range integer handling plus broadened integration-variant coverage.
> 
> **Overview**
> Fixes non-compiling `RECORD` output for Kotlin/Java/Scala when a record field contains an integer outside signed 64-bit range by widening the generated field type to match each language’s overflow-fallback literal (`BigInteger`/`BigInt`).
> 
> Updates the integration test matrix to run the `record_wide_int` numeric cross-product against **all** languages that support `RECORD` (removing the temporary allowlist) and adds new golden fixtures validating the new wide-int record field types across multiple integer formatting/suffix variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d525c0b214d2b4be694f11428111ef8ff62ee28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->