### PR TITLE
Add opt-in RECORD heterogeneous strategy to Python (#2419)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Python` gains an opt-in ``RECORD``
+  ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
+  :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,
+  :class:`~literalizer.Scala` and :class:`~literalizer.Java`).  Each
+  record-shaped dict (non-empty, string-keyed) becomes a generated
+  frozen ``@dataclasses.dataclass`` declared in the preamble (with an
+  ``import dataclasses``) plus a matching ``RecordN(field=value, ...)``
+  literal; field names are the dict keys verbatim and the class-name
+  prefix is configurable via the new ``record_struct_name_prefix``
+  constructor parameter.  Python's ``dict`` is already heterogeneous,
+  so every record-shaped dict is representable as a plain ``dict``;
+  this is purely an idiomatic-output choice, the strategy is opt-in,
+  and the default (``ERROR``) plain-``dict`` output is unchanged.  See
+  #2419.
+
 2026.05.16
 ----------
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -45,6 +45,15 @@ from literalizer._formatters.format_strings import (
     format_string_backslash_single,
     format_string_raw_python,
 )
+from literalizer._formatters.record_strategy import (
+    RecordDeclarationField,
+    RecordFieldType,
+    RecordLiteralField,
+    RecordRenderer,
+    RecordStrategy,
+    build_record_strategy,
+)
+from literalizer._formatters.type_inference import record_shape_for_dict
 from literalizer._language import (
     NO_CALL_PARAMETER_LIMIT,
     NO_HETEROGENEOUS_BEHAVIOR,
@@ -63,6 +72,7 @@ from literalizer._language import (
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
+    RenderedRecordLiteral,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -155,22 +165,38 @@ def _format_bytes_python(value: bytes) -> str:
 
 
 @beartype
-def _needs_type_annotation(data: Value) -> bool:
+def _needs_type_annotation(
+    *,
+    data: Value,
+    record_eligible: Callable[[Value], bool],
+) -> bool:
     """Whether *data* needs a type annotation for type-checkers.
 
     This is true when *data* is or contains an empty collection,
     because type-checkers cannot infer the element types.
+
+    Under the ``RECORD`` strategy a record-shaped dict renders as a
+    fully-annotated ``@dataclasses.dataclass`` instance, so it is
+    self-describing and neither needs a helper annotation nor drags an
+    enclosing collection into needing one (an empty collection that is
+    one of its fields is annotated on the dataclass field instead).
+    *record_eligible* identifies such dicts; it is a constant ``False``
+    predicate when the strategy is not ``RECORD``.
     """
     match data:
         case dict():
+            if record_eligible(data):
+                return False
             return len(data) == 0 or any(
-                _needs_type_annotation(data=v) for v in data.values()
+                _needs_type_annotation(data=v, record_eligible=record_eligible)
+                for v in data.values()
             )
         case set():
             return len(data) == 0
         case list():
             return len(data) == 0 or any(
-                _needs_type_annotation(data=e) for e in data
+                _needs_type_annotation(data=e, record_eligible=record_eligible)
+                for e in data
             )
         case _:
             return False
@@ -195,13 +221,16 @@ def _format_variable_declaration(
     default_dict_value_type: str,
     default_dict_key_type: str,
     join_union: Callable[[list[str]], str],
+    record_eligible: Callable[[Value], bool],
 ) -> str:
     """Format a Python variable declaration.
 
     For empty collections a type annotation is added so that
-    type-checkers can infer the type.
+    type-checkers can infer the type.  *record_eligible* lets a
+    ``RECORD``-strategy record-shaped dict opt out (it is self-typed
+    by its generated dataclass); see :func:`_needs_type_annotation`.
     """
-    if _needs_type_annotation(data=data):
+    if _needs_type_annotation(data=data, record_eligible=record_eligible):
         return _format_inline_type_hint_declaration(
             name=name,
             value=value,
@@ -622,6 +651,37 @@ def _build_type_hint_preamble_py38(
 
 
 @beartype
+def _python_record_field_identifier(key: str, /) -> str:
+    """Return the dataclass field name for a dict *key*.
+
+    Python field identifiers are the dict keys verbatim (no case
+    conversion), matching the keyword-argument literal form
+    ``Record0(id=1, ...)``.
+    """
+    return key
+
+
+@beartype
+def _python_record_literal(
+    name: str,
+    fields: Sequence[RecordLiteralField],
+    /,
+) -> RenderedRecordLiteral:
+    """Render a Python ``Name(field=value, ...)`` keyword constructor
+    call as structured pieces for the shared compact/multiline layout
+    code.
+    """
+    return RenderedRecordLiteral(
+        head=f"{name}(",
+        entries=tuple(
+            f"{field.identifier}={field.formatted}" for field in fields
+        ),
+        closer=")",
+        compact_pad="",
+    )
+
+
+@beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Python(metaclass=LanguageCls):
     """Python language specification.
@@ -693,6 +753,25 @@ class Python(metaclass=LanguageCls):
               etc. for generic collection type hints (PEP 484 style).
             * ``VersionFormats.PY39`` — use built-in ``list``, ``dict``, etc.
               directly as generic aliases (PEP 585, default).
+
+        heterogeneous_strategy: How to render a record-shaped dict
+            (non-empty, string-keyed).
+
+            * ``HeterogeneousStrategies.ERROR`` — render a plain
+              ``dict`` (default).  Python's ``dict`` is already
+              heterogeneous, so every record-shaped dict is
+              representable as one.
+            * ``HeterogeneousStrategies.RECORD`` — opt-in
+              idiomatic-output strategy: render each record-shaped dict
+              as a generated frozen ``@dataclasses.dataclass`` declared
+              in the preamble plus a matching
+              ``RecordN(field=value, ...)`` literal.  Every dict is
+              still representable as a plain ``dict``; this strategy
+              only produces the more idiomatic dataclass form.
+
+        record_struct_name_prefix: Prefix for the auto-generated
+            ``@dataclasses.dataclass`` names under the ``RECORD``
+            strategy (``"Record"`` -> ``Record0``, ``Record1``, ...).
     """
 
     format_integer_widened = no_format_integer_widened
@@ -727,7 +806,7 @@ class Python(metaclass=LanguageCls):
     supports_default_sequence_element_type = True
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
-    supports_record_struct_name_prefix = False
+    supports_record_struct_name_prefix = True
     supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
@@ -890,9 +969,15 @@ class Python(metaclass=LanguageCls):
             default_dict_value_type: str,
             default_dict_key_type: str,
             join_union: Callable[[list[str]], str],
+            record_eligible: Callable[[Value], bool],
         ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
             """Return the variable declaration formatter for this hint
             style.
+
+            *record_eligible* flags ``RECORD``-strategy record-shaped
+            dicts so a bare assignment is kept for them (the generated
+            dataclass already types every field); it is a constant
+            ``False`` predicate for other strategies.
             """
             if self is type(self).ALWAYS:
 
@@ -956,6 +1041,7 @@ class Python(metaclass=LanguageCls):
                     default_dict_value_type=default_dict_value_type,
                     default_dict_key_type=default_dict_key_type,
                     join_union=join_union,
+                    record_eligible=record_eligible,
                 )
 
             return _auto_formatter
@@ -1117,11 +1203,22 @@ class Python(metaclass=LanguageCls):
     modifiers = Modifiers
 
     class HeterogeneousStrategies(enum.Enum):
-        """Heterogeneous-scalar strategy options — this language only
-        supports raising.
+        """Strategy for dicts whose values span more than one Python
+        type.
+
+        ``ERROR`` keeps the default behavior.  Python's ``dict`` is
+        already heterogeneous, so a record-shaped dict is representable
+        as a plain ``dict`` and is rendered that way by default.
+        ``RECORD`` is an opt-in *idiomatic-output* strategy: each
+        record-shaped dict (non-empty, string-keyed) becomes a
+        generated frozen ``@dataclasses.dataclass`` declared in the
+        preamble plus a matching ``RecordN(field=value, ...)`` literal.
+        Every dict is still representable as a plain ``dict``; this
+        strategy only produces the more idiomatic dataclass form.
         """
 
-        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+        ERROR = enum.auto()
+        RECORD = enum.auto()
 
     heterogeneous_strategies = HeterogeneousStrategies
 
@@ -1221,6 +1318,7 @@ class Python(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    record_struct_name_prefix: str = "Record"
     language_version: VersionFormats = VersionFormats.PY39
     indent: str = "    "
 
@@ -1252,15 +1350,133 @@ class Python(metaclass=LanguageCls):
         """Format an assignment to an existing variable."""
         return variable_formatter(template="{name} = {value}")
 
+    def _python_render_declaration(
+        self,
+        name: str,
+        fields: Sequence[RecordDeclarationField],
+        /,
+    ) -> str:
+        """Render a frozen ``@dataclasses.dataclass`` declaration."""
+        lines = [
+            "@dataclasses.dataclass(frozen=True)",
+            f"class {name}:",
+        ]
+        lines += [
+            f"{self.indent}{field.identifier}: {field.type_name}"
+            for field in fields
+        ]
+        return "\n".join(lines)
+
+    @cached_property
+    def _record_field_type(self) -> Callable[[RecordFieldType], str]:
+        """Return the dataclass field-type resolver for the ``RECORD``
+        strategy.
+
+        A field whose value is itself a nested record-shaped dict uses
+        that record's generated class name; every other value is typed
+        through :func:`_python_type_hint`, the same hint function the
+        variable-annotation path uses, so the declared type matches the
+        rendered literal and honors the configured
+        sequence/set/dict/date/datetime formats and the targeted
+        Python version.
+        """
+        if self.language_version is self.version_formats.PY38:
+            mapping = self._py38_names
+            sequence_hint = mapping.get(
+                self.sequence_format.type_hint,
+                self.sequence_format.type_hint,
+            )
+            set_hint = mapping.get(
+                self.set_format.type_hint,
+                self.set_format.type_hint,
+            )
+            dict_hint = mapping["dict"]
+            join_union: Callable[[list[str]], str] = _join_union_typing
+        else:
+            sequence_hint = self.sequence_format.type_hint
+            set_hint = self.set_format.type_hint
+            dict_hint = "dict"
+            join_union = _join_union_pipe
+
+        def _field_type(request: RecordFieldType, /) -> str:
+            """Type a record field from its nested-record name or its
+            raw value.
+            """
+            if request.record_name is not None:
+                return request.record_name
+            return _python_type_hint(
+                data=request.value,
+                bytes_hint=self.bytes_format.type_hint,
+                date_hint=self.date_format.type_hint,
+                datetime_hint=self.datetime_format.type_hint,
+                time_hint="datetime.time",
+                sequence_hint=sequence_hint,
+                set_hint=set_hint,
+                dict_hint=dict_hint,
+                default_set_element_type=self.default_set_element_type,
+                default_sequence_element_type=(
+                    self.default_sequence_element_type
+                ),
+                default_dict_value_type=self.default_dict_value_type,
+                default_dict_key_type=self.default_dict_key_type,
+                join_union=join_union,
+            )
+
+        return _field_type
+
+    @cached_property
+    def _record_renderer(self) -> RecordRenderer:
+        """Python syntax hooks for the ``RECORD`` strategy."""
+        return RecordRenderer(
+            name_prefix=self.record_struct_name_prefix,
+            # Python does not expose a ``record_shape_names``
+            # constructor field (base RECORD only, as for the other
+            # non-Rust ports); an empty mapping keeps every shape on
+            # the auto ``{prefix}{N}`` names.
+            record_shape_names=MappingProxyType(mapping={}),
+            field_identifier=_python_record_field_identifier,
+            field_type=self._record_field_type,
+            render_declaration=self._python_render_declaration,
+            render_literal=_python_record_literal,
+        )
+
+    @cached_property
+    def _record_strategy(self) -> RecordStrategy:
+        """Resolve the active strategy to its behavior + preamble."""
+        cls = type(self.heterogeneous_strategy)
+        if self.heterogeneous_strategy is cls.RECORD:
+            return build_record_strategy(renderer=self._record_renderer)
+        return RecordStrategy(
+            behavior=NO_HETEROGENEOUS_BEHAVIOR,
+            preamble=no_data_preamble,
+        )
+
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
-        """Return data-dependent preamble lines."""
-        return no_data_preamble
+        """Return data-dependent preamble lines.
+
+        Under ``HeterogeneousStrategies.RECORD`` emits ``import
+        dataclasses`` followed by one frozen
+        ``@dataclasses.dataclass`` declaration per record shape present
+        in the data; otherwise produces no preamble.
+        """
+        record_preamble = self._record_strategy.preamble
+
+        def _preamble(data: Value, /) -> tuple[str, ...]:
+            """Prefix the record declarations with ``import
+            dataclasses``.
+            """
+            blocks = record_preamble(data)
+            if not blocks:
+                return ()
+            return ("import dataclasses", *blocks)
+
+        return _preamble
 
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
-        """Return the heterogeneous-behavior config."""
-        return self.heterogeneous_strategy.value
+        """Return the behavior for the chosen heterogeneous strategy."""
+        return self._record_strategy.behavior
 
     @cached_property
     def format_call_stub(
@@ -1457,6 +1673,34 @@ class Python(metaclass=LanguageCls):
         }
 
     @cached_property
+    def _record_eligible_for_annotation(self) -> Callable[[Value], bool]:
+        """Predicate marking a value as a ``RECORD``-strategy
+        record-shaped dict.
+
+        Such a dict renders as a self-typed
+        ``@dataclasses.dataclass`` instance, so the inline
+        variable-annotation path treats it as opaque (see
+        :func:`_needs_type_annotation`).  For any other strategy the
+        predicate is a constant ``False``, leaving the annotation
+        behavior unchanged.
+        """
+        cls = type(self.heterogeneous_strategy)
+        if self.heterogeneous_strategy is not cls.RECORD:
+            return lambda _data: False
+
+        def _eligible(data: Value, /) -> bool:
+            """An ordered map is never record-eligible; a plain
+            non-empty string-keyed dict is.
+            """
+            return (
+                isinstance(data, dict)
+                and not isinstance(data, OrderedMap)
+                and record_shape_for_dict(value=data) is not None
+            )
+
+        return _eligible
+
+    @cached_property
     def format_variable_declaration(
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
@@ -1491,6 +1735,7 @@ class Python(metaclass=LanguageCls):
             default_dict_value_type=self.default_dict_value_type,
             default_dict_key_type=self.default_dict_key_type,
             join_union=join_union,
+            record_eligible=self._record_eligible_for_annotation,
         )
 
     @cached_property

--- a/tests/integration/cases/call_deep_dotted_method/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_deep_dotted_method/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+class _ClientType:
+    def post(self, *_args: object, **_kwargs: object) -> object: ...
+class _ApiType:
+    client = _ClientType()
+class _ObjType:
+    api = _ApiType()
+obj = _ObjType()
+obj.api.client.post(data="hello")
+obj.api.client.post(data=42)
+obj.api.client.post(data=True)

--- a/tests/integration/cases/call_deep_dotted_transformed/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_deep_dotted_transformed/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+class _ClientType:
+    def fetch(self, *_args: object, **_kwargs: object) -> object: ...
+class _AppType:
+    client = _ClientType()
+app = _AppType()
+def emit(*_args: object, **_kwargs: object) -> object: ...
+emit(app.client.fetch(payload="hello"))
+emit(app.client.fetch(payload=42))
+emit(app.client.fetch(payload=True))

--- a/tests/integration/cases/call_dotted_method/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_dotted_method/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+class _ClientType:
+    def fetch(self, *_args: object, **_kwargs: object) -> object: ...
+class _AppType:
+    client = _ClientType()
+app = _AppType()
+app.client.fetch(payload="hello")
+app.client.fetch(payload=42)
+app.client.fetch(payload=True)

--- a/tests/integration/cases/call_dotted_transform_stub/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_dotted_transform_stub/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+def process(*_args: object, **_kwargs: object) -> object: ...
+class _TracerType:
+    def emit(self, *_args: object, **_kwargs: object) -> object: ...
+tracer = _TracerType()
+tracer.emit(process(value="hello"))
+tracer.emit(process(value=42))
+tracer.emit(process(value=True))

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from typing import Any
+def process(*_args: object, **_kwargs: object) -> object: ...
+my_ints = (
+    1,
+    2,
+    3,
+)
+my_strings = (
+    "a",
+    "b",
+)
+my_empty: tuple[Any, ...] = ()
+process(data=my_ints, count=42)
+process(data=my_strings, count=7)
+process(data=my_empty, count=99)

--- a/tests/integration/cases/call_ref_args_reused/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_ref_args_reused/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+def process(*_args: object, **_kwargs: object) -> object: ...
+single_var = (
+    4,
+    5,
+    6,
+)
+repeated_var = 1
+process(data=repeated_var, count=1)
+process(data=single_var, count=0)
+process(data=repeated_var, count=8)

--- a/tests/integration/cases/call_ref_args_trivial_register/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_ref_args_trivial_register/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+def process(*_args: object, **_kwargs: object) -> object: ...
+my_int = 1
+my_bool = True
+my_float = 3.14
+my_list = (
+    1,
+    2,
+    3,
+)
+process(value=my_int, count=42)
+process(value=my_bool, count=7)
+process(value=my_float, count=9)
+process(value=my_list, count=1)

--- a/tests/integration/cases/call_scalar_args/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_scalar_args/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+def process(*_args: object, **_kwargs: object) -> object: ...
+process(value="hello")
+process(value=42)
+process(value=True)

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+def process(*_args: object, **_kwargs: object) -> object: ...
+process(value="hello", label="a")
+process(value=42, label="b")
+process(value=True, label="c")

--- a/tests/integration/cases/call_scalar_args_with_null/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_scalar_args_with_null/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+def process(*_args: object, **_kwargs: object) -> object: ...
+process(value=None)
+process(value="hello")

--- a/tests/integration/cases/call_snake_dotted_method/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_snake_dotted_method/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+class _Http_clientType:
+    def fetch(self, *_args: object, **_kwargs: object) -> object: ...
+class _My_appType:
+    http_client = _Http_clientType()
+my_app = _My_appType()
+my_app.http_client.fetch(payload="hello")
+my_app.http_client.fetch(payload=42)
+my_app.http_client.fetch(payload=True)

--- a/tests/integration/cases/call_transform_no_wrapper/Python_heterogeneous_strategy_record_call@py39.py
+++ b/tests/integration/cases/call_transform_no_wrapper/Python_heterogeneous_strategy_record_call@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+def process(*_args: object, **_kwargs: object) -> object: ...
+process(value="hello")
+process(value=42)
+process(value=True)

--- a/tests/integration/cases/dict_all_scalar_types/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/dict_all_scalar_types/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import datetime
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    s: str
+    i: int
+    f: float
+    b: bool
+    n: None
+    d: datetime.date
+    dt: datetime.datetime
+    by: str
+my_data = Record0(
+    s="string",
+    i=1,
+    f=1.5,
+    b=True,
+    n=None,
+    d=datetime.date(year=2024, month=1, day=15),
+    dt=datetime.datetime(year=2024, month=1, day=15, hour=12, minute=0, second=0),
+    by="48656c6c6f",
+)

--- a/tests/integration/cases/dict_all_scalar_types/Python_heterogeneous_strategy_record_datetime_epoch@py39.py
+++ b/tests/integration/cases/dict_all_scalar_types/Python_heterogeneous_strategy_record_datetime_epoch@py39.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import datetime
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    s: str
+    i: int
+    f: float
+    b: bool
+    n: None
+    d: datetime.date
+    dt: int
+    by: str
+my_data = Record0(
+    s="string",
+    i=1,
+    f=1.5,
+    b=True,
+    n=None,
+    d=datetime.date(year=2024, month=1, day=15),
+    dt=1705320000,
+    by="48656c6c6f",
+)

--- a/tests/integration/cases/dict_mixed_int_widths/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/dict_mixed_int_widths/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    a: int
+    b: int
+    c: str
+my_data = Record0(
+    a=1,
+    b=3000000000,
+    c="x",
+)

--- a/tests/integration/cases/dict_mixed_scalars/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/dict_mixed_scalars/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    a: int
+    b: str
+my_data = Record0(
+    a=1,
+    b="x",
+)

--- a/tests/integration/cases/dict_mixed_scalars/Python_heterogeneous_strategy_record_combined@py38.py
+++ b/tests/integration/cases/dict_mixed_scalars/Python_heterogeneous_strategy_record_combined@py38.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    a: int
+    b: str
+my_data = Record0(
+    a=1,
+    b="x",
+)
+my_data = Record0(
+    a=1,
+    b="x",
+)

--- a/tests/integration/cases/dict_mixed_scalars/Python_heterogeneous_strategy_record_combined@py39.py
+++ b/tests/integration/cases/dict_mixed_scalars/Python_heterogeneous_strategy_record_combined@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    a: int
+    b: str
+my_data = Record0(
+    a=1,
+    b="x",
+)
+my_data = Record0(
+    a=1,
+    b="x",
+)

--- a/tests/integration/cases/dict_with_list_value/Python_heterogeneous_strategy_record_list_val@py39.py
+++ b/tests/integration/cases/dict_with_list_value/Python_heterogeneous_strategy_record_list_val@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    name: str
+    scores: tuple[int, ...]
+my_data = Record0(
+    name="Alice",
+    scores=(
+        10,
+        20,
+        30,
+    ),
+)

--- a/tests/integration/cases/empty_dict/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/empty_dict/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+from typing import Any
+my_data: dict[str, Any] = {}

--- a/tests/integration/cases/heterogeneous_list_with_string/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/heterogeneous_list_with_string/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    "hello",
+    42,
+)

--- a/tests/integration/cases/int_key_dict/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/int_key_dict/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = {
+    1: "one",
+    2: "two",
+    42: "answer",
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Python_heterogeneous_strategy_record_sibling_widening@py39.py
+++ b/tests/integration/cases/multiline_sibling_list_widening/Python_heterogeneous_strategy_record_sibling_widening@py39.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from collections import OrderedDict
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record1:
+    numbers: tuple[int, ...]
+    strings: tuple[str, ...]
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    omap_value: OrderedDict[str, int]
+    sibling_lists: Record1
+    ref_marker_present: tuple[str, ...]
+my_data = Record0(
+    omap_value=OrderedDict([
+        ("first", 1),
+    ]),
+    sibling_lists=Record1(
+        numbers=(
+            1,
+            2,
+        ),
+        strings=(
+            "x",
+            "y",
+        ),
+    ),
+    ref_marker_present=(
+        "$keep",
+        "z",
+    ),
+)

--- a/tests/integration/cases/nested_mixed_dict/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/nested_mixed_dict/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record1:
+    a: int
+    b: str
+    c: None
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    outer: Record1
+my_data = Record0(
+    outer=Record1(
+        a=1,
+        b="x",
+        c=None,
+    ),
+)

--- a/tests/integration/cases/nested_mixed_inner/Python_heterogeneous_strategy_record_inner@py39.py
+++ b/tests/integration/cases/nested_mixed_inner/Python_heterogeneous_strategy_record_inner@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    (1, "a"),
+    (2, "b"),
+)

--- a/tests/integration/cases/nested_mixed_types/Python_heterogeneous_strategy_record_sibling@py39.py
+++ b/tests/integration/cases/nested_mixed_types/Python_heterogeneous_strategy_record_sibling@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    (1, 2),
+    ("a", "b"),
+)

--- a/tests/integration/cases/nested_sequences/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/nested_sequences/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    ((1, 2), (3, 4)),
+    ((5,),),
+)

--- a/tests/integration/cases/ordered_map/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/ordered_map/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+from collections import OrderedDict
+my_data = OrderedDict([
+    ("name", "Alice"),
+    ("age", 30),
+    ("active", True),
+])

--- a/tests/integration/cases/record_basic/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/record_basic/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    id: int
+    description: str
+    is_done: bool
+    blocks: tuple[int, ...]
+my_data = Record0(
+    id=1,
+    description="She said \"hello\", then waved",
+    is_done=False,
+    blocks=(
+        1,
+        2,
+        3,
+    ),
+)

--- a/tests/integration/cases/record_epoch_datetime_i32_overflow/Python_record_epoch_i32_overflow@py39.py
+++ b/tests/integration/cases/record_epoch_datetime_i32_overflow/Python_record_epoch_i32_overflow@py39.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    within_i32: int
+    beyond_i32: int
+my_data = Record0(
+    within_i32=1705320000,
+    beyond_i32=4085195400,
+)

--- a/tests/integration/cases/record_nested_container/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/record_nested_container/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    title: str
+    tags: tuple[str, ...]
+    priority: int
+my_data = Record0(
+    title="report",
+    tags=(
+        "draft",
+        "urgent",
+        "review",
+    ),
+    priority=2,
+)

--- a/tests/integration/cases/record_nested_record/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/record_nested_record/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record1:
+    name: str
+    age: int
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    id: int
+    owner: Record1
+my_data = Record0(
+    id=1,
+    owner=Record1(
+        name="Alice",
+        age=30,
+    ),
+)

--- a/tests/integration/cases/record_pure_scalars/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/record_pure_scalars/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    name: str
+    age: int
+    active: bool
+    score: float
+my_data = Record0(
+    name="Alice",
+    age=30,
+    active=True,
+    score=4.5,
+)

--- a/tests/integration/cases/record_sequence/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/record_sequence/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import Any
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    id: int
+    label: str
+    tags: tuple[Any, ...]
+my_data = (
+    Record0(id=1, label="first", tags=()),
+    Record0(id=2, label="second", tags=()),
+    Record0(id=3, label="third", tags=()),
+)

--- a/tests/integration/cases/record_two_shapes/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/record_two_shapes/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record1:
+    count: int
+    rate: int
+@dataclasses.dataclass(frozen=True)
+class Record2:
+    retries: int
+    timeout: int
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    metrics: Record1
+    flags: Record2
+my_data = Record0(
+    metrics=Record1(
+        count=100,
+        rate=50,
+    ),
+    flags=Record2(
+        retries=3,
+        timeout=30,
+    ),
+)

--- a/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_integer_binary@py39.py
+++ b/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_integer_binary@py39.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    quantity: int
+    big: int
+    ratio: float
+    label: str
+    ok: bool
+my_data = Record0(
+    quantity=0b11110100001001000000,
+    big=0b1111111111111111111111111111111111111111111111111111111111111111,
+    ratio=2.5,
+    label="tag",
+    ok=True,
+)

--- a/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_integer_hex@py39.py
+++ b/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_integer_hex@py39.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    quantity: int
+    big: int
+    ratio: float
+    label: str
+    ok: bool
+my_data = Record0(
+    quantity=0xf4240,
+    big=0xffffffffffffffff,
+    ratio=2.5,
+    label="tag",
+    ok=True,
+)

--- a/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_integer_octal@py39.py
+++ b/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_integer_octal@py39.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    quantity: int
+    big: int
+    ratio: float
+    label: str
+    ok: bool
+my_data = Record0(
+    quantity=0o3641100,
+    big=0o1777777777777777777777,
+    ratio=2.5,
+    label="tag",
+    ok=True,
+)

--- a/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_separator_underscore@py39.py
+++ b/tests/integration/cases/record_wide_int/Python_heterogeneous_strategy_record_separator_underscore@py39.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    quantity: int
+    big: int
+    ratio: float
+    label: str
+    ok: bool
+my_data = Record0(
+    quantity=1_000_000,
+    big=18_446_744_073_709_551_615,
+    ratio=2.5,
+    label="tag",
+    ok=True,
+)

--- a/tests/integration/cases/tuple_int_key_dict_value/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_int_key_dict_value/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+my_data = {
+    1: (1, "email", "a@gmail.com", 100),
+}

--- a/tests/integration/cases/tuple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        "a@gmail.com",
+        100,
+    ),
+)

--- a/tests/integration/cases/tuple_record_seq_sibling/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_record_seq_sibling/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    scores: tuple[int, ...]
+    args: tuple[int | str, ...]
+my_data = Record0(
+    scores=(
+        10,
+        20,
+        30,
+    ),
+    args=(
+        1,
+        "email",
+        "a@gmail.com",
+        100,
+    ),
+)

--- a/tests/integration/cases/tuple_record_sequence/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_record_sequence/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = (
+    Record0(call="send", args=(1, "email", "a@gmail.com", 100)),
+    Record0(call="recv", args=(2, "sms", "b@example.com", 200)),
+)

--- a/tests/integration/cases/tuple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    "a@gmail.com",
+    100,
+)


### PR DESCRIPTION
Adds the opt-in `RECORD` `heterogeneous_strategy` to `Python`, rendering each record-shaped dict as a frozen `@dataclasses.dataclass` (declared in the preamble with `import dataclasses`) plus a matching `RecordN(field=value, ...)` literal, with a configurable `record_struct_name_prefix`. Because Python's `dict` is already heterogeneous this is purely an idiomatic-output choice: the strategy is opt-in and the default (`ERROR`) plain-`dict` output is byte-identical. Field types reuse the existing `_python_type_hint` deriver, and a new `record_eligible` predicate threaded through `_needs_type_annotation` stops a record-shaped dict from forcing a contradictory inline variable annotation (it is self-typed by its generated dataclass). 44 golden fixtures were auto-generated by the existing capability-based variant builders; no existing goldens changed and no other language is affected. Full suite passes (4671 tests, coverage gate satisfied) and all new Python fixtures pass the CI py_compile + execute lint gate.

Closes #2419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in change but it adds new rendering and preamble/type-hint logic for Python under `heterogeneous_strategy=RECORD`, which could introduce subtle formatting or typing regressions when enabled (especially for nested records and empty collections). Default `ERROR` output remains unchanged.
> 
> **Overview**
> Adds an opt-in `Python.heterogeneous_strategy=RECORD` mode that renders record-shaped (non-empty, string-keyed) dicts as generated frozen `@dataclasses.dataclass` declarations in the preamble (with `import dataclasses`) plus `RecordN(field=value, ...)` literals, with a configurable `record_struct_name_prefix`.
> 
> Threads a `record_eligible` predicate through Python’s variable type-hinting path so dataclass-backed records don’t trigger contradictory inline annotations, and reuses existing `_python_type_hint` logic to type dataclass fields (including nested records and PY38 vs PY39 typing syntax). Integration goldens are expanded to cover the new strategy across literals and call rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 459a2f1c79d2ea12591e483068483a6de2f3b0f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->