### PR TITLE
Add Mojo lint/language_version sync comments (#2393)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1455,6 +1455,9 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
+      # ``mojo-compiler==1.0.0b1`` is >= the ``VersionFormats.V24_5``
+      # value of ``Mojo.language_version`` in
+      # ``src/literalizer/languages/mojo.py``; keep them in sync.
       - name: Install Mojo
         run: uv tool install --prerelease=allow 'mojo-compiler==1.0.0b1'
       - name: Check Mojo syntax

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -1302,6 +1302,8 @@ class Mojo(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     heterogeneous_value_variant_name: str = "Value"
+    # Keep in sync with the ``mojo-compiler`` pin in the ``lint-mojo``
+    # job of ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.V24_5
     indent: str = "    "
 


### PR DESCRIPTION
Closes #2393. Part of #1933.

`Mojo.language_version` defaults to `VersionFormats.V24_5` in `src/literalizer/languages/mojo.py`. The toolchain is pinned via `uv tool install --prerelease=allow 'mojo-compiler==1.0.0b1'` in the `lint-mojo` job of `.github/workflows/lint.yml`, but neither side carried the bidirectional cross-reference comment mandated by #1933.

- **Version check:** Mojo moved from calendar-based versioning (`24.5`, Sept 2024) through the `25.x` line to the `1.0` release line, so `mojo-compiler==1.0.0b1` chronologically post-dates `V24_5`; the pin is `>=` the default.
- Added the bidirectional "keep in sync" comments at the pin site (lint.yml) and the `language_version` declaration (mojo.py), following the existing Lua/Swift/C pattern (`#2386`).

No behaviour change; comment-only. No CHANGELOG entry (matches the Lua #2386 precedent for these sync-comment sub-issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only changes that do not alter CI behavior or Mojo runtime logic.
> 
> **Overview**
> Adds **bidirectional “keep in sync” comments** linking the `lint-mojo` CI `mojo-compiler==1.0.0b1` pin in `.github/workflows/lint.yml` with `Mojo.language_version = VersionFormats.V24_5` in `src/literalizer/languages/mojo.py`, clarifying that these version declarations must be updated together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf068099f5bf40ea6762da232061798b95c92cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->