### PR TITLE
Pin lint toolchain version: Raku

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1677,6 +1677,13 @@ jobs:
 
   lint-raku:
     runs-on: ubuntu-latest
+    # The pinned Rakudo ``2026.04`` release implements Raku language
+    # version 6.d, the ``V6D`` default of ``Raku.language_version`` in
+    # ``src/literalizer/languages/raku.py``; keep them in sync. Rakudo
+    # has no ``--langversion``-style flag, so the pinned compiler
+    # release is the only mechanism for pinning the language version.
+    env:
+      RAKU_VERSION: '2026.04'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1686,7 +1693,9 @@ jobs:
         run: find tests/integration/cases -name '*.raku' -print0 > /tmp/files-to-lint
           && test -s /tmp/files-to-lint
       - name: Install Raku
-        run: sudo apt-get update && sudo apt-get install --yes raku
+        uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ env.RAKU_VERSION }}
       - name: Check Raku syntax
         run: xargs -0 -P "$(nproc)" -n1 raku -c < /tmp/files-to-lint
       - name: Run Raku files

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -562,6 +562,11 @@ class Raku(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the Rakudo release pinned via ``RAKU_VERSION``
+    # in the ``lint-raku`` job of ``.github/workflows/lint.yml``. Rakudo
+    # has no ``--langversion``-style flag, so the pinned compiler
+    # release is the only mechanism for pinning the language version;
+    # ``V6D`` is Raku language version 6.d.
     language_version: VersionFormats = VersionFormats.V6D
     indent: str = "    "
 


### PR DESCRIPTION
Pin the Rakudo compiler in the `lint-raku` CI job via a job-scoped `RAKU_VERSION` env var (`2026.04`, which implements Raku language version 6.d, the `Raku.language_version` `V6D` default), installed through `Raku/setup-raku@v1` instead of an unconstrained `apt-get install --yes raku` so the installed Rakudo no longer drifts.

Adds bidirectional "keep in sync" comments at the pin site and the `language_version` declaration in `raku.py`, following the existing Lua/Wren/Zig/Nim pattern.

Part of #1933. Closes #2414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins the Raku compiler/toolchain to improve reproducibility, with no runtime or library behavior changes beyond how fixtures are linted/executed in GitHub Actions.
> 
> **Overview**
> Pins the `lint-raku` GitHub Actions job to a specific Rakudo release (`RAKU_VERSION: 2026.04`) and switches installation from `apt-get install raku` to `Raku/setup-raku@v1` to prevent toolchain drift.
> 
> Adds matching *keep-in-sync* comments in `lint.yml` and `src/literalizer/languages/raku.py` tying the pinned Rakudo release to the default `Raku.language_version` (`V6D`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df7d5fc64e80b9883db0784f3340af3c76f7972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->