### PR TITLE
Pin lint toolchain version: Common Lisp

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1193,12 +1193,14 @@ jobs:
 
   lint-commonlisp:
     runs-on: ubuntu-latest
-    # ``sbcl-bin/2.6.4`` pins the SBCL build that 40ants/setup-lisp
-    # installs (without the version, ``sbcl-bin`` drifts to whatever is
-    # latest). SBCL implements the fixed ``ANSI`` standard that
+    # The ``LISP`` environment variable pins the SBCL build that
+    # 40ants/setup-lisp installs to ``sbcl-bin/2.6.4`` (without the
+    # version, ``sbcl-bin`` drifts to whatever is latest). SBCL
+    # implements the fixed ``ANSI`` standard that
     # ``CommonLisp.language_version`` defaults to in
-    # ``src/literalizer/languages/common_lisp.py``; the pin is for
-    # reproducibility, not standard selection. Keep them in sync.
+    # ``src/literalizer/languages/common_lisp.py``; the pin keeps the
+    # installed SBCL build stable across CI runs rather than selecting
+    # a language standard. Keep them in sync.
     env:
       LISP: sbcl-bin/2.6.4
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1193,8 +1193,14 @@ jobs:
 
   lint-commonlisp:
     runs-on: ubuntu-latest
+    # ``sbcl-bin/2.6.4`` pins the SBCL build that 40ants/setup-lisp
+    # installs (without the version, ``sbcl-bin`` drifts to whatever is
+    # latest). SBCL implements the fixed ``ANSI`` standard that
+    # ``CommonLisp.language_version`` defaults to in
+    # ``src/literalizer/languages/common_lisp.py``; the pin is for
+    # reproducibility, not standard selection. Keep them in sync.
     env:
-      LISP: sbcl-bin
+      LISP: sbcl-bin/2.6.4
     steps:
       - uses: actions/checkout@v6
         with:

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -451,6 +451,10 @@ class CommonLisp(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``LISP`` env var of the ``lint-commonlisp``
+    # job in ``.github/workflows/lint.yml``, which pins
+    # ``sbcl-bin/2.6.4``. ``ANSI`` is a fixed standard; the SBCL pin is
+    # for reproducibility, not standard selection.
     language_version: VersionFormats = VersionFormats.ANSI
     indent: str = "    "
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -451,10 +451,11 @@ class CommonLisp(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
-    # Keep in sync with the ``LISP`` env var of the ``lint-commonlisp``
-    # job in ``.github/workflows/lint.yml``, which pins
-    # ``sbcl-bin/2.6.4``. ``ANSI`` is a fixed standard; the SBCL pin is
-    # for reproducibility, not standard selection.
+    # Keep in sync with the ``LISP`` environment variable of the
+    # ``lint-commonlisp`` job in ``.github/workflows/lint.yml``, which pins
+    # ``sbcl-bin/2.6.4``. ``ANSI`` is a fixed standard; the pin keeps the
+    # installed SBCL build stable across CI runs rather than selecting a
+    # language standard.
     language_version: VersionFormats = VersionFormats.ANSI
     indent: str = "    "
 

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
Pin SBCL in the `lint-commonlisp` CI job by giving the `LISP` env var an explicit `sbcl-bin/2.6.4` version (was bare `sbcl-bin`, which `40ants/setup-lisp` resolves to whatever is latest and so drifts between runs).

`SBCL` implements the fixed `ANSI` standard that `CommonLisp.language_version` defaults to in `src/literalizer/languages/common_lisp.py`, so the pin is purely for reproducibility, not standard selection. Bidirectional "keep in sync" comments are added at both the pin site in `.github/workflows/lint.yml` and the `language_version` declaration, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python/OCaml pattern.

`2.6.4` is the latest SBCL with a prebuilt `roswell/sbcl_bin` binary (released 2026-04-30).

Part of #1933. Closes #2415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that pins the Common Lisp linter toolchain; main risk is unexpected CI failures if the pinned SBCL build behaves differently from the previously-floating latest.
> 
> **Overview**
> Makes Common Lisp fixture linting reproducible by pinning the `lint-commonlisp` CI job’s SBCL install to `sbcl-bin/2.6.4` instead of a drifting `sbcl-bin`, and adds *keep-in-sync* comments alongside `CommonLisp.language_version`.
> 
> Adds new Python integration fixtures covering heterogeneous tuple literals (pair/triple, top-level and record-field variants) under the record heterogeneous-strategy scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 456d522a7f16bb4cf058872ae62f64ce100b4cc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->