### PR TITLE
Repoint stale RECORD field-shape refs at #2317

### DIFF
--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -807,10 +807,11 @@ class Go(metaclass=LanguageCls):
         ``uint64`` to match that typed conversion.
 
         A set or a non-record dict (an empty or non-string-keyed dict)
-        as a record field is outside the ``RECORD`` strategy's MVP --
-        Rust's ``_rust_record_field_type`` is imprecise for the same
-        shapes (#2234) -- so it is declared as Go's top type ``any``,
-        which the rendered literal still assigns into.
+        as a record field has no precise component type under the
+        ``RECORD`` strategy.  Per the cross-language decision in #2317,
+        Rust rejects such a field while Go widens it to the top type
+        ``any`` (documented best effort), which the rendered literal
+        still assigns into.
         """
         if request.record_name is not None:
             return request.record_name

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1432,10 +1432,11 @@ class Java(metaclass=LanguageCls):
         encoded element type (e.g. ``List.of(``) reaches this branch.
 
         A set or a non-record dict (an empty or non-string-keyed dict)
-        as a record field is outside the ``RECORD`` strategy's MVP --
-        the same shapes Rust's ``_rust_record_field_type`` is imprecise
-        for (#2317) -- so it folds into the ``Object`` top type, which
-        the rendered literal still assigns into.
+        as a record field has no precise component type under the
+        ``RECORD`` strategy.  Per the cross-language decision in #2317,
+        Rust rejects such a field while Java folds it into the
+        ``Object`` top type (documented best effort), which the
+        rendered literal still assigns into.
         """
         if request.record_name is not None:
             return request.record_name

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -1256,10 +1256,11 @@ class Kotlin(metaclass=LanguageCls):
         resolver.
 
         A set or a non-record dict (an empty or non-string-keyed dict)
-        as a record field is outside the ``RECORD`` strategy's MVP --
-        the same shapes Rust's ``_rust_record_field_type`` is imprecise
-        for (#2234) -- so it folds into Kotlin's ``Any?`` top type,
-        which the rendered literal still assigns into.
+        as a record field has no precise component type under the
+        ``RECORD`` strategy.  Per the cross-language decision in #2317,
+        Rust rejects such a field while Kotlin folds it into the
+        ``Any?`` top type (documented best effort), which the rendered
+        literal still assigns into.
         """
         if request.record_name is not None:
             return request.record_name

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1106,9 +1106,10 @@ def _gather_record_field_values(  # noqa: C901  # pylint: disable=too-complex
                 )
         case dict():
             # Non-record dicts (empty, non-string-keyed, or an ordered
-            # map) sitting next to record dicts are a #2234 /
-            # out-of-MVP shape.  Keep walking its values so a record
-            # dict nested deeper inside one is still found, even though
+            # map) sitting next to record dicts have no precise Rust
+            # component type under the RECORD strategy (#2317).  Keep
+            # walking its values so a record dict nested deeper inside
+            # one is still found, even though
             # :func:`_rust_record_field_type` later rejects such a dict
             # when it is itself a record field.
             for value in data.values():

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -884,10 +884,11 @@ class Scala(metaclass=LanguageCls):
         (``Int``, or ``Long`` once it leaves 32-bit range past 2038).
 
         A set or a non-record dict (an empty or non-string-keyed dict)
-        as a record field is outside the ``RECORD`` strategy's MVP --
-        Rust's ``_rust_record_field_type`` is imprecise for the same
-        shapes (#2234) -- so it is declared as Scala's top type
-        ``Any``, which the rendered literal still assigns into.
+        as a record field has no precise component type under the
+        ``RECORD`` strategy.  Per the cross-language decision in #2317,
+        Rust rejects such a field while Scala widens it to the top type
+        ``Any`` (documented best effort), which the rendered literal
+        still assigns into.
         """
         if request.record_name is not None:
             return request.record_name


### PR DESCRIPTION
## Summary

Resolves the remaining documentation items on #2317 (cross-language handling of set / non-record-dict RECORD fields).

#2317's decision was made and shipped: a set or non-record dict (empty / non-string-keyed) record field has no precise component type, so **Rust rejects it** with `UnrepresentableInputError` (option (b), merged via #2360) while **Go / Kotlin / Scala / Java widen to the language top type** (`any` / `Any?` / `Any` / `Object`) as documented best effort (option (c)).

The in-code comments lagged that decision: they still cited the **closed** #2234 ("out-of-MVP shape") and described Rust as merely *"imprecise"* for these shapes — stale, since Rust now explicitly *rejects* them. This repoints every such comment in `go.py` / `kotlin.py` / `scala.py` / `rust.py` at #2317 and corrects the wording to the decided behaviour. `java.py` already cited #2317 but carried the same inaccurate *"imprecise"* phrasing, so it is corrected for consistency.

## Scope / impact

- **Comment & docstring only** — no behaviour, API, or golden change. Goldens are byte-identical by construction.
- `ruff check`, `ruff format --check`, and `ty check` clean on all five files. The one pylint spelling flag (`unmapped`, `java.py:1393`) is pre-existing baseline noise on an untouched line, not introduced here.

## Closes out #2317 / #2318

- #2317 checklist: decision made (#2360), all in-code refs now point at #2317, behaviour covered by #2360's error tests — **fully resolved by this PR**.
- #2318 (drive `# pragma: no cover` / `no branch` to zero): `src/` already has **zero** such pragmas on `main`; its inventory text is stale. No code work remains.
- #2370 (Rust option (a)) was closed as superseded (its PR #2373 closed by the owner; option (a) infeasible as a golden-file contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates docstrings/comments and does not change runtime behavior or output. Main risk is minor confusion if wording is inaccurate, but no code paths are modified.
> 
> **Overview**
> Updates in-code documentation for the `RECORD` heterogeneous strategy across Go/Java/Kotlin/Scala/Rust to align with the shipped cross-language decision in `#2317`.
> 
> Specifically, comments now state that set-valued or non-record dict record fields have **no precise component type**; Rust **rejects** these inputs, while Go/Java/Kotlin/Scala **widen to the language top type** (`any`/`Object`/`Any?`/`Any`) as a best-effort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0cce25fe526816338f3c5e6020e40d6af1b90b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->