### PR TITLE
Add OCaml lint/language_version sync comments (#2389)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1119,6 +1119,10 @@ jobs:
       - name: Install OCaml
         uses: ocaml/setup-ocaml@v3
         with:
+          # ``ocaml-compiler: 5`` resolves to the latest OCaml 5.x
+          # release, which is ``>=`` the ``V5`` default of
+          # ``OCaml.language_version`` in
+          # ``src/literalizer/languages/ocaml.py``; keep them in sync.
           ocaml-compiler: 5
       - name: Check OCaml syntax
         run: |-

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -654,6 +654,9 @@ class OCaml(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``ocaml-compiler`` input of the
+    # ``Install OCaml`` step in ``.github/workflows/lint.yml``, which
+    # pins ``5`` (latest OCaml 5.x), satisfying this ``V5`` default.
     language_version: VersionFormats = VersionFormats.V5
     indent: str = "    "
     type_name: str = "val_t"


### PR DESCRIPTION
Closes #2389. Part of #1933.

`OCaml.language_version` defaults to `VersionFormats.V5` and the lint toolchain is pinned via `ocaml/setup-ocaml@v3` with `ocaml-compiler: 5` in the `lint-ocaml` job of `.github/workflows/lint.yml`, but neither side carried the cross-reference comment mandated by #1930/#1933.

**Verification:** `ocaml-compiler: 5` resolves to the latest OCaml 5.x release, which is `>=` the `V5` default.

**Change:** added the bidirectional "keep them in sync" comments at both the pin site and the `language_version` declaration in `ocaml.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern.

No behaviour change; comment-only (no CHANGELOG entry, matching the SystemVerilog #1932 sync-comment precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes that add documentation around CI/tooling version alignment; no runtime or lint behavior is modified.
> 
> **Overview**
> Adds **bidirectional “keep in sync” comments** linking the OCaml CI toolchain pin (`ocaml-compiler: 5` in `lint.yml`) with the default `OCaml.language_version` (`VersionFormats.V5` in `ocaml.py`) to prevent them drifting out of alignment.
> 
> No functional or configuration changes beyond these clarifying annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b6b29a5fdbc9602787411d9235c3a2615c29b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->