### PR TITLE
Pin lint toolchain version: Roc

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -419,6 +419,21 @@ jobs:
 
   lint-roc:
     runs-on: ubuntu-latest
+    # Roc has no stable release, and the upstream ``nightly`` GitHub
+    # release only ever retains the moving
+    # ``roc_nightly-linux_x86_64-latest.tar.gz`` asset -- old dated
+    # nightlies are not kept, so there is no dated URL to ``curl``.
+    # Instead we download ``-latest`` and assert its embedded build id
+    # (the tarball's top-level directory, which carries the build date
+    # and commit) equals ``ROC_NIGHTLY_BUILD``, so CI fails loudly when
+    # upstream replaces the nightly instead of silently drifting. This
+    # ``2025-10-28`` build is documented against the ``V0`` default of
+    # ``Roc.language_version`` in ``src/literalizer/languages/roc.py``;
+    # keep them in sync. Roc has no ``--langversion``-style flag, so the
+    # pinned nightly build is the only mechanism for pinning the
+    # language version.
+    env:
+      ROC_NIGHTLY_BUILD: roc_nightly-linux_x86_64-2025-10-28-ea210f57
     steps:
       - uses: actions/checkout@v6
         with:
@@ -427,6 +442,13 @@ jobs:
         run: |-
           curl -fsSL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-linux_x86_64-latest.tar.gz \
             -o /tmp/roc.tar.gz
+          actual=$(tar -tzf /tmp/roc.tar.gz | head -1)
+          actual=${actual%/}
+          if [ "$actual" != "$ROC_NIGHTLY_BUILD" ]; then
+            echo "Roc nightly drifted: got '$actual', pinned '$ROC_NIGHTLY_BUILD'." >&2
+            echo "Update ROC_NIGHTLY_BUILD here and the Roc.language_version comment in src/literalizer/languages/roc.py together." >&2
+            exit 1
+          fi
           mkdir -p /tmp/roc-nightly
           tar -xzf /tmp/roc.tar.gz -C /tmp/roc-nightly --strip-components=1
           sudo install /tmp/roc-nightly/roc /usr/local/bin/roc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -442,16 +442,20 @@ jobs:
         run: |-
           curl -fsSL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-linux_x86_64-latest.tar.gz \
             -o /tmp/roc.tar.gz
-          actual=$(tar -tzf /tmp/roc.tar.gz | head -1)
-          actual=${actual%/}
+          mkdir -p /tmp/roc-nightly
+          tar -xzf /tmp/roc.tar.gz -C /tmp/roc-nightly
+          # Read the extracted top-level directory by globbing rather
+          # than `tar -tzf | head`: under the default `bash -eo
+          # pipefail` shell, `head` closing the pipe sends `tar`
+          # SIGPIPE (exit 141), which `pipefail` would propagate and
+          # `set -e` would abort on.
+          actual=$(cd /tmp/roc-nightly && echo *)
           if [ "$actual" != "$ROC_NIGHTLY_BUILD" ]; then
             echo "Roc nightly drifted: got '$actual', pinned '$ROC_NIGHTLY_BUILD'." >&2
             echo "Update ROC_NIGHTLY_BUILD here and the Roc.language_version comment in src/literalizer/languages/roc.py together." >&2
             exit 1
           fi
-          mkdir -p /tmp/roc-nightly
-          tar -xzf /tmp/roc.tar.gz -C /tmp/roc-nightly --strip-components=1
-          sudo install /tmp/roc-nightly/roc /usr/local/bin/roc
+          sudo install "/tmp/roc-nightly/$ROC_NIGHTLY_BUILD/roc" /usr/local/bin/roc
       - name: Lint Roc
         run: |-
           find tests/integration/cases -name '*.roc' -print0 > /tmp/files-roc && test -s /tmp/files-roc

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -953,6 +953,11 @@ class Roc(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    # Keep in sync with the pinned ``ROC_NIGHTLY_BUILD`` downloaded in
+    # the ``Install Roc`` step of ``.github/workflows/lint.yml``. Roc
+    # has no stable release and no ``--langversion``-style flag, so the
+    # pinned nightly build is the only mechanism for pinning the
+    # version; ``V0`` maps to the ``2025-10-28`` nightly.
     language_version: VersionFormats = VersionFormats.V0
     indent: str = "    "
     type_name: str = "Val"


### PR DESCRIPTION
## Summary

`Roc.language_version` defaults to `VersionFormats.V0`, but the `lint-roc` job downloaded `roc_nightly-linux_x86_64-latest.tar.gz`, so the Roc compiler drifted with every upstream nightly.

Roc has no stable release, and upstream's `nightly` GitHub release retains **only** the moving `-latest` asset (verified via the releases API; no dated nightly assets are kept), so there is no dated URL to `curl`. Instead this:

- Downloads `-latest` and asserts its embedded build id (the tarball's top-level directory, which carries the build date and commit) equals the pinned `ROC_NIGHTLY_BUILD` (`roc_nightly-linux_x86_64-2025-10-28-ea210f57`). CI now fails loudly when upstream replaces the nightly instead of silently drifting.
- Adds the bidirectional "keep them in sync" comment at the `lint-roc` pin site and at the `Roc.language_version` declaration in `src/literalizer/languages/roc.py`, following the existing Wren/Elixir/Zig/Odin pattern.

No `CHANGELOG.rst` entry, consistent with the other #1933 pin PRs (D / Nix / Tcl).

Part of #1933. Closes #2418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes that make Roc linting deterministic by pinning and validating the downloaded nightly; failure mode is limited to the `lint-roc` job if upstream packaging changes.
> 
> **Overview**
> Stops the `lint-roc` CI job from silently drifting with upstream Roc nightlies by introducing a pinned `ROC_NIGHTLY_BUILD` and validating the extracted tarball’s build-id directory before installing `roc`.
> 
> Adds a *bidirectional keep-in-sync* note linking the workflow pin and the `Roc.language_version` (`VersionFormats.V0`) documentation in `src/literalizer/languages/roc.py` so future updates change both together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6918b848d475e6604c1f6c8edfef4a1bfed84215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->