### PR TITLE
Pin lint toolchain version: Bash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -173,8 +173,20 @@ jobs:
         with:
           php-version: '8.1'
 
+      # ``ubuntu-latest`` preinstalls the ``bash`` that both runs this job
+      # and lints/executes the ``.sh`` fixtures. That runner default (the
+      # 5.x series) is ``>=`` the ``V5_1`` default of
+      # ``Bash.language_version`` in ``src/literalizer/languages/bash.py``;
+      # keep them in sync. Bash has no ``--langversion``-style flag and is
+      # the workflow's own shell, so rather than swap the interpreter the
+      # runner default is the pinned floor; the ``BASH_VERSINFO`` guard
+      # below fails the job if that floor ever drifts below 5.1.
       - name: Lint Bash
         run: |-
+          if (( BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1) )); then
+            echo "bash ${BASH_VERSION} is below the pinned V5_1 floor" >&2
+            exit 1
+          fi
           find tests/integration/cases -name '*.sh' -print0 > /tmp/files-bash && test -s /tmp/files-bash
           xargs -0 bash -n < /tmp/files-bash
           xargs -0 -P "$(nproc)" -n1 bash < /tmp/files-bash

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -542,6 +542,13 @@ class Bash(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``Lint Bash`` step of
+    # ``.github/workflows/lint.yml``. ``ubuntu-latest`` preinstalls the
+    # ``bash`` that both runs and lints the fixtures; that runner default
+    # (the 5.x series) is ``>=`` this ``V5_1`` default and serves as the
+    # pinned floor. Bash has no ``--langversion``-style flag, so the
+    # runner default is the pin; the step's ``BASH_VERSINFO`` guard fails
+    # the job if it ever drifts below 5.1.
     language_version: VersionFormats = VersionFormats.V5_1
     indent: str = "    "
 

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -543,12 +543,12 @@ class Bash(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     # Keep in sync with the ``Lint Bash`` step of
-    # ``.github/workflows/lint.yml``. ``ubuntu-latest`` preinstalls the
-    # ``bash`` that both runs and lints the fixtures; that runner default
-    # (the 5.x series) is ``>=`` this ``V5_1`` default and serves as the
-    # pinned floor. Bash has no ``--langversion``-style flag, so the
-    # runner default is the pin; the step's ``BASH_VERSINFO`` guard fails
-    # the job if it ever drifts below 5.1.
+    # ``.github/workflows/lint.yml``. The ``bash`` preinstalled on
+    # ``ubuntu-latest`` both runs and lints the fixtures; that runner
+    # default (the 5.x series) is ``>=`` this ``V5_1`` default and serves
+    # as the pinned floor. Bash has no ``--langversion``-style flag, so
+    # the runner default is the pin; the step's ``BASH_VERSINFO`` guard
+    # fails the job if it ever drifts below 5.1.
     language_version: VersionFormats = VersionFormats.V5_1
     indent: str = "    "
 


### PR DESCRIPTION
Part of #1933. Closes #2409.

Bash comes from `ubuntu-latest`'s preinstalled binary with no pin and is the workflow's own `shell`, so rather than swap the interpreter the runner default (the bash 5.x series) is documented as the pinned floor. The `Lint Bash` step in `.github/workflows/lint.yml` now carries the bidirectional "keep in sync" comment and a `BASH_VERSINFO` guard that fails the job if bash ever drifts below the `V5_1` default of `Bash.language_version`, and a matching cross-reference comment is added at that `language_version` declaration in `src/literalizer/languages/bash.py`. This follows the established Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern and matches the scope of the merged sibling pin PRs (workflow + language module only, no CHANGELOG entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds a version guard and documentation, with no impact on runtime code paths beyond potential new lint-job failures if the runner’s Bash drops below 5.1.
> 
> **Overview**
> Aligns Bash fixture linting with the declared `Bash.language_version` default by documenting `ubuntu-latest`’s preinstalled Bash as the pinned floor and adding a `BASH_VERSINFO` check in the `Lint Bash` workflow step to fail CI if Bash is < 5.1.
> 
> Adds a matching cross-reference comment next to `language_version = VersionFormats.V5_1` in `src/literalizer/languages/bash.py` to keep the workflow and language default synchronized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 450c1fe8ee56fee2cecf04d1088f4f93423f8bc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->