### PR TITLE
Add SystemVerilog lint/language_version sync comments (#1932)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1690,6 +1690,10 @@ jobs:
           && test -s /tmp/files-to-lint
       - name: Install Verilator
         uses: veryl-lang/setup-verilator@v2
+      # `--language 1800-2017` matches `SystemVerilog.language_version` in
+      # `src/literalizer/languages/systemverilog.py`
+      # (`SystemVerilog.VersionFormats.IEEE_1800_2017` maps to the
+      # IEEE 1800-2017 SystemVerilog standard); keep them in sync.
       - name: Check SystemVerilog syntax
         run: xargs -0 -P "$(nproc)" -n1 verilator --lint-only --language 1800-2017
           -Wno-REALCVT < /tmp/files-to-lint

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -567,6 +567,10 @@ class SystemVerilog(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     call_style: CallStyles = CallStyles.POSITIONAL
+    # The `Check SystemVerilog syntax` step in
+    # `.github/workflows/lint.yml` passes `verilator --language 1800-2017`,
+    # matching this default (`IEEE_1800_2017` is the IEEE 1800-2017
+    # SystemVerilog standard). Keep the two in sync.
     language_version: VersionFormats = VersionFormats.IEEE_1800_2017
     indent: str = "    "
 


### PR DESCRIPTION
Closes the last gap in the #1932 catch-all ("add std/langversion lint flags to remaining languages that accept one"). An audit of every language module against `lint.yml` found that all flag-capable languages except SystemVerilog already pass a matching standard flag with bidirectional sync comments; the rest have no per-invocation version flag and fall under #1933 instead. For SystemVerilog, `verilator --lint-only --language 1800-2017` was already passed and already matched `SystemVerilog.VersionFormats.IEEE_1800_2017`, but neither side carried the cross-reference comment mandated by #1930. This PR adds the "keep in sync" comments on both the lint step and the `language_version` declaration; it is comment-only with no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change that adds cross-references between CI lint flags and the SystemVerilog default `language_version`, with no runtime or CI behavior modifications.
> 
> **Overview**
> Adds **bidirectional “keep in sync” comments** linking the SystemVerilog CI lint invocation (`verilator --language 1800-2017` in `.github/workflows/lint.yml`) to the default `SystemVerilog.language_version` (`IEEE_1800_2017` in `src/literalizer/languages/systemverilog.py`).
> 
> No functional changes: lint commands, language defaults, and generated output remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9416909ac3a363f837259f97ccf6f9bdd9e9d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->