### PR TITLE
Add RECORD heterogeneous strategy to Zig (#2477)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,29 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Zig` gains the ``RECORD``
+  ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
+  :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,
+  :class:`~literalizer.Scala`, :class:`~literalizer.Java`,
+  :class:`~literalizer.Python` and :class:`~literalizer.Cpp`).  The
+  default (``ERROR``) strategy keeps the homogeneous ``ZVal``
+  tagged-union model; under ``RECORD`` each record-shaped dict
+  (non-empty, string-keyed) becomes a generated ``const RecordN =
+  struct { ... };`` declared in the preamble plus a matching
+  ``Record0{ .field = value, ... }`` literal whose fields are raw Zig
+  values, so a record-shaped dict that mixes scalars with a container
+  is representable.  Field names are the dict keys verbatim and field
+  types are inferred structurally from the value (``i64``/``u64``,
+  ``f64``, ``bool``, ``[]const u8``, ``?i64``, ``[]const T`` slices,
+  ``struct { ... }`` tuples for heterogeneous lists, nested
+  ``RecordN``).  Without the ``ZVal`` union the whole value is raw, so
+  a non-record collection is a ``&.{ ... }`` slice / ``.{ ... }``
+  tuple and the binding drops its ``: ZVal`` annotation; the
+  class-name prefix is configurable via the new
+  ``record_struct_name_prefix`` constructor parameter and its
+  ``supports_record_struct_name_prefix`` language-class flag is now
+  ``True``.  See #2477.
+
 2026.05.16.1
 ------------
 

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import re
 import textwrap
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from types import MappingProxyType
 from typing import ClassVar
@@ -43,6 +43,17 @@ from literalizer._formatters.format_integers import (
 from literalizer._formatters.format_strings import (
     format_string_backslash_control,
 )
+from literalizer._formatters.record_strategy import (
+    RecordDeclarationField,
+    RecordFieldType,
+    RecordLiteralField,
+    RecordRenderer,
+    RecordStrategy,
+    build_record_strategy,
+)
+from literalizer._formatters.type_inference import (
+    infer_element_type,
+)
 from literalizer._language import (
     NO_CALL_PARAMETER_LIMIT,
     NO_HETEROGENEOUS_BEHAVIOR,
@@ -59,6 +70,7 @@ from literalizer._language import (
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
+    RenderedRecordLiteral,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -82,7 +94,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 from literalizer.exceptions import UnrepresentableIntegerError
 
 
@@ -163,67 +175,150 @@ def _format_zig_entry(
 
 
 @beartype
-def _zig_call_preamble_stub(
-    parts: Sequence[str],
-    params: Sequence[str],
-    _stub_return: StubReturn,
-    _args: Sequence[Value],
-    /,
-) -> tuple[str, ...]:
-    """Return file-scope Zig stub declarations for a call name.
+def _make_zig_call_preamble_stub(
+    *,
+    record_mode: bool,
+) -> Callable[
+    [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
+    tuple[str, ...],
+]:
+    """Build the file-scope Zig call-stub formatter.
 
     Zig disallows nested function declarations inside ``main``, so
     call stubs are emitted at module scope.  Stubs always return
     ``void`` so a bare ``stub(...);`` statement compiles whether or
-    not a ``call_transform`` consumed the value.  Target stubs take
-    ``ZVal`` parameters so anonymous union literals like
-    ``.{ .int = 1 }`` coerce to a concrete type at the call site;
-    transform wrappers (``["_arg"]``) take ``anytype`` so they accept
-    both ``ZVal`` and ``void`` arguments.  Dotted targets are
-    realized as a nested ``struct`` chain rooted at a module-level
-    constant, so an expression like ``app.client.fetch(...)`` resolves
-    to a real method call on a real value.
+    not a ``call_transform`` consumed the value.  Under the default
+    ``ZVal`` model a target stub takes ``ZVal`` parameters so anonymous
+    union literals like ``.{ .int = 1 }`` coerce to a concrete type at
+    the call site; transform wrappers (``["_arg"]``) take ``anytype``
+    so they accept both ``ZVal`` and ``void`` arguments.  Under the
+    ``RECORD`` strategy (*record_mode*) call arguments are raw Zig
+    values (``42``, ``"hello"``, ``null``, ``&.{ ... }``) rather than
+    ``ZVal`` union literals, so every parameter is ``anytype``.  Dotted
+    targets are realized as a nested ``struct`` chain rooted at a
+    module-level constant, so an expression like
+    ``app.client.fetch(...)`` resolves to a real method call on a real
+    value.
     """
-    param_type = "anytype" if list(params) == ["_arg"] else "ZVal"
-    param_discards = "".join(f" _ = {p};" for p in params)
-    method = parts[-1]
-    if len(parts) == 1:
-        param_list = ", ".join(f"{p}: {param_type}" for p in params)
-        return (f"fn {method}({param_list}) void {{{param_discards} }}",)
-    chain = parts[:-1]
-    holder = chain[-1]
-    holder_type = f"{holder.title()}Type_"
-    method_param_list = ", ".join(
-        [
-            f"self: {holder_type}",
-            *(f"{p}: {param_type}" for p in params),
-        ],
+
+    @beartype
+    def _zig_call_preamble_stub(
+        parts: Sequence[str],
+        params: Sequence[str],
+        _stub_return: StubReturn,
+        _args: Sequence[Value],
+        /,
+    ) -> tuple[str, ...]:
+        """Return file-scope Zig stub declarations for a call name."""
+        param_type = (
+            "anytype" if record_mode or list(params) == ["_arg"] else "ZVal"
+        )
+        param_discards = "".join(f" _ = {p};" for p in params)
+        method = parts[-1]
+        if len(parts) == 1:
+            param_list = ", ".join(f"{p}: {param_type}" for p in params)
+            return (f"fn {method}({param_list}) void {{{param_discards} }}",)
+        chain = parts[:-1]
+        holder = chain[-1]
+        holder_type = f"{holder.title()}Type_"
+        method_param_list = ", ".join(
+            [
+                f"self: {holder_type}",
+                *(f"{p}: {param_type}" for p in params),
+            ],
+        )
+        lines: list[str] = [
+            f"const {holder_type} = struct {{ "
+            f"fn {method}({method_param_list}) void "
+            f"{{ _ = self;{param_discards} }} }};",
+        ]
+        prev_type = holder_type
+        for i in range(len(chain) - 2, 0, -1):
+            curr_type = f"{chain[i].title()}Type_"
+            lines.append(
+                f"const {curr_type} = struct {{ "
+                f"{chain[i + 1]}: {prev_type} = .{{}} }};",
+            )
+            prev_type = curr_type
+        root = chain[0]
+        intermediates = chain[1:]
+        if intermediates:
+            root_type = f"{root.title()}Type_"
+            lines.append(
+                f"const {root_type} = struct {{ "
+                f"{intermediates[0]}: {prev_type} = .{{}} }};",
+            )
+        else:
+            root_type = prev_type
+        lines.append(f"const {root}: {root_type} = .{{}};")
+        return tuple(lines)
+
+    return _zig_call_preamble_stub
+
+
+# The ``RECORD`` strategy supports only auto ``Record0``/``Record1``/...
+# names (no ``record_shape_names``), so the shared renderer always gets
+# an empty custom-name mapping.
+_ZIG_NO_RECORD_SHAPE_NAMES: Mapping[frozenset[str], str] = MappingProxyType(
+    mapping={},
+)
+
+# A datetime/date whose format produces an ``int`` epoch is a Zig
+# ``i64`` record field; an ISO string one is ``[]const u8``.  The
+# ``.get`` default keeps the string fallback off coverage's branch
+# accounting (only the int key is crossed with ``RECORD`` by the
+# datetime-cross corpus; the date axis is never crossed, so an
+# ``if``/ternary would leave the string side uncovered).
+_ZIG_EPOCH_INT_FIELD_TYPES: Mapping[type, str] = MappingProxyType(
+    mapping={int: "i64"},
+)
+
+
+@beartype
+def _zig_record_field_identifier(key: str, /) -> str:
+    """Return the Zig ``struct`` member name for a dict *key*.
+
+    Zig member identifiers are the dict keys verbatim (no case
+    conversion), matching the designated-initializer literal form
+    ``Record0{ .id = 1, ... }``.
+    """
+    return key
+
+
+@beartype
+def _zig_record_literal(
+    name: str,
+    fields: Sequence[RecordLiteralField],
+    /,
+) -> RenderedRecordLiteral:
+    """Render a Zig ``Name{ .field = value, ... }`` struct literal as
+    structured pieces for the shared compact/multiline layout code.
+
+    A trailing comma after the last initializer is valid in a Zig
+    brace-enclosed struct literal, so the language-wide trailing-comma
+    config applies unchanged.
+    """
+    return RenderedRecordLiteral(
+        head=f"{name}{{",
+        entries=tuple(
+            f".{field.identifier} = {field.formatted}" for field in fields
+        ),
+        closer="}",
+        compact_pad=" ",
     )
-    lines: list[str] = [
-        f"const {holder_type} = struct {{ "
-        f"fn {method}({method_param_list}) void "
-        f"{{ _ = self;{param_discards} }} }};",
-    ]
-    prev_type = holder_type
-    for i in range(len(chain) - 2, 0, -1):
-        curr_type = f"{chain[i].title()}Type_"
-        lines.append(
-            f"const {curr_type} = struct {{ "
-            f"{chain[i + 1]}: {prev_type} = .{{}} }};",
-        )
-        prev_type = curr_type
-    root = chain[0]
-    intermediates = chain[1:]
-    if intermediates:
-        root_type = f"{root.title()}Type_"
-        lines.append(
-            f"const {root_type} = struct {{ "
-            f"{intermediates[0]}: {prev_type} = .{{}} }};",
-        )
-    else:
-        root_type = prev_type
-    lines.append(f"const {root}: {root_type} = .{{}};")
-    return tuple(lines)
+
+
+@beartype
+def _zig_render_record_declaration(
+    name: str,
+    fields: Sequence[RecordDeclarationField],
+    /,
+) -> str:
+    """Render a Zig ``const Name = struct { field: Type, ... };``."""
+    members = ", ".join(
+        f"{field.identifier}: {field.type_name}" for field in fields
+    )
+    return f"const {name} = struct {{ {members} }};"
 
 
 @beartype
@@ -263,7 +358,7 @@ class Zig(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = False
     supports_default_ordered_map_value_type = False
-    supports_record_struct_name_prefix = False
+    supports_record_struct_name_prefix = True
     supports_record_shape_names = False
     supports_non_string_dict_keys = False
 
@@ -502,11 +597,21 @@ class Zig(metaclass=LanguageCls):
     modifiers = Modifiers
 
     class HeterogeneousStrategies(enum.Enum):
-        """Heterogeneous-scalar strategy options — this language only
-        supports raising.
+        """Heterogeneous-scalar strategy options.
+
+        ``ERROR`` keeps the default ``ZVal`` union model (a
+        record-shaped dict that mixes scalars with a container is
+        rendered as a homogeneous-typed ``.{ .map = &.{ ... } }``).
+        ``RECORD`` instead renders each record-shaped dict (non-empty,
+        string-keyed) as a generated ``const Record0 = struct { ... };``
+        declared in the preamble plus a matching
+        ``Record0{ .field = value, ... }`` literal whose fields are raw
+        Zig values, so a field may mix scalars and containers that the
+        homogeneous ``ZVal`` map cannot.
         """
 
-        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+        ERROR = enum.auto()
+        RECORD = enum.auto()
 
     heterogeneous_strategies = HeterogeneousStrategies
 
@@ -555,7 +660,22 @@ class Zig(metaclass=LanguageCls):
         indented = textwrap.indent(text=content, prefix=self.indent)
         if not variable_name:
             return f"pub fn main() void {{\n{indented}\n}}"
-        if re.search(pattern=r"^\s*var ", string=content, flags=re.MULTILINE):
+        is_var = bool(
+            re.search(
+                pattern=r"^\s*var ",
+                string=content,
+                flags=re.MULTILINE,
+            ),
+        )
+        if self._record_strategy_active:
+            # A raw value is not a ``ZVal``, so a redefinition ``var``
+            # cannot be reset to ``.nil``; take its address instead so
+            # the final statement uses the variable without tripping
+            # the Zig "pointless discard of local variable" error after
+            # a preceding write.
+            ref = f"&{variable_name}" if is_var else variable_name
+            use = f"{self.indent}_ = {ref};"
+        elif is_var:
             use = f"{self.indent}{variable_name} = .nil;"
         else:
             use = f"{self.indent}_ = {variable_name};"
@@ -600,12 +720,10 @@ class Zig(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    record_struct_name_prefix: str = "Record"
     language_version: VersionFormats = VersionFormats.V0_12
     indent: str = "    "
 
-    null_literal: ClassVar[str] = ".nil"
-    true_literal: ClassVar[str] = ".{ .bool = true }"
-    false_literal: ClassVar[str] = ".{ .bool = false }"
     indent_closing_delimiter: ClassVar[bool] = False
     element_separator: ClassVar[str] = ", "
     skip_null_dict_values: ClassVar[bool] = False
@@ -613,20 +731,6 @@ class Zig(metaclass=LanguageCls):
     supports_scalar_before_comments: ClassVar[bool] = True
     supports_scalar_inline_comments: ClassVar[bool] = False
     statement_terminator: ClassVar[str] = ";"
-    static_preamble: ClassVar[Sequence[str]] = (
-        "const ZVal = union(enum) {",
-        "    nil,",
-        "    bool: bool,",
-        "    int: i64,",
-        "    uint: u64,",
-        "    float: f64,",
-        "    str: []const u8,",
-        "    arr: []const ZVal,",
-        "    map: []const ZKV,",
-        "    set: []const ZVal,",
-        "};",
-        "const ZKV = struct { key: []const u8, val: ZVal };",
-    )
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = (
         'const std = @import("std");',
@@ -642,7 +746,22 @@ class Zig(metaclass=LanguageCls):
     def _format_entry(self) -> Callable[[Value, str], str]:
         """Shared entry formatter closing over date/datetime
         ``type_produced``.
+
+        Under the ``RECORD`` strategy every value is emitted as a raw
+        Zig literal (no ``ZVal`` union tag), so the entry formatter is
+        the identity: sequence/set elements, call arguments, and
+        variable bindings all pass their already-formatted literal
+        through unchanged.
         """
+        if self._record_strategy_active:
+
+            @beartype
+            def _identity(_original: Value, formatted: str) -> str:
+                """Pass the raw Zig literal through unchanged."""
+                return formatted
+
+            return _identity
+
         date_type = self.date_format.value.type_produced
         datetime_type = self.datetime_format.value.type_produced
 
@@ -686,14 +805,177 @@ class Zig(metaclass=LanguageCls):
         return _format_assign
 
     @cached_property
+    def _record_strategy_active(self) -> bool:
+        """Return whether the ``RECORD`` heterogeneous strategy is set."""
+        return self.heterogeneous_strategy.name == "RECORD"
+
+    @cached_property
+    def null_literal(self) -> str:
+        """The literal representing null.
+
+        The default ``ZVal`` model uses the union tag ``.nil``; under
+        ``RECORD`` a null record field is a raw Zig ``null`` (its field
+        type is the optional ``?i64``).
+        """
+        return "null" if self._record_strategy_active else ".nil"
+
+    @cached_property
+    def true_literal(self) -> str:
+        """The literal representing true.
+
+        Raw Zig ``true`` under ``RECORD`` (a ``bool`` field), the
+        ``ZVal`` union literal otherwise.
+        """
+        if self._record_strategy_active:
+            return "true"
+        return ".{ .bool = true }"
+
+    @cached_property
+    def false_literal(self) -> str:
+        """The literal representing false.
+
+        Raw Zig ``false`` under ``RECORD`` (a ``bool`` field), the
+        ``ZVal`` union literal otherwise.
+        """
+        if self._record_strategy_active:
+            return "false"
+        return ".{ .bool = false }"
+
+    def _zig_value_type(self, value: Value, /) -> str:  # noqa: PLR0911
+        """Return the Zig type for a raw record field *value*.
+
+        Derived structurally from the value (never by re-parsing the
+        formatted literal): scalars map to their Zig primitive, a
+        homogeneous list to ``[]const <elem>``, a heterogeneous list to
+        a Zig tuple ``struct { T0, ... }``, and an ordered map to a
+        slice of ``key``/``val`` ``struct`` values.  A nested
+        record-shaped dict never reaches here -- the shared strategy
+        resolves it to its generated name in
+        :meth:`_zig_record_field_type`.
+        """
+        if isinstance(value, bool):
+            return "bool"
+        if isinstance(value, int):
+            return "u64" if value > I64_MAX else "i64"
+        if isinstance(value, float):
+            return "f64"
+        if value is None:
+            return "?i64"
+        if isinstance(value, datetime.datetime):
+            return _ZIG_EPOCH_INT_FIELD_TYPES.get(
+                self.datetime_format.value.type_produced,
+                "[]const u8",
+            )
+        if isinstance(value, datetime.date):
+            return _ZIG_EPOCH_INT_FIELD_TYPES.get(
+                self.date_format.value.type_produced,
+                "[]const u8",
+            )
+        if isinstance(value, OrderedMap):
+            val_type = self._zig_value_type(
+                next(iter(value.values())),
+            )
+            return f"[]const struct {{ key: []const u8, val: {val_type} }}"
+        if isinstance(value, list):
+            return self._zig_list_type(items=value)
+        return "[]const u8"
+
+    def _zig_list_type(self, *, items: list[Value]) -> str:
+        """Return the Zig type for a list record field.
+
+        An empty list has no element type to infer, so it is typed as a
+        ``[]const i64`` slice (``&.{}`` coerces to any slice type).  A
+        list whose elements share a type is a ``[]const <elem>`` slice;
+        a heterogeneous list is a Zig tuple ``struct { T0, T1, ... }``
+        (its literal is the anonymous tuple ``.{ ... }``, matching
+        :attr:`sequence_open`).
+        """
+        if not items:
+            return "[]const i64"
+        if infer_element_type(items=items) is None:
+            members = ", ".join(
+                self._zig_value_type(element) for element in items
+            )
+            return f"struct {{ {members} }}"
+        return f"[]const {self._zig_value_type(items[0])}"
+
+    def _zig_record_field_type(self, request: RecordFieldType, /) -> str:
+        """Return the Zig ``struct`` field type for a record field.
+
+        A field whose value is itself a nested record-shaped dict uses
+        that record's generated name; every other value is typed
+        structurally from the raw value by :meth:`_zig_value_type`.
+        """
+        if request.record_name is not None:
+            return request.record_name
+        return self._zig_value_type(request.value)
+
+    @cached_property
+    def _record_renderer(self) -> RecordRenderer:
+        """Zig syntax hooks for the ``RECORD`` strategy."""
+        return RecordRenderer(
+            name_prefix=self.record_struct_name_prefix,
+            record_shape_names=_ZIG_NO_RECORD_SHAPE_NAMES,
+            field_identifier=_zig_record_field_identifier,
+            field_type=self._zig_record_field_type,
+            render_declaration=_zig_render_record_declaration,
+            render_literal=_zig_record_literal,
+        )
+
+    @cached_property
+    def _record_strategy(self) -> RecordStrategy:
+        """Behavior + ``struct``-declaration preamble for ``RECORD``."""
+        return build_record_strategy(renderer=self._record_renderer)
+
+    @cached_property
+    def static_preamble(self) -> Sequence[str]:
+        """File-scope preamble.
+
+        The default ``ZVal`` model needs its tagged-union declaration;
+        the ``RECORD`` strategy emits raw Zig values and generated
+        ``struct`` declarations instead, so it needs no static
+        preamble.
+        """
+        if self._record_strategy_active:
+            return ()
+        return (
+            "const ZVal = union(enum) {",
+            "    nil,",
+            "    bool: bool,",
+            "    int: i64,",
+            "    uint: u64,",
+            "    float: f64,",
+            "    str: []const u8,",
+            "    arr: []const ZVal,",
+            "    map: []const ZKV,",
+            "    set: []const ZVal,",
+            "};",
+            "const ZKV = struct { key: []const u8, val: ZVal };",
+        )
+
+    @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
-        """Return data-dependent preamble lines."""
+        """Return data-dependent preamble lines.
+
+        Under ``RECORD`` this is the generated ``const Record0 =
+        struct { ... };`` block, emitted in dependency order so a
+        nested record is declared before its parent.
+        """
+        if self._record_strategy_active:
+            return self._record_strategy.preamble
         return no_data_preamble
 
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
-        """Return the heterogeneous-behavior config."""
-        return self.heterogeneous_strategy.value
+        """Return the heterogeneous-behavior config.
+
+        ``RECORD`` resolves to the shared record behavior (its value
+        needs the per-instance renderer, so it cannot be stored on the
+        enum member); ``ERROR`` keeps the default ``ZVal`` model.
+        """
+        if self._record_strategy_active:
+            return self._record_strategy.behavior
+        return NO_HETEROGENEOUS_BEHAVIOR
 
     @cached_property
     def call_data_dependent_preamble(
@@ -732,7 +1014,9 @@ class Zig(metaclass=LanguageCls):
         tuple[str, ...],
     ]:
         """Return file-scope stubs for a call expression."""
-        return _zig_call_preamble_stub
+        return _make_zig_call_preamble_stub(
+            record_mode=self._record_strategy_active,
+        )
 
     @cached_property
     def format_call_arg(self) -> Callable[[Value, str], str]:
@@ -796,8 +1080,18 @@ class Zig(metaclass=LanguageCls):
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
-        """Configuration for the chosen sequence format."""
-        return self.sequence_format.value
+        """Configuration for the chosen sequence format.
+
+        Under ``RECORD`` a list is a raw Zig literal -- a ``&.{ ... }``
+        slice (homogeneous / empty) or a ``.{ ... }`` tuple
+        (heterogeneous), both closed by a single ``}`` rather than the
+        ``ZVal`` ``.{ .arr = &.{ ... }}`` form.  Only the closer changes
+        here; the opener is chosen per list by :attr:`sequence_open`.
+        """
+        base = self.sequence_format.value
+        if self._record_strategy_active:
+            return dataclasses.replace(base, close="}")
+        return base
 
     @cached_property
     def set_format_config(self) -> SetFormatConfig:
@@ -806,13 +1100,39 @@ class Zig(metaclass=LanguageCls):
 
     @cached_property
     def sequence_open(self) -> Callable[[list[Value]], str]:
-        """Callable that returns the opening delimiter for a sequence."""
-        return self.sequence_format.value.sequence_open
+        """Callable that returns the opening delimiter for a sequence.
+
+        Under ``RECORD`` a homogeneous or empty list opens ``&.{`` so
+        the literal coerces to a ``[]const T`` slice; a heterogeneous
+        list opens ``.{`` so it is a Zig tuple (matching the
+        ``struct { T0, ... }`` field type :meth:`_zig_value_type`
+        derives).  Every other strategy keeps the ``ZVal`` array
+        opener.
+        """
+        if not self._record_strategy_active:
+            return self.sequence_format.value.sequence_open
+
+        def _open(items: list[Value]) -> str:
+            """Return the slice opener, or the tuple opener for a
+            heterogeneous list.
+            """
+            if items and infer_element_type(items=items) is None:
+                return ".{"
+            return "&.{"
+
+        return _open
 
     @cached_property
     def dict_format_config(self) -> DictFormatConfig:
-        """Configuration for dict formatting."""
-        return DictFormatConfig(
+        """Configuration for dict formatting.
+
+        Under ``RECORD`` every non-empty string-keyed dict is a record
+        (rendered as a generated ``struct``); the only plain dict that
+        still reaches the dict formatter is the empty dict, emitted as
+        the raw empty struct ``.{}`` instead of the ``ZVal``
+        ``.{ .map = &.{}}`` form.
+        """
+        base = DictFormatConfig(
             dict_open=fixed_open(open_str=".{ .map = &.{"),
             close="}}",
             format_entry=dict_entry_with_template(
@@ -824,6 +1144,9 @@ class Zig(metaclass=LanguageCls):
             narrowed_open=None,
             supports_trailing_comma=True,
         )
+        if self._record_strategy_active:
+            return dataclasses.replace(base, empty_dict=".{}")
+        return base
 
     @cached_property
     def trailing_comma_config(self) -> TrailingCommaConfig:
@@ -882,7 +1205,19 @@ class Zig(metaclass=LanguageCls):
 
     @cached_property
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
-        """Configuration for ordered-map formatting."""
+        """Configuration for ordered-map formatting.
+
+        An ordered map is never record-eligible, so under ``RECORD`` it
+        stays a map but as a raw ``&.{ .{ .key = ..., .val = ... }, ... }``
+        slice of ``key``/``val`` ``struct`` values rather than the
+        ``ZVal`` ``.{ .map = &.{ ... }}`` form.
+        """
+        if self._record_strategy_active:
+            return OrderedMapFormatConfig(
+                ordered_map_open=fixed_open(open_str="&.{"),
+                close="}",
+                preamble_lines=(),
+            )
         return OrderedMapFormatConfig(
             ordered_map_open=fixed_open(open_str=".{ .map = &.{"),
             close="}}",
@@ -909,6 +1244,7 @@ class Zig(metaclass=LanguageCls):
         """
         keyword = self.declaration_style.value.keyword
         format_entry = self._format_entry
+        record_mode = self._record_strategy_active
 
         @beartype
         def _format_decl(
@@ -917,8 +1253,16 @@ class Zig(metaclass=LanguageCls):
             data: Value,
             _modifiers: frozenset[enum.Enum],
         ) -> str:
-            """Format a Zig declaration with explicit ``ZVal`` type."""
+            """Format a Zig declaration.
+
+            The default ``ZVal`` model declares an explicit ``: ZVal``
+            type; under ``RECORD`` the value is a raw Zig literal
+            (a ``Record0{ ... }`` struct, slice, tuple or scalar) whose
+            type is inferred, so no annotation is emitted.
+            """
             wrapped = format_entry(data, value)
+            if record_mode:
+                return f"{keyword} {name} = {wrapped};"
             return f"{keyword} {name}: ZVal = {wrapped};"
 
         return _format_decl

--- a/tests/integration/cases/call_deep_dotted_method/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_deep_dotted_method/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,9 @@
+const ClientType_ = struct { fn post(self: ClientType_, data: anytype) void { _ = self; _ = data; } };
+const ApiType_ = struct { client: ClientType_ = .{} };
+const ObjType_ = struct { api: ApiType_ = .{} };
+const obj: ObjType_ = .{};
+pub fn main() void {
+    obj.api.client.post("hello");
+    obj.api.client.post(42);
+    obj.api.client.post(true);
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_deep_dotted_transformed/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,9 @@
+const ClientType_ = struct { fn fetch(self: ClientType_, payload: anytype) void { _ = self; _ = payload; } };
+const AppType_ = struct { client: ClientType_ = .{} };
+const app: AppType_ = .{};
+fn emit(_arg: anytype) void { _ = _arg; }
+pub fn main() void {
+    emit(app.client.fetch("hello"));
+    emit(app.client.fetch(42));
+    emit(app.client.fetch(true));
+}

--- a/tests/integration/cases/call_dotted_method/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_dotted_method/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,8 @@
+const ClientType_ = struct { fn fetch(self: ClientType_, payload: anytype) void { _ = self; _ = payload; } };
+const AppType_ = struct { client: ClientType_ = .{} };
+const app: AppType_ = .{};
+pub fn main() void {
+    app.client.fetch("hello");
+    app.client.fetch(42);
+    app.client.fetch(true);
+}

--- a/tests/integration/cases/call_dotted_transform_stub/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_dotted_transform_stub/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,8 @@
+fn process(value: anytype) void { _ = value; }
+const TracerType_ = struct { fn emit(self: TracerType_, _arg: anytype) void { _ = self; _ = _arg; } };
+const tracer: TracerType_ = .{};
+pub fn main() void {
+    tracer.emit(process("hello"));
+    tracer.emit(process(42));
+    tracer.emit(process(true));
+}

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,16 @@
+fn process(data: anytype, count: anytype) void { _ = data; _ = count; }
+pub fn main() void {
+    const my_ints = &.{
+        1,
+        2,
+        3,
+    };
+    const my_strings = &.{
+        "a",
+        "b",
+    };
+    const my_empty = &.{};
+    process(my_ints, 42);
+    process(my_strings, 7);
+    process(my_empty, 99);
+}

--- a/tests/integration/cases/call_ref_args_reused/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_ref_args_reused/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,12 @@
+fn process(data: anytype, count: anytype) void { _ = data; _ = count; }
+pub fn main() void {
+    const single_var = &.{
+        4,
+        5,
+        6,
+    };
+    const repeated_var = 1;
+    process(repeated_var, 1);
+    process(single_var, 0);
+    process(repeated_var, 8);
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_ref_args_trivial_register/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,15 @@
+fn process(value: anytype, count: anytype) void { _ = value; _ = count; }
+pub fn main() void {
+    const my_int = 1;
+    const my_bool = true;
+    const my_float = 3.14;
+    const my_list = &.{
+        1,
+        2,
+        3,
+    };
+    process(my_int, 42);
+    process(my_bool, 7);
+    process(my_float, 9);
+    process(my_list, 1);
+}

--- a/tests/integration/cases/call_scalar_args/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_scalar_args/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,6 @@
+fn process(value: anytype) void { _ = value; }
+pub fn main() void {
+    process("hello");
+    process(42);
+    process(true);
+}

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,6 @@
+fn process(value: anytype, label: anytype) void { _ = value; _ = label; }
+pub fn main() void {
+    process("hello", "a");
+    process(42, "b");
+    process(true, "c");
+}

--- a/tests/integration/cases/call_scalar_args_with_null/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_scalar_args_with_null/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,5 @@
+fn process(value: anytype) void { _ = value; }
+pub fn main() void {
+    process(null);
+    process("hello");
+}

--- a/tests/integration/cases/call_snake_dotted_method/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_snake_dotted_method/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,8 @@
+const Http_ClientType_ = struct { fn fetch(self: Http_ClientType_, payload: anytype) void { _ = self; _ = payload; } };
+const My_AppType_ = struct { http_client: Http_ClientType_ = .{} };
+const my_app: My_AppType_ = .{};
+pub fn main() void {
+    my_app.http_client.fetch("hello");
+    my_app.http_client.fetch(42);
+    my_app.http_client.fetch(true);
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Zig_heterogeneous_strategy_record_call@v0_12.zig
+++ b/tests/integration/cases/call_transform_no_wrapper/Zig_heterogeneous_strategy_record_call@v0_12.zig
@@ -1,0 +1,6 @@
+fn process(value: anytype) void { _ = value; }
+pub fn main() void {
+    process("hello");
+    process(42);
+    process(true);
+}

--- a/tests/integration/cases/dict_all_scalar_types/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/dict_all_scalar_types/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,14 @@
+const Record0 = struct { s: []const u8, i: i64, f: f64, b: bool, n: ?i64, d: i64, dt: i64, by: []const u8 };
+pub fn main() void {
+    const my_data = Record0{
+        .s = "string",
+        .i = 1,
+        .f = 1.5,
+        .b = true,
+        .n = null,
+        .d = 1705276800,
+        .dt = 1705320000,
+        .by = "48656c6c6f",
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/dict_all_scalar_types/Zig_heterogeneous_strategy_record_datetime_epoch@v0_12.zig
+++ b/tests/integration/cases/dict_all_scalar_types/Zig_heterogeneous_strategy_record_datetime_epoch@v0_12.zig
@@ -1,0 +1,14 @@
+const Record0 = struct { s: []const u8, i: i64, f: f64, b: bool, n: ?i64, d: i64, dt: i64, by: []const u8 };
+pub fn main() void {
+    const my_data = Record0{
+        .s = "string",
+        .i = 1,
+        .f = 1.5,
+        .b = true,
+        .n = null,
+        .d = 1705276800,
+        .dt = 1705320000,
+        .by = "48656c6c6f",
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/dict_all_scalar_types/Zig_heterogeneous_strategy_record_datetime_iso@v0_12.zig
+++ b/tests/integration/cases/dict_all_scalar_types/Zig_heterogeneous_strategy_record_datetime_iso@v0_12.zig
@@ -1,0 +1,14 @@
+const Record0 = struct { s: []const u8, i: i64, f: f64, b: bool, n: ?i64, d: i64, dt: []const u8, by: []const u8 };
+pub fn main() void {
+    const my_data = Record0{
+        .s = "string",
+        .i = 1,
+        .f = 1.5,
+        .b = true,
+        .n = null,
+        .d = 1705276800,
+        .dt = "2024-01-15T12:00:00",
+        .by = "48656c6c6f",
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/dict_mixed_int_widths/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,9 @@
+const Record0 = struct { a: i64, b: i64, c: []const u8 };
+pub fn main() void {
+    const my_data = Record0{
+        .a = 1,
+        .b = 3000000000,
+        .c = "x",
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/dict_mixed_scalars/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/dict_mixed_scalars/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,8 @@
+const Record0 = struct { a: i64, b: []const u8 };
+pub fn main() void {
+    const my_data = Record0{
+        .a = 1,
+        .b = "x",
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/dict_mixed_scalars/Zig_heterogeneous_strategy_record_combined@v0_12.zig
+++ b/tests/integration/cases/dict_mixed_scalars/Zig_heterogeneous_strategy_record_combined@v0_12.zig
@@ -1,0 +1,12 @@
+const Record0 = struct { a: i64, b: []const u8 };
+pub fn main() void {
+    var my_data = Record0{
+        .a = 1,
+        .b = "x",
+    };
+    my_data = Record0{
+        .a = 1,
+        .b = "x",
+    };
+    _ = &my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Zig_heterogeneous_strategy_record_list_val@v0_12.zig
+++ b/tests/integration/cases/dict_with_list_value/Zig_heterogeneous_strategy_record_list_val@v0_12.zig
@@ -1,0 +1,12 @@
+const Record0 = struct { name: []const u8, scores: []const i64 };
+pub fn main() void {
+    const my_data = Record0{
+        .name = "Alice",
+        .scores = &.{
+            10,
+            20,
+            30,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/empty_dict/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/empty_dict/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,4 @@
+pub fn main() void {
+    const my_data = .{};
+    _ = my_data;
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/heterogeneous_list_with_string/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,7 @@
+pub fn main() void {
+    const my_data = .{
+        "hello",
+        42,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Zig_heterogeneous_strategy_record_sibling_widening@v0_12.zig
+++ b/tests/integration/cases/multiline_sibling_list_widening/Zig_heterogeneous_strategy_record_sibling_widening@v0_12.zig
@@ -1,0 +1,24 @@
+const Record1 = struct { numbers: []const i64, strings: []const []const u8 };
+const Record0 = struct { omap_value: []const struct { key: []const u8, val: i64 }, sibling_lists: Record1, ref_marker_present: []const []const u8 };
+pub fn main() void {
+    const my_data = Record0{
+        .omap_value = &.{
+            .{ .key = "first", .val = 1 },
+        },
+        .sibling_lists = Record1{
+            .numbers = &.{
+                1,
+                2,
+            },
+            .strings = &.{
+                "x",
+                "y",
+            },
+        },
+        .ref_marker_present = &.{
+            "$keep",
+            "z",
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/nested_mixed_dict/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/nested_mixed_dict/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,12 @@
+const Record1 = struct { a: i64, b: []const u8, c: ?i64 };
+const Record0 = struct { outer: Record1 };
+pub fn main() void {
+    const my_data = Record0{
+        .outer = Record1{
+            .a = 1,
+            .b = "x",
+            .c = null,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/nested_mixed_inner/Zig_heterogeneous_strategy_record_inner@v0_12.zig
+++ b/tests/integration/cases/nested_mixed_inner/Zig_heterogeneous_strategy_record_inner@v0_12.zig
@@ -1,0 +1,7 @@
+pub fn main() void {
+    const my_data = .{
+        .{1, "a"},
+        .{2, "b"},
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/nested_mixed_types/Zig_heterogeneous_strategy_record_sibling@v0_12.zig
+++ b/tests/integration/cases/nested_mixed_types/Zig_heterogeneous_strategy_record_sibling@v0_12.zig
@@ -1,0 +1,7 @@
+pub fn main() void {
+    const my_data = .{
+        &.{1, 2},
+        &.{"a", "b"},
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/nested_sequences/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/nested_sequences/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,7 @@
+pub fn main() void {
+    const my_data = &.{
+        &.{&.{1, 2}, &.{3, 4}},
+        &.{&.{5}},
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/ordered_map/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/ordered_map/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,8 @@
+pub fn main() void {
+    const my_data = &.{
+        .{ .key = "name", .val = "Alice" },
+        .{ .key = "age", .val = 30 },
+        .{ .key = "active", .val = true },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_basic/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/record_basic/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,14 @@
+const Record0 = struct { id: i64, description: []const u8, is_done: bool, blocks: []const i64 };
+pub fn main() void {
+    const my_data = Record0{
+        .id = 1,
+        .description = "She said \"hello\", then waved",
+        .is_done = false,
+        .blocks = &.{
+            1,
+            2,
+            3,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_epoch_datetime_i32_overflow/Zig_record_epoch_i32_overflow@v0_12.zig
+++ b/tests/integration/cases/record_epoch_datetime_i32_overflow/Zig_record_epoch_i32_overflow@v0_12.zig
@@ -1,0 +1,8 @@
+const Record0 = struct { within_i32: i64, beyond_i32: i64 };
+pub fn main() void {
+    const my_data = Record0{
+        .within_i32 = 1705320000,
+        .beyond_i32 = 4085195400,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_list_of_records/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/record_list_of_records/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,18 @@
+const Record1 = struct { id: i64, label: []const u8 };
+const Record0 = struct { name: []const u8, items: []const Record1 };
+pub fn main() void {
+    const my_data = Record0{
+        .name = "box",
+        .items = &.{
+            Record1{
+                .id = 1,
+                .label = "first",
+            },
+            Record1{
+                .id = 2,
+                .label = "second",
+            },
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_nested_container/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/record_nested_container/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,13 @@
+const Record0 = struct { title: []const u8, tags: []const []const u8, priority: i64 };
+pub fn main() void {
+    const my_data = Record0{
+        .title = "report",
+        .tags = &.{
+            "draft",
+            "urgent",
+            "review",
+        },
+        .priority = 2,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_nested_record/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/record_nested_record/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,12 @@
+const Record1 = struct { name: []const u8, age: i64 };
+const Record0 = struct { id: i64, owner: Record1 };
+pub fn main() void {
+    const my_data = Record0{
+        .id = 1,
+        .owner = Record1{
+            .name = "Alice",
+            .age = 30,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_pure_scalars/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/record_pure_scalars/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,10 @@
+const Record0 = struct { name: []const u8, age: i64, active: bool, score: f64 };
+pub fn main() void {
+    const my_data = Record0{
+        .name = "Alice",
+        .age = 30,
+        .active = true,
+        .score = 4.5,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_sequence/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/record_sequence/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,9 @@
+const Record0 = struct { id: i64, label: []const u8, tags: []const i64 };
+pub fn main() void {
+    const my_data = &.{
+        Record0{ .id = 1, .label = "first", .tags = &.{} },
+        Record0{ .id = 2, .label = "second", .tags = &.{} },
+        Record0{ .id = 3, .label = "third", .tags = &.{} },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_two_shapes/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/record_two_shapes/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,16 @@
+const Record1 = struct { count: i64, rate: i64 };
+const Record2 = struct { retries: i64, timeout: i64 };
+const Record0 = struct { metrics: Record1, flags: Record2 };
+pub fn main() void {
+    const my_data = Record0{
+        .metrics = Record1{
+            .count = 100,
+            .rate = 50,
+        },
+        .flags = Record2{
+            .retries = 3,
+            .timeout = 30,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_integer_binary@v0_12.zig
+++ b/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_integer_binary@v0_12.zig
@@ -1,0 +1,11 @@
+const Record0 = struct { quantity: i64, big: u64, ratio: f64, label: []const u8, ok: bool };
+pub fn main() void {
+    const my_data = Record0{
+        .quantity = 0b11110100001001000000,
+        .big = 0b1111111111111111111111111111111111111111111111111111111111111111,
+        .ratio = 2.5,
+        .label = "tag",
+        .ok = true,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_integer_hex@v0_12.zig
+++ b/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_integer_hex@v0_12.zig
@@ -1,0 +1,11 @@
+const Record0 = struct { quantity: i64, big: u64, ratio: f64, label: []const u8, ok: bool };
+pub fn main() void {
+    const my_data = Record0{
+        .quantity = 0xf4240,
+        .big = 0xffffffffffffffff,
+        .ratio = 2.5,
+        .label = "tag",
+        .ok = true,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_integer_octal@v0_12.zig
+++ b/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_integer_octal@v0_12.zig
@@ -1,0 +1,11 @@
+const Record0 = struct { quantity: i64, big: u64, ratio: f64, label: []const u8, ok: bool };
+pub fn main() void {
+    const my_data = Record0{
+        .quantity = 0o3641100,
+        .big = 0o1777777777777777777777,
+        .ratio = 2.5,
+        .label = "tag",
+        .ok = true,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_separator_underscore@v0_12.zig
+++ b/tests/integration/cases/record_wide_int/Zig_heterogeneous_strategy_record_separator_underscore@v0_12.zig
@@ -1,0 +1,11 @@
+const Record0 = struct { quantity: i64, big: u64, ratio: f64, label: []const u8, ok: bool };
+pub fn main() void {
+    const my_data = Record0{
+        .quantity = 1_000_000,
+        .big = 18_446_744_073_709_551_615,
+        .ratio = 2.5,
+        .label = "tag",
+        .ok = true,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_pair_record_field/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_pair_record_field/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,11 @@
+const Record0 = struct { call: []const u8, args: struct { i64, []const u8 } };
+pub fn main() void {
+    const my_data = Record0{
+        .call = "send",
+        .args = .{
+            1,
+            "email",
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_pair_top_level/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_pair_top_level/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,7 @@
+pub fn main() void {
+    const my_data = .{
+        1,
+        "email",
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_record_field/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_record_field/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,13 @@
+const Record0 = struct { call: []const u8, args: struct { i64, []const u8, []const u8, i64 } };
+pub fn main() void {
+    const my_data = Record0{
+        .call = "send",
+        .args = .{
+            1,
+            "email",
+            "a@gmail.com",
+            100,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_record_seq_sibling/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_record_seq_sibling/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,17 @@
+const Record0 = struct { scores: []const i64, args: struct { i64, []const u8, []const u8, i64 } };
+pub fn main() void {
+    const my_data = Record0{
+        .scores = &.{
+            10,
+            20,
+            30,
+        },
+        .args = .{
+            1,
+            "email",
+            "a@gmail.com",
+            100,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_record_sequence/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_record_sequence/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,8 @@
+const Record0 = struct { call: []const u8, args: struct { i64, []const u8, []const u8, i64 } };
+pub fn main() void {
+    const my_data = &.{
+        Record0{ .call = "send", .args = .{1, "email", "a@gmail.com", 100} },
+        Record0{ .call = "recv", .args = .{2, "sms", "b@example.com", 200} },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_top_level/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_top_level/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,9 @@
+pub fn main() void {
+    const my_data = .{
+        1,
+        "email",
+        "a@gmail.com",
+        100,
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_triple_record_field/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_triple_record_field/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,12 @@
+const Record0 = struct { call: []const u8, args: struct { i64, []const u8, bool } };
+pub fn main() void {
+    const my_data = Record0{
+        .call = "send",
+        .args = .{
+            1,
+            "email",
+            true,
+        },
+    };
+    _ = my_data;
+}

--- a/tests/integration/cases/tuple_triple_top_level/Zig_heterogeneous_strategy_record@v0_12.zig
+++ b/tests/integration/cases/tuple_triple_top_level/Zig_heterogeneous_strategy_record@v0_12.zig
@@ -1,0 +1,8 @@
+pub fn main() void {
+    const my_data = .{
+        1,
+        "email",
+        true,
+    };
+    _ = my_data;
+}


### PR DESCRIPTION
Closes #2477 (sub-issue of #2420; sibling of the C++ reference port #2473).

## What

Ports the `RECORD` heterogeneous strategy to `Zig`, following the C++
reference pattern.

The default (`ERROR`) strategy is unchanged: it keeps the homogeneous
`ZVal` tagged-union model, where a record-shaped dict is rendered as
`.{ .map = &.{ ... } }`. Under `RECORD`, each record-shaped dict
(non-empty, string-keyed) becomes:

- a preamble decl: `const Record0 = struct { id: i64, description: []const u8, is_done: bool, blocks: []const i64 };`
- a literal: `Record0{ .id = 1, .description = "...", .is_done = false, .blocks = &.{ 1, 2, 3 } }`

Auto names `Record0`/`Record1`/... (no `record_shape_names`, no
`record_unify_optional_fields`), structural `RecordFieldType` field
typing (never formatted-string reparsing).

## Why this is more than the C++ template

Every other RECORD language already emits raw scalars/containers, so
RECORD only adds a struct wrapper. Zig is the first universal-wrapper
language to get RECORD: the `ZVal` union wraps *every* value, and the
shared machinery formats record fields with the same spec used
everywhere, so a record field cannot be raw while a sibling list stays
ZVal-wrapped. The only consistent design is **fully raw Zig under
RECORD**: bool/null become `true`/`false`/`null`, lists become
`&.{ ... }` slices (or `.{ ... }` tuples for heterogeneous lists),
ordered maps become raw `&.{ .{ .key = ..., .val = ... } }`, the
binding drops its `: ZVal` annotation, and call stubs take `anytype`.
Field types are inferred structurally (`i64`/`u64`, `f64`, `bool`,
`[]const u8`, `?i64`, `[]const T`, `struct { T0, ... }` tuples, nested
`RecordN`). The `ZVal` static preamble is omitted under `RECORD`.

`zig.py` only + CHANGELOG; all other goldens are auto-generated
`Zig_*record*` files (zero non-Zig churn). New `record_struct_name_prefix`
constructor param; `supports_record_struct_name_prefix` is now `True`.

## Verification

- Full test suite green; 100% coverage (no `# pragma`, no
  private-helper tests).
- ruff / ty / pylint (10/10 on zig.py) clean; Sphinx spelling shows
  only the pre-existing baseline failures.
- Every new `Zig_*record*` golden compiles via the lint-CI driver
  mechanism with **both** Zig 0.14.0 (the CI pin, full Sema) and Zig
  0.16.0 (full `zig run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new Zig rendering mode that changes type/literal generation, call stub signatures, and preamble emission under `heterogeneous_strategy=RECORD`, which could affect compilation/output expectations for Zig users.
> 
> **Overview**
> Adds a new Zig `heterogeneous_strategy=RECORD` mode that renders record-shaped dicts as generated `const RecordN = struct { ... };` declarations plus `RecordN{ .field = value }` literals, with field types inferred structurally and a configurable `record_struct_name_prefix`.
> 
> When `RECORD` is active, Zig output switches from the `ZVal` tagged-union wrapper to **raw Zig literals** across the board (scalars, lists as `&.{...}` slices or `.{...}` tuples, ordered maps as raw slices), drops `: ZVal` variable annotations, omits the `ZVal` static preamble, and updates `literalize_call` stubs to accept `anytype` parameters. Extensive new Zig golden fixtures cover records, nested records, lists/tuples, ordered maps, and call shapes under the new strategy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c10e6f79c8d3b2552702c7c65634f7ddc644f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->