### PR TITLE
Pin Node lint toolchain to 22; sync with JavaScript.language_version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,6 +108,20 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      # `.js` fixtures are executed by `node` below;
+      # `JavaScript.language_version` is `VersionFormats.ES2015` in
+      # `src/literalizer/languages/javascript.py`. Without an explicit
+      # `node-version` the runtime drifts with the `setup-node` action
+      # default. Node 22 is a current LTS and fully supports that ES2015
+      # default. This same pin is repeated on every Node lint job
+      # (`lint-npm-installed`, `lint-typescript-run`, `lint-elm`,
+      # `lint-elm-run`); keep all of them and that `language_version`
+      # declaration in sync.
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
       - name: Lint Bash
         run: |-
           find tests/integration/cases -name '*.sh' -print0 > /tmp/files-bash && test -s /tmp/files-bash
@@ -421,8 +435,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # `node-version` pinned to Node 22 LTS, which supports the
+      # `ES2015` `JavaScript.language_version` default; keep in sync with
+      # the other Node lint jobs and the `language_version` declaration in
+      # `src/literalizer/languages/javascript.py` (see the `Set up Node`
+      # step in `lint-fast` for the full rationale).
       - uses: actions/setup-node@v6
         with:
+          node-version: '22'
           cache: npm
           cache-dependency-path: .github/npm-linters/package-lock.json
       - name: Install npm-sourced linters
@@ -469,8 +489,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # `node-version` pinned to Node 22 LTS, which supports the
+      # `ES2015` `JavaScript.language_version` default; keep in sync with
+      # the other Node lint jobs and the `language_version` declaration in
+      # `src/literalizer/languages/javascript.py` (see the `Set up Node`
+      # step in `lint-fast` for the full rationale).
       - uses: actions/setup-node@v6
         with:
+          node-version: '22'
           cache: npm
           cache-dependency-path: .github/npm-linters/package-lock.json
       - name: Install npm-sourced linters
@@ -494,8 +520,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # `node-version` pinned to Node 22 LTS, which supports the
+      # `ES2015` `JavaScript.language_version` default; keep in sync with
+      # the other Node lint jobs and the `language_version` declaration in
+      # `src/literalizer/languages/javascript.py` (see the `Set up Node`
+      # step in `lint-fast` for the full rationale).
       - uses: actions/setup-node@v6
         with:
+          node-version: '22'
           cache: npm
           cache-dependency-path: .github/npm-linters/package-lock.json
       - name: Install npm-sourced linters
@@ -524,8 +556,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # `node-version` pinned to Node 22 LTS, which supports the
+      # `ES2015` `JavaScript.language_version` default; keep in sync with
+      # the other Node lint jobs and the `language_version` declaration in
+      # `src/literalizer/languages/javascript.py` (see the `Set up Node`
+      # step in `lint-fast` for the full rationale).
       - uses: actions/setup-node@v6
         with:
+          node-version: '22'
           cache: npm
           cache-dependency-path: .github/npm-linters/package-lock.json
       - name: Install npm-sourced linters

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -562,8 +562,11 @@ class JavaScript(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the `tsc --target es2015 --lib es2015` flags in
-    # `.github/workflows/lint.yml` and `TypeScript.language_version` in
+    # Keep in sync with the `tsc --target es2015 --lib es2015` flags and
+    # the `node-version` pins on the Node lint jobs (`lint-fast`,
+    # `lint-npm-installed`, `lint-typescript-run`, `lint-elm`,
+    # `lint-elm-run`) in `.github/workflows/lint.yml`, and with
+    # `TypeScript.language_version` in
     # `src/literalizer/languages/typescript.py` (TypeScript fixtures share
     # this ECMAScript target).
     language_version: VersionFormats = VersionFormats.ES2015


### PR DESCRIPTION
Part of #1933. Closes #2394.

The `.js` fixtures are run by `node` and the four npm-based jobs run on the Node runtime, but `lint-fast` had no `setup-node` step and `lint-npm-installed`, `lint-typescript-run`, `lint-elm`, `lint-elm-run` used `actions/setup-node@v6` with no `node-version`, so the Node runtime drifted with the action default. This pins every Node lint job to Node 22 LTS (>= a runtime that supports the `VersionFormats.ES2015` `JavaScript.language_version` default) and adds the bidirectional "keep in sync" comments at the pin sites and the `language_version` declaration in `src/literalizer/languages/javascript.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern. No behaviour change; no CHANGELOG entry, matching the analogous sibling #2393 convention for CI-only sync changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that pins the Node runtime for lint/fixture execution; main impact is potential CI failures if any tooling/fixtures behave differently under Node 22.
> 
> **Overview**
> Pins all GitHub Actions lint jobs that execute JavaScript/TypeScript/Elm via Node to `node-version: '22'` (including adding a new Node setup step in `lint-fast`) to prevent runtime drift from `actions/setup-node` defaults.
> 
> Updates the `JavaScript.language_version` “keep in sync” comment to explicitly link the ES2015 target to both the `tsc` flags and the workflow’s Node version pins, making the relationship between declared language version and CI toolchain explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0082f9cf98e813b6828aea3186f674905d064219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->