### PR TITLE
Pin lint toolchain version: Tcl

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,10 @@ jobs:
       # ``src/literalizer/languages/forth.py``; keep them in sync.
       # ``ANS`` is a fixed standard, so the version pin here is for
       # reproducibility rather than language selection.
+      # The ``tcl`` apt metapackage is pinned to ``8.6.14build1`` (the
+      # Ubuntu 24.04 build of Tcl 8.6.14), which is ``>=`` the ``V8_6``
+      # (Tcl 8.6) default of ``Tcl.language_version`` in
+      # ``src/literalizer/languages/tcl.py``; keep them in sync.
       # The ``guile-3.0`` apt package pins Guile to the 3.x series,
       # which implements ``R7RS``, matching ``Scheme.language_version``
       # (``R7RS``) in ``src/literalizer/languages/scheme.py``; keep them
@@ -92,7 +96,7 @@ jobs:
       - name: Install apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: tcl gforth=0.7.3+dfsg-9build4.1 guile-3.0
+          packages: tcl=8.6.14build1 gforth=0.7.3+dfsg-9build4.1 guile-3.0
           version: 1.0
       - name: Install Dhall
         # The pinned ``dhall-haskell`` 1.42.2 binary implements Dhall

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,7 +82,7 @@ jobs:
       # ``src/literalizer/languages/forth.py``; keep them in sync.
       # ``ANS`` is a fixed standard, so the version pin here is for
       # reproducibility rather than language selection.
-      # The ``tcl`` apt metapackage is pinned to ``8.6.14build1`` (the
+      # The ``tcl`` apt package is pinned to ``8.6.14build1`` (the
       # Ubuntu 24.04 build of Tcl 8.6.14), which is ``>=`` the ``V8_6``
       # (Tcl 8.6) default of ``Tcl.language_version`` in
       # ``src/literalizer/languages/tcl.py``; keep them in sync.

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -480,6 +480,11 @@ class Tcl(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``tcl`` apt-package pin in the ``Install
+    # apt packages`` step of the ``lint-fast`` job in
+    # ``.github/workflows/lint.yml``; the pinned ``tcl`` metapackage
+    # (``8.6.14build1``) must be ``>=`` this ``V8_6`` (Tcl 8.6)
+    # default.
     language_version: VersionFormats = VersionFormats.V8_6
     indent: str = "    "
 

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -482,7 +482,7 @@ class Tcl(metaclass=LanguageCls):
     )
     # Keep in sync with the ``tcl`` apt-package pin in the ``Install
     # apt packages`` step of the ``lint-fast`` job in
-    # ``.github/workflows/lint.yml``; the pinned ``tcl`` metapackage
+    # ``.github/workflows/lint.yml``; the pinned ``tcl`` apt package
     # (``8.6.14build1``) must be ``>=`` this ``V8_6`` (Tcl 8.6)
     # default.
     language_version: VersionFormats = VersionFormats.V8_6


### PR DESCRIPTION
Part of #1933. Closes #2410.

`Tcl.language_version` defaults to `VersionFormats.V8_6`, but the `lint-fast` job installed the apt `tcl` package with no version constraint, so the installed Tcl could drift.

- Pin the apt `tcl` metapackage to `8.6.14build1` (the Ubuntu 24.04 build of Tcl 8.6.14), which is `>=` the `V8_6` default.
- Add the bidirectional "keep them in sync" comment at the pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `tcl.py`, following the existing Forth/Scheme/R/Racket/Nim pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/tooling change; main risk is CI breakage if the pinned `tcl=8.6.14build1` package becomes unavailable on `ubuntu-latest`.
> 
> **Overview**
> Ensures the `lint-fast` GitHub Actions job uses a deterministic Tcl toolchain by pinning the `tcl` apt package to `8.6.14build1`.
> 
> Adds explicit *keep-in-sync* documentation linking the CI pin to `Tcl.language_version` (`V8_6`) in `src/literalizer/languages/tcl.py` to prevent future drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de6ff58b4a9635edae1c48f96466de6ac60541e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->