### PR TITLE
Pin lint toolchain version: Groovy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -898,11 +898,17 @@ jobs:
         with:
           clj-kondo: latest
           bb: latest
+      # The pinned Apache Groovy 4.0.32 binary distribution is ``>=`` the
+      # ``V4`` (Groovy 4.x) default of ``Groovy.language_version`` in
+      # ``src/literalizer/languages/groovy.py``; keep them in sync. The
+      # Ubuntu ``groovy`` apt package is Groovy 2.4.x (``< V4``), so the
+      # pinned binary distribution is the only mechanism for installing a
+      # Groovy ``>= V4``.
       - name: Install Groovy
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: groovy
-          version: 1.0
+        run: |-
+          curl -fsSL https://archive.apache.org/dist/groovy/4.0.32/distribution/apache-groovy-binary-4.0.32.zip -o /tmp/groovy.zip
+          unzip -q -o /tmp/groovy.zip -d /tmp/groovy
+          echo "/tmp/groovy/groovy-4.0.32/bin" >> "$GITHUB_PATH"
 
       - name: Lint Clojure
         run: |-
@@ -916,14 +922,10 @@ jobs:
       # instead of cold-starting groovyc/groovy per file. A fresh
       # GroovyShell per fixture keeps classloaders isolated, since
       # some fixtures declare top-level classes with shared names.
-      # Invoke the wrapper at /usr/share/groovy/bin/groovy directly rather
-      # than ``groovy`` because cache-apt-pkgs-action does not replay the
-      # package's ``update-alternatives`` postinst on cache hit, so
-      # ``/usr/bin/groovy`` is missing.
       - name: Lint Groovy
         run: |-
           find tests/integration/cases -name '*.groovy' -print0 > /tmp/files-groovy && test -s /tmp/files-groovy
-          /usr/share/groovy/bin/groovy .github/scripts/lint-groovy.groovy < /tmp/files-groovy
+          groovy .github/scripts/lint-groovy.groovy < /tmp/files-groovy
 
   # Haskell + PureScript share the Haskell toolchain.
   lint-haskell-family:

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -484,6 +484,12 @@ class Groovy(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the Apache Groovy binary distribution downloaded
+    # in the ``Install Groovy`` step of ``.github/workflows/lint.yml``.
+    # The Ubuntu ``groovy`` apt package is Groovy 2.4.x (``< V4``), so
+    # the pinned binary distribution is the only mechanism for
+    # installing a Groovy ``>= V4``; ``V4`` maps to the pinned
+    # ``4.0.32`` release.
     language_version: VersionFormats = VersionFormats.V4
     indent: str = "    "
 

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
Replace the unconstrained `cache-apt-pkgs-action` `groovy` install in the `lint-jvm-mini` CI job with a pinned Apache Groovy **4.0.32** binary distribution.

The Ubuntu `groovy` apt package is Groovy 2.4.x (`< V4`), so it cannot satisfy the `Groovy.language_version` `V4` default. There is no maintained `setup-groovy` action that pins a Groovy 4.x release, so a pinned binary distribution (curl + unzip + `$GITHUB_PATH`) is the only mechanism for installing a Groovy `>= V4` — mirroring the existing Dhall/Wren binary-download pattern.

- Install the pinned `apache-groovy-binary-4.0.32.zip` and put its `bin` on `PATH`.
- Invoke `groovy` from `PATH` in the Lint Groovy step (the prior comment about `cache-apt-pkgs-action` not replaying `update-alternatives` no longer applies and was removed).
- Add bidirectional "keep in sync" comments at the pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `src/literalizer/languages/groovy.py`, following the Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern.

Part of #1933. Closes #2413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI lint tool installation/invocation and add new Python fixture goldens, with no production runtime logic changes.
> 
> **Overview**
> Pins the `lint-jvm-mini` Groovy toolchain by downloading the Apache Groovy **4.0.32** binary distribution instead of relying on Ubuntu’s `groovy` apt package, and updates the Groovy lint step to invoke `groovy` from `PATH`.
> 
> Adds cross-referenced “keep in sync” comments between `.github/workflows/lint.yml` and `src/literalizer/languages/groovy.py` for the Groovy language version pin, and introduces a few new Python integration fixture goldens covering heterogeneous tuple/record cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c3ae37e0e481526e2d017e32e3ef593b6d034a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->