### PR TITLE
Pin lint toolchain version: Perl

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -450,13 +450,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Install cpanminus
-        uses: awalsh128/cache-apt-pkgs-action@v1
+      # ``perl-version: '5.36'`` is ``>=`` the ``V5_36``
+      # ``Perl.language_version`` default in
+      # ``src/literalizer/languages/perl.py``; keep them in sync. Without
+      # this setup step the ``perl`` binary is whatever ``ubuntu-latest``
+      # ships and drifts. The action also bundles ``cpanm`` for the
+      # pinned interpreter, so ``DateTime`` installs against it (no
+      # ``sudo``, which would target the system Perl instead).
+      - name: Set up Perl
+        uses: shogo82148/actions-setup-perl@v1
         with:
-          packages: cpanminus
-          version: 1.0
+          perl-version: '5.36'
       - name: Install Perl DateTime
-        run: sudo cpanm --notest DateTime
+        run: cpanm --notest DateTime
       - name: Lint Perl
         run: |-
           find tests/integration/cases -name '*.pl' -print0 > /tmp/files-perl && test -s /tmp/files-perl

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -531,6 +531,8 @@ class Perl(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the ``perl-version`` pin passed to
+    # ``shogo82148/actions-setup-perl`` in ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.V5_36
     indent: str = "    "
 


### PR DESCRIPTION
Part of #1933. Closes #2408.

The `lint-perl` CI job previously ran against whatever `perl` `ubuntu-latest` ships, which drifts; this passes an explicit Perl `5.36` (`>=` the `Perl.language_version` `V5_36` default) to `shogo82148/actions-setup-perl@v1`. Because that action bundles `cpanm` for the pinned interpreter, the `awalsh128/cache-apt-pkgs-action` cpanminus step is removed and `DateTime` now installs via `cpanm --notest DateTime` without `sudo` (which would otherwise target the system Perl). Bidirectional "keep in sync" comments were added at the pin site in `lint.yml` and at the `language_version` declaration in `perl.py`, following the existing Ruby/Racket pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins the Perl interpreter and adjusts dependency installation; main failure mode is the `lint-perl` job behaving differently if the setup action or module install changes.
> 
> **Overview**
> Pins the `lint-perl` GitHub Actions job to a specific Perl toolchain (`5.36`) via `shogo82148/actions-setup-perl`, avoiding drift from `ubuntu-latest`’s system Perl.
> 
> Removes the apt-installed `cpanminus` step and switches `DateTime` installation to `cpanm` (no `sudo`) so modules install against the pinned interpreter, and adds cross-file comments to keep the workflow pin and `Perl.language_version` (`V5_36`) in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2c2eea7ab04ff7bf27e55fd24b546a6790415b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->