### PR TITLE
Add Crystal lint/language_version sync comments (#2387)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1409,6 +1409,9 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
+          # `crystal: 1.20.0` is `>=` `Crystal.language_version` (`V1`,
+          # i.e. Crystal 1.x) in `src/literalizer/languages/crystal.py`;
+          # keep them in sync.
           crystal: 1.20.0
       # Compile every fixture in a single `crystal run` invocation to
       # pay Crystal's front-end + LLVM codegen + link cost once instead

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -573,6 +573,9 @@ class Crystal(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``crystal:`` pin passed to
+    # ``crystal-lang/install-crystal`` in the ``lint-crystal`` job of
+    # ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.V1
     indent: str = "    "
 


### PR DESCRIPTION
Closes #2387. Part of #1933.

`crystal-lang/install-crystal` in the `lint-crystal` job already pinned `crystal: 1.20.0`, which is `>=` `Crystal.language_version` (`V1`, i.e. Crystal 1.x), but neither side carried the bidirectional cross-reference comment mandated by #1930. This adds the "keep them in sync" comments at both the pin site and the `language_version` declaration in `crystal.py`, following the existing C/Go/Kotlin/Python pattern. Comment-only change with no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change that adds documentation to keep the Crystal CI install pin and `Crystal.language_version` aligned; no runtime or CI behavior is modified.
> 
> **Overview**
> Adds bidirectional **“keep in sync”** comments between the Crystal toolchain pin (`crystal: 1.20.0`) in `.github/workflows/lint.yml` and the `language_version` default (`VersionFormats.V1`) in `src/literalizer/languages/crystal.py`, matching the existing cross-reference pattern used for other languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5181443d440a8b745472e1a0a9474d1cac0ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->