### PR TITLE
Add Python RECORD goldens for tuple_* case dirs

### DIFF
--- a/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+    ),
+)

--- a/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_pair_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+)

--- a/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_record_field/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import dataclasses
+@dataclasses.dataclass(frozen=True)
+class Record0:
+    call: str
+    args: tuple[int | str | bool, ...]
+my_data = Record0(
+    call="send",
+    args=(
+        1,
+        "email",
+        True,
+    ),
+)

--- a/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
+++ b/tests/integration/cases/tuple_triple_top_level/Python_heterogeneous_strategy_record@py39.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+my_data = (
+    1,
+    "email",
+    True,
+)


### PR DESCRIPTION
`main` is red: `test_format_variant_golden_file[Python]` has four missing-golden subfailures.

The Python opt-in `RECORD` `heterogeneous_strategy` (#2419) and the `tuple_*` case dirs (#2327) landed in separate PRs. The `Python_heterogeneous_strategy_record` variant was never regenerated against `tuple_pair_record_field`, `tuple_pair_top_level`, `tuple_triple_record_field`, and `tuple_triple_top_level`, so the variant golden test enumerates a combination with no committed goldens.

This regenerates the four missing goldens, matching the existing Go/Kotlin/Java/Scala `heterogeneous_strategy_record` goldens already present in those dirs:

- record-shaped inputs become a frozen `@dataclasses.dataclass` with a tuple-typed field
- bare top-level heterogeneous lists fall back to a plain tuple

Each file compiles (`py_compile`) and executes under Python, satisfying the Python lint gate. The full `tests/integration/test_literalize_golden.py` module passes locally (24855 subtests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only new Python golden outputs for integration tests, with no production code or runtime behavior changes.
> 
> **Overview**
> Adds four missing Python `Python_heterogeneous_strategy_record@py39.py` golden files for the `tuple_pair_*` and `tuple_triple_*` integration cases.
> 
> Record-shaped inputs now have expected frozen `@dataclasses.dataclass` wrappers with heterogeneous `tuple[...]` field types, while top-level heterogeneous values are represented as plain tuples, unblocking the `test_format_variant_golden_file[Python]` variant coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63d63d5e0c63fd8cf5e82d7cc584938e4eef0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->