### PR TITLE
Port record_shape_names to the Java RECORD strategy (#2333)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,20 @@ Next
   and the default (``ERROR``) plain-``dict`` output is unchanged.  See
   #2419.
 
+- :class:`~literalizer.Java` gains the same ``record_shape_names``
+  constructor parameter (already on :class:`~literalizer.Rust`,
+  :class:`~literalizer.Go` and :class:`~literalizer.Kotlin`), a
+  ``Mapping[frozenset[str], str]`` from a record shape's key-set to a
+  custom ``record`` name.  A mapped shape is declared and rendered with
+  the given name instead of the auto-generated ``RecordN``; the
+  ``record_struct_name_prefix`` counter advances only for the shapes
+  with no custom name.  Names are validated as PascalCase Java
+  identifiers that do not collide with the auto ``{prefix}{N}`` pattern,
+  the wrapper class name (``module_name``), or each other, raising
+  :class:`~literalizer.exceptions.InvalidRecordNameError`.  Its
+  ``supports_record_shape_names`` language-class flag is now ``True``.
+  See #2333.
+
 2026.05.16
 ----------
 

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -4,7 +4,8 @@ import dataclasses
 import datetime
 import enum
 import functools
-from collections.abc import Callable, Sequence
+import re
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import Any, ClassVar, assert_never
@@ -103,8 +104,11 @@ from literalizer._language import (
 from literalizer._types import OrderedMap, Scalar, Value
 from literalizer.exceptions import (
     IncompatibleFormatsError,
+    InvalidRecordNameError,
     NullInCollectionError,
 )
+
+_PASCAL_CASE_IDENTIFIER = re.compile(pattern=r"^[A-Z][A-Za-z0-9_]*$")
 
 
 class _JavaModifiers(enum.Enum):
@@ -686,7 +690,7 @@ class Java(metaclass=LanguageCls):
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
     supports_record_struct_name_prefix = True
-    supports_record_shape_names = False
+    supports_record_shape_names = True
     supports_non_string_dict_keys = True
 
     format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
@@ -1066,6 +1070,59 @@ class Java(metaclass=LanguageCls):
             and self.language_version is not jdk_16
         ):
             object.__setattr__(self, "language_version", jdk_16)
+        self._validate_record_naming()
+
+    def _validate_record_naming(self) -> None:
+        """Validate ``record_shape_names`` for PascalCase identifier
+        shape, collisions with the auto-generated ``{prefix}{N}``
+        record names, collisions with the wrapper class name, and
+        duplicate target names.
+
+        Ported from
+        :meth:`literalizer.languages.Rust._validate_record_naming`.
+        Java has no ``heterogeneous_value_enum_name`` so that collision
+        check does not apply, and Rust's reserved-keyword check is
+        unnecessary here: every Java keyword is lowercase, so the
+        PascalCase requirement already rejects every one of them.  Java
+        records are emitted as top-level types before
+        ``class {module_name}`` (default ``Module``, ``Main`` in the
+        golden harness), so a custom name must not collide with that
+        wrapper class either.
+        """
+        prefix = self.record_struct_name_prefix
+        auto_name_pattern = re.compile(
+            pattern=rf"^{re.escape(pattern=prefix)}\d+$",
+        )
+        seen_names: set[str] = set()
+        for keys, name in self.record_shape_names.items():
+            if not _PASCAL_CASE_IDENTIFIER.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which is not a PascalCase Java "
+                    f"identifier."
+                )
+                raise InvalidRecordNameError(msg)
+            if name == self.module_name:
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which collides with the wrapper "
+                    f"class name (module_name)."
+                )
+                raise InvalidRecordNameError(msg)
+            if auto_name_pattern.match(string=name):
+                msg = (
+                    f"record_shape_names entry for keys {sorted(keys)!r} "
+                    f"maps to {name!r}, which collides with the "
+                    f"auto-generated {prefix!r}-prefixed record names."
+                )
+                raise InvalidRecordNameError(msg)
+            if name in seen_names:
+                msg = (
+                    f"record_shape_names maps multiple key-sets to "
+                    f"{name!r}; record names must be unique."
+                )
+                raise InvalidRecordNameError(msg)
+            seen_names.add(name)
 
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid code for *data*.
@@ -1320,6 +1377,10 @@ class Java(metaclass=LanguageCls):
     # Keep those literals in sync with `VersionFormats` above.
     language_version: VersionFormats = VersionFormats.JDK_11
     record_struct_name_prefix: str = "Record"
+    record_shape_names: Mapping[frozenset[str], str] = dataclasses.field(
+        default_factory=lambda: MappingProxyType(mapping={}),
+        hash=False,
+    )
     indent: str = "    "
 
     null_literal: ClassVar[str] = "null"
@@ -1468,11 +1529,7 @@ class Java(metaclass=LanguageCls):
         """Java syntax hooks for the ``RECORD`` strategy."""
         return RecordRenderer(
             name_prefix=self.record_struct_name_prefix,
-            # Java does not yet expose a ``record_shape_names``
-            # constructor field (ported with its own RECORD work); an
-            # empty mapping keeps every shape on the auto
-            # ``{prefix}{N}`` names.
-            record_shape_names=MappingProxyType(mapping={}),
+            record_shape_names=self.record_shape_names,
             field_identifier=_java_record_field_identifier,
             field_type=self._java_record_field_type,
             render_declaration=_java_render_declaration,

--- a/tests/errors/test_record_naming_errors.py
+++ b/tests/errors/test_record_naming_errors.py
@@ -5,7 +5,7 @@
 import pytest
 
 from literalizer.exceptions import InvalidRecordNameError
-from literalizer.languages import Go, Kotlin, Rust
+from literalizer.languages import Go, Java, Kotlin, Rust
 
 
 @pytest.mark.parametrize(
@@ -129,6 +129,56 @@ def test_kotlin_duplicate_shape_names_raises() -> None:
     """
     with pytest.raises(expected_exception=InvalidRecordNameError):
         Kotlin(
+            record_shape_names={
+                frozenset({"id", "name"}): "Task",
+                frozenset({"id", "title"}): "Task",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    argnames="name",
+    argvalues=["task", "My-Task", "9Task"],
+)
+def test_java_invalid_shape_name_raises(name: str) -> None:
+    """Values in Java's ``record_shape_names`` must be PascalCase
+    identifiers.
+
+    Java has no PascalCase reserved keyword (every Java keyword is
+    lowercase), so the PascalCase check is the only name-shape gate.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Java(record_shape_names={frozenset({"id", "name"}): name})
+
+
+def test_java_shape_name_collides_with_module_name_raises() -> None:
+    """A mapped record name that matches ``module_name`` is rejected
+    because Java records are emitted as top-level types alongside the
+    ``class {module_name}`` wrapper, so the two declarations would
+    share an identifier.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Java(
+            module_name="Task",
+            record_shape_names={frozenset({"id", "name"}): "Task"},
+        )
+
+
+def test_java_shape_name_collides_with_auto_generated_raises() -> None:
+    """A mapped record name that matches the auto-generated
+    ``{prefix}{N}`` pattern is rejected because the user-named record
+    would clash with an index-named record at render time.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Java(record_shape_names={frozenset({"id", "name"}): "Record0"})
+
+
+def test_java_duplicate_shape_names_raises() -> None:
+    """Two distinct key-sets cannot map to the same Java record
+    name.
+    """
+    with pytest.raises(expected_exception=InvalidRecordNameError):
+        Java(
             record_shape_names={
                 frozenset({"id", "name"}): "Task",
                 frozenset({"id", "title"}): "Task",

--- a/tests/integration/cases/record_named_nested_record/Java_record_shape_names_Task@jdk_16.java
+++ b/tests/integration/cases/record_named_nested_record/Java_record_shape_names_Task@jdk_16.java
@@ -1,0 +1,19 @@
+import java.util.Map;
+record Task(int id, String description, boolean is_done, int[] blocks) {}
+record Record0(String project, Task lead_task) {}
+class Module {
+    public static void module() {
+var my_data = new Record0(
+    "alpha",
+    new Task(
+        100,
+        "first task",
+        false,
+        new int[]{
+            102,
+            103
+        }
+    )
+);
+    }
+}

--- a/tests/integration/cases/record_named_nested_record/Java_record_shape_names_Task@jdk_16.java
+++ b/tests/integration/cases/record_named_nested_record/Java_record_shape_names_Task@jdk_16.java
@@ -1,8 +1,8 @@
 import java.util.Map;
 record Task(int id, String description, boolean is_done, int[] blocks) {}
 record Record0(String project, Task lead_task) {}
-class Module {
-    public static void module() {
+class Main {
+    public static void main() {
 var my_data = new Record0(
     "alpha",
     new Task(

--- a/tests/integration/cases/record_named_shape/Java_record_shape_names_Task@jdk_16.java
+++ b/tests/integration/cases/record_named_shape/Java_record_shape_names_Task@jdk_16.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+record Task(int id, String description, boolean is_done, int[] blocks) {}
+class Module {
+    public static void module() {
+var my_data = new Object[]{
+    new Task(100, "first task", false, new int[]{102, 103}),
+    new Task(101, "second task", true, new int[]{100})
+};
+    }
+}

--- a/tests/integration/cases/record_named_shape/Java_record_shape_names_Task@jdk_16.java
+++ b/tests/integration/cases/record_named_shape/Java_record_shape_names_Task@jdk_16.java
@@ -1,7 +1,7 @@
 import java.util.Map;
 record Task(int id, String description, boolean is_done, int[] blocks) {}
-class Module {
-    public static void module() {
+class Main {
+    public static void main() {
 var my_data = new Object[]{
     new Task(100, "first task", false, new int[]{102, 103}),
     new Task(101, "second task", true, new int[]{100})

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -916,7 +916,7 @@ def build_record_shape_names_variants() -> Iterable[Variant]:
         # builder bypasses it): a language whose ``wrap_in_file``
         # introduces a named scope (e.g. Java's ``class {module_name}``,
         # which its CI lint host loads as ``Main``) needs the same
-        # ``"main"`` name the other goldens use.
+        # ``"main"`` name that :func:`make_spec` uses.
         if lang_cls.supports_module_name:
             spec_kwargs["module_name"] = lang_cls.module_name_case.convert(
                 name="main",

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -908,10 +908,20 @@ def build_record_shape_names_variants() -> Iterable[Variant]:
             for strategy in default_spec.heterogeneous_strategies
             if strategy.name == "RECORD"
         )
-        spec = lang_cls(
-            heterogeneous_strategy=record_strategy,
-            record_shape_names={shape_keys: custom_name},
-        )
+        spec_kwargs: dict[str, object] = {
+            "heterogeneous_strategy": record_strategy,
+            "record_shape_names": {shape_keys: custom_name},
+        }
+        # Mirror :func:`make_spec`'s ``module_name`` default (this
+        # builder bypasses it): a language whose ``wrap_in_file``
+        # introduces a named scope (e.g. Java's ``class {module_name}``,
+        # which its CI lint host loads as ``Main``) needs the same
+        # ``"main"`` name the other goldens use.
+        if lang_cls.supports_module_name:
+            spec_kwargs["module_name"] = lang_cls.module_name_case.convert(
+                name="main",
+            )
+        spec = lang_cls(**spec_kwargs)
         variants.append(
             Variant(
                 name=(f"{lang_cls.__name__}_record_shape_names_{custom_name}"),


### PR DESCRIPTION
Closes #2333.

Java gains the `record_shape_names` constructor parameter (a `Mapping[frozenset[str], str]` from a record shape's key-set to a custom `record` name) threaded into the shared `RecordRenderer`, with `supports_record_shape_names` flipped to `True`. Names are validated as PascalCase Java identifiers that do not collide with the auto `{prefix}{N}` pattern, the wrapper class name (`module_name`), or each other, raising `InvalidRecordNameError`; there is no reserved-keyword or `heterogeneous_value_enum_name` check because Java keywords are all lowercase and Java has no such attribute. Adds four Java validation tests, two auto-discovered goldens (`record_named_shape` and `record_named_nested_record`, both compiled locally under `javac --release 16`), and a `CHANGELOG.rst` entry under `Next`. Java already handles nested custom-named records correctly (it checks `request.record_name is not None`), so it does not exhibit the Kotlin #2348 bug. The metadata constructor-parity test is auto-parametrized over all languages, so no manual extension was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Java RECORD codegen behavior and adds new validation paths that can raise `InvalidRecordNameError`, affecting users who configure record naming.
> 
> **Overview**
> Adds `record_shape_names` support to Java’s `RECORD` heterogeneous strategy, threading the mapping into the shared `RecordRenderer` so record-shaped dicts can be emitted with user-chosen `record` type names instead of auto `RecordN`.
> 
> Introduces Java-side validation for custom names (PascalCase identifier, no collisions with auto `Record{N}` pattern, `module_name`, or duplicates), updates test coverage for these error cases, and adds new Java golden integration fixtures demonstrating custom-named records (including nested records).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85d9d35a244fb0b4a63d94583dbb5afae7e49cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->