### PR TITLE
Pin lint toolchain version: R

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1468,6 +1468,11 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           windows-path-include-rtools: false
+          # `4.4.0` is `>=` the `R.language_version` default (`V4`) in
+          # `src/literalizer/languages/r.py`; keep them in sync. Without
+          # this pin `setup-r` installs whatever it considers `release`,
+          # so the R that compiles the fixtures drifts.
+          r-version: 4.4.0
       - name: Check R syntax
         run: xargs -0 Rscript -e 'for (f in commandArgs(trailingOnly=TRUE)) parse(file=f)'
           < /tmp/files-to-lint

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -533,6 +533,10 @@ class R(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the `r-version` pin passed to
+    # `r-lib/actions/setup-r` in the `lint-r` job of
+    # `.github/workflows/lint.yml`; `V4` maps to R `4.x`, and that pin
+    # (`4.4.0`) must stay `>=` this default.
     language_version: VersionFormats = VersionFormats.V4
     indent: str = "    "
 


### PR DESCRIPTION
**R lint pin (#2397, part of #1933):** the `lint-r` CI job used `r-lib/actions/setup-r@v2` with no `r-version` input, so the installed R drifted away from the `R.language_version` `V4` default in `src/literalizer/languages/r.py`. This adds an explicit `r-version: 4.4.0` (`>=` the `V4` default) to the setup step, with bidirectional "keep them in sync" comments at the pin site and the `language_version` declaration in `r.py`, following the existing Dart/Kotlin/Elixir pattern.

`yamlfix` canonicalised the pin to unquoted `4.4.0` (already an unambiguous string given the two dots); `actionlint`/`zizmor`/`yamlfix` all pass.

Closes #2397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that pins the R toolchain version to avoid drift; primary impact is potential CI breakage if the chosen R version is unavailable on runners.
> 
> **Overview**
> Pins the `lint-r` GitHub Actions job to install **R 4.4.0** via `r-lib/actions/setup-r`, preventing fixture compilation/runtime from drifting with whatever `setup-r` considers “release”.
> 
> Adds cross-referenced comments in `.github/workflows/lint.yml` and `src/literalizer/languages/r.py` to keep the CI pin aligned with the default `R.language_version` (`V4`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1123f081444680786e85813bf2131ada433da528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->