### PR TITLE
Add Lua lint/language_version sync comments (#2386)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # ``luaVersion: '5.4'`` matches ``Lua.language_version`` (``V5_4``)
+      # in ``src/literalizer/languages/lua.py``; keep them in sync.
       - name: Install Lua
         uses: leafo/gh-actions-lua@v13
         with:

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -486,6 +486,8 @@ class Lua(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``luaVersion`` pin passed to
+    # ``leafo/gh-actions-lua`` in ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.V5_4
     indent: str = "    "
 


### PR DESCRIPTION
Closes #2386.

`leafo/gh-actions-lua@v13` in the `lint-fast` job already pins
`luaVersion: '5.4'`, which is `>=` the `Lua.language_version` default
`V5_4` (Lua 5.4) in `src/literalizer/languages/lua.py`. Neither side
carried the bidirectional "keep in sync" cross-reference comment
mandated by #1933.

- Verified `luaVersion: '5.4'` matches the `V5_4` default.
- Added the cross-reference comment at both the pin site (`lint.yml`)
  and the `language_version` declaration in `lua.py`, following the
  established C/Rust/Java/SystemVerilog pattern.

No behaviour change. Following the #1932 SystemVerilog precedent (same
class of comment-only sync change), no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes that add cross-references between the Lua CI toolchain pin and the default `Lua.language_version`, with no runtime or CI behavior changes.
> 
> **Overview**
> Adds **bidirectional “keep in sync” comments** linking the Lua version pinned in `lint-fast` (`luaVersion: '5.4'`) with the default `Lua.language_version` (`VersionFormats.V5_4`) in `src/literalizer/languages/lua.py` to prevent future drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2688595fbe7924b6d4126908f59be873b0030a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->