### PR TITLE
Pin lint toolchain version: Racket

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1727,7 +1727,16 @@ jobs:
         shell: bash
         run: find tests/integration/cases -name '*.rkt' -print0 > /tmp/files-to-lint
           && test -s /tmp/files-to-lint
+      # The pinned Racket ``8.17`` is ``>=`` the ``V8`` default of
+      # ``Racket.language_version`` in
+      # ``src/literalizer/languages/racket.py``; keep them in sync.
+      # Racket has no ``--langversion``-style flag, so the pinned
+      # release is the only mechanism for pinning the language version.
+      # Without an explicit ``version`` the installed Racket drifts
+      # with the ``setup-racket`` action default.
       - uses: Bogdanp/setup-racket@v1.15
+        with:
+          version: '8.17'
       - name: Check Racket syntax
         run: xargs -0 raco make < /tmp/files-to-lint
       - name: Run Racket files

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -440,6 +440,12 @@ class Racket(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``version`` pin passed to
+    # ``Bogdanp/setup-racket`` in the ``lint-racket`` job of
+    # ``.github/workflows/lint.yml``. Racket has no
+    # ``--langversion``-style flag, so the pinned release is the only
+    # mechanism for pinning the language version; the pin (``8.17``) is
+    # ``>=`` the ``V8`` default.
     language_version: VersionFormats = VersionFormats.V8
     indent: str = "    "
 


### PR DESCRIPTION
Pass an explicit Racket `8.17` (>= the `Racket.language_version` `V8` default) to `Bogdanp/setup-racket` in the `lint-racket` CI job, instead of relying on the drifting `setup-racket` action default. Racket has no `--langversion`-style flag, so the pinned release is the only mechanism for pinning the language version.

Bidirectional "keep in sync" comments are added at the pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `src/literalizer/languages/racket.py`, following the existing Lua/Dhall/Wren/PowerShell/PHP/Python pattern.

Part of #1933. Closes #2398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins the Racket toolchain version to avoid drift, with no runtime or production code behavior changes.
> 
> **Overview**
> Pins the `lint-racket` GitHub Actions job to install Racket `8.17` via `Bogdanp/setup-racket` instead of relying on the action’s drifting default, improving CI reproducibility.
> 
> Adds *bidirectional “keep in sync”* comments linking the workflow’s Racket pin to `Racket.language_version` (`VersionFormats.V8`) in `src/literalizer/languages/racket.py` to prevent future version mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f33d2610eddff32610fbdda50a26870fda485a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->