### PR TITLE
Use match statements for type-dispatch ladders

### DIFF
--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -85,6 +85,7 @@ def _value_type_family(  # noqa: C901, PLR0911, PLR0912
     *,
     value: Value,
 ) -> str:
+    # pylint: disable=too-complex,too-many-branches
     """Return a broad type family label for a value."""
     # Check bool before int (bool is a subclass of int), datetime
     # before date (datetime is a subclass of date), and OrderedMap

--- a/src/literalizer/_checks.py
+++ b/src/literalizer/_checks.py
@@ -25,27 +25,31 @@ if TYPE_CHECKING:
 
 
 @beartype
-def scalar_type_bucket(*, value: Value) -> type | None:
+def scalar_type_bucket(*, value: Value) -> type | None:  # noqa: PLR0911
     """Return the type bucket for a scalar, or ``None`` for
     collections.
     """
-    if value is None:
-        return type(None)
     # Check bool before int (bool is a subclass of int), and
     # datetime before date (datetime is a subclass of date).
-    _buckets = (
-        bool,
-        int,
-        float,
-        str,
-        bytes,
-        datetime.date,
-        datetime.time,
-    )
-    for bucket in _buckets:
-        if isinstance(value, bucket):
-            return bucket
-    return None
+    match value:
+        case None:
+            return type(None)
+        case bool():
+            return bool
+        case int():
+            return int
+        case float():
+            return float
+        case str():
+            return str
+        case bytes():
+            return bytes
+        case datetime.date():
+            return datetime.date
+        case datetime.time():
+            return datetime.time
+        case _:
+            return None
 
 
 @beartype
@@ -77,28 +81,41 @@ def _all_scalars_heterogeneous(
 
 
 @beartype
-def _value_type_family(*, value: Value) -> str:
+def _value_type_family(  # noqa: C901, PLR0911, PLR0912
+    *,
+    value: Value,
+) -> str:
     """Return a broad type family label for a value."""
-    if value is None:
-        return "none"
-    # Check bool before int (bool is a subclass of int), and
-    # datetime before date (datetime is a subclass of date).
-    for check_type, family in (
-        (bool, "bool"),
-        (int, "int"),
-        (float, "float"),
-        (str, "str"),
-        (bytes, "bytes"),
-        (datetime.datetime, "datetime"),
-        (datetime.date, "date"),
-        (datetime.time, "time"),
-        (list, "list"),
-        (OrderedMap, "dict"),
-        (dict, "dict"),
-    ):
-        if isinstance(value, check_type):
-            return family
-    return "set"
+    # Check bool before int (bool is a subclass of int), datetime
+    # before date (datetime is a subclass of date), and OrderedMap
+    # before dict (OrderedMap is a subclass of dict).
+    match value:
+        case None:
+            return "none"
+        case bool():
+            return "bool"
+        case int():
+            return "int"
+        case float():
+            return "float"
+        case str():
+            return "str"
+        case bytes():
+            return "bytes"
+        case datetime.datetime():
+            return "datetime"
+        case datetime.date():
+            return "date"
+        case datetime.time():
+            return "time"
+        case list():
+            return "list"
+        case OrderedMap():
+            return "dict"
+        case dict():
+            return "dict"
+        case _:
+            return "set"
 
 
 @beartype

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -402,24 +402,28 @@ def _purescript_needs_prelude(val: Value) -> bool:
     Prelude is required for ``negate`` (any negative int or float)
     and for ``/`` (infinity / NaN expressed as ``1.0 / 0.0``).
     """
-    if isinstance(val, bool):
-        result = False
-    elif isinstance(val, float):
-        result = _purescript_negative_float(val=val)
-    elif isinstance(val, int):
-        result = val < 0
-    elif isinstance(val, list):
-        result = any(_purescript_needs_prelude(val=v) for v in val)
-    elif isinstance(val, dict):
-        result = any(_purescript_needs_prelude(val=v) for v in val.values())
-    elif isinstance(val, set):
-        result = any(
-            _purescript_needs_prelude(val=v)
-            for v in val
-            if isinstance(v, (int, float)) and not isinstance(v, bool)
-        )
-    else:
-        result = False
+    # Check bool before int (bool is a subclass of int).
+    match val:
+        case bool():
+            result = False
+        case float():
+            result = _purescript_negative_float(val=val)
+        case int():
+            result = val < 0
+        case list():
+            result = any(_purescript_needs_prelude(val=v) for v in val)
+        case dict():
+            result = any(
+                _purescript_needs_prelude(val=v) for v in val.values()
+            )
+        case set():
+            result = any(
+                _purescript_needs_prelude(val=v)
+                for v in val
+                if isinstance(v, (int, float)) and not isinstance(v, bool)
+            )
+        case _:
+            result = False
     return result
 
 


### PR DESCRIPTION
Converts the `isinstance`/type-dispatch ladders in `_purescript_needs_prelude`, `scalar_type_bucket`, and `_value_type_family` from if/elif chains to `match`/`case`. MRO-sensitive ordering is preserved (bool before int, datetime before date, OrderedMap before dict), so behavior is unchanged and verified against the PureScript golden suite plus the multi-language heterogeneity/mixed-type tests (983 passed, 3033 subtests). The two `_checks.py` functions exceed ruff's return-count/branch/complexity limits in `match` form, so `PLR0911`/`PLR0912`/`C901` are suppressed inline with `# noqa` per request. No behavior or output changes; no CHANGELOG entry as this is an internal refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal refactor that rewrites type-dispatch logic in data checks and PureScript prelude detection; behavior should remain the same but relies on correct match ordering for subclass cases (e.g., `bool` vs `int`, `OrderedMap` vs `dict`).
> 
> **Overview**
> Refactors several type-dispatch functions to use Python `match`/`case` instead of `isinstance`/`if` chains: `_checks.scalar_type_bucket`, `_checks._value_type_family`, and `purescript._purescript_needs_prelude`.
> 
> Adds inline linter suppressions (`# noqa` / pylint) for increased branch/return complexity introduced by the `match` form, while preserving subclass-sensitive ordering (e.g., `bool` before `int`, `datetime` before `date`, `OrderedMap` before `dict`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dc0ff21e53bdaee7e6ae707a0f5dac6d8879145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->