### PR TITLE
Pin lint toolchain version: PowerShell

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,21 @@ jobs:
           curl -fsSL https://github.com/wren-lang/wren-cli/releases/download/0.4.0/wren-cli-linux-0.4.0.zip -o /tmp/wren.zip
           unzip -o /tmp/wren.zip -d /tmp/wren
           sudo install /tmp/wren/wren-cli-linux-0.4.0/wren_cli /usr/local/bin/wren_cli
+      # ``ubuntu-latest`` preinstalls a ``pwsh``, but that runner default
+      # drifts, so install an explicit release and put it first on
+      # ``PATH`` for the ``Lint PowerShell`` / ``Run PowerShell files``
+      # steps. The pinned PowerShell ``7.4.6`` (LTS) is ``>=`` the ``V7``
+      # default of ``PowerShell.language_version`` in
+      # ``src/literalizer/languages/powershell.py``; keep them in sync.
+      # PowerShell has no ``--langversion``-style flag, so the pinned
+      # release is the only mechanism for pinning the language version.
+      - name: Install PowerShell
+        run: |-
+          mkdir -p /tmp/powershell
+          curl -fsSL https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/powershell-7.4.6-linux-x64.tar.gz \
+            | tar -xz -C /tmp/powershell
+          chmod +x /tmp/powershell/pwsh
+          echo "/tmp/powershell" >> "$GITHUB_PATH"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -497,6 +497,13 @@ class PowerShell(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the pinned PowerShell release downloaded in the
+    # ``Install PowerShell`` step of ``.github/workflows/lint.yml``.
+    # ``ubuntu-latest`` ships a drifting ``pwsh``, so that step installs
+    # an explicit release whose version is ``>=`` this ``V7`` default.
+    # PowerShell has no ``--langversion``-style flag, so the pinned
+    # release is the only mechanism for pinning the language version;
+    # ``V7`` maps to PowerShell 7.
     language_version: VersionFormats = VersionFormats.V7
     indent: str = "    "
 

--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
**PowerShell lint pin (#2407, part of #1933):** the `lint-fast` CI job relied on the `pwsh` preinstalled on `ubuntu-latest`, so the PowerShell version drifted away from the `PowerShell.language_version` `V7` default. This adds an `Install PowerShell` step that downloads an explicit PowerShell 7.4.6 (LTS, `>=` the `V7` default) and prepends it to `PATH`, with bidirectional "keep in sync" comments at the pin site and the `language_version` declaration in `powershell.py` (following the existing Wren/Dhall/Nim pattern). Closes #2407.

**CI fix (pre-existing main bug):** the previously merged #2419 (Python opt-in RECORD strategy) added the `Python_heterogeneous_strategy_record` variant but never committed its golden files for the four `tuple_*` variant-only case dirs, so the `build` job failed on every platform with "File not found in data directory"; this adds the four missing `@py39` goldens (each compiles and executes cleanly and the full golden suite now passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI toolchain pinning and adding a few Python integration golden fixtures, with no production logic changes.
> 
> **Overview**
> The `lint-fast` GitHub Actions job now installs a pinned PowerShell `7.4.6` and prepends it to `PATH` so `Lint PowerShell`/`Run PowerShell files` no longer depend on the drifting `ubuntu-latest` preinstall.
> 
> Adds bidirectional “keep in sync” comments between the workflow pin and `PowerShell.language_version` (`V7`) in `src/literalizer/languages/powershell.py`, and introduces new Python 3.9 integration golden files covering the `Python_heterogeneous_strategy_record` behavior for heterogeneous tuples (pair/triple, top-level and record-field cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65032c8edc41d07871fecd119f5a74f22c3040c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->