### PR TITLE
Add RECORD heterogeneous strategy to Odin (#2481)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Odin` gains the ``RECORD``
+  ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
+  :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,
+  :class:`~literalizer.Scala`, :class:`~literalizer.Java` and
+  :class:`~literalizer.Python`).  Each record-shaped dict (non-empty,
+  string-keyed) becomes a generated package-scope ``struct`` declared
+  in the preamble plus a matching ``Record0{ field = value, ... }``
+  literal, so a record-shaped dict that mixes scalars with a container
+  is representable even though ``map[string]V`` requires homogeneous
+  values.  Field names are the dict keys verbatim, and the class-name
+  prefix is configurable via the new ``record_struct_name_prefix``
+  constructor parameter; its ``supports_record_struct_name_prefix``
+  language-class flag is now ``True``.  A list or ordered-map record
+  field keeps Odin's standard ``[dynamic]any{...}`` /
+  ``map[string]any{...}`` rendering and is typed as the matching
+  ``any`` container (no element type is inferred), and an integer
+  field beyond the signed 64-bit range is typed ``u64`` to match its
+  literal.  The default (``ERROR``) ``map[string]any`` output is
+  unchanged.  See #2481.
+
 2026.05.16.1
 ------------
 

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar
@@ -16,6 +16,7 @@ from literalizer._formatters.collection_openers import (
     make_type_to_opener,
 )
 from literalizer._formatters.format_dates import (
+    datetime_epoch_seconds,
     format_date_iso,
     format_datetime_epoch,
     format_datetime_iso,
@@ -36,12 +37,22 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_integers import (
+    I64_MAX,
+    I64_MIN,
     format_integer_binary,
     format_integer_hex,
     format_integer_octal,
     format_integer_underscore,
 )
 from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._formatters.record_strategy import (
+    RecordDeclarationField,
+    RecordFieldType,
+    RecordLiteralField,
+    RecordRenderer,
+    RecordStrategy,
+    build_record_strategy,
+)
 from literalizer._language import (
     NO_CALL_PARAMETER_LIMIT,
     NO_HETEROGENEOUS_BEHAVIOR,
@@ -59,6 +70,7 @@ from literalizer._language import (
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
+    RenderedRecordLiteral,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -210,6 +222,90 @@ def _odin_call_body_stub(
     return (f"{root}: {root_type} = {init_expr}",)
 
 
+# The ``RECORD`` strategy supports only auto ``Record0``/``Record1``/...
+# names (no ``record_shape_names``, consistent with the other non-Rust
+# ports), so the shared renderer always gets an empty custom-name
+# mapping.
+_ODIN_NO_RECORD_SHAPE_NAMES: Mapping[frozenset[str], str] = MappingProxyType(
+    mapping={},
+)
+
+
+@beartype
+def _odin_record_field_identifier(key: str, /) -> str:
+    """Return the Odin ``struct`` member name for a dict *key*.
+
+    Odin member identifiers are the dict keys verbatim (no case
+    conversion), matching the ``Record0{ id = 1, ... }`` literal form.
+    """
+    return key
+
+
+@beartype
+def _odin_int_field_type(value: int, /) -> str:
+    """Return the Odin ``struct`` field type for an integer record
+    field.
+
+    Odin's ``int`` is 64-bit on the targets the fixtures build for, so
+    every value within the signed 64-bit range is ``int``.  The only
+    out-of-range integer the record corpus carries is the unsigned
+    64-bit maximum (``2**64 - 1``); it is typed ``u64`` so the
+    decimal/hex/octal/binary literal -- every integer literal is a
+    bare constant in Odin with no inherent type -- fits the declared
+    field.  A value beyond unsigned 64-bit range is out of scope for
+    the base
+    ``RECORD`` port (Rust is imprecise here too) and is not reached by
+    any record golden.
+    """
+    if not I64_MIN <= value <= I64_MAX:
+        return "u64"
+    return "int"
+
+
+@beartype
+def _odin_render_record_declaration(
+    name: str,
+    fields: Sequence[RecordDeclarationField],
+    /,
+) -> str:
+    """Render an Odin ``Name :: struct { field: Type, ... }``.
+
+    Emitted at package scope by the data-dependent preamble (each
+    fixture is its own compilation unit, so file-scope ``struct``
+    declarations never collide).  The matching record *literal* stays
+    inside ``main`` via the normal value path, avoiding the Odin
+    compiler crash on nested struct literals at global scope that
+    :func:`_odin_call_preamble_stub` already works around.
+    """
+    members = ", ".join(
+        f"{field.identifier}: {field.type_name}" for field in fields
+    )
+    return f"{name} :: struct {{ {members} }}"
+
+
+@beartype
+def _odin_record_literal(
+    name: str,
+    fields: Sequence[RecordLiteralField],
+    /,
+) -> RenderedRecordLiteral:
+    """Render an Odin ``Name{ field = value, ... }`` struct literal as
+    structured pieces for the shared compact/multiline layout code.
+
+    A trailing comma after the last field is valid in an Odin compound
+    literal, so the language-wide trailing-comma config applies
+    unchanged in the multiline form.
+    """
+    return RenderedRecordLiteral(
+        head=f"{name}{{",
+        entries=tuple(
+            f"{field.identifier} = {field.formatted}" for field in fields
+        ),
+        closer="}",
+        compact_pad=" ",
+    )
+
+
 @beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Odin(metaclass=LanguageCls):
@@ -247,7 +343,7 @@ class Odin(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
-    supports_record_struct_name_prefix = False
+    supports_record_struct_name_prefix = True
     supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
@@ -493,11 +589,18 @@ class Odin(metaclass=LanguageCls):
     modifiers = Modifiers
 
     class HeterogeneousStrategies(enum.Enum):
-        """Heterogeneous-scalar strategy options — this language only
-        supports raising.
+        """Heterogeneous-scalar strategy options.
+
+        ``ERROR`` raises on a heterogeneous scalar collection.
+        ``RECORD`` instead renders each record-shaped dict (non-empty,
+        string-keyed) as a generated package-scope ``struct`` plus a
+        matching ``Record0{ field = value, ... }`` literal, so a dict
+        may mix scalars and containers that the homogeneous
+        ``map[string]V`` cannot.
         """
 
-        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+        ERROR = enum.auto()
+        RECORD = enum.auto()
 
     heterogeneous_strategies = HeterogeneousStrategies
 
@@ -585,6 +688,7 @@ class Odin(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    record_struct_name_prefix: str = "Record"
     language_version: VersionFormats = VersionFormats.DEV_2024
     indent: str = "\t"
 
@@ -631,15 +735,97 @@ class Odin(metaclass=LanguageCls):
         """Format an assignment to an existing variable."""
         return variable_formatter(template="{name} = {value}")
 
+    def _odin_record_field_type(  # noqa: PLR0911
+        self,
+        request: RecordFieldType,
+        /,
+    ) -> str:
+        """Return the Odin ``struct`` field type for a record field,
+        derived structurally from the raw value.
+
+        A field whose value is itself a nested record-shaped dict uses
+        that record's generated name.  Every container Odin renders is
+        ``any``-boxed -- a list is ``[dynamic]any{...}`` and an ordered
+        map or non-record dict is ``map[string]any{...}`` -- so the
+        declared field type is the matching ``any`` container; no
+        element type is inferred.  A scalar maps to its Odin type, with
+        an integer's width following its own value (so a wide-integer
+        literal still fits its field) and a datetime typed ``int`` only
+        when the active datetime format renders it as an epoch number.
+        A set or non-record dict field is out of scope for the base
+        ``RECORD`` port (the cross-language decision is tracked in
+        #2317); a non-record dict still renders as a plain
+        ``map[string]any`` so the catch-all type matches its literal.
+        """
+        if request.record_name is not None:
+            return request.record_name
+        value = request.value
+        match value:
+            case None:
+                return "any"
+            case bool():
+                return "bool"
+            case int():
+                return _odin_int_field_type(value)
+            case float():
+                return "f64"
+            case str() | bytes():
+                return "string"
+            case datetime.datetime() if (
+                self.datetime_format.value.type_produced is int
+            ):
+                return _odin_int_field_type(
+                    datetime_epoch_seconds(value=value),
+                )
+            case datetime.date() | datetime.time():
+                return "string"
+            case list():
+                return "[dynamic]any"
+            case _:
+                return "map[string]any"
+
+    @cached_property
+    def _record_renderer(self) -> RecordRenderer:
+        """Odin syntax hooks for the ``RECORD`` strategy."""
+        return RecordRenderer(
+            name_prefix=self.record_struct_name_prefix,
+            record_shape_names=_ODIN_NO_RECORD_SHAPE_NAMES,
+            field_identifier=_odin_record_field_identifier,
+            field_type=self._odin_record_field_type,
+            render_declaration=_odin_render_record_declaration,
+            render_literal=_odin_record_literal,
+        )
+
+    @cached_property
+    def _record_strategy(self) -> RecordStrategy:
+        """Resolve the active strategy to its behavior + preamble.
+
+        ``RECORD`` resolves to the shared record behavior plus the
+        package-scope ``struct``-declaration preamble; ``ERROR`` keeps
+        the raising behavior and emits no data preamble.
+        """
+        cls = type(self.heterogeneous_strategy)
+        if self.heterogeneous_strategy is cls.RECORD:
+            return build_record_strategy(renderer=self._record_renderer)
+        return RecordStrategy(
+            behavior=NO_HETEROGENEOUS_BEHAVIOR,
+            preamble=no_data_preamble,
+        )
+
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
-        """Return data-dependent preamble lines."""
-        return no_data_preamble
+        """Return data-dependent preamble lines.
+
+        For ``HeterogeneousStrategies.RECORD`` emits one ``struct``
+        declaration per record shape present in the data; otherwise
+        produces no preamble.
+        """
+        return self._record_strategy.preamble
 
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
-        """Return the heterogeneous-behavior config."""
-        return self.heterogeneous_strategy.value
+        """Return the behavior for the chosen heterogeneous strategy."""
+        return self._record_strategy.behavior
 
     @cached_property
     def call_data_dependent_preamble(

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -735,7 +735,7 @@ class Odin(metaclass=LanguageCls):
         """Format an assignment to an existing variable."""
         return variable_formatter(template="{name} = {value}")
 
-    def _odin_record_field_type(  # noqa: PLR0911
+    def _odin_record_field_type(  # noqa: PLR0911  # pylint: disable=too-complex
         self,
         request: RecordFieldType,
         /,

--- a/tests/integration/cases/call_deep_dotted_method/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_deep_dotted_method/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,13 @@
+#+feature dynamic-literals
+package main
+_client_post_ :: proc(args: ..any) -> any { return nil }
+ClientType_ :: struct { post: proc(..any) -> any }
+ApiType_ :: struct { client: ClientType_ }
+ObjType_ :: struct { api: ApiType_ }
+
+main :: proc() {
+obj: ObjType_ = ObjType_{ api = ApiType_{ client = ClientType_{ post = _client_post_ } } }
+obj.api.client.post("hello");
+obj.api.client.post(42);
+obj.api.client.post(true);
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_deep_dotted_transformed/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,13 @@
+#+feature dynamic-literals
+package main
+_client_fetch_ :: proc(args: ..any) -> any { return nil }
+ClientType_ :: struct { fetch: proc(..any) -> any }
+AppType_ :: struct { client: ClientType_ }
+emit :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+app: AppType_ = AppType_{ client = ClientType_{ fetch = _client_fetch_ } }
+emit(app.client.fetch("hello"));
+emit(app.client.fetch(42));
+emit(app.client.fetch(true));
+}

--- a/tests/integration/cases/call_dotted_method/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_dotted_method/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+_client_fetch_ :: proc(args: ..any) -> any { return nil }
+ClientType_ :: struct { fetch: proc(..any) -> any }
+AppType_ :: struct { client: ClientType_ }
+
+main :: proc() {
+app: AppType_ = AppType_{ client = ClientType_{ fetch = _client_fetch_ } }
+app.client.fetch("hello");
+app.client.fetch(42);
+app.client.fetch(true);
+}

--- a/tests/integration/cases/call_dotted_transform_stub/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_dotted_transform_stub/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+_tracer_emit_ :: proc(args: ..any) -> any { return nil }
+TracerType_ :: struct { emit: proc(..any) -> any }
+
+main :: proc() {
+tracer: TracerType_ = TracerType_{ emit = _tracer_emit_ }
+tracer.emit(process("hello"));
+tracer.emit(process(42));
+tracer.emit(process(true));
+}

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,19 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+my_ints := [dynamic]any{
+	1,
+	2,
+	3,
+}
+my_strings := [dynamic]any{
+	"a",
+	"b",
+}
+my_empty := [dynamic]any{}
+process(my_ints, 42);
+process(my_strings, 7);
+process(my_empty, 99);
+}

--- a/tests/integration/cases/call_ref_args_reused/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_ref_args_reused/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,15 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+single_var := [dynamic]any{
+	4,
+	5,
+	6,
+}
+repeated_var := 1
+process(repeated_var, 1);
+process(single_var, 0);
+process(repeated_var, 8);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_ref_args_trivial_register/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,18 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+my_int := 1
+my_bool := true
+my_float := 3.14
+my_list := [dynamic]any{
+	1,
+	2,
+	3,
+}
+process(my_int, 42);
+process(my_bool, 7);
+process(my_float, 9);
+process(my_list, 1);
+}

--- a/tests/integration/cases/call_scalar_args/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_scalar_args/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,9 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process("hello");
+process(42);
+process(true);
+}

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,9 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process("hello", "a");
+process(42, "b");
+process(true, "c");
+}

--- a/tests/integration/cases/call_scalar_args_with_null/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_scalar_args_with_null/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,8 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process(nil);
+process("hello");
+}

--- a/tests/integration/cases/call_snake_dotted_method/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_snake_dotted_method/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+_http_client_fetch_ :: proc(args: ..any) -> any { return nil }
+Http_ClientType_ :: struct { fetch: proc(..any) -> any }
+My_AppType_ :: struct { http_client: Http_ClientType_ }
+
+main :: proc() {
+my_app: My_AppType_ = My_AppType_{ http_client = Http_ClientType_{ fetch = _http_client_fetch_ } }
+my_app.http_client.fetch("hello");
+my_app.http_client.fetch(42);
+my_app.http_client.fetch(true);
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Odin_heterogeneous_strategy_record_call@dev_2024.odin
+++ b/tests/integration/cases/call_transform_no_wrapper/Odin_heterogeneous_strategy_record_call@dev_2024.odin
@@ -1,0 +1,9 @@
+#+feature dynamic-literals
+package main
+process :: proc(args: ..any) -> any { return nil }
+
+main :: proc() {
+process("hello");
+process(42);
+process(true);
+}

--- a/tests/integration/cases/dict_all_scalar_types/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/dict_all_scalar_types/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,17 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { s: string, i: int, f: f64, b: bool, n: any, d: string, dt: string, by: string }
+
+main :: proc() {
+my_data := Record0{
+	s = "string",
+	i = 1,
+	f = 1.5,
+	b = true,
+	n = nil,
+	d = "2024-01-15",
+	dt = "2024-01-15T12:00:00",
+	by = "48656c6c6f",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_all_scalar_types/Odin_heterogeneous_strategy_record_datetime_epoch@dev_2024.odin
+++ b/tests/integration/cases/dict_all_scalar_types/Odin_heterogeneous_strategy_record_datetime_epoch@dev_2024.odin
@@ -1,0 +1,17 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { s: string, i: int, f: f64, b: bool, n: any, d: string, dt: int, by: string }
+
+main :: proc() {
+my_data := Record0{
+	s = "string",
+	i = 1,
+	f = 1.5,
+	b = true,
+	n = nil,
+	d = "2024-01-15",
+	dt = 1705320000,
+	by = "48656c6c6f",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/dict_mixed_int_widths/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { a: int, b: int, c: string }
+
+main :: proc() {
+my_data := Record0{
+	a = 1,
+	b = 3000000000,
+	c = "x",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_mixed_scalars/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/dict_mixed_scalars/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,11 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { a: int, b: string }
+
+main :: proc() {
+my_data := Record0{
+	a = 1,
+	b = "x",
+}
+_ = my_data
+}

--- a/tests/integration/cases/dict_with_list_value/Odin_heterogeneous_strategy_record_list_val@dev_2024.odin
+++ b/tests/integration/cases/dict_with_list_value/Odin_heterogeneous_strategy_record_list_val@dev_2024.odin
@@ -1,0 +1,15 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { name: string, scores: [dynamic]any }
+
+main :: proc() {
+my_data := Record0{
+	name = "Alice",
+	scores = [dynamic]any{
+		10,
+		20,
+		30,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/empty_dict/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/empty_dict/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,7 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := map[string]any{}
+_ = my_data
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/heterogeneous_list_with_string/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,10 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := [dynamic]any{
+	"hello",
+	42,
+}
+_ = my_data
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Odin_heterogeneous_strategy_record_sibling_widening@dev_2024.odin
+++ b/tests/integration/cases/multiline_sibling_list_widening/Odin_heterogeneous_strategy_record_sibling_widening@dev_2024.odin
@@ -1,0 +1,27 @@
+#+feature dynamic-literals
+package main
+Record1 :: struct { numbers: [dynamic]any, strings: [dynamic]any }
+Record0 :: struct { omap_value: map[string]any, sibling_lists: Record1, ref_marker_present: [dynamic]any }
+
+main :: proc() {
+my_data := Record0{
+	omap_value = map[string]any{
+		"first" = 1,
+	},
+	sibling_lists = Record1{
+		numbers = [dynamic]any{
+			1,
+			2,
+		},
+		strings = [dynamic]any{
+			"x",
+			"y",
+		},
+	},
+	ref_marker_present = [dynamic]any{
+		"$keep",
+		"z",
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_mixed_dict/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/nested_mixed_dict/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,15 @@
+#+feature dynamic-literals
+package main
+Record1 :: struct { a: int, b: string, c: any }
+Record0 :: struct { outer: Record1 }
+
+main :: proc() {
+my_data := Record0{
+	outer = Record1{
+		a = 1,
+		b = "x",
+		c = nil,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_mixed_inner/Odin_heterogeneous_strategy_record_inner@dev_2024.odin
+++ b/tests/integration/cases/nested_mixed_inner/Odin_heterogeneous_strategy_record_inner@dev_2024.odin
@@ -1,0 +1,10 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := [dynamic]any{
+	[dynamic]any{1, "a"},
+	[dynamic]any{2, "b"},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_mixed_types/Odin_heterogeneous_strategy_record_sibling@dev_2024.odin
+++ b/tests/integration/cases/nested_mixed_types/Odin_heterogeneous_strategy_record_sibling@dev_2024.odin
@@ -1,0 +1,10 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := [dynamic]any{
+	[dynamic]any{1, 2},
+	[dynamic]any{"a", "b"},
+}
+_ = my_data
+}

--- a/tests/integration/cases/nested_sequences/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/nested_sequences/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,10 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := [dynamic]any{
+	[dynamic]any{[dynamic]any{1, 2}, [dynamic]any{3, 4}},
+	[dynamic]any{[dynamic]any{5}},
+}
+_ = my_data
+}

--- a/tests/integration/cases/ordered_map/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/ordered_map/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,11 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := map[string]any{
+	"name" = "Alice",
+	"age" = 30,
+	"active" = true,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_basic/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/record_basic/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,17 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { id: int, description: string, is_done: bool, blocks: [dynamic]any }
+
+main :: proc() {
+my_data := Record0{
+	id = 1,
+	description = "She said \"hello\", then waved",
+	is_done = false,
+	blocks = [dynamic]any{
+		1,
+		2,
+		3,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_epoch_datetime_i32_overflow/Odin_record_epoch_i32_overflow@dev_2024.odin
+++ b/tests/integration/cases/record_epoch_datetime_i32_overflow/Odin_record_epoch_i32_overflow@dev_2024.odin
@@ -1,0 +1,11 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { within_i32: int, beyond_i32: int }
+
+main :: proc() {
+my_data := Record0{
+	within_i32 = 1705320000,
+	beyond_i32 = 4085195400,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_nested_container/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/record_nested_container/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,16 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { title: string, tags: [dynamic]any, priority: int }
+
+main :: proc() {
+my_data := Record0{
+	title = "report",
+	tags = [dynamic]any{
+		"draft",
+		"urgent",
+		"review",
+	},
+	priority = 2,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_nested_record/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/record_nested_record/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,15 @@
+#+feature dynamic-literals
+package main
+Record1 :: struct { name: string, age: int }
+Record0 :: struct { id: int, owner: Record1 }
+
+main :: proc() {
+my_data := Record0{
+	id = 1,
+	owner = Record1{
+		name = "Alice",
+		age = 30,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_pure_scalars/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/record_pure_scalars/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,13 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { name: string, age: int, active: bool, score: f64 }
+
+main :: proc() {
+my_data := Record0{
+	name = "Alice",
+	age = 30,
+	active = true,
+	score = 4.5,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_sequence/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/record_sequence/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { id: int, label: string, tags: [dynamic]any }
+
+main :: proc() {
+my_data := [dynamic]any{
+	Record0{ id = 1, label = "first", tags = [dynamic]any{} },
+	Record0{ id = 2, label = "second", tags = [dynamic]any{} },
+	Record0{ id = 3, label = "third", tags = [dynamic]any{} },
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_two_shapes/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/record_two_shapes/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,19 @@
+#+feature dynamic-literals
+package main
+Record1 :: struct { count: int, rate: int }
+Record2 :: struct { retries: int, timeout: int }
+Record0 :: struct { metrics: Record1, flags: Record2 }
+
+main :: proc() {
+my_data := Record0{
+	metrics = Record1{
+		count = 100,
+		rate = 50,
+	},
+	flags = Record2{
+		retries = 3,
+		timeout = 30,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_integer_binary@dev_2024.odin
+++ b/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_integer_binary@dev_2024.odin
@@ -1,0 +1,14 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { quantity: int, big: u64, ratio: f64, label: string, ok: bool }
+
+main :: proc() {
+my_data := Record0{
+	quantity = 0b11110100001001000000,
+	big = 0b1111111111111111111111111111111111111111111111111111111111111111,
+	ratio = 2.5,
+	label = "tag",
+	ok = true,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_integer_hex@dev_2024.odin
+++ b/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_integer_hex@dev_2024.odin
@@ -1,0 +1,14 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { quantity: int, big: u64, ratio: f64, label: string, ok: bool }
+
+main :: proc() {
+my_data := Record0{
+	quantity = 0xf4240,
+	big = 0xffffffffffffffff,
+	ratio = 2.5,
+	label = "tag",
+	ok = true,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_integer_octal@dev_2024.odin
+++ b/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_integer_octal@dev_2024.odin
@@ -1,0 +1,14 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { quantity: int, big: u64, ratio: f64, label: string, ok: bool }
+
+main :: proc() {
+my_data := Record0{
+	quantity = 0o3641100,
+	big = 0o1777777777777777777777,
+	ratio = 2.5,
+	label = "tag",
+	ok = true,
+}
+_ = my_data
+}

--- a/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_separator_underscore@dev_2024.odin
+++ b/tests/integration/cases/record_wide_int/Odin_heterogeneous_strategy_record_separator_underscore@dev_2024.odin
@@ -1,0 +1,14 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { quantity: int, big: u64, ratio: f64, label: string, ok: bool }
+
+main :: proc() {
+my_data := Record0{
+	quantity = 1_000_000,
+	big = 18_446_744_073_709_551_615,
+	ratio = 2.5,
+	label = "tag",
+	ok = true,
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_pair_record_field/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_pair_record_field/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,14 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { call: string, args: [dynamic]any }
+
+main :: proc() {
+my_data := Record0{
+	call = "send",
+	args = [dynamic]any{
+		1,
+		"email",
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_pair_top_level/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_pair_top_level/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,10 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := [dynamic]any{
+	1,
+	"email",
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_record_field/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_record_field/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,16 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { call: string, args: [dynamic]any }
+
+main :: proc() {
+my_data := Record0{
+	call = "send",
+	args = [dynamic]any{
+		1,
+		"email",
+		"a@gmail.com",
+		100,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_record_seq_sibling/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_record_seq_sibling/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,20 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { scores: [dynamic]any, args: [dynamic]any }
+
+main :: proc() {
+my_data := Record0{
+	scores = [dynamic]any{
+		10,
+		20,
+		30,
+	},
+	args = [dynamic]any{
+		1,
+		"email",
+		"a@gmail.com",
+		100,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_record_sequence/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_record_sequence/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,11 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { call: string, args: [dynamic]any }
+
+main :: proc() {
+my_data := [dynamic]any{
+	Record0{ call = "send", args = [dynamic]any{1, "email", "a@gmail.com", 100} },
+	Record0{ call = "recv", args = [dynamic]any{2, "sms", "b@example.com", 200} },
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_top_level/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_top_level/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,12 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := [dynamic]any{
+	1,
+	"email",
+	"a@gmail.com",
+	100,
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_triple_record_field/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_triple_record_field/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,15 @@
+#+feature dynamic-literals
+package main
+Record0 :: struct { call: string, args: [dynamic]any }
+
+main :: proc() {
+my_data := Record0{
+	call = "send",
+	args = [dynamic]any{
+		1,
+		"email",
+		true,
+	},
+}
+_ = my_data
+}

--- a/tests/integration/cases/tuple_triple_top_level/Odin_heterogeneous_strategy_record@dev_2024.odin
+++ b/tests/integration/cases/tuple_triple_top_level/Odin_heterogeneous_strategy_record@dev_2024.odin
@@ -1,0 +1,11 @@
+#+feature dynamic-literals
+package main
+
+main :: proc() {
+my_data := [dynamic]any{
+	1,
+	"email",
+	true,
+}
+_ = my_data
+}


### PR DESCRIPTION
Closes #2481.

Ports the `RECORD` heterogeneous strategy to Odin (sub-issue of #2420, sibling of #2237). Odin's `map[K]V` requires a homogeneous value type, so record-shaped dicts mixing scalars with a container previously fell back to `map[string]any`; with `heterogeneous_strategy=RECORD` they now render as generated structs.

## Rendering (decisions recorded)

- **Declaration** (package scope, via the data-dependent preamble; each fixture is its own compilation unit so file-scope structs never collide): `Record0 :: struct { id: int, description: string, is_done: bool, blocks: [dynamic]any }`.
- **Literal**: `Record0{ id = 100, description = "first task", is_done = false, blocks = [dynamic]any{102, 103} }`. **Container literal form**: a list / ordered-map / non-record-dict record field keeps Odin's standard `[dynamic]any{...}` / `map[string]any{...}` rendering and is typed as the matching `any` container — no element type is inferred (Odin boxes every container element as `any`, unlike the typed-collection RECORD languages).
- Auto names `Record0`, `Record1`, ...; **no** `record_shape_names`, **no** `record_unify_optional_fields` (consistent with the other non-Rust ports).
- Structural `RecordFieldType` field typing: scalars map to their Odin type; an integer beyond the signed 64-bit range is typed `u64` to match its (decimal/hex/octal/binary) literal; a datetime is typed `int` only when the active datetime format renders it as an epoch number.

## Implementation

`src/literalizer/languages/odin.py` only (+ CHANGELOG + new `Odin_*record*` goldens). `HeterogeneousStrategies` moves to `enum.auto()` (`ERROR` + `RECORD`) with behavior/preamble dispatched per-instance (Go/C++ reference pattern from #2473/#2468); reuses the shared `_formatters/type_inference.py` shape walker and `_formatters/record_strategy.py` orchestration. `supports_record_struct_name_prefix` is now `True` with a configurable `record_struct_name_prefix`.

## Tests

44 auto-generated Odin goldens (record/heterogeneous + numeric-cross + epoch-i32-overflow + datetime-cross variant axes, and the call RECORD-variant axis) regenerated. Every new `.odin` fixture compiles under `odin run .` with the dev-2026-04 toolchain that lint CI pins. No other language's goldens or any shared infra changed. Full Odin golden/call/meta/orphan test selection is green; `_odin_record_field_type` / `_odin_int_field_type` branches are all exercised by the variant corpus (no `# pragma: no cover`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Odin rendering behavior and data-dependent preamble generation for heterogeneous dicts, which could affect existing Odin outputs when `heterogeneous_strategy=RECORD` is selected and may surface edge cases in type inference for nested records/large integers/datetimes.
> 
> **Overview**
> **Adds opt-in `RECORD` support for Odin heterogeneous collections.** Odin can now render record-shaped dicts as generated package-scope `struct` declarations plus `RecordN{ field = value }` literals (instead of raising), with a configurable `record_struct_name_prefix` and `supports_record_struct_name_prefix` flipped to `True`.
> 
> The Odin implementation wires in the shared `record_strategy` machinery, including Odin-specific field typing (notably `u64` for integers beyond signed 64-bit and `int` for epoch datetimes) and emits struct declarations via `data_dependent_preamble` only when the `RECORD` strategy is active.
> 
> Integration fixtures are regenerated/added to cover the new Odin `RECORD` strategy across dict/record shapes, nested records/containers, wide-integer and datetime variants, and call-mode cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b71df27103a79cc6ada29695aab915e9a453b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->