### PR TITLE
Resolve #1947: promote StubReturn, ban private imports in tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.StubReturn` is now part of the public API.  It
+  was already the parameter type of the public
+  :class:`~literalizer.Language` protocol's ``format_call_stub`` and
+  ``format_call_preamble_stub`` methods, so it is now re-exported from
+  the package root for consumers implementing that protocol.  See
+  #1947.
+
 2026.05.16.1
 ------------
 

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -25,6 +25,7 @@ from literalizer._language import (
     PrefixCallStyle,
     SequenceFormatConfig,
     SetFormatConfig,
+    StubReturn,
     TrailingCommaConfig,
 )
 from literalizer._literalize import (
@@ -67,6 +68,7 @@ __all__ = [
     "PrefixCallStyle",
     "SequenceFormatConfig",
     "SetFormatConfig",
+    "StubReturn",
     "TrailingCommaConfig",
     "VariableForm",
     "fixed_open",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -324,10 +324,21 @@ class FloatSpecialsMixin:
 
 
 class StubReturn(enum.Enum):
-    """Whether a call stub should return a value or void."""
+    """Whether a generated call stub returns a value or nothing.
+
+    Passed to :attr:`Language.format_call_stub` and
+    :attr:`Language.format_call_preamble_stub` to control the return
+    type of the no-op target-function stub emitted when a call is
+    wrapped in a self-contained file.
+    """
 
     VOID = "void"
+    """The call result is discarded, so the stub returns nothing."""
+
     VALUE = "value"
+    """The call result is consumed (passed to a ``call_transform`` or
+    bound to a variable), so the stub returns a value.
+    """
 
 
 class IdentifierCase(enum.Enum):

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -18,7 +18,7 @@ from beartype import beartype
 from pytest_regressions.file_regression import FileRegressionFixture
 
 import literalizer
-from literalizer._language import StubReturn
+from literalizer import StubReturn
 from literalizer.exceptions import (
     CallArgNotSupportedError,
     DottedCallTargetNotSupportedError,

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,7 +1,5 @@
 """Meta-tests for project structure and CI configuration."""
 
-import ast
-import pathlib
 from typing import Any
 
 import pytest
@@ -9,68 +7,6 @@ from beartype import beartype
 from ruamel.yaml import YAML
 
 from literalizer.languages import ALL_LANGUAGES
-
-_TESTS_ROOT = pathlib.Path(__file__).parent
-
-
-@beartype
-def _private_literalizer_imports(*, tree: ast.Module) -> list[str]:
-    """Return a description of every ``literalizer._*`` import in *tree*.
-
-    ``ast.walk`` visits ``TYPE_CHECKING``-guarded imports too, so this
-    catches both module-level and type-checking-only offenders.
-    """
-    offenders: list[str] = []
-    for node in ast.walk(node=tree):
-        match node:
-            case ast.Import():
-                offenders.extend(
-                    f"line {node.lineno}: import {alias.name}"
-                    for alias in node.names
-                    if alias.name.startswith("literalizer._")
-                )
-            case ast.ImportFrom():
-                module = node.module or ""
-                from_private_module = module.startswith("literalizer._")
-                private_names = (
-                    [
-                        alias.name
-                        for alias in node.names
-                        if alias.name.startswith("_")
-                    ]
-                    if module == "literalizer"
-                    else []
-                )
-                if from_private_module or private_names:
-                    imported = ", ".join(alias.name for alias in node.names)
-                    offenders.append(
-                        f"line {node.lineno}: from {module} import {imported}"
-                    )
-            case _:
-                pass
-    return offenders
-
-
-def test_no_private_literalizer_imports_in_tests() -> None:
-    """No ``tests/**/*.py`` file imports from a ``literalizer._*``
-    module (issue #1947).
-
-    Private imports pin internal structure and hide public-API gaps;
-    tests must exercise the package through its public surface.  This
-    check also covers ``TYPE_CHECKING``-only imports so a future test
-    cannot reintroduce one.
-    """
-    violations: dict[str, list[str]] = {}
-    for path in sorted(_TESTS_ROOT.rglob(pattern="*.py")):
-        tree = ast.parse(source=path.read_text(encoding="utf-8"))
-        offenders = _private_literalizer_imports(tree=tree)
-        if offenders:
-            violations[str(object=path)] = offenders
-
-    assert not violations, (
-        "tests/ must not import from private literalizer._* modules; "
-        f"offenders: {violations}"
-    )
 
 
 @pytest.fixture(scope="session", name="lint_workflow")

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -22,29 +22,32 @@ def _private_literalizer_imports(*, tree: ast.Module) -> list[str]:
     """
     offenders: list[str] = []
     for node in ast.walk(node=tree):
-        if isinstance(node, ast.Import):
-            offenders.extend(
-                f"line {node.lineno}: import {alias.name}"
-                for alias in node.names
-                if alias.name.startswith("literalizer._")
-            )
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            from_private_module = module.startswith("literalizer._")
-            private_names = (
-                [
-                    alias.name
+        match node:
+            case ast.Import():
+                offenders.extend(
+                    f"line {node.lineno}: import {alias.name}"
                     for alias in node.names
-                    if alias.name.startswith("_")
-                ]
-                if module == "literalizer"
-                else []
-            )
-            if from_private_module or private_names:
-                imported = ", ".join(alias.name for alias in node.names)
-                offenders.append(
-                    f"line {node.lineno}: from {module} import {imported}"
+                    if alias.name.startswith("literalizer._")
                 )
+            case ast.ImportFrom():
+                module = node.module or ""
+                from_private_module = module.startswith("literalizer._")
+                private_names = (
+                    [
+                        alias.name
+                        for alias in node.names
+                        if alias.name.startswith("_")
+                    ]
+                    if module == "literalizer"
+                    else []
+                )
+                if from_private_module or private_names:
+                    imported = ", ".join(alias.name for alias in node.names)
+                    offenders.append(
+                        f"line {node.lineno}: from {module} import {imported}"
+                    )
+            case _:
+                pass
     return offenders
 
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,5 +1,7 @@
 """Meta-tests for project structure and CI configuration."""
 
+import ast
+import pathlib
 from typing import Any
 
 import pytest
@@ -7,6 +9,65 @@ from beartype import beartype
 from ruamel.yaml import YAML
 
 from literalizer.languages import ALL_LANGUAGES
+
+_TESTS_ROOT = pathlib.Path(__file__).parent
+
+
+@beartype
+def _private_literalizer_imports(*, tree: ast.Module) -> list[str]:
+    """Return a description of every ``literalizer._*`` import in *tree*.
+
+    ``ast.walk`` visits ``TYPE_CHECKING``-guarded imports too, so this
+    catches both module-level and type-checking-only offenders.
+    """
+    offenders: list[str] = []
+    for node in ast.walk(node=tree):
+        if isinstance(node, ast.Import):
+            offenders.extend(
+                f"line {node.lineno}: import {alias.name}"
+                for alias in node.names
+                if alias.name.startswith("literalizer._")
+            )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            from_private_module = module.startswith("literalizer._")
+            private_names = (
+                [
+                    alias.name
+                    for alias in node.names
+                    if alias.name.startswith("_")
+                ]
+                if module == "literalizer"
+                else []
+            )
+            if from_private_module or private_names:
+                imported = ", ".join(alias.name for alias in node.names)
+                offenders.append(
+                    f"line {node.lineno}: from {module} import {imported}"
+                )
+    return offenders
+
+
+def test_no_private_literalizer_imports_in_tests() -> None:
+    """No ``tests/**/*.py`` file imports from a ``literalizer._*``
+    module (issue #1947).
+
+    Private imports pin internal structure and hide public-API gaps;
+    tests must exercise the package through its public surface.  This
+    check also covers ``TYPE_CHECKING``-only imports so a future test
+    cannot reintroduce one.
+    """
+    violations: dict[str, list[str]] = {}
+    for path in sorted(_TESTS_ROOT.rglob(pattern="*.py")):
+        tree = ast.parse(source=path.read_text(encoding="utf-8"))
+        offenders = _private_literalizer_imports(tree=tree)
+        if offenders:
+            violations[str(object=path)] = offenders
+
+    assert not violations, (
+        "tests/ must not import from private literalizer._* modules; "
+        f"offenders: {violations}"
+    )
 
 
 @pytest.fixture(scope="session", name="lint_workflow")


### PR DESCRIPTION
Promotes `StubReturn` to the public API (re-exported from `literalizer/__init__.py` with expanded class/member docstrings), since it was already the parameter type of the public `Language.format_call_stub` / `format_call_preamble_stub` protocol methods and consumers implementing that protocol need it. Swaps the last private import in `tests/integration/call_cases.py` (`from literalizer._language import StubReturn`) to the public path, completing the removal of all `literalizer._*` imports from `tests/`. Adds an AST-based meta-test (`tests/test_meta.py`) that fails if any `tests/**/*.py` imports from a `literalizer._*` module, including under `TYPE_CHECKING`, so this cannot regress. Adds a CHANGELOG entry for the public-API addition. Verified: mypy/ty/pyrefly/ruff clean on changed files, full `test_calls.py` suite unchanged (the public re-export is the same enum object), and the new meta-test passes; this closes #1947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small API-surface change (re-export) plus doc/comment updates and a test import path change; no runtime logic changes beyond symbol visibility.
> 
> **Overview**
> Promotes `StubReturn` to the public API by re-exporting it from `literalizer.__init__` and documenting it as part of the supported surface.
> 
> Updates `StubReturn` docstrings to better describe how it controls generated call-stub return behavior, switches the integration test to import it from the public package root, and records the change in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08917ff1f1d7b75d0d219027dcc1f74c61703065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->