### PR TITLE
Pin PureScript lint toolchain version (#2399)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -971,9 +971,14 @@ jobs:
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: latest
+      # ``purescript: 0.15.15`` is ``>=`` the ``V0_15`` (PureScript
+      # 0.15.x) default of ``PureScript.language_version`` in
+      # ``src/literalizer/languages/purescript.py``; keep them in sync.
+      # Without an explicit pin ``setup-purescript`` installs whatever
+      # ``purescript: latest`` resolves to and drifts.
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: latest
+          purescript: 0.15.15
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -1056,6 +1056,9 @@ class PureScript(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # ``V0_15`` (PureScript 0.15.x) matches the ``purescript: 0.15.15``
+    # pin in the ``lint-haskell-family`` job of
+    # ``.github/workflows/lint.yml``; keep them in sync.
     language_version: VersionFormats = VersionFormats.V0_15
     indent: str = "    "
     type_name: str = "Val"


### PR DESCRIPTION
Part of #1933. Closes #2399.

`PureScript.language_version` defaults to `VersionFormats.V0_15`, but the `lint-haskell-family` job used `purescript: latest`, so the installed PureScript drifted.

- Replace `latest` with an explicit `0.15.15` pin (`>=` the `V0_15` default).
- Add the bidirectional "keep them in sync" comment at the pin site in `.github/workflows/lint.yml` and the `language_version` declaration in `src/literalizer/languages/purescript.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern.

(`yamlfix` renders the version unquoted as `0.15.15`; it stays a YAML string since it is not numeric.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that pins the PureScript toolchain to avoid drift; no runtime or production code paths are modified beyond comments.
> 
> **Overview**
> Makes PureScript linting deterministic by pinning `purescript-contrib/setup-purescript` from `latest` to `0.15.15` in the `lint-haskell-family` GitHub Actions job.
> 
> Adds mirrored “keep in sync” comments in `.github/workflows/lint.yml` and `src/literalizer/languages/purescript.py` tying the CI pin to the default `PureScript.language_version` (`V0_15`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f003ba979911598d6e4ea64cbe8bb013d2c185d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->