### PR TITLE
Port record_shape_names to the Scala RECORD strategy (#2332)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Scala` gains the same ``record_shape_names``
+  constructor parameter, a ``Mapping[frozenset[str], str]`` from a
+  record shape's key-set to a custom ``case class`` name.  A mapped
+  shape is declared and rendered with the given name instead of the
+  auto-generated ``RecordN``; the ``record_struct_name_prefix`` counter
+  advances only for the shapes with no custom name.  Names are
+  validated as PascalCase Scala identifiers that do not collide with
+  the auto ``{prefix}{N}`` pattern or each other, raising
+  :class:`~literalizer.exceptions.InvalidRecordNameError`.  Its
+  ``supports_record_shape_names`` language-class flag is now ``True``.
+  See #2332.
+
 - :class:`~literalizer.Python` gains an opt-in ``RECORD``
   ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
   :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -3,7 +3,8 @@
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+import re
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar
@@ -108,7 +109,10 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import OrderedMap, Value
-from literalizer.exceptions import NullInCollectionError
+from literalizer.exceptions import (
+    InvalidRecordNameError,
+    NullInCollectionError,
+)
 
 
 @beartype
@@ -277,6 +281,8 @@ _SCALA_UNTYPED_OPENERS: dict[str, str] = {
 _SCALA_INT32_MIN = -(2**31)
 _SCALA_INT32_MAX = 2**31 - 1
 
+_PASCAL_CASE_IDENTIFIER = re.compile(pattern=r"^[A-Z][A-Za-z0-9_]*$")
+
 
 @beartype
 def _scala_record_field_identifier(key: str, /) -> str:
@@ -361,7 +367,7 @@ class Scala(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = True
-    supports_record_shape_names = False
+    supports_record_shape_names = True
     supports_non_string_dict_keys = False
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
@@ -779,6 +785,10 @@ class Scala(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     record_struct_name_prefix: str = "Record"
+    record_shape_names: Mapping[frozenset[str], str] = dataclasses.field(
+        default_factory=lambda: MappingProxyType(mapping={}),
+        hash=False,
+    )
     # Keep in sync with the `-S` flag passed to `scala-cli run` in
     # `.github/workflows/lint.yml` (which only accepts the Scala major
     # version, so `V3` maps to `-S 3`).
@@ -798,6 +808,51 @@ class Scala(metaclass=LanguageCls):
     static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
+
+    def __post_init__(self) -> None:
+        """Validate ``record_shape_names`` after construction."""
+        self._validate_record_naming()
+
+    def _validate_record_naming(self) -> None:
+        """Validate ``record_shape_names`` for PascalCase identifier
+        shape, collisions with the auto-generated ``{prefix}{N}``
+        struct names, and duplicate target names.
+
+        Ported from
+        :meth:`literalizer.languages.Rust._validate_record_naming`.
+        Scala has no ``heterogeneous_value_enum_name`` so that
+        collision check does not apply, and Rust's reserved-keyword
+        check is unnecessary here: every Scala keyword is lowercase,
+        so the PascalCase requirement already rejects every one of
+        them.
+        """
+        prefix = self.record_struct_name_prefix
+        auto_name_pattern = re.compile(
+            pattern=rf"^{re.escape(pattern=prefix)}\d+$",
+        )
+        seen_names: set[str] = set()
+        for keys, name in self.record_shape_names.items():
+            if not _PASCAL_CASE_IDENTIFIER.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which is not a PascalCase Scala "
+                    f"identifier."
+                )
+                raise InvalidRecordNameError(msg)
+            if auto_name_pattern.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which collides with the "
+                    f"auto-generated {prefix!r}-prefixed struct names."
+                )
+                raise InvalidRecordNameError(msg)
+            if name in seen_names:
+                msg = (
+                    f"record_shape_names maps multiple key-sets to "
+                    f"{name!r}; struct names must be unique."
+                )
+                raise InvalidRecordNameError(msg)
+            seen_names.add(name)
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -927,11 +982,7 @@ class Scala(metaclass=LanguageCls):
         """Scala syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
-            # Scala does not yet expose a ``record_shape_names``
-            # constructor field (ported with its own RECORD work); an
-            # empty mapping keeps every shape on the auto
-            # ``{prefix}{N}`` names.
-            record_shape_names=MappingProxyType(mapping={}),
+            record_shape_names=self.record_shape_names,
             field_identifier=_scala_record_field_identifier,
             field_type=self._scala_record_field_type,
             render_declaration=_scala_render_declaration,

--- a/tests/errors/test_record_naming_errors.py
+++ b/tests/errors/test_record_naming_errors.py
@@ -5,7 +5,7 @@
 import pytest
 
 from literalizer.exceptions import InvalidRecordNameError
-from literalizer.languages import Go, Kotlin, Rust
+from literalizer.languages import Go, Kotlin, Rust, Scala
 
 
 @pytest.mark.parametrize(
@@ -129,6 +129,43 @@ def test_kotlin_duplicate_shape_names_raises() -> None:
     """
     with pytest.raises(expected_exception=InvalidRecordNameError):
         Kotlin(
+            record_shape_names={
+                frozenset({"id", "name"}): "Task",
+                frozenset({"id", "title"}): "Task",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    argnames="name",
+    argvalues=["task", "My-Task", "9Task"],
+)
+def test_scala_invalid_shape_name_raises(name: str) -> None:
+    """Values in Scala's ``record_shape_names`` must be PascalCase
+    identifiers.
+
+    Scala has no PascalCase reserved keyword (every Scala keyword is
+    lowercase), so the PascalCase check is the only name-shape gate.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Scala(record_shape_names={frozenset({"id", "name"}): name})
+
+
+def test_scala_shape_name_collides_with_auto_generated_raises() -> None:
+    """A mapped struct name that matches the auto-generated
+    ``{prefix}{N}`` pattern is rejected because the user-named record
+    would clash with an index-named record at render time.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Scala(record_shape_names={frozenset({"id", "name"}): "Record0"})
+
+
+def test_scala_duplicate_shape_names_raises() -> None:
+    """Two distinct key-sets cannot map to the same Scala struct
+    name.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Scala(
             record_shape_names={
                 frozenset({"id", "name"}): "Task",
                 frozenset({"id", "title"}): "Task",

--- a/tests/integration/cases/record_named_nested_record/Scala_record_shape_names_Task@v3.scala
+++ b/tests/integration/cases/record_named_nested_record/Scala_record_shape_names_Task@v3.scala
@@ -1,0 +1,16 @@
+object Fixture_record_named_nested_record_Scala_record_shape_names_Task {
+case class Task(id: Int, description: String, is_done: Boolean, blocks: List[Int])
+case class Record0(project: String, lead_task: Task)
+val my_data = Record0(
+    project = "alpha",
+    lead_task = Task(
+        id = 100,
+        description = "first task",
+        is_done = false,
+        blocks = List[Int](
+            102,
+            103,
+        ),
+    ),
+)
+}

--- a/tests/integration/cases/record_named_shape/Scala_record_shape_names_Task@v3.scala
+++ b/tests/integration/cases/record_named_shape/Scala_record_shape_names_Task@v3.scala
@@ -1,0 +1,7 @@
+object Fixture_record_named_shape_Scala_record_shape_names_Task {
+case class Task(id: Int, description: String, is_done: Boolean, blocks: List[Int])
+val my_data = List(
+    Task(id = 100, description = "first task", is_done = false, blocks = List[Int](102, 103)),
+    Task(id = 101, description = "second task", is_done = true, blocks = List[Int](100)),
+)
+}


### PR DESCRIPTION
Adds the `record_shape_names` constructor field to `Scala` (a `Mapping[frozenset[str], str]` from a record shape's key-set to a custom `case class` name), threaded into the shared `RecordRenderer`, with `__post_init__` validation for PascalCase identifiers, auto-`{prefix}{N}` collisions, and duplicate targets, raising `InvalidRecordNameError`. The reserved-keyword and `heterogeneous_value_enum_name` collision checks from Rust are intentionally omitted (every Scala keyword is lowercase, and Scala has no `heterogeneous_value_enum_name`), matching the established Go/Kotlin precedent and the 100%-coverage gate. Flips `supports_record_shape_names` to `True`, adds Scala validation tests, the auto-discovered goldens in both `record_named_shape` and `record_named_nested_record` (compiled locally with `scala-cli run -S 3`), and a CHANGELOG entry. Closes #2332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Scala’s RECORD naming/validation behavior and threads new user-provided names into generated `case class` declarations/literals; mistakes could cause name collisions or invalid generated Scala, though guarded by new validation and golden tests.
> 
> **Overview**
> Adds opt-in custom naming for Scala `RECORD` rendering via a new `Scala.record_shape_names: Mapping[frozenset[str], str]`, allowing specific record shapes to emit `case class Task(...)` (and `Task(...)` literals) instead of auto `RecordN` names, while only incrementing the `record_struct_name_prefix` counter for unmapped shapes.
> 
> Implements Scala-side validation in `__post_init__` (PascalCase identifier check, rejection of `{prefix}{N}` collisions, and duplicate mapped names) raising `InvalidRecordNameError`, flips `Scala.supports_record_shape_names` to `True`, and adds unit + integration golden fixtures plus a CHANGELOG entry documenting the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39cf89b8e03cb870e19acfce0abb5c17a9c618a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->