### PR TITLE
Support literalize_call variable_form for Erlang

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Erlang` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`, binding the call result with
+  ``My_data = make_widget(...)``.  A ``wrap_in_file=True`` Erlang
+  scaffold hoists the generated call stub to module scope between
+  ``-export`` and ``x()`` (previously the literal-binding scaffold
+  nested it inside the ``x/0`` clause, producing invalid Erlang) while
+  keeping the binding and the trailing ``My_data.`` return inside
+  ``x()``.  See #2454.
 - The mapping arm of the public ``ValueInput`` type (accepted by
   ``ref_values`` and ``bound_refs``) is now a covariant-key read-only
   ``ValueItemsMap`` protocol instead of an invariant ``Mapping``, so

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -214,7 +214,7 @@ class Erlang(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -532,6 +532,34 @@ class Erlang(metaclass=LanguageCls):
         parts.extend(body_preamble)
         parts.append("x() ->")
         parts.append(f"{indented}.")
+        return "\n".join(parts)
+
+    def wrap_call_variable_in_file(
+        self,
+        content: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap a call-result variable binding in an Erlang module.
+
+        :meth:`wrap_in_file`'s variable branch places *body_preamble*
+        inside ``x()``, but for a call binding those lines are the
+        module-level stub function definitions emitted by
+        :func:`_erlang_call_stub`; nesting a function definition inside
+        the ``x/0`` clause is a syntax error.  This hook hoists
+        *body_preamble* to module scope between ``-export`` and ``x()``
+        (matching the call-without-binding branch of
+        :meth:`wrap_in_file`) while keeping the
+        ``My_data = make_widget(...)`` binding and the trailing
+        ``My_data.`` return inside ``x()``.
+        """
+        erlang_varname = variable_name[0].upper() + variable_name[1:]
+        indented = textwrap.indent(text=content, prefix=self.indent)
+        parts = [f"-module({self.module_name}).", "-export([x/0])."]
+        parts.extend(body_preamble)
+        parts.append("x() ->")
+        parts.append(indented)
+        parts.append(f"{self.indent}{erlang_varname}.")
         return "\n".join(parts)
 
     @staticmethod

--- a/tests/integration/cases/call_variable_form_existing/Erlang_call@otp_25.erl
+++ b/tests/integration/cases/call_variable_form_existing/Erlang_call@otp_25.erl
@@ -1,0 +1,6 @@
+-module(fixture_call_variable_form_existing_erlang_call).
+-export([x/0]).
+make_widget(_) -> undefined.
+x() ->
+    My_data = make_widget(42),
+    My_data.

--- a/tests/integration/cases/call_variable_form_new/Erlang_call@otp_25.erl
+++ b/tests/integration/cases/call_variable_form_new/Erlang_call@otp_25.erl
@@ -1,0 +1,6 @@
+-module(fixture_call_variable_form_new_erlang_call).
+-export([x/0]).
+make_widget(_) -> undefined.
+x() ->
+    My_data = make_widget(42),
+    My_data.


### PR DESCRIPTION
Closes #2454.

Erlang previously rejected `variable_form` for `literalize_call` because `wrap_in_file`'s variable branch nested the generated call stub inside the `x/0` clause, producing invalid Erlang. This adds a `wrap_call_variable_in_file` hook that hoists the stub to module scope between `-export` and `x()` (matching the call-without-binding branch) while keeping the `My_data = make_widget(...)` binding and trailing `My_data.` return inside `x()`, and flips `supports_call_variable_binding` to `True` (removing the `UnsupportedCallShapeError` path). New golden cases are added for both the `NewVariable` and `ExistingVariable` forms (both compile under `erlc -Werror` and run via `M:x()`), with existing Erlang literal-binding and call-without-binding output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a previously unsupported `literalize_call(variable_form=...)` path for Erlang and changes file-wrapping behavior for call bindings; risk is mainly around generating syntactically valid Erlang modules and ensuring no regressions in existing wrap logic.
> 
> **Overview**
> Adds Erlang support for `literalize_call(..., variable_form=NewVariable|ExistingVariable)` by flipping `Erlang.supports_call_variable_binding` to `True` and introducing `Erlang.wrap_call_variable_in_file` to wrap call-result bindings correctly.
> 
> For `wrap_in_file=True` call bindings, the generated call stub functions are now hoisted to module scope (between `-export` and `x()`), while the `My_data = make_widget(...)` binding and returned `My_data.` remain inside `x()`, fixing previously invalid Erlang output. Integration golden fixtures are added for both new/existing variable forms, and the changelog documents the behavior and the #2454 fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4b55656f622d6e4f5e7c485e8b7565fd1f06472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->