### PR TITLE
Add SML lint/language_version sync comments (#2391)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -672,6 +672,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # The pinned MLton implements SML '97, matching
+      # ``SML.language_version`` (``SML_97``) in
+      # ``src/literalizer/languages/sml.py``; keep them in sync.
+      # ``SML_97`` is a fixed standard, so the version pin here is for
+      # reproducibility rather than language selection.
       - name: Install MLton
         run: |
           curl -fsSL https://github.com/MLton/mlton/releases/download/on-20241230-release/mlton-20241230-1.amd64-linux.ubuntu-24.04_static.tgz | tar xz -C /tmp

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -703,6 +703,10 @@ class Sml(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # The `Install MLton` step in `.github/workflows/lint.yml` pins a
+    # `MLton` build implementing the Standard `ML` '97 language, matching
+    # this default (`SML_97`). The pin is for reproducible builds, not
+    # language selection. Keep the two in sync.
     language_version: VersionFormats = VersionFormats.SML_97
     indent: str = "    "
     type_name: str = "val_t"


### PR DESCRIPTION
Closes #2391 (part of #1933).

The pinned `mlton-20241230` already implements SML '97, matching `SML.language_version` (`SML_97`), but neither side carried the cross-reference comment mandated by #1930. This adds the bidirectional "keep in sync" comments at the `Install MLton` lint step in `.github/workflows/lint.yml` and the `language_version` declaration in `src/literalizer/languages/sml.py`. `SML_97` is a fixed standard, so the version pin is for reproducible builds rather than language selection. No behaviour change; no CHANGELOG entry (matching the SystemVerilog #1932 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in CI and the SML language spec to document a required version-sync invariant; no functional behavior is modified.
> 
> **Overview**
> Adds **bidirectional “keep in sync” documentation** between the `lint-sml` CI step that installs a pinned MLton build and the SML language default `language_version` (`SML_97`).
> 
> Clarifies that the MLton pin is for *reproducibility* (SML ’97 is fixed) and should be updated in tandem with `src/literalizer/languages/sml.py` and `.github/workflows/lint.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfcff943e4d001afba8c5b6f01a1a96add4cb34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->