### PR TITLE
Pin Objective-C lint runner to macos-15; sync with language_version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1791,7 +1791,14 @@ jobs:
         run: xargs -0 -P "$(nproc)" -n1 v run < /tmp/files-to-lint
 
   lint-objectivec:
-    runs-on: macos-latest
+    # ``macos-15`` pins the runner image (the current ``macos-latest``
+    # alias) so the Apple ``clang`` it ships stays fixed. That clang
+    # supports the Objective-C 2.0 (``V2``) language generation that
+    # ``ObjectiveC.language_version`` in
+    # ``src/literalizer/languages/objective_c.py`` defaults to; keep them
+    # in sync. ``V2`` is a fixed language generation, so the pin is for
+    # build reproducibility, not to track a moving standard.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1827,7 +1834,12 @@ jobs:
           xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 bash /tmp/run-objc.sh < /tmp/files-to-lint
 
   lint-objectivec-tidy:
-    runs-on: macos-latest
+    # ``macos-15`` pins the runner image to match ``lint-objectivec`` so
+    # the Apple ``clang`` headers that Homebrew ``clang-tidy`` parses stay
+    # fixed against the Objective-C 2.0 (``V2``)
+    # ``ObjectiveC.language_version`` default in
+    # ``src/literalizer/languages/objective_c.py``; keep them in sync.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
         with:

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -647,6 +647,10 @@ class ObjectiveC(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``macos-15`` runner image pinned for the
+    # ``lint-objectivec`` / ``lint-objectivec-tidy`` jobs in
+    # ``.github/workflows/lint.yml``, whose Apple ``clang`` supports this
+    # Objective-C 2.0 (``V2``) language generation.
     language_version: VersionFormats = VersionFormats.V2
     indent: str = "    "
 

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
Closes #2416.

The `lint-objectivec` / `lint-objectivec-tidy` jobs ran on `macos-latest`, so the Apple `clang` (and Homebrew `llvm` `clang-tidy`) building the Objective-C fixtures drifted with the runner image; both are now pinned to `macos-15` (the image `macos-latest` currently resolves to, so no behaviour change) for build reproducibility. Added the bidirectional "keep them in sync" comments at both pin sites and the `ObjectiveC.language_version` (`V2`) declaration in `objective_c.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern. `V2` (Objective-C 2.0) is a fixed language generation, so the pin is purely for reproducibility. No CHANGELOG entry, matching the sibling sync-comment PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only pins GitHub Actions runner images for Objective-C linting and adds/updates fixture goldens, with no runtime or core logic changes.
> 
> **Overview**
> Pins the `lint-objectivec` and `lint-objectivec-tidy` GitHub Actions jobs from `macos-latest` to `macos-15` to keep Apple `clang`/headers stable for reproducible Objective-C fixture builds, and adds explicit “keep in sync” documentation tying the pin to `ObjectiveC.language_version` (`V2`).
> 
> Adds new Python integration golden fixtures for heterogeneous tuple data (pair/triple, top-level and record-field variants) under `tests/integration/cases/*/Python_heterogeneous_strategy_record@py39.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0095be7b89899eb6f6aaaa24ef268767703c5e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->