### PR TITLE
Add Dhall lint/language_version sync comments (#2388)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,6 +80,12 @@ jobs:
           packages: tcl gforth guile-3.0
           version: 1.0
       - name: Install Dhall
+        # The pinned ``dhall-haskell`` 1.42.2 binary implements Dhall
+        # language standard 23.1.0, which is ``>=`` the ``V17`` (Dhall
+        # standard 17.0.0) default of ``Dhall.language_version`` in
+        # ``src/literalizer/languages/dhall.py``; keep them in sync.
+        # Note the binary version (1.42.2) is distinct from the Dhall
+        # *language* standard version (23.1.0) it implements.
         run: |-
           curl -fsSL https://github.com/dhall-lang/dhall-haskell/releases/download/1.42.2/dhall-1.42.2-x86_64-linux.tar.bz2 \
             | tar -xj

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -909,6 +909,13 @@ class Dhall(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     heterogeneous_value_union_name: str = "Value"
+    # Keep in sync with the pinned ``dhall`` binary in the ``Install
+    # Dhall`` step of ``.github/workflows/lint.yml``.  Note the Dhall
+    # *language* standard version is distinct from the ``dhall-haskell``
+    # binary version: the pinned binary ``dhall-haskell`` 1.42.2
+    # implements Dhall language standard 23.1.0, which is ``>=`` this
+    # ``V17`` (Dhall standard 17.0.0) default, so the fixture gate runs
+    # under a binary that accepts the declared language version.
     language_version: VersionFormats = VersionFormats.V17
     indent: str = "  "
     call_style: CallStyles = CallStyles.POSITIONAL


### PR DESCRIPTION
Closes #2388. Part of #1933.

`Dhall.language_version` defaults to `VersionFormats.V17` and the lint toolchain is pinned via the `dhall-1.42.2-x86_64-linux` download in the `Install Dhall` step of `.github/workflows/lint.yml`, but neither side carried the cross-reference comment mandated by #1930/#1933.

**Verification:** `dhall-haskell` 1.42.2 implements Dhall language standard **23.1.0** ([release notes](https://github.com/dhall-lang/dhall-haskell/releases/tag/1.42.2)), which is `>=` the `V17` (Dhall standard 17.0.0) default, so the pinned binary accepts the declared language version.

**Change:** added the bidirectional "keep them in sync" comments at both the pin site and the `language_version` declaration in `dhall.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern. Both comments explicitly document that the `dhall-haskell` binary version (1.42.2) is distinct from the Dhall *language* standard version (23.1.0) it implements.

No behaviour change; comment-only (no CHANGELOG entry, matching the SystemVerilog #1932 sync-comment precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only changes that clarify CI/tooling version coupling without altering runtime or lint behavior.
> 
> **Overview**
> Adds **bidirectional “keep in sync” comments** linking the pinned `dhall-haskell` binary in `.github/workflows/lint.yml` to the default `Dhall.language_version` in `src/literalizer/languages/dhall.py`, explicitly noting the difference between the binary version (`1.42.2`) and the Dhall language standard it implements (`23.1.0`).
> 
> No functional changes; this is documentation to prevent future drift between CI tool pins and the declared Dhall language version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 720bf1288b28b11992089a66fa000369583da883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->