### PR TITLE
Pin lint toolchain version: Nix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,8 +74,18 @@ jobs:
         uses: leafo/gh-actions-lua@v13
         with:
           luaVersion: '5.4'
+      # The pinned Nix ``2.34.7`` is in the Nix 2.x series, which is
+      # ``>=`` the ``V2`` default of ``Nix.language_version`` in
+      # ``src/literalizer/languages/nix.py``; keep them in sync. ``V2``
+      # is a fixed language generation, so the pin is for build
+      # reproducibility rather than to track a moving standard.
+      # ``cachix/install-nix-action`` has no version input, so the
+      # ``install_url`` release URL is the only mechanism for pinning
+      # the Nix version.
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.34.7/install
       # ``gforth`` is pinned to ``0.7.3+dfsg-9build4.1`` (the Ubuntu
       # 24.04 build), which implements ANS Forth, matching
       # ``Forth.language_version`` (``ANS``) in

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -529,6 +529,11 @@ class Nix(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``install_url`` Nix release pin passed to
+    # ``cachix/install-nix-action`` in the ``lint-fast`` job of
+    # ``.github/workflows/lint.yml``. ``V2`` is a fixed language
+    # generation (the Nix 2.x series), so the pin is for build
+    # reproducibility rather than to track a moving standard.
     language_version: VersionFormats = VersionFormats.V2
     indent: str = "  "
 


### PR DESCRIPTION
Pin Nix to `2.34.7` (Nix 2.x series, `>=` the `Nix.language_version` `V2` default) via the `install_url` release URL of `cachix/install-nix-action` in the `lint-fast` CI job, instead of relying on the action's unconstrained latest stable (which drifts).

`cachix/install-nix-action` has no dedicated version input, so `install_url` (`https://releases.nixos.org/nix/nix-2.34.7/install`) is the only mechanism for pinning the Nix version.

Adds bidirectional "keep in sync" comments at the pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `src/literalizer/languages/nix.py`, following the existing Lua/Tcl/Python/Odin/etc. pattern. `V2` is a fixed Nix language generation, so the pin is for build reproducibility rather than to track a moving standard.

No changelog entry (consistent with the other `Part of #1933` pin PRs).

Part of #1933. Closes #2401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins the Nix installer version for reproducibility; no runtime/application logic changes.
> 
> **Overview**
> Pins the Nix toolchain used by the `lint-fast` GitHub Actions job to `nix-2.34.7` by supplying `install_url` to `cachix/install-nix-action`, avoiding drift from the action’s implicit latest.
> 
> Adds matching “keep in sync” comments in `.github/workflows/lint.yml` and alongside `Nix.language_version` in `src/literalizer/languages/nix.py` to document the relationship between the CI pin and the language-version default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7688884471be5c53c6e99931c6805553d6dce09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->