### PR TITLE
Test mixed dict keys through the public API (issue #1947)

### DIFF
--- a/tests/errors/test_mixed_dict_keys.py
+++ b/tests/errors/test_mixed_dict_keys.py
@@ -1,33 +1,24 @@
-"""Heterogeneity check for dict keys.
+"""Heterogeneity check for dict keys, exercised through the public API.
 
-The check runs inside :func:`literalizer._checks.check_data` and rejects
-dicts whose keys span multiple type families when the target language
-sets ``dict_supports_heterogeneous_values = False``.  The YAML parser
-preserves non-string keys natively, so this check is reachable through
-:func:`literalizer.literalize`; the tests here invoke ``check_data``
-directly to exercise the helper contract in isolation.
+The check rejects dicts whose keys span multiple type families when
+the target language sets ``dict_supports_heterogeneous_values = False``.
+The YAML parser preserves non-string keys natively, so the check is
+reachable through :func:`literalizer.literalize`; these tests drive it
+that way (rather than calling the internal helper) so the recursion
+into nested lists and dict values is covered end to end.
 """
 
-from __future__ import annotations
-
 import re
-from typing import TYPE_CHECKING
 
 import pytest
 
-from literalizer._checks import check_data
+import literalizer
 from literalizer.exceptions import MixedDictKeysError
 from literalizer.languages import Mojo
-
-if TYPE_CHECKING:
-    from literalizer._types import Scalar, Value
 
 
 def test_mixed_int_str_keys_raise_on_homogeneous_target() -> None:
     """Mojo rejects a dict mixing ``int`` and ``str`` keys."""
-    data: dict[Scalar, Value] = {}
-    data[1] = "a"
-    data["x"] = "b"
     expected_msg = re.escape(
         pattern="Dict contains keys of mixed types that cannot be "
         "represented in the target language "
@@ -37,64 +28,72 @@ def test_mixed_int_str_keys_raise_on_homogeneous_target() -> None:
         expected_exception=MixedDictKeysError,
         match=f"^{expected_msg}$",
     ):
-        check_data(data=data, spec=Mojo())
+        literalizer.literalize(
+            source="1: a\nx: b\n",
+            input_format=literalizer.InputFormat.YAML,
+            language=Mojo(),
+            variable_form=literalizer.NewVariable(name="my_data"),
+        )
 
 
 def test_mixed_bool_int_keys_raise_on_homogeneous_target() -> None:
     """``bool`` and ``int`` are distinct type families for key
     checking.
     """
-    data: dict[Scalar, Value] = {}
-    data[True] = "a"
-    data[2] = "b"
     with pytest.raises(expected_exception=MixedDictKeysError):
-        check_data(data=data, spec=Mojo())
+        literalizer.literalize(
+            source="true: a\n2: b\n",
+            input_format=literalizer.InputFormat.YAML,
+            language=Mojo(),
+            variable_form=literalizer.NewVariable(name="my_data"),
+        )
 
 
 def test_nested_mixed_keys_raise() -> None:
     """Mixed-key dicts nested in a list raise."""
-    inner: dict[Scalar, Value] = {}
-    inner[1] = "a"
-    inner["x"] = "b"
-    data: list[Value] = [inner]
     with pytest.raises(expected_exception=MixedDictKeysError):
-        check_data(data=data, spec=Mojo())
+        literalizer.literalize(
+            source="- 1: a\n  x: b\n",
+            input_format=literalizer.InputFormat.YAML,
+            language=Mojo(),
+            variable_form=literalizer.NewVariable(name="my_data"),
+        )
 
 
 def test_mixed_keys_inside_dict_value_raise() -> None:
     """Mixed-key dicts found by descending through outer dict values
     raise.
     """
-    inner: dict[Scalar, Value] = {}
-    inner[1] = "a"
-    inner["x"] = "b"
-    data: dict[Scalar, Value] = {}
-    data["outer"] = inner
     with pytest.raises(expected_exception=MixedDictKeysError):
-        check_data(data=data, spec=Mojo())
+        literalizer.literalize(
+            source="outer:\n  1: a\n  x: b\n",
+            input_format=literalizer.InputFormat.YAML,
+            language=Mojo(),
+            variable_form=literalizer.NewVariable(name="my_data"),
+        )
 
 
 def test_mixed_keys_in_second_list_element_raise() -> None:
     """Mixed-key dicts found past a homogeneous first list element
     raise.
     """
-    inner: dict[Scalar, Value] = {}
-    inner[1] = "a"
-    inner["x"] = "b"
-    sibling: dict[Scalar, Value] = {"only": "string"}
-    data: list[Value] = [sibling, inner]
     with pytest.raises(expected_exception=MixedDictKeysError):
-        check_data(data=data, spec=Mojo())
+        literalizer.literalize(
+            source="- foo: string\n- 1: a\n  x: b\n",
+            input_format=literalizer.InputFormat.YAML,
+            language=Mojo(),
+            variable_form=literalizer.NewVariable(name="my_data"),
+        )
 
 
 def test_mixed_keys_past_set_sibling_raise() -> None:
     """Recursion skips past a set sibling before finding the mixed
     dict.
     """
-    inner: dict[Scalar, Value] = {}
-    inner[1] = "a"
-    inner["x"] = "b"
-    sibling: set[Scalar] = {1, 2}
-    data: list[Value] = [sibling, inner]
     with pytest.raises(expected_exception=MixedDictKeysError):
-        check_data(data=data, spec=Mojo())
+        literalizer.literalize(
+            source="- !!set\n  ? 1\n  ? 2\n- 1: a\n  x: b\n",
+            input_format=literalizer.InputFormat.YAML,
+            language=Mojo(),
+            variable_form=literalizer.NewVariable(name="my_data"),
+        )


### PR DESCRIPTION
Rewrites `tests/errors/test_mixed_dict_keys.py` to exercise the mixed-dict-key check through `literalizer.literalize` with YAML input instead of importing and calling the private `literalizer._checks.check_data` helper. This removes the `literalizer._checks` import and the `TYPE_CHECKING` `literalizer._types` import (plus the `dict[Scalar, Value]` annotations that existed only to satisfy pyrefly's dict invariance), clearing this file from the remaining work in issue #1947. All six scenarios (mixed int/str and bool/int keys, nesting in a list, inside a dict value, past a homogeneous sibling, and past a `!!set` sibling) are preserved as equivalent YAML inputs, keeping the exact-message assertion on the int/str case. Verified with pytest, ruff, mypy, pyright, pyrefly, ty, and pylint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that changes how the mixed-dict-key error is exercised but doesn’t modify production logic.
> 
> **Overview**
> Updates `tests/errors/test_mixed_dict_keys.py` to validate `MixedDictKeysError` through the public `literalizer.literalize` API with YAML inputs instead of calling the private `literalizer._checks.check_data` helper.
> 
> The scenarios covered remain the same (including nested/list/set traversal), while removing internal imports/type-only annotations and keeping the exact error-message assertion for the int/str-key case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3ef26e0863cc87d40a6d5f24228195aa0710c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->