### PR TITLE
Add Wren lint/language_version sync comments (#2392)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,6 +84,11 @@ jobs:
           curl -fsSL https://github.com/dhall-lang/dhall-haskell/releases/download/1.42.2/dhall-1.42.2-x86_64-linux.tar.bz2 \
             | tar -xj
           echo "$PWD/bin" >> "$GITHUB_PATH"
+      # The ``0.4.0`` wren-cli release downloaded here matches
+      # ``Wren.language_version`` (``V0_4``) in
+      # ``src/literalizer/languages/wren.py``; keep them in sync. Wren
+      # has no ``--langversion``-style flag, so the pinned CLI release
+      # is the only mechanism for pinning the language version.
       - name: Install Wren CLI
         run: |
           curl -fsSL https://github.com/wren-lang/wren-cli/releases/download/0.4.0/wren-cli-linux-0.4.0.zip -o /tmp/wren.zip

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -510,6 +510,11 @@ class Wren(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the wren release downloaded in the
+    # `Install Wren CLI` step of `.github/workflows/lint.yml`. Wren has
+    # no `--langversion`-style flag, so the pinned compiler release is
+    # the only mechanism for pinning the version; `V0_4` maps to
+    # `0.4.0`.
     language_version: VersionFormats = VersionFormats.V0_4
     indent: str = "    "
 


### PR DESCRIPTION
Closes #2392 (part of #1933). The `lint-fast` job downloads `wren-cli-linux-0.4.0`, which is at or above `Wren.language_version`'s `VersionFormats.V0_4` default, but neither side carried the bidirectional cross-reference comment that the other pinned languages use. This adds the "keep them in sync" comment at the `Install Wren CLI` pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `src/literalizer/languages/wren.py`. Comment-only with no behaviour change, so no CHANGELOG entry (matching the SystemVerilog #1932 sync-comment precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only updates that add documentation around existing version pins, with no runtime or CI behavior changes.
> 
> **Overview**
> Adds explicit **“keep in sync”** cross-reference comments between the pinned Wren CLI download in `.github/workflows/lint.yml` and the default `Wren.language_version` (`VersionFormats.V0_4`) in `src/literalizer/languages/wren.py`, noting that pinning the CLI release is the only way to pin Wren’s language version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1f51703ad41b4e0fffac5f7a9f59b37cdd47d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->