### PR TITLE
Pin Elm lint toolchain to Elm.language_version (#2404)

### DIFF
--- a/.github/npm-linters/package-lock.json
+++ b/.github/npm-linters/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "elm": "^0.19.1-6",
+        "elm": "0.19.1-6",
         "elm-format": "^0.8.8",
         "json5": "^2.2.3",
         "tree-sitter-cli": "^0.26.8",

--- a/.github/npm-linters/package.json
+++ b/.github/npm-linters/package.json
@@ -2,8 +2,9 @@
   "name": "npm-linters",
   "version": "1.0.0",
   "license": "ISC",
+  "//": "The `elm` devDependency is pinned to an exact version `>=` the `Elm.language_version` (`VersionFormats.V0_19`) default in `src/literalizer/languages/elm.py`; keep them in sync.",
   "devDependencies": {
-    "elm": "^0.19.1-6",
+    "elm": "0.19.1-6",
     "elm-format": "^0.8.8",
     "json5": "^2.2.3",
     "tree-sitter-cli": "^0.26.8",

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -922,6 +922,9 @@ class Elm(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the exact ``elm`` dependency pin in
+    # ``.github/npm-linters/package.json``, which is pinned to a version
+    # ``>=`` this ``V0_19`` default.
     language_version: VersionFormats = VersionFormats.V0_19
     indent: str = "    "
     type_name: str = "Val"

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
Closes #2404 (part of #1933). The `elm` npm devDependency used the `^0.19.1-6` range, so the effective Elm compiler drifted with `package-lock.json` and nothing tied it to the `Elm.language_version` (`VersionFormats.V0_19`) fixture default. This pins `elm` to the exact `0.19.1-6` (the previously locked build, which is `>=` `V0_19`), updates `package-lock.json` to match so `npm ci` stays in sync (verified via `npm ci --dry-run`), and adds the bidirectional "keep them in sync" comments (a JSON-safe top-level `"//"` key in `package.json` and a reciprocal comment above `language_version` in `elm.py`), following the existing Crystal/Kotlin/Python pattern. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: pins a dev-only linter/compiler dependency and adds sync comments; no runtime/library behavior changes, only potential CI/tooling reproducibility impacts.
> 
> **Overview**
> Pins the `.github/npm-linters` `elm` devDependency to an exact `0.19.1-6` (and updates `package-lock.json` accordingly) to prevent the Elm compiler used in CI/linting from drifting.
> 
> Adds explicit "keep in sync" comments linking this pin to the default `Elm.language_version` (`VersionFormats.V0_19`) in `src/literalizer/languages/elm.py`, and introduces new Python integration fixtures for the `Python_heterogeneous_strategy_record` output for heterogeneous tuples (pair/triple, top-level and record-field cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e831080767d08154276a87018bd6e28c264255e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->