### PR TITLE
Cover Rust datetime.time scalar typing via golden files

### DIFF
--- a/tests/integration/cases/time_dict/Dart_declaration_style_const@v3.dart
+++ b/tests/integration/cases/time_dict/Dart_declaration_style_const@v3.dart
@@ -1,0 +1,5 @@
+const my_data = <String, String>{
+    "morning": "09:30:00",
+    "afternoon": "14:15:00",
+    "evening": "23:59:59",
+};

--- a/tests/integration/cases/time_dict/Dart_declaration_style_var@v3.dart
+++ b/tests/integration/cases/time_dict/Dart_declaration_style_var@v3.dart
@@ -1,0 +1,5 @@
+var my_data = <String, String>{
+    "morning": "09:30:00",
+    "afternoon": "14:15:00",
+    "evening": "23:59:59",
+};

--- a/tests/integration/cases/time_dict/FSharp_declaration_style_let_mutable@v8.fs
+++ b/tests/integration/cases/time_dict/FSharp_declaration_style_let_mutable@v8.fs
@@ -1,0 +1,10 @@
+module Main
+
+type Val =
+    | FStr of string
+    | FMap of (string * Val) list
+let mutable my_data: Val = FMap [
+    ("morning", FStr (string (System.TimeOnly(9, 30, 0))));
+    ("afternoon", FStr (string (System.TimeOnly(14, 15, 0))));
+    ("evening", FStr (string (System.TimeOnly(23, 59, 59))))
+]

--- a/tests/integration/cases/time_dict/Go_declaration_style_var@v1_18.go
+++ b/tests/integration/cases/time_dict/Go_declaration_style_var@v1_18.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+var my_data = map[string]string{
+	"morning": "09:30:00",
+	"afternoon": "14:15:00",
+	"evening": "23:59:59",
+}
+_ = my_data
+}

--- a/tests/integration/cases/time_dict/JavaScript_declaration_style_let@es2015.js
+++ b/tests/integration/cases/time_dict/JavaScript_declaration_style_let@es2015.js
@@ -1,0 +1,5 @@
+let my_data = {
+  "morning": "09:30:00",
+  "afternoon": "14:15:00",
+  "evening": "23:59:59",
+};

--- a/tests/integration/cases/time_dict/Kotlin_declaration_style_var@v1_9.kts
+++ b/tests/integration/cases/time_dict/Kotlin_declaration_style_var@v1_9.kts
@@ -1,0 +1,6 @@
+import java.time.LocalTime
+var my_data = mapOf<String, LocalTime>(
+    "morning" to LocalTime.of(9, 30),
+    "afternoon" to LocalTime.of(14, 15),
+    "evening" to LocalTime.of(23, 59, 59),
+)

--- a/tests/integration/cases/time_dict/Nim_declaration_style_const@v2.nim
+++ b/tests/integration/cases/time_dict/Nim_declaration_style_const@v2.nim
@@ -1,0 +1,5 @@
+const my_data = {
+    "morning": "09:30:00",
+    "afternoon": "14:15:00",
+    "evening": "23:59:59"
+}

--- a/tests/integration/cases/time_dict/Nim_declaration_style_let@v2.nim
+++ b/tests/integration/cases/time_dict/Nim_declaration_style_let@v2.nim
@@ -1,0 +1,6 @@
+import json
+let my_data = %* {
+    "morning": "09:30:00",
+    "afternoon": "14:15:00",
+    "evening": "23:59:59"
+}

--- a/tests/integration/cases/time_dict/Rust_declaration_style_lazy_static@edition_2021.rs
+++ b/tests/integration/cases/time_dict/Rust_declaration_style_lazy_static@edition_2021.rs
@@ -1,0 +1,10 @@
+use std::sync::LazyLock;
+use std::collections::HashMap;
+fn main() {
+    static my_data: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| HashMap::from([
+        ("morning", "09:30:00"),
+        ("afternoon", "14:15:00"),
+        ("evening", "23:59:59"),
+    ]));
+    let _ = my_data;
+}

--- a/tests/integration/cases/time_dict/Rust_declaration_style_let_mut@edition_2021.rs
+++ b/tests/integration/cases/time_dict/Rust_declaration_style_let_mut@edition_2021.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+fn main() {
+    let mut my_data = HashMap::from([
+        ("morning", "09:30:00"),
+        ("afternoon", "14:15:00"),
+        ("evening", "23:59:59"),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/time_dict/Scala_declaration_style_var@v3.scala
+++ b/tests/integration/cases/time_dict/Scala_declaration_style_var@v3.scala
@@ -1,0 +1,8 @@
+import java.time.LocalTime
+object Fixture_time_dict_Scala_declaration_style_var {
+var my_data = Map[String, LocalTime](
+    "morning" -> LocalTime.of(9, 30),
+    "afternoon" -> LocalTime.of(14, 15),
+    "evening" -> LocalTime.of(23, 59, 59),
+)
+}

--- a/tests/integration/cases/time_dict/Swift_declaration_style_var@v5_9.swift
+++ b/tests/integration/cases/time_dict/Swift_declaration_style_var@v5_9.swift
@@ -1,0 +1,5 @@
+var my_data: Any = [
+    "morning": "09:30:00",
+    "afternoon": "14:15:00",
+    "evening": "23:59:59",
+]

--- a/tests/integration/cases/time_dict/TypeScript_declaration_style_let@v5.ts
+++ b/tests/integration/cases/time_dict/TypeScript_declaration_style_let@v5.ts
@@ -1,0 +1,6 @@
+let my_data = {
+  "morning": "09:30:00",
+  "afternoon": "14:15:00",
+  "evening": "23:59:59",
+};
+export {};

--- a/tests/integration/cases/time_dict/TypeScript_declaration_style_var@v5.ts
+++ b/tests/integration/cases/time_dict/TypeScript_declaration_style_var@v5.ts
@@ -1,0 +1,6 @@
+var my_data = {
+  "morning": "09:30:00",
+  "afternoon": "14:15:00",
+  "evening": "23:59:59",
+};
+export {};

--- a/tests/integration/cases/time_dict/V_declaration_style_mut@v0_4.v
+++ b/tests/integration/cases/time_dict/V_declaration_style_mut@v0_4.v
@@ -1,0 +1,9 @@
+
+fn main() {
+	mut my_data := {
+		'morning': "09:30:00",
+		'afternoon': "14:15:00",
+		'evening': "23:59:59",
+	}
+	_ = my_data
+}

--- a/tests/integration/cases/time_dict/Zig_declaration_style_var@v0_12.zig
+++ b/tests/integration/cases/time_dict/Zig_declaration_style_var@v0_12.zig
@@ -1,0 +1,20 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+pub fn main() void {
+    var my_data: ZVal = .{ .map = &.{
+        .{ .key = "morning", .val = .{ .str = "09:30:00" } },
+        .{ .key = "afternoon", .val = .{ .str = "14:15:00" } },
+        .{ .key = "evening", .val = .{ .str = "23:59:59" } },
+    }};
+    my_data = .nil;
+}

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -1993,6 +1993,7 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
             "scalar_null",
             "scalar_date",
             "scalar_datetime",
+            "time_dict",
             "binary",
             "set_mixed_int_widths",
         )

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -740,24 +740,6 @@ def test_datetime_time_heterogeneous_variant_renders(spec: Language) -> None:
     assert "Time" in result.code
 
 
-def test_datetime_time_rust_lazy_static_renders() -> None:
-    """Rust LAZY_STATIC infers ``&str`` for a ``datetime.time`` value.
-
-    Covers the ``case datetime.time():`` arm of ``_rust_scalar_type``,
-    which only runs when a typed declaration walks scalar values.
-    Delete with the rest of the time-coverage shims once issue #2230
-    lands.
-    """
-    result = literalize(
-        source="val = 09:30:00\n",
-        input_format=InputFormat.TOML,
-        language=Rust(declaration_style=Rust.declaration_styles.LAZY_STATIC),
-        variable_form=NewVariable(name="X"),
-        wrap_in_file=True,
-    )
-    assert "HashMap<&str, &str>" in result.code
-
-
 def test_datetime_time_union_annotation_renders() -> None:
     """Annotated heterogeneous sequence with a ``datetime.time`` element
     renders without crashing.


### PR DESCRIPTION
Replaces the `test_datetime_time_rust_lazy_static_renders` string-assertion shim with golden-file coverage by adding `time_dict` to the `declaration_style` axis, so the generated Rust `LAZY_STATIC` golden walks `datetime.time` scalars through the `case datetime.time()` arm of `_rust_scalar_type`. This regenerated 16 declaration-style goldens across multi-declaration-style languages, mirroring the existing `scalar_datetime` precedent in that axis. Verified via `coverage` that rendering the new golden in declaration form still hits `rust.py:206-207`, so removing the pytest shim does not regress line coverage. The orphan-golden guard, golden suite, and language tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test fixtures and test-case selection, with no production logic modified.
> 
> **Overview**
> Adds a new `time_dict` input to the `declaration_style` golden-matrix and checks in regenerated declaration-style fixtures across multiple languages (including Rust `LAZY_STATIC`/`let mut`) so `datetime.time` values are exercised via golden files.
> 
> Removes the dedicated Rust pytest shim (`test_datetime_time_rust_lazy_static_renders`) now that the same scalar-typing behavior is covered by the new golden coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae529bee5866f54b0eb50966edcee008379f143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->