### PR TITLE
Remove private literalizer._types.Value import from call_cases test

### DIFF
--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -7,6 +7,7 @@ driven through :func:`literalizer.literalize_call`.  The runner
 """
 
 import dataclasses
+import datetime
 import enum
 import functools
 from collections.abc import Callable, Sequence
@@ -18,7 +19,6 @@ from pytest_regressions.file_regression import FileRegressionFixture
 
 import literalizer
 from literalizer._language import StubReturn
-from literalizer._types import Value
 from literalizer.exceptions import (
     CallArgNotSupportedError,
     DottedCallTargetNotSupportedError,
@@ -33,6 +33,23 @@ from .language_specs import (
     sorted_languages,
     with_per_fixture_module_name,
 )
+
+# Spelled out locally to mirror ``literalizer._types.Value`` without
+# importing from a private module (see issue #1947); ``source_data``
+# flows in from the parsed YAML, so containers may be ruamel
+# comment-tracking subclasses of ``list``/``dict``.
+type _Scalar = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | datetime.date
+    | datetime.datetime
+    | datetime.time
+    | bytes
+)
+type _Value = _Scalar | list[_Value] | dict[_Scalar, _Value] | set[_Scalar]
 
 
 @beartype
@@ -1652,9 +1669,9 @@ def _run_call_with_declarations(
 @beartype
 def _arg_values_for_stub(
     *,
-    source_data: Value,
+    source_data: _Value,
     per_element: bool,
-) -> Sequence[Value]:
+) -> Sequence[_Value]:
     """Mirror ``_literalize.py``'s ``arg_values`` shape: a list of
     arguments rows for per-element calls; a single-entry list
     wrapping the whole data otherwise.
@@ -1808,7 +1825,7 @@ def run_call_golden_case(
         *(d.types_present for d in decl_results),
         result.types_present,
     )
-    combined_source_data: list[Value] = [
+    combined_source_data: list[_Value] = [
         *(d.source_data for d in decl_results),
         result.source_data,
     ]


### PR DESCRIPTION
Progresses #1947 (disallow private `literalizer._*` imports from tests).

Replaces the `from literalizer._types import Value` private import in `tests/integration/call_cases.py` with a local recursive `_Value`/`_Scalar` alias that mirrors `literalizer._types.Value`, following the established precedent in `literalize_ref_cases.py` / `case_discovery.py`. The three annotation sites (`_arg_values_for_stub` signature and `combined_source_data`) are repointed at the local alias; there is no production change. Verified by importing the module (the `@beartype`-decorated helper accepts the recursive alias at runtime) and running the Python call-golden suite (45 passed, 90 subtests) with no golden churn. The remaining `from literalizer._language import StubReturn` import is intentionally left for separate work, as it is a genuine public-API gap rather than a test-only cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only type annotation changes to remove a private import; runtime behavior should be unchanged aside from type checking/beartype annotation evaluation.
> 
> **Overview**
> Stops importing the private `literalizer._types.Value` in `tests/integration/call_cases.py` by introducing local recursive `_Scalar`/`_Value` type aliases (including datetime/bytes support) and updating the few affected annotations (`_arg_values_for_stub`, `combined_source_data`).
> 
> This is a test harness cleanup to reduce reliance on private `literalizer._*` modules, with no intended changes to golden generation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad33730d5349133b9343a93637d3ac964ef0bc33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->