### PR TITLE
Reconcile Python language_version default with CI floor (#2263)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -147,10 +147,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          # Pinned to ``Python.language_version`` (``PY_3_12``) in
-          # ``src/literalizer/languages/python.py``; keep this version
-          # in sync with that default so the Python fixture gate runs
-          # under the declared minimum interpreter.
+          # Pinned to the ``requires-python = ">=3.12"`` floor in
+          # ``pyproject.toml``; keep this in sync with that floor so the
+          # Python fixture gate runs under the declared minimum
+          # interpreter. The ``Python.VersionFormats`` enum
+          # (``PY38``/``PY39``) only selects typing-alias syntax and does
+          # not encode this runtime floor, so it is not the source of
+          # truth here.
           python-version: '3.12'
 
       # The fixture set spans every `Java.VersionFormats` member in
@@ -1773,8 +1776,15 @@ jobs:
         shell: bash
         run: find tests/integration/cases -name 'Python@py39.py' -print0 > /tmp/files-python
           && test -s /tmp/files-python
+      # The default (``@py39``) Python fixtures emit ``datetime.UTC``,
+      # which requires Python 3.11+, so they cannot run on the 3.8
+      # interpreter used above. Pin this run to the
+      # ``requires-python = ">=3.12"`` floor in ``pyproject.toml`` so a
+      # generator change that outpaces the declared minimum interpreter
+      # fails CI loudly here rather than silently working on a newer
+      # version; keep this in sync with that floor.
       - name: Run default Python golden files
-        run: xargs -0 -P "$(nproc)" -n1 uv run --python 3.13 --no-project python <
+        run: xargs -0 -P "$(nproc)" -n1 uv run --python 3.12 --no-project python <
           /tmp/files-python
 
   lint-racket:

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1225,10 +1225,18 @@ class Python(metaclass=LanguageCls):
     class VersionFormats(enum.Enum):
         """Python version to target.
 
+        This selects typing-alias syntax; it is *not* the runtime
+        version floor.  The floor under which the default fixtures are
+        exercised in CI is governed by ``requires-python`` in
+        ``pyproject.toml`` (``>=3.12``), not by this enum.
+
         * ``VersionFormats.PY38`` — target Python 3.8; uses ``typing.List``,
-          ``typing.Dict``, etc. for generic type hints.
-        * ``VersionFormats.PY39`` — target Python 3.9+; uses built-in generic
-          aliases ``list``, ``dict``, etc. (PEP 585).
+          ``typing.Dict``, etc. for generic type hints, and emits
+          ``datetime.timezone.utc`` for UTC.
+        * ``VersionFormats.PY39`` — uses built-in generic aliases
+          ``list``, ``dict``, etc. (PEP 585, valid 3.9+).  Note this
+          variant also emits ``datetime.UTC``, which requires Python
+          3.11+, so its true minimum interpreter is 3.11, not 3.9.
         """
 
         PY38 = enum.auto()


### PR DESCRIPTION
Resolves #2263. Three sources of truth for the default Python fixture interpreter disagreed: the `lint-python` "Run default Python golden files" step was pinned to an arbitrary `3.13`, the main lint job's uv comment referenced a nonexistent `PY_3_12` enum member, and the `VersionFormats.PY39` docstring claimed "3.9+" while its output emits `datetime.UTC` (3.11+). This makes `pyproject.toml`'s `requires-python = ">=3.12"` the single source of truth for the runtime floor: the default-fixture step is pinned to `3.12` so a generator change outpacing the declared minimum fails CI loudly under the floor interpreter. The stale uv comment is rewritten to point at `requires-python` (noting the `VersionFormats` enum only selects typing-alias syntax, not the runtime floor), and the `VersionFormats` docstring is corrected to state `PY39`'s true minimum interpreter is 3.11. No runtime or public-API behavior change (CI config + docstring accuracy only), so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates are limited to CI configuration and docstrings, with no runtime behavior changes in the library itself.
> 
> **Overview**
> Aligns Python fixture CI to treat `pyproject.toml`’s `requires-python (>=3.12)` as the single runtime-floor source of truth.
> 
> Updates `lint.yml` to run the default Python golden fixtures under Python `3.12` (instead of `3.13`) and clarifies comments that `Python.VersionFormats` only controls typing-alias syntax. Corrects the `Python.VersionFormats` docstring to note that `PY39` output (`datetime.UTC`) requires Python `3.11+`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be7a19b07e8ba8fd272d14314e527a2f332acc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->