### PR TITLE
Add missing @beartype decorators to module-level functions

### DIFF
--- a/src/literalizer/_formatters/type_inference.py
+++ b/src/literalizer/_formatters/type_inference.py
@@ -61,6 +61,7 @@ _I32_MIN = -(2**31)
 _I32_MAX = 2**31 - 1
 
 
+@beartype
 def _int_needs_widening(items: list[Value]) -> bool:
     """Return ``True`` if any int in *items* is outside i32 range."""
     return any(
@@ -82,6 +83,7 @@ class _Collected:
 _INFER_FAILED = object()
 
 
+@beartype
 def _collect_element_types(
     items: list[Value],
 ) -> _Collected | object:
@@ -266,6 +268,7 @@ def unify_record_shapes(
     }
 
 
+@beartype
 def _ordered_unique_shapes(
     *,
     data: Value,
@@ -295,6 +298,7 @@ def _ordered_unique_shapes(
     return ordered
 
 
+@beartype
 def _key_order_from_shapes(
     *,
     raw_shapes: Sequence[RecordShape],
@@ -313,6 +317,7 @@ def _key_order_from_shapes(
     return order
 
 
+@beartype
 def _partition_shapes_by_shared_keys(
     *,
     raw_shapes: Sequence[RecordShape],
@@ -355,6 +360,7 @@ def _partition_shapes_by_shared_keys(
     return [groups[root] for root in sorted(groups)]
 
 
+@beartype
 def _build_unified_shape(
     *,
     group: Sequence[RecordShape],
@@ -382,6 +388,7 @@ def _build_unified_shape(
     return RecordShape(keys=ordered_keys, optional_keys=optional_keys)
 
 
+@beartype
 def _accumulate_record_shapes(
     *,
     data: Value,

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -581,11 +581,13 @@ class HeterogeneousBehavior:
     compute_tuple_list_ids: Callable[[Value], frozenset[int]] | None = None
 
 
+@beartype
 def no_compute_wrap_ids(_data: Value, /) -> frozenset[int]:
     """Return an empty wrap-id set — used by non-wrapping languages."""
     return frozenset()
 
 
+@beartype
 def _no_compute_call_slot_wrap_ids(
     _slot_values: Sequence[Value],
     /,
@@ -1913,6 +1915,7 @@ class Language(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
 
+@beartype
 def _no_call_stub(
     _parts: Sequence[str],
     _params: Sequence[str],
@@ -1931,6 +1934,7 @@ no_call_stub: Callable[
 """Shared callable for languages that need no call stubs."""
 
 
+@beartype
 def _identity_call_target(parts: Sequence[str], /) -> str:
     """Return the parts joined with ``"."``."""
     return ".".join(parts)
@@ -1940,6 +1944,7 @@ identity_call_target: Callable[[Sequence[str]], str] = _identity_call_target
 """Shared callable for languages that need no call-target rewriting."""
 
 
+@beartype
 def _identity_call_ref_identifier(name: str, value: Value | None, /) -> str:
     """Return *name* unchanged.
 
@@ -1986,6 +1991,7 @@ predicate that returns ``True`` for those values.
 """
 
 
+@beartype
 def _no_type_hint_preamble(
     _empty_collection_types: frozenset[type],
     /,
@@ -2002,6 +2008,7 @@ no_type_hint_preamble: Callable[[frozenset[type]], tuple[str, ...]] = (
 """Shared callable for languages that need no type-hint preamble."""
 
 
+@beartype
 def _no_data_preamble(_data: Value, /) -> tuple[str, ...]:
     """Return no preamble lines — used by languages that do not need
     data-dependent preamble.
@@ -2013,6 +2020,7 @@ no_data_preamble: Callable[[Value], tuple[str, ...]] = _no_data_preamble
 """Shared callable for languages with no data-dependent preamble."""
 
 
+@beartype
 def _no_validate_spec_for_data(self: "Language", data: Value) -> None:
     """Default ``validate_spec_for_data`` — no spec/data constraints."""
     del self, data
@@ -2026,6 +2034,7 @@ check.
 """
 
 
+@beartype
 def _default_wrap_calls_with_declarations(
     self: "Language",
     declarations: tuple[str, ...],
@@ -2053,6 +2062,7 @@ expressions.
 """
 
 
+@beartype
 def _no_format_integer_widened(self: "Language") -> None:
     """Default ``format_integer_widened`` -- no mixed-magnitude integer
     widening, so the renderer keeps the normal integer formatter.
@@ -2067,6 +2077,7 @@ falls back to the language's normal integer formatter.
 """
 
 
+@beartype
 def _default_format_call_variable_declaration(
     self: "Language",
 ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
@@ -2084,6 +2095,7 @@ formatted exactly like a literal binding (no value-type tag to drop).
 """
 
 
+@beartype
 def _default_format_call_variable_assignment(
     self: "Language",
 ) -> Callable[[str, str, Value], str]:
@@ -2101,6 +2113,7 @@ formatted exactly like a literal binding (no value-type tag to drop).
 """
 
 
+@beartype
 def _default_sequence_binding_declarations(
     self: "Language", declarations: tuple[str, ...]
 ) -> str:
@@ -2119,6 +2132,7 @@ default_sequence_binding_declarations: Callable[
 """
 
 
+@beartype
 def _no_call_binding_body_preamble(self: "Language") -> tuple[str, ...]:
     """Default ``format_call_binding_body_preamble`` -- no extra body
     preamble lines for an inference-bound call result.
@@ -2133,6 +2147,7 @@ no_call_binding_body_preamble: Callable[["Language"], tuple[str, ...]] = (
 """Shared callable for languages needing no call-binding body preamble."""
 
 
+@beartype
 def _no_call_binding_file_pragmas(self: "Language") -> tuple[str, ...]:
     """Default ``format_call_binding_file_pragmas`` -- no file-level
     compiler-pragma line for an inference-bound call result.
@@ -2211,6 +2226,7 @@ def wrap_combined_in_file_noop(
     )
 
 
+@beartype
 def body_preamble_from_scalars(
     *,
     scalar_body_preamble: dict[type, tuple[str, ...]],

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2886,6 +2886,7 @@ def literalize(
     )
 
 
+@beartype
 def _active_literalize_ref_key(
     *,
     source: str,
@@ -2907,6 +2908,7 @@ def _active_literalize_ref_key(
     return _DISABLED_REF_KEY
 
 
+@beartype
 def _extract_call_arg_ref_name(*, value: Value, ref_key: str) -> str | None:
     """Return the identifier name for a ``{ref_key: "name"}`` marker.
 
@@ -2922,6 +2924,7 @@ def _extract_call_arg_ref_name(*, value: Value, ref_key: str) -> str | None:
     return ref_value
 
 
+@beartype
 def _contains_ref_marker(*, value: Value, ref_key: str) -> bool:
     """Return whether *value* contains a ``{ref_key: "name"}`` marker."""
     if _extract_call_arg_ref_name(value=value, ref_key=ref_key) is not None:
@@ -3997,6 +4000,7 @@ def _validate_call_preconditions(
         )
 
 
+@beartype
 def _is_value_mapping(
     value: ValueInput, /
 ) -> TypeIs[ValueItemsMap[Scalar, ValueInput]]:
@@ -4010,6 +4014,7 @@ def _is_value_mapping(
     return isinstance(value, Mapping)
 
 
+@beartype
 def _is_value_sequence(value: ValueInput, /) -> TypeIs[Sequence[ValueInput]]:
     """Narrow ``value`` to the ``Sequence`` arm of ``ValueInput``,
     excluding the ``str``/``bytes`` scalars that are also sequences.
@@ -4091,6 +4096,7 @@ def _wrap_call_in_file(
     return wrapped
 
 
+@beartype
 def _materialize_value_input(*, value: ValueInput) -> Value:
     """Convert a user-supplied ``ValueInput`` into the internal ``Value``
     form, replacing any non-``list`` ``Sequence`` and non-``dict``

--- a/src/literalizer/_preamble.py
+++ b/src/literalizer/_preamble.py
@@ -205,6 +205,7 @@ def _has_special_float(*, data: Value) -> bool:
             return False
 
 
+@beartype
 def _list_merge_dicts(*, elements: list[Value]) -> list[Value]:
     """Return *elements* with plain dicts pooled and ordered dicts pooled.
 
@@ -243,6 +244,7 @@ def _list_merge_dicts(*, elements: list[Value]) -> list[Value]:
     return merged
 
 
+@beartype
 def _structural_type_id(  # noqa: C901, PLR0911, PLR0912  # pylint: disable=too-complex,too-many-branches,too-many-return-statements
     *,
     value: Value,
@@ -309,6 +311,7 @@ def _structural_type_id(  # noqa: C901, PLR0911, PLR0912  # pylint: disable=too-
             assert_never(unreachable)
 
 
+@beartype
 def _has_union_in_type_hints(*, data: Value) -> bool:
     """Return ``True`` if the Python type hints for *data* would contain
     a union (``Union[A, B]`` or ``A | B``).

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -84,6 +84,7 @@ _ADA_FLOAT_SPECIAL_DECLS = {
 }
 
 
+@beartype
 def _ada_special_float_kinds(*, data: Value) -> frozenset[str]:
     """Return which IEEE-special float kinds appear anywhere in *data*.
 
@@ -112,6 +113,7 @@ def _ada_special_float_kinds(*, data: Value) -> frozenset[str]:
     return frozenset(kinds)
 
 
+@beartype
 def _ada_narrowed_empty_form(_siblings: Sequence[list[Value]]) -> str:
     """Ada's structured empty literal beside typed siblings.
 

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -144,6 +144,7 @@ def _make_format_c_entry(
 _SWAPPABLE_PARAMS_NOLINT_THRESHOLD = 4
 
 
+@beartype
 def _c_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -78,6 +78,7 @@ from literalizer._types import Value
 from literalizer.exceptions import CallArgNotSupportedError
 
 
+@beartype
 def _clojure_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -78,6 +78,7 @@ from literalizer.exceptions import CallArgNotSupportedError
 _COBOL_EMPTY_LITERAL = "05 FILLER PIC X(1) VALUE SPACES."
 
 
+@beartype
 def _cobol_narrowed_empty_form(_siblings: Sequence[list[Value]]) -> str:
     """Keep COBOL's structured empty literal beside typed siblings.
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -87,6 +87,7 @@ def _format_cons_entry(
     return f"(cons {key} {formatted_value})"
 
 
+@beartype
 def _common_lisp_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -400,6 +400,7 @@ class _NumericLiteralSuffixConfig:
     formatter_wrapper: Callable[[Callable[[int], str]], Callable[[int], str]]
 
 
+@beartype
 def _identity_wrapper(
     base: Callable[[int], str],
 ) -> Callable[[int], str]:
@@ -1034,6 +1035,7 @@ def _renders_as_string_literal(
             return False
 
 
+@beartype
 def _cpp_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -89,6 +89,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 
+@beartype
 def _to_pascal_case(name: str) -> str:
     """Convert *name* to PascalCase."""
     return IdentifierCase.PASCAL.convert(name=name)

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -289,6 +289,7 @@ class _CSharpDictSpec:
     opener_template: str
 
 
+@beartype
 def _csharp_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -83,6 +83,7 @@ from literalizer._types import Value
 _D_EMPTY_JSON_ARRAY = 'parseJSON("[]")'
 
 
+@beartype
 def _d_narrowed_empty_form(_siblings: Sequence[list[Value]]) -> str:
     """Keep D's ``parseJSON("[]")`` empty literal beside typed siblings.
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -93,6 +93,7 @@ _DHALL_UNESCAPE_RE = re.compile(pattern=r"\\([$\"\\nrt]|u\{([0-9A-Fa-f]+)\})")
 _BACKTICK_LABEL_RE = re.compile(pattern=r"^[\x20-\x5f\x61-\x7e]+$")
 
 
+@beartype
 def _unescape_dhall_string(value: str) -> str:
     """Reverse Dhall double-quoted string escapes to produce raw
     content.
@@ -297,6 +298,7 @@ _DHALL_BRACKET_DELTA: dict[str, tuple[str, int]] = {
 _DHALL_STRING_RE = re.compile(pattern=r'"(?:[^"\\]|\\.)*"')
 
 
+@beartype
 def _dhall_validate_call_stmt(call_expr: str) -> None:
     """Raise :exc:`~literalizer.exceptions.CallArgNotSupportedError` for
     call expressions that cannot be represented as valid Dhall.
@@ -350,6 +352,7 @@ def _dhall_validate_call_stmt(call_expr: str) -> None:
         prev_is_word = next_prev_is_word
 
 
+@beartype
 def _dhall_reject_ref_identifier(name: str, _value: Value | None, /) -> str:
     """Raise :exc:`~literalizer.exceptions.CallArgNotSupportedError` for
     any ``$ref`` argument.
@@ -444,6 +447,7 @@ class _HeterogeneousStrategyConfig:
     build_preamble: Callable[[str, str], Callable[[Value], tuple[str, ...]]]
 
 
+@beartype
 def _build_error_behavior(
     _union_name: str,
     _datetime_inner_type: str,
@@ -453,6 +457,7 @@ def _build_error_behavior(
     return NO_HETEROGENEOUS_BEHAVIOR
 
 
+@beartype
 def _build_error_preamble(
     _union_name: str,
     _datetime_inner_type: str,
@@ -462,6 +467,7 @@ def _build_error_preamble(
     return no_data_preamble
 
 
+@beartype
 def _build_union_type_behavior(
     union_name: str,
     datetime_inner_type: str,
@@ -492,6 +498,7 @@ def _build_union_type_behavior(
     )
 
 
+@beartype
 def _build_union_type_preamble(
     union_name: str,
     datetime_inner_type: str,

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -81,6 +81,7 @@ def _apply_elm_date_iso(value: datetime.date, prefix: str) -> str:
     return f"{prefix}Str {format_date_iso(value=value)}"
 
 
+@beartype
 def _build_elm_date_iso(
     prefix: str,
 ) -> Callable[[datetime.date], str]:
@@ -101,6 +102,7 @@ def _apply_elm_time_iso(value: datetime.time, prefix: str) -> str:
     return f"{prefix}Str {format_time_iso(value=value)}"
 
 
+@beartype
 def _build_elm_time_iso(
     prefix: str,
 ) -> Callable[[datetime.time], str]:
@@ -121,6 +123,7 @@ def _apply_elm_datetime_iso(value: datetime.datetime, prefix: str) -> str:
     return f"{prefix}Str {format_datetime_iso(value=value)}"
 
 
+@beartype
 def _build_elm_datetime_iso(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -135,6 +138,7 @@ def _build_elm_datetime_iso(
     return _format
 
 
+@beartype
 def _build_elm_datetime_epoch(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -152,6 +156,7 @@ def _apply_elm_bytes_hex(value: bytes, prefix: str) -> str:
     return f"{prefix}Str {format_bytes_hex(value=value)}"
 
 
+@beartype
 def _build_elm_bytes_hex(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -172,6 +177,7 @@ def _apply_elm_bytes_base64(value: bytes, prefix: str) -> str:
     return f"{prefix}Str {format_bytes_base64(value=value)}"
 
 
+@beartype
 def _build_elm_bytes_base64(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -197,6 +203,7 @@ def _apply_elm_integer_formatter(
     return f"{prefix}Int {formatted}"
 
 
+@beartype
 def _build_elm_integer_formatter(
     prefix: str,
     base: Callable[[int], str],
@@ -225,6 +232,7 @@ def _apply_elm_float_wrapper(
     return f"{prefix}Float {formatted}"
 
 
+@beartype
 def _build_elm_float_wrapper(
     prefix: str,
     inner: Callable[[float], str],
@@ -252,6 +260,7 @@ def _apply_elm_string(value: str, prefix: str) -> str:
     return f"{prefix}Str {escaped}"
 
 
+@beartype
 def _build_elm_str_formatter(
     prefix: str,
 ) -> Callable[[str], str]:
@@ -282,6 +291,7 @@ def _apply_elm_dict_entry(
     return f"({key}, {formatted_value})"
 
 
+@beartype
 def _build_elm_dict_entry(
     prefix: str,
 ) -> Callable[[str, Value, str], str]:
@@ -381,6 +391,7 @@ def _build_elm_body_preamble(
     return _compute
 
 
+@beartype
 def _elm_flatten_dotted(parts: Sequence[str]) -> str:
     """Flatten call target parts to an Elm identifier.
 
@@ -411,6 +422,7 @@ def _elm_type_var(*, index: int) -> str:
     return f"{letter}{group}"
 
 
+@beartype
 def _elm_call_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -436,6 +448,7 @@ def _elm_call_stub(
     return (type_signature, implementation)
 
 
+@beartype
 def _elm_format_call_arg(_original: Value, formatted: str, /) -> str:
     """Wrap a formatted Elm value in parentheses for curried application.
 
@@ -466,6 +479,7 @@ _BYTES_FORMATTERS: dict[
 }
 
 
+@beartype
 def _elm_platform_worker_suffix(indent: str) -> str:
     """Return the Elm ``Platform.worker`` suffix indented by
     ``indent``.
@@ -482,6 +496,7 @@ def _elm_platform_worker_suffix(indent: str) -> str:
     )
 
 
+@beartype
 def _elm_call_module(preamble: str, let_lines: list[str], indent: str) -> str:
     """Build a complete Elm call-mode module from preamble and let-
     bindings.

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -187,6 +187,7 @@ def _format_forth_dict_entry(
     return f"{key} {formatted_value}"
 
 
+@beartype
 def _forth_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -130,6 +130,7 @@ def _apply_fsharp_entry(original: Value, formatted: str, prefix: str) -> str:
             return formatted
 
 
+@beartype
 def _build_fsharp_entry_formatter(
     prefix: str,
 ) -> Callable[[Value, str], str]:
@@ -147,6 +148,7 @@ def _build_fsharp_entry_formatter(
 _format_fsharp_entry = _build_fsharp_entry_formatter(prefix="F")
 
 
+@beartype
 def _build_fsharp_datetime_epoch(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -261,6 +263,7 @@ def _build_fsharp_call_stub_lines(
     return tuple(lines)
 
 
+@beartype
 def _fsharp_call_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -274,6 +277,7 @@ def _fsharp_call_stub(
     )
 
 
+@beartype
 def _fsharp_curried_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -114,6 +114,7 @@ def _apply_gleam_str_wrapped_date(value: datetime.date, prefix: str) -> str:
     return f"{prefix}Str({format_date_iso(value=value)})"
 
 
+@beartype
 def _build_gleam_date_iso(
     prefix: str,
 ) -> Callable[[datetime.date], str]:
@@ -134,6 +135,7 @@ def _apply_gleam_str_wrapped_time(value: datetime.time, prefix: str) -> str:
     return f"{prefix}Str({format_time_iso(value=value)})"
 
 
+@beartype
 def _build_gleam_time_iso(
     prefix: str,
 ) -> Callable[[datetime.time], str]:
@@ -156,6 +158,7 @@ def _apply_gleam_str_wrapped_datetime(
     return f"{prefix}Str({format_datetime_iso(value=value)})"
 
 
+@beartype
 def _build_gleam_datetime_iso(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -170,6 +173,7 @@ def _build_gleam_datetime_iso(
     return _format
 
 
+@beartype
 def _build_gleam_datetime_epoch(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -187,6 +191,7 @@ def _apply_gleam_bytes_hex(value: bytes, prefix: str) -> str:
     return f"{prefix}Str({format_bytes_hex(value=value)})"
 
 
+@beartype
 def _build_gleam_bytes_hex(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -207,6 +212,7 @@ def _apply_gleam_bytes_base64(value: bytes, prefix: str) -> str:
     return f"{prefix}Str({format_bytes_base64(value=value)})"
 
 
+@beartype
 def _build_gleam_bytes_base64(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -228,6 +234,7 @@ def _apply_gleam_string(value: str, prefix: str) -> str:
     return f"{prefix}Str({escaped})"
 
 
+@beartype
 def _build_gleam_str_formatter(
     prefix: str,
 ) -> Callable[[str], str]:
@@ -250,6 +257,7 @@ def _apply_gleam_integer_wrapped(
     return f"{prefix}Int({base(value)})"
 
 
+@beartype
 def _build_gleam_integer_wrapper(
     prefix: str,
     base: Callable[[int], str],
@@ -275,6 +283,7 @@ def _apply_gleam_float_wrapped(
     return f"{prefix}Float({inner(value)})"
 
 
+@beartype
 def _build_gleam_float_wrapper(
     prefix: str,
     inner: Callable[[float], str],
@@ -308,6 +317,7 @@ def _apply_gleam_dict_entry(
     return f"#({key}, {formatted_value})"
 
 
+@beartype
 def _build_gleam_dict_entry(
     prefix: str,
 ) -> Callable[[str, Value, str], str]:
@@ -370,6 +380,7 @@ _GLEAM_BYTES_FORMATTERS: dict[
 }
 
 
+@beartype
 def _gleam_type_var(index: int) -> str:
     """Return a unique lowercase identifier for a type variable.
 
@@ -385,6 +396,7 @@ def _gleam_type_var(index: int) -> str:
     return f"{letter}{group}"
 
 
+@beartype
 def _gleam_call_preamble_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -408,6 +420,7 @@ def _gleam_call_preamble_stub(
     return (f"pub fn {flat_name}({param_list}) -> Nil {{ Nil }}",)
 
 
+@beartype
 def _gleam_format_call_target(parts: Sequence[str]) -> str:
     """Flatten a sequence of call target parts to an underscored Gleam
     identifier.

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -82,6 +82,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 
+@beartype
 def _groovy_call_stub_factory(
     *,
     keyword_style: bool,

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -195,6 +195,7 @@ def _build_haskell_call_stub_lines(
     return tuple(lines)
 
 
+@beartype
 def _build_haskell_call_stub(
     *,
     type_name: str,
@@ -256,6 +257,7 @@ def _format_haskell_datetime(value: datetime.datetime, prefix: str) -> str:
     )
 
 
+@beartype
 def _build_haskell_datetime_formatter(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -475,6 +477,7 @@ def _build_string_formatters(
     )
 
 
+@beartype
 def _num_instance(
     *,
     has_int: bool,
@@ -524,6 +527,7 @@ def _num_instance(
     )
 
 
+@beartype
 def _has_microsecond_datetime(*, data: Value) -> bool:
     """Return whether *data* contains any datetime with microseconds."""
     match data:
@@ -541,6 +545,7 @@ def _has_microsecond_datetime(*, data: Value) -> bool:
             return False
 
 
+@beartype
 def _has_nonmicrosecond_datetime(*, data: Value) -> bool:
     """Return whether *data* contains any datetime without
     microseconds.
@@ -560,6 +565,7 @@ def _has_nonmicrosecond_datetime(*, data: Value) -> bool:
             return False
 
 
+@beartype
 def _datetime_import_items(
     *,
     has_from_gregorian: bool,

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -139,6 +139,7 @@ class _JavaModifiers(enum.Enum):
     """Immutability: cannot be reassigned."""
 
 
+@beartype
 def _java_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -92,6 +92,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 
+@beartype
 def _js_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -102,6 +102,7 @@ def _format_jsonnet_dict_entry(
     return f"{key}: {formatted_value}"
 
 
+@beartype
 def _jsonnet_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -91,6 +91,7 @@ from literalizer._types import Value
 from literalizer.exceptions import CallArgNotSupportedError
 
 
+@beartype
 def _julia_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -462,6 +462,7 @@ class _KotlinDictSpec:
     opener_template: str
 
 
+@beartype
 def _kotlin_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -345,6 +345,7 @@ def _mojo_typed_param_list(
     return info.typed_params
 
 
+@beartype
 def _mojo_cross_call_scalar_wrap_ids(
     slot_values: Sequence[Value],
 ) -> frozenset[int]:
@@ -375,6 +376,7 @@ def _mojo_cross_call_scalar_wrap_ids(
     return frozenset(id(value) for value in slot_values)
 
 
+@beartype
 def _mojo_init_expr(parts: Sequence[str]) -> str:
     """Return the constructor expression for a multi-part call target.
 
@@ -650,6 +652,7 @@ class _HeterogeneousStrategyConfig:
     build_preamble: Callable[[str, type], Callable[[Value], tuple[str, ...]]]
 
 
+@beartype
 def _build_error_behavior(
     _variant_name: str, _datetime_type_produced: type, /
 ) -> HeterogeneousBehavior:
@@ -657,6 +660,7 @@ def _build_error_behavior(
     return NO_HETEROGENEOUS_BEHAVIOR
 
 
+@beartype
 def _build_error_preamble(
     _variant_name: str,
     _datetime_type_produced: type,
@@ -669,6 +673,7 @@ def _build_error_preamble(
 _VARIANT_IMPORT_LINE = "from std.utils.variant import Variant"
 
 
+@beartype
 def _build_variant_behavior(
     variant_name: str,
     datetime_type_produced: type,
@@ -797,6 +802,7 @@ def _render_variant_preamble(
     )
 
 
+@beartype
 def _build_variant_preamble(
     variant_name: str,
     datetime_type_produced: type,
@@ -886,6 +892,7 @@ def _mojo_element_renders_as_string(
             return False
 
 
+@beartype
 def _mojo_list_format(default_type: str, /) -> SequenceFormatConfig:
     """Build a Mojo LIST ``SequenceFormatConfig`` for the given type."""
     return SequenceFormatConfig(

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -307,6 +307,7 @@ class _HeterogeneousStrategyConfig:
     ]
 
 
+@beartype
 def _build_error_behavior(
     _variant_name: str,
     _date_type: str,
@@ -317,6 +318,7 @@ def _build_error_behavior(
     return NO_HETEROGENEOUS_BEHAVIOR
 
 
+@beartype
 def _build_error_preamble(
     _variant_name: str,
     _date_type: str,
@@ -328,6 +330,7 @@ def _build_error_preamble(
     return no_data_preamble
 
 
+@beartype
 def _needs_json_wrap_for_field(field_type: str | None) -> bool:
     """Return whether *field_type* requires ``%*`` to convert a
     formatted scalar into the variant payload.
@@ -339,6 +342,7 @@ def _needs_json_wrap_for_field(field_type: str | None) -> bool:
     return field_type == "JsonNode"
 
 
+@beartype
 def _build_object_variant_behavior(
     variant_name: str,
     date_type: str,
@@ -379,6 +383,7 @@ def _build_object_variant_behavior(
     )
 
 
+@beartype
 def _build_object_variant_preamble(
     variant_name: str,
     date_type: str,

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -224,6 +224,7 @@ def _objc_format_call_target(parts: Sequence[str], /) -> str:
 _SWAPPABLE_PARAMS_NOLINT_THRESHOLD = 4
 
 
+@beartype
 def _objc_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -112,6 +112,7 @@ def _apply_ocaml_entry(original: Value, formatted: str, prefix: str) -> str:
     return f"{prefix}{tag} {literal}"
 
 
+@beartype
 def _build_ocaml_entry_formatter(
     prefix: str,
 ) -> Callable[[Value, str], str]:
@@ -164,6 +165,7 @@ def _build_ocaml_call_stub_lines(
     return tuple(lines)
 
 
+@beartype
 def _ocaml_call_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -177,6 +179,7 @@ def _ocaml_call_stub(
     )
 
 
+@beartype
 def _ocaml_curried_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -96,6 +96,7 @@ def _format_occam_entry(original: Value, formatted: str) -> str:
             return formatted
 
 
+@beartype
 def _occam_stub_parameters(params: Sequence[str], /) -> str:
     """Return an Occam parameter list for a generated call stub."""
     if not params:
@@ -104,6 +105,7 @@ def _occam_stub_parameters(params: Sequence[str], /) -> str:
     return f"({formatted})"
 
 
+@beartype
 def _occam_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -90,6 +90,7 @@ from literalizer._language import (
 from literalizer._types import Value
 
 
+@beartype
 def _php_format_call_target(parts: Sequence[str], /) -> str:
     """Rewrite a dotted call target into PHP's ``$obj->method`` form."""
     if len(parts) == 1:
@@ -97,11 +98,13 @@ def _php_format_call_target(parts: Sequence[str], /) -> str:
     return "$" + parts[0] + "".join(f"->{p}" for p in parts[1:])
 
 
+@beartype
 def _php_format_call_ref_identifier(name: str, _value: Value | None, /) -> str:
     """Prepend PHP's ``$`` variable sigil to a call-ref identifier."""
     return f"${name}"
 
 
+@beartype
 def _php_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -88,6 +88,7 @@ def _apply_purescript_date_iso(value: datetime.date, prefix: str) -> str:
     return f"{prefix}Str {format_date_iso(value=value)}"
 
 
+@beartype
 def _build_purescript_date_iso(
     prefix: str,
 ) -> Callable[[datetime.date], str]:
@@ -108,6 +109,7 @@ def _apply_purescript_time_iso(value: datetime.time, prefix: str) -> str:
     return f"{prefix}Str {format_time_iso(value=value)}"
 
 
+@beartype
 def _build_purescript_time_iso(
     prefix: str,
 ) -> Callable[[datetime.time], str]:
@@ -130,6 +132,7 @@ def _apply_purescript_datetime_iso(
     return f"{prefix}Str {format_datetime_iso(value=value)}"
 
 
+@beartype
 def _build_purescript_datetime_iso(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -144,6 +147,7 @@ def _build_purescript_datetime_iso(
     return _format
 
 
+@beartype
 def _build_purescript_datetime_epoch(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -164,6 +168,7 @@ def _apply_purescript_bytes_hex(value: bytes, prefix: str) -> str:
     return f"{prefix}Str {format_bytes_hex(value=value)}"
 
 
+@beartype
 def _build_purescript_bytes_hex(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -184,6 +189,7 @@ def _apply_purescript_bytes_base64(value: bytes, prefix: str) -> str:
     return f"{prefix}Str {format_bytes_base64(value=value)}"
 
 
+@beartype
 def _build_purescript_bytes_base64(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -208,6 +214,7 @@ def _purescript_int_fits_in_int32(value: int) -> bool:
     return _PURESCRIPT_INT32_MIN <= value <= _PURESCRIPT_INT32_MAX
 
 
+@beartype
 def _purescript_has_large_int(val: Value) -> bool:
     """Return True if *val* contains an integer that overflows
     PureScript's 32-bit ``Int``.
@@ -252,6 +259,7 @@ def _apply_purescript_integer_formatter(
     return f"{prefix}Long {value}.0"
 
 
+@beartype
 def _build_purescript_integer_formatter(
     prefix: str,
     base: Callable[[int], str],
@@ -281,6 +289,7 @@ def _apply_purescript_float_wrapper(
     return f"{prefix}Float {formatted}"
 
 
+@beartype
 def _build_purescript_float_wrapper(
     prefix: str,
     inner: Callable[[float], str],
@@ -308,6 +317,7 @@ def _apply_purescript_string(value: str, prefix: str) -> str:
     return f"{prefix}Str {escaped}"
 
 
+@beartype
 def _build_purescript_str_formatter(
     prefix: str,
 ) -> Callable[[str], str]:
@@ -338,6 +348,7 @@ def _apply_purescript_dict_entry(
     return f"(Tuple {key} ({formatted_value}))"
 
 
+@beartype
 def _build_purescript_dict_entry(
     prefix: str,
 ) -> Callable[[str, Value, str], str]:
@@ -390,6 +401,7 @@ _format_purescript_string = _build_purescript_str_formatter(prefix="P")
 _purescript_dict_entry = _build_purescript_dict_entry(prefix="P")
 
 
+@beartype
 def _purescript_negative_float(val: float) -> bool:
     """Return True if *val* is a float requiring ``import Prelude``."""
     return math.copysign(1, val) < 0 or math.isinf(val) or math.isnan(val)
@@ -527,6 +539,7 @@ def _build_purescript_call_stub_lines(
     return (f"{root} :: {inner_type}", f"{root} = {inner_val}")
 
 
+@beartype
 def _build_purescript_call_stub(
     type_name: str,
 ) -> Callable[
@@ -562,6 +575,7 @@ def _purescript_format_call_arg(_original: Value, formatted: str, /) -> str:
     return f"({formatted})"
 
 
+@beartype
 def _indent_purescript_let_calls(calls: str, indent: str) -> str:
     """Indent call expressions for a PureScript ``let`` block.
 
@@ -575,6 +589,7 @@ def _indent_purescript_let_calls(calls: str, indent: str) -> str:
     return "\n".join(binding_prefix + line for line in calls.split(sep="\n"))
 
 
+@beartype
 def _build_purescript_call_output(
     preamble: str,
     decl_part: str,

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -291,11 +291,13 @@ def _format_inline_type_hint_declaration(
     return f"{name}: {hint} = {value}"
 
 
+@beartype
 def _join_union_pipe(types: list[str]) -> str:
     """Join *types* with ``|`` (Python 3.10+ union syntax)."""
     return " | ".join(types)
 
 
+@beartype
 def _join_union_typing(types: list[str]) -> str:
     """Join *types* as ``Union[...]`` (Python 3.8-compatible)."""
     return f"Union[{', '.join(types)}]"
@@ -544,6 +546,7 @@ def _build_type_hint_preamble(
     return _preamble
 
 
+@beartype
 def _build_python_call_stub(
     *,
     indent: str,

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -78,6 +78,7 @@ from literalizer._types import Value
 from literalizer.exceptions import CallArgNotSupportedError
 
 
+@beartype
 def _racket_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -111,6 +111,7 @@ def _apply_roc_str_wrapped_date(value: datetime.date, prefix: str) -> str:
     return f"{prefix}Str {format_date_iso(value=value)}"
 
 
+@beartype
 def _build_roc_date_iso(
     prefix: str,
 ) -> Callable[[datetime.date], str]:
@@ -131,6 +132,7 @@ def _apply_roc_str_wrapped_time(value: datetime.time, prefix: str) -> str:
     return f"{prefix}Str {format_time_iso(value=value)}"
 
 
+@beartype
 def _build_roc_time_iso(
     prefix: str,
 ) -> Callable[[datetime.time], str]:
@@ -153,6 +155,7 @@ def _apply_roc_str_wrapped_datetime(
     return f"{prefix}Str {format_datetime_iso(value=value)}"
 
 
+@beartype
 def _build_roc_datetime_iso(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -167,6 +170,7 @@ def _build_roc_datetime_iso(
     return _format
 
 
+@beartype
 def _build_roc_datetime_epoch(
     prefix: str,
 ) -> Callable[[datetime.datetime], str]:
@@ -184,6 +188,7 @@ def _apply_roc_bytes_hex(value: bytes, prefix: str) -> str:
     return f"{prefix}Str {format_bytes_hex(value=value)}"
 
 
+@beartype
 def _build_roc_bytes_hex(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -204,6 +209,7 @@ def _apply_roc_bytes_base64(value: bytes, prefix: str) -> str:
     return f"{prefix}Str {format_bytes_base64(value=value)}"
 
 
+@beartype
 def _build_roc_bytes_base64(
     prefix: str,
 ) -> Callable[[bytes], str]:
@@ -224,6 +230,7 @@ def _apply_roc_string(value: str, prefix: str) -> str:
     return f"{prefix}Str {_format_roc_string_literal(value=value)}"
 
 
+@beartype
 def _build_roc_str_formatter(
     prefix: str,
 ) -> Callable[[str], str]:
@@ -254,6 +261,7 @@ def _apply_roc_integer(
     return f"{prefix}Int {base(value)}i128"
 
 
+@beartype
 def _build_roc_integer_formatter(
     prefix: str,
     base: Callable[[int], str],
@@ -277,6 +285,7 @@ def _apply_roc_float(
     return f"{prefix}Float {inner(value)}"
 
 
+@beartype
 def _build_roc_float_formatter(
     prefix: str,
     inner: Callable[[float], str],
@@ -308,6 +317,7 @@ def _apply_roc_dict_entry(
     return f"({key}, {formatted_value})"
 
 
+@beartype
 def _build_roc_dict_entry(
     prefix: str,
 ) -> Callable[[str, Value, str], str]:
@@ -435,6 +445,7 @@ def _build_roc_body_preamble(
     return _compute
 
 
+@beartype
 def _roc_format_call_target(parts: Sequence[str]) -> str:
     """Flatten a sequence of call target parts to an underscored Roc
     identifier.
@@ -461,6 +472,7 @@ def _roc_type_var(*, index: int) -> str:
     return f"{letter}{group}"
 
 
+@beartype
 def _roc_call_body_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -497,6 +509,7 @@ def _roc_format_call_arg(_value: Value, formatted: str) -> str:
     return f"({formatted})"
 
 
+@beartype
 def _indent_call_lines(*, content: str, indent: str) -> str:
     """Wrap each call line of *content* in ``dbg (...)`` for a Roc
     ``main`` body.

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -93,11 +93,13 @@ from literalizer._types import Value
 from literalizer.exceptions import CallArgNotSupportedError
 
 
+@beartype
 def _to_pascal_case(name: str) -> str:
     """Convert *name* to PascalCase."""
     return IdentifierCase.PASCAL.convert(name=name)
 
 
+@beartype
 def _ruby_call_stub(
     format_class_name: Callable[[str], str],
     parts: Sequence[str],

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -124,6 +124,7 @@ _I64_MIN = -(2**63)
 _I64_MAX = 2**63 - 1
 
 
+@beartype
 def _rust_integer_type(value: int) -> str:
     """Return the narrowest Rust integer type for *value*."""
     if _I32_MIN <= value <= _I32_MAX:
@@ -565,6 +566,7 @@ class _HeterogeneousStrategyConfig:
     ]
 
 
+@beartype
 def _build_error_behavior(
     _params: _StrategyParams,
     /,
@@ -573,6 +575,7 @@ def _build_error_behavior(
     return NO_HETEROGENEOUS_BEHAVIOR
 
 
+@beartype
 def _build_error_preamble(
     _params: _StrategyParams,
     /,
@@ -581,6 +584,7 @@ def _build_error_preamble(
     return no_data_preamble
 
 
+@beartype
 def _build_tagged_enum_behavior(
     params: _StrategyParams,
     /,
@@ -611,6 +615,7 @@ def _build_tagged_enum_behavior(
     )
 
 
+@beartype
 def _build_tagged_enum_preamble(
     params: _StrategyParams,
     /,
@@ -734,6 +739,7 @@ def _rust_record_field_type(
             return signature.inner_type
 
 
+@beartype
 def _build_record_behavior(
     params: _StrategyParams,
     /,
@@ -824,6 +830,7 @@ def _build_record_behavior(
     )
 
 
+@beartype
 def _render_rust_tuple(
     value: list[Value],
     elements: Sequence[str],
@@ -849,6 +856,7 @@ def _render_rust_tuple(
     )
 
 
+@beartype
 def _rust_tuple_list_ids(data: Value, /) -> frozenset[int]:
     """Adapt :func:`collect_tuple_list_ids` to the positional
     ``compute_tuple_list_ids`` hook signature.
@@ -856,6 +864,7 @@ def _rust_tuple_list_ids(data: Value, /) -> frozenset[int]:
     return collect_tuple_list_ids(data=data)
 
 
+@beartype
 def _build_tuple_behavior(
     params: _StrategyParams,
     /,
@@ -877,6 +886,7 @@ def _build_tuple_behavior(
     )
 
 
+@beartype
 def _ordered_record_shapes(
     *,
     data: Value,
@@ -896,6 +906,7 @@ def _ordered_record_shapes(
     return ordered
 
 
+@beartype
 def _accumulate_ordered_shapes(
     *,
     data: Value,
@@ -932,6 +943,7 @@ def _accumulate_ordered_shapes(
             return
 
 
+@beartype
 def _record_preamble_impl(
     params: _StrategyParams,
     /,
@@ -1012,6 +1024,7 @@ def _record_preamble_impl(
     return _preamble
 
 
+@beartype
 def _build_record_preamble(
     params: _StrategyParams,
     /,
@@ -1020,6 +1033,7 @@ def _build_record_preamble(
     return _record_preamble_impl(params, enable_tuples=False)
 
 
+@beartype
 def _build_tuple_preamble(
     params: _StrategyParams,
     /,
@@ -1031,6 +1045,7 @@ def _build_tuple_preamble(
     return _record_preamble_impl(params, enable_tuples=True)
 
 
+@beartype
 def _accumulate_emit_order(
     *,
     data: Value,
@@ -1066,6 +1081,7 @@ def _accumulate_emit_order(
             return
 
 
+@beartype
 def _gather_record_field_values(  # noqa: C901  # pylint: disable=too-complex
     *,
     data: Value,
@@ -1149,6 +1165,7 @@ def _rust_type_var(*, index: int) -> str:
     return f"{letter}{group}"
 
 
+@beartype
 def _rust_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -216,6 +216,7 @@ class _ScalaDictSpec:
     preamble_lines: tuple[str, ...]
 
 
+@beartype
 def _scala_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -95,6 +95,7 @@ def _apply_sml_negate_int(value: int, formatter: Callable[[int], str]) -> str:
     return result
 
 
+@beartype
 def _sml_negate_int(
     formatter: Callable[[int], str],
 ) -> Callable[[int], str]:
@@ -118,6 +119,7 @@ def _apply_sml_negate_float(
     return result
 
 
+@beartype
 def _sml_negate_float(
     formatter: Callable[[float], str],
 ) -> Callable[[float], str]:
@@ -186,6 +188,7 @@ def _apply_sml_entry_formatter(
     return result
 
 
+@beartype
 def _build_sml_entry_formatter(
     prefix: str,
 ) -> Callable[[Value, str], str]:
@@ -245,6 +248,7 @@ def _build_sml_declaration(
     return _format
 
 
+@beartype
 def _format_sml_preamble_lines(
     lines: list[str],
     *,
@@ -295,6 +299,7 @@ def _build_sml_call_stub_lines(
     return tuple(lines)
 
 
+@beartype
 def _sml_call_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -308,6 +313,7 @@ def _sml_call_stub(
     )
 
 
+@beartype
 def _sml_curried_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -161,6 +161,7 @@ def _swift_args_contain_nil(*, args: Sequence[Value]) -> bool:
     return any(v is None for v in inner)
 
 
+@beartype
 def _swift_call_stub(
     parts: Sequence[str],
     params: Sequence[str],

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -96,6 +96,7 @@ from literalizer._language import (
 from literalizer._types import OrderedMap, Scalar, Value
 
 
+@beartype
 def _ts_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -127,6 +127,7 @@ def _format_v_u64_positive(value: int) -> str:
     return f"u64({value})"
 
 
+@beartype
 def _make_v_i64_formatter(
     base: Callable[[int], str],
 ) -> Callable[[int], str]:
@@ -145,6 +146,7 @@ def _make_v_i64_formatter(
     return _format
 
 
+@beartype
 def _v_collect_ids_needing_wrap(  # pylint: disable=too-complex
     data: Value,
 ) -> frozenset[int]:
@@ -205,6 +207,7 @@ class _VHeterogeneousStrategyConfig:
     build_preamble: Callable[[], Callable[[Value], tuple[str, ...]]]
 
 
+@beartype
 def _build_v_interface_behavior() -> HeterogeneousBehavior:
     """INTERFACE strategy: wrap scalars in ``IVal(...)``."""
 
@@ -235,6 +238,7 @@ def _build_v_interface_behavior() -> HeterogeneousBehavior:
     )
 
 
+@beartype
 def _build_v_interface_preamble() -> Callable[[Value], tuple[str, ...]]:
     """INTERFACE strategy: emit ``interface IVal {}`` when needed."""
 
@@ -250,6 +254,7 @@ def _build_v_interface_preamble() -> Callable[[Value], tuple[str, ...]]:
     return _preamble
 
 
+@beartype
 def _build_v_empty_container_preamble() -> Callable[[Value], tuple[str, ...]]:
     """ERROR strategy: emit ``interface IVal {}`` when empty containers
     will render as ``[]IVal{}`` / ``map[string]IVal{}``.

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -162,6 +162,7 @@ def _format_string_vb(value: str) -> str:
     return " & ".join(parts)
 
 
+@beartype
 def _vb_unique_class_name(*, segment: str, position: int) -> str:
     """Build a stub class name unique to a segment's path position.
 
@@ -174,6 +175,7 @@ def _vb_unique_class_name(*, segment: str, position: int) -> str:
     return f"{segment.title()}Type_{position}_"
 
 
+@beartype
 def _vb_call_stub(
     parts: Sequence[str],
     params: Sequence[str],


### PR DESCRIPTION
The codebase convention is to decorate module-level functions with `@beartype`, but 183 such functions across 43 files were missing it (class methods, enum methods, and Protocol stubs are conventionally left undecorated, so they were not touched). This change adds the missing decorators to restore consistency. `_checks._has_mixed_record_shapes` was intentionally left undecorated because it annotates a parameter with a `TYPE_CHECKING`-only name (`RecordShape`) that beartype cannot resolve at call time. The full test suite (4764 passed, 28303 subtests), `ruff`, and strict `mypy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical addition of runtime type-checking decorators; main risk is new `beartype` runtime errors or minor perf impact in frequently-called helpers, but behavior should be unchanged and tests pass.
> 
> **Overview**
> Restores the project convention of decorating module-level helpers with `@beartype` across core modules (type inference, literalization, preamble) and many `languages/*` utilities (e.g., call-stub generators and formatter factories).
> 
> No functional logic is intentionally changed; the primary effect is stricter runtime validation of function arguments/returns, which can surface previously-silent type mismatches earlier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d6d35df1839ddb4764c94d14142d7f24178d714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->