### PR TITLE
Pin lint toolchain version: Clojure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -940,11 +940,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      # ``bb: 1.12.218`` bundles Clojure 1.12.x, which is ``>=`` the
+      # ``V1_11`` (Clojure 1.11) default of ``Clojure.language_version``
+      # in ``src/literalizer/languages/clojure.py``; keep them in sync.
+      # Babashka determines the effective Clojure runtime, so it must be
+      # pinned (not ``latest``) to stop the effective version drifting.
+      # ``clj-kondo`` is a static linter, pinned for reproducibility.
       - name: Install clj-kondo and Babashka
         uses: DeLaGuardo/setup-clojure@13
         with:
-          clj-kondo: latest
-          bb: latest
+          clj-kondo: 2026.04.15
+          bb: 1.12.218
       # The pinned Apache Groovy 4.0.32 binary distribution is ``>=`` the
       # ``V4`` (Groovy 4.x) default of ``Groovy.language_version`` in
       # ``src/literalizer/languages/groovy.py``; keep them in sync. The

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -436,8 +436,9 @@ class Clojure(metaclass=LanguageCls):
     )
     # ``V1_11`` (Clojure 1.11) is ``<=`` the Clojure 1.12.x bundled by
     # the ``bb: 1.12.218`` pin in the ``lint-jvm-mini`` job of
-    # ``.github/workflows/lint.yml`` (Babashka determines the effective
-    # Clojure runtime); keep them in sync.
+    # ``.github/workflows/lint.yml`` (that pinned interpreter runs the
+    # fixtures, so its bundled Clojure is the effective runtime
+    # version); keep them in sync.
     language_version: VersionFormats = VersionFormats.V1_11
     indent: str = "    "
 

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -434,6 +434,10 @@ class Clojure(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # ``V1_11`` (Clojure 1.11) is ``<=`` the Clojure 1.12.x bundled by
+    # the ``bb: 1.12.218`` pin in the ``lint-jvm-mini`` job of
+    # ``.github/workflows/lint.yml`` (Babashka determines the effective
+    # Clojure runtime); keep them in sync.
     language_version: VersionFormats = VersionFormats.V1_11
     indent: str = "    "
 


### PR DESCRIPTION
Part of #1933. Closes #2400.

Pins `bb` and `clj-kondo` in the `lint-jvm-mini` CI job instead of the drifting `latest` defaults of `DeLaGuardo/setup-clojure`. `bb: 1.12.218` bundles Clojure 1.12.x, which is `>=` the `V1_11` default of `Clojure.language_version`; Babashka determines the effective Clojure runtime so it is the pin that matters, and `clj-kondo` is a static linter pinned only for reproducibility. Bidirectional "keep in sync" comments are added at the pin site in `lint.yml` and the `language_version` declaration in `clojure.py`, following the existing Elixir/Erlang/Gleam/Kotlin/Zig/Odin/Python/Racket pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: pins `bb`/`clj-kondo` to fixed versions to avoid drifting runtimes; no production code paths are affected beyond comments.
> 
> **Overview**
> **Stabilizes Clojure CI linting.** The `lint-jvm-mini` GitHub Actions job now pins `bb` and `clj-kondo` instead of using `latest`, preventing Clojure runtime drift and improving reproducibility.
> 
> Adds *bidirectional “keep in sync”* comments between the workflow tool pins and `Clojure.language_version` in `src/literalizer/languages/clojure.py` to make future version bumps coordinated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5984a51624b77034ed7b476ba21d1b9ed8a9b10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->