### PR TITLE
Remove defaults from CallCaseConfig and related test helpers

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -89,29 +89,27 @@ class CallCaseConfig:
     # exercise the call-binding output mode.  Only meaningful with
     # ``per_element=False`` and (typically) ``wrap_in_file=True`` so
     # the generated file is self-contained around the binding.
-    variable_form: literalizer.VariableForm | None = None
+    variable_form: literalizer.VariableForm | None
     # Companion source whose parsed top-level elements pair
     # positionally with the generated calls and are exposed on
     # ``CallContext.zipped``.  Requires ``call_transform``.  Parsed
     # with ``zip_input_format``.
-    zip_source: str | None = None
-    zip_input_format: literalizer.InputFormat | None = None
+    zip_source: str | None
+    zip_input_format: literalizer.InputFormat | None
     # Trailing source-code comments, one per generated call, paired
     # positionally and emitted after the statement terminator using the
     # language's comment syntax.  An empty entry emits no comment.
-    comment_source: list[str] | None = None
+    comment_source: list[str] | None
     # Parameter names used when stubbing each ``transform_stub_names``
     # wrapper.  The length sets how many parameters the wrapper takes,
     # so a transform that calls the wrapper with the call *and* the
     # zipped value (two arguments) compiles in fixed-parameter-count
     # languages.
-    transform_stub_param_names: list[str] = dataclasses.field(
-        default_factory=lambda: ["_arg"],
-    )
+    transform_stub_param_names: list[str]
     # Languages (by class name) that cannot represent this case's
     # generated fixture and are skipped (no golden) instead of emitting
     # non-compiling output.
-    skip_lang_names: frozenset[str] = frozenset()
+    skip_lang_names: frozenset[str]
 
 
 CALL_STYLE_VARIANTS: list[tuple[str, type[literalizer.CallStyle]]] = [
@@ -138,6 +136,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=True,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_scalar_args",
@@ -154,6 +158,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_line_comments",
@@ -174,7 +184,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         # comments; languages without that support raise
         # UnsupportedCallShapeError (see _validate_comment_source_supported).
         requires_standalone_wrapped_comments=True,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
         comment_source=["first edition", "", "cyberpunk"],
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_comments",
@@ -191,6 +206,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=True,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_comments_dict_args",
@@ -207,6 +228,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=True,
         requires_standalone_wrapped_comments=True,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_negative_int",
@@ -223,6 +250,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_multi_args",
@@ -239,6 +272,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         # Four-parameter call.
@@ -256,6 +295,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_reserved_target",
@@ -272,6 +317,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_dotted_method",
@@ -288,6 +339,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_homogeneous_dotted_method",
@@ -304,6 +361,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_deep_dotted_method",
@@ -320,6 +383,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_snake_dotted_method",
@@ -336,6 +405,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_deep_dotted_transformed",
@@ -352,6 +427,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=True,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_dotted_transform_stub",
@@ -368,6 +449,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=True,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_zip_values",
@@ -384,8 +471,10 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=True,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
         zip_source="---\n- true\n- false\n",
         zip_input_format=literalizer.InputFormat.YAML,
+        comment_source=None,
         transform_stub_param_names=["_call", "_zip"],
         # Zig types the 2-parameter wrapper stub strongly while the
         # call stub returns ``void``; Groovy stubs the wrapper
@@ -411,8 +500,10 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=True,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
         zip_source="--- true\n",
         zip_input_format=literalizer.InputFormat.YAML,
+        comment_source=None,
         transform_stub_param_names=["_call", "_zip"],
         # Same wrapper-stub limitations as ``call_zip_values``.
         skip_lang_names=frozenset({"Zig", "Groovy"}),
@@ -432,6 +523,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_no_params",
@@ -448,6 +545,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_no_params_transform",
@@ -464,6 +567,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=True,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_no_params_dotted",
@@ -480,6 +589,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_no_params_curried",
@@ -496,6 +611,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_no_params_curried_dotted",
@@ -512,6 +633,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_per_element_false",
@@ -528,6 +655,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_per_element_false_dict_arg",
@@ -544,6 +677,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=True,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_homogeneous_value_dict_arg",
@@ -560,6 +699,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=True,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_existing_ref_arg",
@@ -576,6 +721,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args",
@@ -595,6 +746,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         # Same ref reused across multiple per-element calls.  The
@@ -624,6 +781,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         # Mix of register-trivial (Int / Bool / Float64) and non-trivial
@@ -655,6 +818,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args_converted",
@@ -674,6 +843,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args_converted_whole",
@@ -692,6 +867,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args_converted_nonsnake",
@@ -711,6 +892,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         # Slot 0 holds lists whose Mojo element type disagrees across
@@ -736,6 +923,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_args_escaped_quote",
@@ -752,6 +945,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_nested_in_list",
@@ -771,6 +970,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_nested_in_dict",
@@ -789,6 +994,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_ref_nested_converted",
@@ -807,6 +1018,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_mixed_type_dicts",
@@ -823,6 +1040,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=True,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         # Drive ``literalize_call(..., wrap_in_file=True)`` directly so
@@ -841,6 +1064,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_variable_form_new",
@@ -858,6 +1087,11 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
         variable_form=literalizer.NewVariable(name="my_data"),
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         # 27-parameter call exercises the type-variable generators in
@@ -878,6 +1112,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_wrap_in_file_escaped_quote",
@@ -894,6 +1134,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_scalar_args_uniform_second_slot",
@@ -910,6 +1156,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     CallCaseConfig(
         case_dir_name="call_scalar_args_with_null",
@@ -926,6 +1178,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
         requires_call_returns_expression=False,
         requires_inline_multiline_dict_args=False,
         requires_standalone_wrapped_comments=False,
+        variable_form=None,
+        zip_source=None,
+        zip_input_format=None,
+        comment_source=None,
+        transform_stub_param_names=["_arg"],
+        skip_lang_names=frozenset(),
     ),
     *[
         CallCaseConfig(
@@ -958,6 +1216,12 @@ CALL_CASE_CONFIGS: list[CallCaseConfig] = [
             ),
             requires_inline_multiline_dict_args=False,
             requires_standalone_wrapped_comments=False,
+            variable_form=None,
+            zip_source=None,
+            zip_input_format=None,
+            comment_source=None,
+            transform_stub_param_names=["_arg"],
+            skip_lang_names=frozenset(),
         )
         for name, cls in CALL_STYLE_VARIANTS
     ],
@@ -970,7 +1234,7 @@ class CallCase:
 
     config: CallCaseConfig
     lang_cls: literalizer.LanguageCls
-    expected_exception: type[Exception] | None = None
+    expected_exception: type[Exception] | None
 
 
 _SUBSTITUTION_CALL_STYLES = (

--- a/tests/integration/call_variant_cases.py
+++ b/tests/integration/call_variant_cases.py
@@ -11,6 +11,8 @@ from collections.abc import Callable, Iterable
 
 from beartype import beartype
 
+import literalizer
+
 from .call_cases import CALL_CASE_CONFIGS, CallCaseConfig
 from .language_specs import make_spec, sorted_languages
 from .variant_cases import (
@@ -54,6 +56,7 @@ def build_statement_terminator_style_call_variants() -> list[Variant]:
                     statement_terminator_style=statement_terminator_style,
                 ),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
             for statement_terminator_style in spec.statement_terminator_styles
             if statement_terminator_style
@@ -81,6 +84,7 @@ def build_heterogeneous_strategy_call_variants() -> list[Variant]:
                     heterogeneous_strategy=strategy,
                 ),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
             for strategy in spec.heterogeneous_strategies
             if strategy is not default_strategy

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -381,9 +381,7 @@ class Variant:
     name: str
     spec: literalizer.Language
     lang_cls: literalizer.LanguageCls
-    collection_layout: literalizer.CollectionLayout = (
-        literalizer.CollectionLayout.COMPACT
-    )
+    collection_layout: literalizer.CollectionLayout
 
 
 @dataclasses.dataclass(frozen=True)
@@ -427,6 +425,7 @@ def build_non_default_variants(
                     name=f"{lang_name}_{category}_{fmt.name.lower()}",
                     spec=make_variant_spec(lang_cls, fmt),
                     lang_cls=lang_cls,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
                 )
             )
     return variants
@@ -442,6 +441,7 @@ def build_default_set_element_type_variants() -> Iterable[Variant]:
                 lang_cls=lang_cls, default_set_element_type=type_name
             ),
             lang_cls=lang_cls,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
         )
         for lang_cls, type_name in DEFAULT_SET_ELEMENT_TYPES.items()
     ]
@@ -459,6 +459,7 @@ def build_default_sequence_element_type_variants() -> Iterable[Variant]:
                 lang_cls=lang_cls, default_sequence_element_type=type_name
             ),
             lang_cls=lang_cls,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
         )
         for lang_cls, type_name in DEFAULT_SEQUENCE_ELEMENT_TYPES.items()
     ]
@@ -507,6 +508,7 @@ def build_empty_dict_key_variants() -> Iterable[Variant]:
                         empty_dict_key=fmt,
                     ),
                     lang_cls=lang_cls,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
                 )
             )
     return variants
@@ -524,6 +526,7 @@ def build_default_dict_value_type_variants() -> Iterable[Variant]:
                 lang_cls=lang_cls, default_dict_value_type=type_name
             ),
             lang_cls=lang_cls,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
         )
         for lang_cls, type_name in DEFAULT_DICT_VALUE_TYPES.items()
     ]
@@ -539,6 +542,7 @@ def build_default_dict_key_type_variants() -> Iterable[Variant]:
             name=f"{lang_cls.__name__}_default_dict_key_type",
             spec=make_spec(lang_cls=lang_cls, default_dict_key_type=type_name),
             lang_cls=lang_cls,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
         )
         for lang_cls, type_name in DEFAULT_DICT_KEY_TYPES.items()
     ]
@@ -556,6 +560,7 @@ def build_default_ordered_map_value_type_variants() -> Iterable[Variant]:
                 lang_cls=lang_cls, default_ordered_map_value_type=type_name
             ),
             lang_cls=lang_cls,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
         )
         for lang_cls, type_name in DEFAULT_ORDERED_MAP_VALUE_TYPES.items()
     ]
@@ -599,6 +604,7 @@ def build_statement_terminator_style_decl_variants() -> Iterable[Variant]:
                     declaration_style=declaration_style,
                 ),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
             for statement_terminator_style in (
                 non_default_statement_terminator_styles
@@ -666,6 +672,7 @@ def build_sequence_decl_variants() -> Iterable[Variant]:
                     declaration_style=declaration_style,
                 ),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
             for sequence_format in non_default_sequence_formats
             for declaration_style in non_default_declaration_styles
@@ -740,6 +747,7 @@ def build_set_decl_variants() -> Iterable[Variant]:
                         ),
                         spec=make_spec(lang_cls=lang_cls, **kwargs),
                         lang_cls=lang_cls,
+                        collection_layout=literalizer.CollectionLayout.COMPACT,
                     )
                 )
     return variants
@@ -789,6 +797,7 @@ def build_dict_decl_variants() -> Iterable[Variant]:
                         ),
                         spec=make_spec(lang_cls=lang_cls, **kwargs),
                         lang_cls=lang_cls,
+                        collection_layout=literalizer.CollectionLayout.COMPACT,
                     )
                 )
     return variants
@@ -809,6 +818,7 @@ def build_constructor_name_variants() -> Iterable[Variant]:
                 name=f"{lang_cls.__name__}_constructor_names_j",
                 spec=make_spec(lang_cls=lang_cls, **kwargs),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -832,6 +842,7 @@ def build_type_name_variants() -> Iterable[Variant]:
                 name=f"{lang_cls.__name__}_type_name_{custom_name}",
                 spec=make_spec(lang_cls=lang_cls, type_name=custom_name),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -854,6 +865,7 @@ def build_constructor_prefix_variants() -> Iterable[Variant]:
                     lang_cls=lang_cls, constructor_prefix=custom_prefix
                 ),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -905,6 +917,7 @@ def build_record_shape_names_variants() -> Iterable[Variant]:
                 name=(f"{lang_cls.__name__}_record_shape_names_{custom_name}"),
                 spec=spec,
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -934,6 +947,7 @@ def build_record_unify_optional_fields_variants() -> Iterable[Variant]:
             name="Rust_record_unify_optional_fields",
             spec=spec,
             lang_cls=Rust,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
         )
     ]
 
@@ -981,6 +995,7 @@ def build_record_epoch_i32_overflow_variants() -> Iterable[Variant]:
                     datetime_format=epoch,
                 ),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -1059,6 +1074,7 @@ def build_record_numeric_cross_variants() -> Iterable[Variant]:
                             **{kwarg: fmt},
                         ),
                         lang_cls=lang_cls,
+                        collection_layout=literalizer.CollectionLayout.COMPACT,
                     )
                 )
     return variants
@@ -1095,6 +1111,7 @@ def build_heterogeneous_value_name_variants() -> Iterable[Variant]:
                 ),
                 spec=spec,
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -1115,6 +1132,7 @@ def build_c_field_name_variants() -> Iterable[Variant]:
                 name=f"{lang_cls.__name__}_field_names_custom",
                 spec=make_spec(lang_cls=lang_cls, **kwargs),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -1144,6 +1162,7 @@ def build_language_version_variants() -> Iterable[Variant]:
                         lang_cls=lang_cls, language_version=version
                     ),
                     lang_cls=lang_cls,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
                 )
             )
     return variants
@@ -1169,6 +1188,7 @@ def build_language_version_cross_dict_type_variants() -> Iterable[Variant]:
                 default_dict_value_type=DEFAULT_DICT_VALUE_TYPES[Python],
             ),
             lang_cls=Python,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
         )
     ]
 
@@ -1204,6 +1224,7 @@ def build_heterogeneous_value_union_name_variants() -> Iterable[Variant]:
                 ),
                 spec=spec,
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -1242,6 +1263,7 @@ def build_heterogeneous_value_variant_name_variants() -> Iterable[Variant]:
                 ),
                 spec=spec,
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
         )
     return variants
@@ -1288,6 +1310,7 @@ def build_string_format_cross_variants(
                             **{other_kwarg: of},
                         ),
                         lang_cls=lang_cls,
+                        collection_layout=literalizer.CollectionLayout.COMPACT,
                     )
                 )
     return variants
@@ -1330,6 +1353,7 @@ def build_heterogeneous_strategy_datetime_cross_variants() -> list[Variant]:
                             datetime_format=dt,
                         ),
                         lang_cls=lang_cls,
+                        collection_layout=literalizer.CollectionLayout.COMPACT,
                     )
                 )
     return variants
@@ -1416,6 +1440,7 @@ def build_type_hints_cross_variants() -> list[Variant]:
                                 **{kwarg: fmt},
                             ),
                             lang_cls=lang_cls,
+                            collection_layout=literalizer.CollectionLayout.COMPACT,
                         ),
                     )
     return variants
@@ -1459,6 +1484,7 @@ def build_modifier_variant_cases() -> list[VariantCase]:
                 name=f"{lang_cls.__name__}_modifiers_{mod_name}",
                 spec=make_spec(lang_cls=lang_cls),
                 lang_cls=lang_cls,
+                collection_layout=literalizer.CollectionLayout.COMPACT,
             )
             cases.extend(
                 VariantCase(
@@ -1484,6 +1510,7 @@ def build_modifier_variant_cases() -> list[VariantCase]:
             sequence_format=CSharp.sequence_formats.ARRAY,
         ),
         lang_cls=CSharp,
+        collection_layout=literalizer.CollectionLayout.COMPACT,
     )
     cases.append(
         VariantCase(
@@ -1503,6 +1530,7 @@ def build_modifier_variant_cases() -> list[VariantCase]:
             sequence_format=CSharp.sequence_formats.ARRAY,
         ),
         lang_cls=CSharp,
+        collection_layout=literalizer.CollectionLayout.COMPACT,
     )
     cases.append(
         VariantCase(
@@ -1523,7 +1551,7 @@ class CaseInput:
     """An input case directory plus a variant-name suffix."""
 
     case_dir_name: str
-    suffix: str = ""
+    suffix: str
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -1762,35 +1790,35 @@ _COMPLEX_BUILDERS: dict[str, Callable[[], Iterable[Variant]]] = {
 
 
 @beartype
-def _ci(*, case_dir_name: str, suffix: str = "") -> CaseInput:
+def _ci(*, case_dir_name: str, suffix: str) -> CaseInput:
     """Shorthand for :class:`CaseInput` to keep the table compact."""
     return CaseInput(case_dir_name=case_dir_name, suffix=suffix)
 
 
 INT_INPUTS: tuple[CaseInput, ...] = (
-    _ci(case_dir_name="int_list"),
+    _ci(case_dir_name="int_list", suffix=""),
     _ci(case_dir_name="int_list_large", suffix="_large"),
     _ci(case_dir_name="int_list_with_zero", suffix="_zero"),
-    _ci(case_dir_name="scalar_int"),
-    _ci(case_dir_name="scalar_int_large"),
+    _ci(case_dir_name="scalar_int", suffix=""),
+    _ci(case_dir_name="scalar_int_large", suffix=""),
 )
 
 FLOAT_INPUTS: tuple[CaseInput, ...] = (
-    _ci(case_dir_name="float_list"),
+    _ci(case_dir_name="float_list", suffix=""),
     _ci(case_dir_name="float_scientific_notation", suffix="_s"),
     _ci(case_dir_name="float_special_values", suffix="_v"),
     _ci(case_dir_name="nested_float_list", suffix="_n"),
-    _ci(case_dir_name="scalar_float"),
+    _ci(case_dir_name="scalar_float", suffix=""),
 )
 
 BASIC_COLLECTIONS: tuple[CaseInput, ...] = (
-    _ci(case_dir_name="simple_sequence"),
+    _ci(case_dir_name="simple_sequence", suffix=""),
     _ci(case_dir_name="simple_dict", suffix="_dict"),
     _ci(case_dir_name="set", suffix="_set"),
 )
 
 ADT_INPUTS: tuple[CaseInput, ...] = (
-    _ci(case_dir_name="simple_dict"),
+    _ci(case_dir_name="simple_dict", suffix=""),
     _ci(case_dir_name="float_special_values", suffix="_v"),
     _ci(case_dir_name="float_list", suffix="_float"),
     _ci(case_dir_name="binary", suffix="_binary"),
@@ -1836,26 +1864,26 @@ HETEROGENEOUS_INPUTS: tuple[CaseInput, ...] = tuple(
 # rest render both as plain maps, identical to the default output.
 HETEROGENEOUS_STRATEGY_INPUTS: tuple[CaseInput, ...] = (
     *HETEROGENEOUS_INPUTS,
-    _ci(case_dir_name="int_key_dict"),
-    _ci(case_dir_name="empty_dict"),
+    _ci(case_dir_name="int_key_dict", suffix=""),
+    _ci(case_dir_name="empty_dict", suffix=""),
 )
 
 DICT_FORMAT_INPUTS: tuple[CaseInput, ...] = (
-    _ci(case_dir_name="simple_dict"),
+    _ci(case_dir_name="simple_dict", suffix=""),
     _ci(case_dir_name="dict_with_list_value", suffix="_list_val"),
 )
 
 DEFAULT_DICT_INPUTS: tuple[CaseInput, ...] = (
-    _ci(case_dir_name="empty_dict"),
-    _ci(case_dir_name="simple_dict"),
+    _ci(case_dir_name="empty_dict", suffix=""),
+    _ci(case_dir_name="simple_dict", suffix=""),
 )
 
 _NUMERIC_INPUTS: tuple[CaseInput, ...] = (
-    _ci(case_dir_name="int_list"),
+    _ci(case_dir_name="int_list", suffix=""),
     _ci(case_dir_name="int_list_large", suffix="_large"),
     _ci(case_dir_name="int_list_with_zero", suffix="_zero"),
-    _ci(case_dir_name="scalar_int"),
-    _ci(case_dir_name="scalar_int_large"),
+    _ci(case_dir_name="scalar_int", suffix=""),
+    _ci(case_dir_name="scalar_int_large", suffix=""),
     _ci(case_dir_name="float_list", suffix="_float"),
     _ci(case_dir_name="float_scientific_notation", suffix="_float_s"),
     _ci(case_dir_name="float_special_values", suffix="_float_v"),
@@ -1870,18 +1898,18 @@ _NUMERIC_INPUTS: tuple[CaseInput, ...] = (
 # yields the full set of golden-file test cases.
 AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     "date": (
-        _ci(case_dir_name="scalar_date"),
-        _ci(case_dir_name="date_list"),
-        _ci(case_dir_name="date_set"),
+        _ci(case_dir_name="scalar_date", suffix=""),
+        _ci(case_dir_name="date_list", suffix=""),
+        _ci(case_dir_name="date_set", suffix=""),
     ),
     "datetime": (
-        _ci(case_dir_name="scalar_datetime"),
+        _ci(case_dir_name="scalar_datetime", suffix=""),
         _ci(case_dir_name="scalar_datetime_naive", suffix="_naive"),
         _ci(case_dir_name="scalar_datetime_non_utc", suffix="_non_utc"),
-        _ci(case_dir_name="datetime_list"),
+        _ci(case_dir_name="datetime_list", suffix=""),
     ),
     "sequence": (
-        _ci(case_dir_name="simple_sequence"),
+        _ci(case_dir_name="simple_sequence", suffix=""),
         _ci(case_dir_name="pair_sequence", suffix="_pair"),
         _ci(case_dir_name="triple_sequence", suffix="_triple"),
         _ci(case_dir_name="simple_sequence", suffix="_varname"),
@@ -1890,27 +1918,29 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
         _ci(case_dir_name="binary_list", suffix="_binary"),
     ),
     "set": (
-        _ci(case_dir_name="set"),
-        _ci(case_dir_name="int_set"),
-        _ci(case_dir_name="mixed_set"),
-        _ci(case_dir_name="empty_set"),
-        _ci(case_dir_name="set_mixed_int_widths"),
+        _ci(case_dir_name="set", suffix=""),
+        _ci(case_dir_name="int_set", suffix=""),
+        _ci(case_dir_name="mixed_set", suffix=""),
+        _ci(case_dir_name="empty_set", suffix=""),
+        _ci(case_dir_name="set_mixed_int_widths", suffix=""),
     ),
     "default_set_element_type": (
-        _ci(case_dir_name="empty_set"),
-        _ci(case_dir_name="set"),
+        _ci(case_dir_name="empty_set", suffix=""),
+        _ci(case_dir_name="set", suffix=""),
     ),
     "default_sequence_element_type": (
-        _ci(case_dir_name="empty_sequence"),
-        _ci(case_dir_name="simple_sequence"),
+        _ci(case_dir_name="empty_sequence", suffix=""),
+        _ci(case_dir_name="simple_sequence", suffix=""),
     ),
     "default_dict_value_type": DEFAULT_DICT_INPUTS,
     "default_dict_key_type": DEFAULT_DICT_INPUTS,
-    "empty_dict_key": (_ci(case_dir_name="simple_dict"),),
-    "default_ordered_map_value_type": (_ci(case_dir_name="ordered_map"),),
-    "comment": (_ci(case_dir_name="comments"),),
+    "empty_dict_key": (_ci(case_dir_name="simple_dict", suffix=""),),
+    "default_ordered_map_value_type": (
+        _ci(case_dir_name="ordered_map", suffix=""),
+    ),
+    "comment": (_ci(case_dir_name="comments", suffix=""),),
     "type_hints": tuple(
-        _ci(case_dir_name=d)
+        _ci(case_dir_name=d, suffix="")
         for d in (
             "type_hints",
             "scalar_date",
@@ -1932,7 +1962,7 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
         )
     ),
     "type_hints_cross": tuple(
-        _ci(case_dir_name=d)
+        _ci(case_dir_name=d, suffix="")
         for d in (
             "int_list",
             "int_list_large",
@@ -1947,7 +1977,7 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
         )
     ),
     "declaration_style": tuple(
-        _ci(case_dir_name=d)
+        _ci(case_dir_name=d, suffix="")
         for d in (
             "simple_sequence",
             "simple_dict",
@@ -1974,22 +2004,22 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     "numeric_literal_suffix": _NUMERIC_INPUTS,
     "numeric_separator": _NUMERIC_INPUTS,
     "string_format": (
-        _ci(case_dir_name="string_list"),
-        _ci(case_dir_name="string_with_backslash"),
+        _ci(case_dir_name="string_list", suffix=""),
+        _ci(case_dir_name="string_with_backslash", suffix=""),
         _ci(case_dir_name="simple_dict", suffix="_dict"),
         _ci(case_dir_name="binary", suffix="_binary"),
-        _ci(case_dir_name="scalar_string"),
+        _ci(case_dir_name="scalar_string", suffix=""),
         _ci(case_dir_name="time_list", suffix="_time"),
     ),
-    "string_format_date_cross": (_ci(case_dir_name="scalar_date"),),
+    "string_format_date_cross": (_ci(case_dir_name="scalar_date", suffix=""),),
     "string_format_datetime_cross": (
         _ci(case_dir_name="scalar_datetime", suffix="_dt"),
     ),
-    "bytes_format": (_ci(case_dir_name="binary"),),
+    "bytes_format": (_ci(case_dir_name="binary", suffix=""),),
     "trailing_comma": BASIC_COLLECTIONS,
     "statement_terminator_style": BASIC_COLLECTIONS,
     "collection_layout": tuple(
-        _ci(case_dir_name=d)
+        _ci(case_dir_name=d, suffix="")
         for d in (
             "dict_with_list_value",
             "nested",
@@ -1997,61 +2027,63 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
             "multiline_sibling_list_widening",
         )
     ),
-    "statement_terminator_style_decl": (_ci(case_dir_name="simple_sequence"),),
+    "statement_terminator_style_decl": (
+        _ci(case_dir_name="simple_sequence", suffix=""),
+    ),
     "sequence_decl": (
-        _ci(case_dir_name="int_list"),
+        _ci(case_dir_name="int_list", suffix=""),
         # A one-element list pins the single-element-tuple trailing
         # comma in both the type annotation and the value (e.g. Rust
         # ``static my_data: (i32,) = (1,);``); a multi-element input
         # cannot exercise that carve-out.
-        _ci(case_dir_name="int_list_single"),
+        _ci(case_dir_name="int_list_single", suffix=""),
     ),
-    "set_decl": (_ci(case_dir_name="set_mixed_int_widths"),),
-    "dict_decl": (_ci(case_dir_name="int_key_dict"),),
+    "set_decl": (_ci(case_dir_name="set_mixed_int_widths", suffix=""),),
+    "dict_decl": (_ci(case_dir_name="int_key_dict", suffix=""),),
     "type_name": ADT_INPUTS,
     "constructor_prefix": ADT_INPUTS,
     "numeric_style": (
-        _ci(case_dir_name="int_list"),
+        _ci(case_dir_name="int_list", suffix=""),
         _ci(case_dir_name="int_list_large", suffix="_large"),
         _ci(case_dir_name="int_list_with_zero", suffix="_zero"),
-        _ci(case_dir_name="float_list"),
-        _ci(case_dir_name="float_special_values"),
-        _ci(case_dir_name="mixed_number_list"),
-        _ci(case_dir_name="scalars"),
+        _ci(case_dir_name="float_list", suffix=""),
+        _ci(case_dir_name="float_special_values", suffix=""),
+        _ci(case_dir_name="mixed_number_list", suffix=""),
+        _ci(case_dir_name="scalars", suffix=""),
     ),
     "c_field_name": (
-        _ci(case_dir_name="simple_dict"),
-        _ci(case_dir_name="simple_sequence"),
+        _ci(case_dir_name="simple_dict", suffix=""),
+        _ci(case_dir_name="simple_sequence", suffix=""),
     ),
-    "constructor_name": (_ci(case_dir_name="simple_dict"),),
+    "constructor_name": (_ci(case_dir_name="simple_dict", suffix=""),),
     "heterogeneous_strategy": HETEROGENEOUS_STRATEGY_INPUTS,
     "heterogeneous_strategy_datetime_cross": (
-        _ci(case_dir_name="dict_all_scalar_types"),
+        _ci(case_dir_name="dict_all_scalar_types", suffix=""),
     ),
     "heterogeneous_value_enum_name": HETEROGENEOUS_INPUTS,
     "record_shape_names": (
-        _ci(case_dir_name="record_named_shape"),
-        _ci(case_dir_name="record_named_nested_record"),
+        _ci(case_dir_name="record_named_shape", suffix=""),
+        _ci(case_dir_name="record_named_nested_record", suffix=""),
     ),
     "heterogeneous_value_union_name": HETEROGENEOUS_INPUTS,
     "heterogeneous_value_variant_name": HETEROGENEOUS_INPUTS,
     "record_unify_optional_fields": (
-        _ci(case_dir_name="record_optional_unify"),
+        _ci(case_dir_name="record_optional_unify", suffix=""),
     ),
     "record_epoch_i32_overflow": (
-        _ci(case_dir_name="record_epoch_datetime_i32_overflow"),
+        _ci(case_dir_name="record_epoch_datetime_i32_overflow", suffix=""),
     ),
-    "record_numeric_cross": (_ci(case_dir_name="record_wide_int"),),
+    "record_numeric_cross": (_ci(case_dir_name="record_wide_int", suffix=""),),
     "language_version": tuple(
-        _ci(case_dir_name=case_dir_name)
+        _ci(case_dir_name=case_dir_name, suffix="")
         for case_dir_name in dict.fromkeys(
             case_dir_name
             for case_dir_name, _ in discover_cases(cases_dir=_CASES_DIR)
         )
     ),
     "language_version_cross_dict_type": (
-        _ci(case_dir_name="empty_dict"),
-        _ci(case_dir_name="empty_ordered_map"),
+        _ci(case_dir_name="empty_dict", suffix=""),
+        _ci(case_dir_name="empty_ordered_map", suffix=""),
     ),
 }
 


### PR DESCRIPTION
Removes default values from the integration test helpers so every call site passes all arguments explicitly, following the no-defaults-on-internal-helpers convention. `CallCaseConfig` and `CallCase` (`call_cases.py`) lose their field defaults, with all ~46 constructions updated to pass them explicitly. `Variant.collection_layout` (`variant_cases.py` / `call_variant_cases.py`) loses its default and now passes `CollectionLayout.COMPACT` explicitly everywhere, and `CaseInput.suffix` / the `_ci()` shorthand lose their `""` defaults with `suffix` passed at every call site. There are no golden-file output changes since the explicit values equal the former defaults, and the affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactor limited to integration test helper dataclasses/builders, with call sites updated to pass the same values explicitly and no expected golden output changes.
> 
> **Overview**
> Refactors integration test helpers to follow a *no-defaults* convention by removing field defaults from `CallCaseConfig`, `CallCase`, `Variant`, and `CaseInput` (plus the `_ci()` shorthand).
> 
> Updates all call/variant case construction sites to pass `None`/`""`/`CollectionLayout.COMPACT` and other formerly-defaulted values explicitly, without changing the semantics of the generated golden fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd7bcf88cca8537621e5563036f1a17833dca96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->