### PR TITLE
Pin lint toolchain version: D

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1507,10 +1507,15 @@ jobs:
         shell: bash
         run: find tests/integration/cases -name '*.d' -print0 > /tmp/files-to-lint
           && test -s /tmp/files-to-lint
+      # ``compiler: dmd-2.112.0`` implements D ``>=`` the ``V2`` default
+      # of ``D.language_version`` in ``src/literalizer/languages/d.py``;
+      # keep them in sync. Every ``dmd-2.x`` release implements the D2
+      # language, so this pin tracks a concrete compiler build rather
+      # than a language standard, and avoids the ``dmd-latest`` drift.
       - name: Install DMD
         uses: dlang-community/setup-dlang@v2
         with:
-          compiler: dmd-latest
+          compiler: dmd-2.112.0
       # D derives the module name from the source filename and rejects
       # ``@`` as a non-identifier character, so copy each fixture to a
       # sanitized name before invoking ``dmd``.

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -523,6 +523,11 @@ class D(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``compiler`` input of the
+    # ``dlang-community/setup-dlang`` step in
+    # ``.github/workflows/lint.yml``. Every ``dmd-2.x`` release
+    # implements the D2 language, so the pin there is ``>=`` this
+    # ``V2`` default.
     language_version: VersionFormats = VersionFormats.V2
     indent: str = "    "
 


### PR DESCRIPTION
Part of #1933. Closes #2402.

`D.language_version` defaults to `VersionFormats.V2` in `src/literalizer/languages/d.py`. The `lint-d` job used `dlang-community/setup-dlang@v2` with `compiler: dmd-latest`, so the installed DMD drifted on every run.

## Changes

- Replace `dmd-latest` with an explicit `dmd-2.112.0` (latest stable DMD). Every `dmd-2.x` release implements the D2 language, so this pin is `>=` the `V2` default and tracks a concrete compiler build rather than a language standard.
- Add the bidirectional "keep them in sync" comment at the pin site in `.github/workflows/lint.yml` and at the `language_version` declaration in `d.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes CI toolchain pinning and adds comments; the main impact is potential CI failures if the pinned DMD version has different diagnostics than the previous floating `latest`.
> 
> **Overview**
> Makes D fixture linting deterministic by pinning the `lint-d` GitHub Actions job from `dmd-latest` to `dmd-2.112.0`, preventing toolchain drift across runs.
> 
> Adds **bidirectional “keep in sync”** documentation tying the workflow pin to the `D.language_version` default (`VersionFormats.V2`) in `src/literalizer/languages/d.py` so future bumps are reviewed together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b033894e7bacabefacff518475ab6cb35a61ceae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->