### PR TITLE
Support variable_form on literalize_call for Objective-C (drop @() boxing for call RHS)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.ObjectiveC` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call`, emitting ``id my_data =
+  make_widget(@42);`` directly.  The literal-binding declaration boxes
+  a primitive right-hand side via ``@(...)`` because an ``id`` is a
+  pointer type, but a call expression already yields an object pointer,
+  so the boxing is dropped for the call-result binding.  Its
+  ``supports_call_variable_binding`` language-class flag is now
+  ``True``; existing literal-binding output is unchanged.  See #2223.
 - The mapping arm of the public ``ValueInput`` type (accepted by
   ``ref_values`` and ``bound_refs``) is now a covariant-key read-only
   ``ValueItemsMap`` protocol instead of an invariant ``Mapping``, so

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -56,8 +56,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
@@ -133,6 +131,33 @@ def _format_objc_declaration(
 def _format_objc_assignment(name: str, value: str, data: Value) -> str:
     """Format an Objective-C reassignment, boxing primitive scalars."""
     return f"{name} = {_format_objc_entry(data, value)};"
+
+
+@beartype
+def _format_objc_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format an Objective-C ``id`` declaration binding a call result.
+
+    The literal-binding declaration boxes a primitive right-hand side
+    as ``NSNumber`` / ``NSString`` because an ``id`` is a pointer type.
+    A call expression already evaluates to an object pointer, so the
+    ``@(...)`` boxing is dropped and the call result is bound directly.
+    """
+    return f"id {name} = {value};"
+
+
+@beartype
+def _format_objc_call_assignment(name: str, value: str, _data: Value) -> str:
+    """Format an Objective-C reassignment binding a call result.
+
+    The call-expression counterpart of :func:`_format_objc_assignment`;
+    no ``@(...)`` boxing since a call already yields an object pointer.
+    """
+    return f"{name} = {value};"
 
 
 @beartype
@@ -297,8 +322,6 @@ class ObjectiveC(metaclass=LanguageCls):
     """Objective-C language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -310,7 +333,7 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -695,6 +718,32 @@ class ObjectiveC(metaclass=LanguageCls):
     def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
         """Format an assignment to an existing variable."""
         return _format_objc_assignment
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call expression.
+
+        The literal-binding declaration boxes a primitive right-hand
+        side as ``NSNumber`` / ``NSString`` (an ``id`` is a pointer
+        type); a call expression already yields an object pointer, so
+        the ``@(...)`` boxing is dropped and the call result is bound
+        directly.
+        """
+        return _format_objc_call_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call expression.
+
+        The call-expression counterpart of
+        :attr:`format_variable_assignment`; the ``@(...)`` boxing is
+        dropped since a call already yields an object pointer.
+        """
+        return _format_objc_call_assignment
 
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:

--- a/tests/integration/cases/call_variable_form_new/ObjectiveC_call@v2.m
+++ b/tests/integration/cases/call_variable_form_new/ObjectiveC_call@v2.m
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+static id make_widget(id _a0) { (void)_a0; return nil; }
+int main(void) {
+@autoreleasepool {
+id my_data = make_widget(@42);
+    (void)my_data;
+}
+    return 0;
+}


### PR DESCRIPTION
Closes #2223 (follow-up to #1961).

Objective-C's literal-binding declaration boxes a primitive right-hand side via `@(...)` because an `id` is a pointer type, which is wrong for a call expression whose result is already an object pointer. Objective-C now sets `supports_call_variable_binding = True` and supplies dedicated `format_call_variable_declaration` / `format_call_variable_assignment` formatters that drop the boxing, emitting `id my_data = make_widget(@42);` directly and removing the generic `UnsupportedCallShapeError` raise for the language. A new `call_variable_form_new/ObjectiveC_call@v2.m` golden covers this, with a CHANGELOG entry. Existing literal-binding output is unchanged (full ObjectiveC golden suite and the 2773-case call suite pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to Objective-C call-result variable binding and adds a golden integration fixture to lock in output; existing literal-binding formatting is intended to remain unchanged.
> 
> **Overview**
> Enables Objective-C `literalize_call(..., variable_form=...)` by flipping `ObjectiveC.supports_call_variable_binding` to `True` and adding call-specific variable declaration/assignment formatters that **bind call results without `@(...)` boxing** (e.g. `id my_data = make_widget(@42);`).
> 
> Adds a new Objective-C integration golden (`call_variable_form_new`) and documents the behavior in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadb86b9bb1c5ed784b1a27b55844a7c004463d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->