### PR TITLE
Pin lint toolchain version: PHP

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,6 +135,16 @@ jobs:
         with:
           node-version: '22'
 
+      # ``php-version: '8.1'`` matches ``Php.language_version`` (``V8_1``)
+      # in ``src/literalizer/languages/php.py``; keep them in sync. PHP
+      # has no ``--langversion``-style flag, so the pinned interpreter is
+      # the only mechanism for pinning the language version. Without this
+      # step `php` is whatever `ubuntu-latest` ships and drifts.
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
       - name: Lint Bash
         run: |-
           find tests/integration/cases -name '*.sh' -print0 > /tmp/files-bash && test -s /tmp/files-bash

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -538,6 +538,11 @@ class Php(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``php-version`` pin passed to
+    # ``shivammathur/setup-php`` in the ``Set up PHP`` step of
+    # ``.github/workflows/lint.yml``. PHP has no ``--langversion``-style
+    # flag, so the pinned interpreter is the only mechanism for pinning
+    # the language version; ``V8_1`` maps to ``8.1``.
     language_version: VersionFormats = VersionFormats.V8_1
     indent: str = "    "
 

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
Part of #1933. Closes #2406.

The `lint-fast` job invoked `php` with no setup step, so the version drifted with whatever `ubuntu-latest` ships. This adds a pinned PHP via `shivammathur/setup-php@v2` at `php-version: '8.1'` (matching the `Php.language_version` `V8_1` default), and adds the bidirectional keep-in-sync comments at the pin site and the `language_version` declaration in `php.py`, following the existing Wren/Nim pattern. CI-only change with no CHANGELOG entry, matching the precedent set by the Nim pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only toolchain pin plus new integration golden fixtures; main impact is potential CI failures if PHP 8.1 setup or the new fixtures expose existing lint/runtime issues.
> 
> **Overview**
> Pins the `lint-fast` GitHub Actions job to **PHP 8.1** via `shivammathur/setup-php@v2` to prevent `ubuntu-latest` PHP version drift, with keep-in-sync comments tied to `Php.language_version` (`V8_1`).
> 
> Adds new Python integration golden fixtures for `Python_heterogeneous_strategy_record` covering heterogeneous tuple pairs/triples both at top level and inside record fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e2c14010b67319795363b543d488fe99f3154a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->