### PR TITLE
Pin lint toolchain version: Ruby

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -141,6 +141,15 @@ jobs:
           xargs -0 bash -n < /tmp/files-bash
           xargs -0 -P "$(nproc)" -n1 bash < /tmp/files-bash
 
+      # ``ruby-version: '3.4'`` is ``>=`` the ``V3`` (Ruby 3.x) default of
+      # ``Ruby.language_version`` in ``src/literalizer/languages/ruby.py``;
+      # keep them in sync. Without this setup step the ``ruby`` binary is
+      # whatever ``ubuntu-latest`` ships and drifts.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
       - name: Lint Ruby
         run: |-
           find tests/integration/cases -name '*.rb' -print0 > /tmp/files-ruby && test -s /tmp/files-ruby

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -579,6 +579,8 @@ class Ruby(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``ruby-version`` pin passed to
+    # ``ruby/setup-ruby`` in ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.V3
     indent: str = "  "
 

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
Part of #1933. Closes #2405.

`Ruby.language_version` defaults to `VersionFormats.V3`, but the `lint-fast` job ran `ruby` with no setup step, so the version was whatever `ubuntu-latest` shipped and drifted.

- Add a `ruby/setup-ruby@v1` step to `lint-fast` pinned to `ruby-version: '3.4'` (`>=` the `V3` default), placed before the `Lint Ruby` step that syntax-checks and runs the `.rb` fixtures.
- Add the bidirectional "keep them in sync" comments at the pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `src/literalizer/languages/ruby.py`, following the existing Lua/Dhall/Kotlin/Nim pattern.

CI-only change with no library behavior change, so (matching the sibling #1933 pin PRs, e.g. Nim) there is no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that pins the Ruby runtime used to syntax-check/run Ruby fixtures; main risk is potential CI failures if Ruby 3.4 incompatibilities surface in existing fixtures.
> 
> **Overview**
> Ensures Ruby fixture linting runs against a deterministic Ruby toolchain by adding a `ruby/setup-ruby@v1` step in `lint-fast` pinned to Ruby `3.4`, with cross-references to keep it aligned with `Ruby.language_version`.
> 
> Adds new Python integration fixtures for the `heterogeneous_strategy_record` cases covering heterogeneous 2- and 3-element tuples at top level and within a record field (using `tuple[...]` with union element types).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7e24d413ccb64158a95c7b1c1ce9b80474edc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->