### PR TITLE
Pin lint toolchain version: COBOL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1033,6 +1033,13 @@ jobs:
 
   lint-cobol:
     runs-on: ubuntu-latest
+    env:
+      # Pin the GnuCOBOL toolchain so the implicitly installed compiler
+      # does not drift. ``3.2`` supports the COBOL 2002 standard, which
+      # matches ``Cobol.language_version`` (``V2002``) in
+      # ``src/literalizer/languages/cobol.py``; keep them in sync (the
+      # pin must stay ``>=`` that ``V2002`` default).
+      GNUCOBOL_VERSION: '3.2'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1043,6 +1050,8 @@ jobs:
           && test -s /tmp/files-to-lint
       - name: Install GnuCOBOL
         uses: fabasoad/setup-cobol-action@v1.6.2
+        with:
+          version: ${{ env.GNUCOBOL_VERSION }}
       # GnuCOBOL caps the file base name length and rejects ``@``-laden
       # names that exceed it, so copy each fixture to a fixed short
       # filename before invoking ``cobc``.

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -676,6 +676,9 @@ class Cobol(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``GNUCOBOL_VERSION`` pin in the
+    # ``lint-cobol`` job of ``.github/workflows/lint.yml``; the pinned
+    # GnuCOBOL must support COBOL ``>=`` this ``V2002`` default.
     language_version: VersionFormats = VersionFormats.V2002
     indent: str = "    "
 

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
Part of #1933. Closes #2403.

`Cobol.language_version` defaults to `VersionFormats.V2002`, but the `lint-cobol` job only action-pinned `fabasoad/setup-cobol-action@v1.6.2` while letting it install an implicit GnuCOBOL version, so the effective COBOL standard support could drift.

This pins the installed GnuCOBOL via a job-scoped `GNUCOBOL_VERSION` env var (`3.2`, which supports the COBOL 2002 standard and is therefore `>=` the `V2002` default), passed to the action's `version` input. Bidirectional "keep in sync" comments are added at the pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `src/literalizer/languages/cobol.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python/Nim pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI lint configuration and new integration fixtures, with no runtime/library behavior modifications.
> 
> **Overview**
> Makes COBOL fixture linting reproducible by pinning the `lint-cobol` GitHub Actions job to GnuCOBOL `3.2` (via `GNUCOBOL_VERSION`) and documenting that it must stay compatible with `Cobol.language_version` (`V2002`).
> 
> Adds new Python 3.9 integration fixtures covering heterogeneous tuple data at both top level and within record fields (pair and triple variants) under the `Python_heterogeneous_strategy_record@py39.py` golden set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebdec00a897aeb9b0abfb42f299a51e5d424c271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->