### PR TITLE
Add RECORD heterogeneous strategy to Crystal (#2482)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Crystal` gains the ``RECORD``
+  ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
+  :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,
+  :class:`~literalizer.Scala`, :class:`~literalizer.Java`,
+  :class:`~literalizer.Cpp` and :class:`~literalizer.Python`).  Each
+  record-shaped dict (non-empty, string-keyed) becomes a generated
+  ``record`` struct declared in the per-fixture module body plus a
+  matching positional ``Record0.new(value, ...)`` literal, so a
+  record-shaped dict that mixes scalars with a container is
+  representable even though ``Hash`` requires a homogeneous value
+  type.  Field names are the dict keys verbatim, an integer field is
+  sized to match its rendered literal (``Int32`` / ``Int64`` / the
+  ``_i128``-suffixed ``Int128``), and the struct-name prefix is
+  configurable via the new ``record_struct_name_prefix`` constructor
+  parameter; its ``supports_record_struct_name_prefix``
+  language-class flag is now ``True``.  The default (``ERROR``)
+  strategy still raises for such a dict.  See #2420.
+
 2026.05.16.1
 ------------
 

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -790,10 +790,13 @@ class Crystal(metaclass=LanguageCls):
         way, while every other date/datetime/time/bytes format renders
         a string).  A list compiles to ``Array`` of the union of its
         items' types (empty -> ``[] of Nil`` -> ``Array(Nil)``); an
-        ordered map compiles to ``Hash(String, ...)`` of the union of
-        its value types.  The union is built to match the compiler's
-        own canonical ordering so the invariant ``Array`` / ``Hash``
-        field type accepts the inferred literal.
+        ordered map compiles to ``Hash`` keyed by
+        :attr:`default_dict_key_type` of the union of its value types,
+        or -- when empty, matching the ``{} of K => V`` literal the
+        formatter emits -- of :attr:`default_dict_value_type`.  The
+        union is built to match the compiler's own canonical ordering
+        so the invariant ``Array`` / ``Hash`` field type accepts the
+        inferred literal.
         """
         if (
             isinstance(value, datetime.datetime)
@@ -815,7 +818,14 @@ class Crystal(metaclass=LanguageCls):
                     self._crystal_type_for_value(item)
                     for item in value.values()
                 }
-                return f"Hash(String, {_crystal_union(parts)})"
+                # An empty ordered map renders as ``{} of K => V`` with
+                # the configured dict defaults, so the union falls back
+                # to ``default_dict_value_type`` (``or`` keeps the
+                # never-empty corpus path branch-free).
+                value_type = (
+                    _crystal_union(parts) or self.default_dict_value_type
+                )
+                return f"Hash({self.default_dict_key_type}, {value_type})"
             case _:
                 # A set or non-record dict field is out of scope for
                 # the base ``RECORD`` port (#2317) and is not reached

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -3,7 +3,7 @@
 import dataclasses
 import datetime
 import enum
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property, partial
 from types import MappingProxyType
 from typing import ClassVar
@@ -16,6 +16,7 @@ from literalizer._formatters.collection_openers import (
     make_narrowed_empty_form,
 )
 from literalizer._formatters.format_dates import (
+    datetime_epoch_seconds,
     format_date_iso,
     format_datetime_epoch,
     format_datetime_iso,
@@ -40,10 +41,20 @@ from literalizer._formatters.format_floats import (
     format_float_scientific,
 )
 from literalizer._formatters.format_integers import (
+    I64_MAX,
+    I64_MIN,
     format_integer_underscore,
     make_overflow_fallback_formatter,
 )
 from literalizer._formatters.format_strings import format_string_backslash_hash
+from literalizer._formatters.record_strategy import (
+    RecordDeclarationField,
+    RecordFieldType,
+    RecordLiteralField,
+    RecordRenderer,
+    RecordStrategy,
+    build_record_strategy,
+)
 from literalizer._language import (
     NO_CALL_PARAMETER_LIMIT,
     NO_HETEROGENEOUS_BEHAVIOR,
@@ -62,6 +73,7 @@ from literalizer._language import (
     ModifierCombination,
     OrderedMapFormatConfig,
     PositionalCallStyle,
+    RenderedRecordLiteral,
     SequenceFormatConfig,
     SetFormatConfig,
     StubReturn,
@@ -86,7 +98,7 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Value
+from literalizer._types import OrderedMap, Value
 
 
 def _to_pascal_case(name: str) -> str:
@@ -124,6 +136,132 @@ def _format_crystal_i128_literal(value: int) -> str:
     ``-2^127`` to ``2^127 - 1``.
     """
     return f"{value}_i128"
+
+
+# Crystal infers a bare integer literal as ``Int32`` when it fits the
+# signed 32-bit range and ``Int64`` when it only fits the signed 64-bit
+# range, so a ``RECORD`` integer field is typed by the same thresholds
+# to match the rendered literal.  Keep these bounds in sync with
+# ``_I32_MIN`` / ``_I32_MAX`` in
+# :mod:`literalizer._formatters.type_inference` (the widening threshold
+# the value formatter uses for homogeneous lists, which has a
+# back-reference to here).
+_CRYSTAL_I32_MIN = -(2**31)
+_CRYSTAL_I32_MAX = 2**31 - 1
+
+# The ``RECORD`` strategy supports only auto ``Record0``/``Record1``/...
+# names (no ``record_shape_names``), so the shared renderer always gets
+# an empty custom-name mapping.
+_CRYSTAL_NO_RECORD_SHAPE_NAMES: Mapping[frozenset[str], str] = (
+    MappingProxyType(mapping={})
+)
+
+# Crystal scalar type for a record field, keyed by the value's exact
+# Python type.  ``bool`` and ``int`` are not here (they have dedicated
+# width-aware handling); a ``bytes`` value renders as a hex/base64
+# string and every date/datetime/time format Crystal supports renders
+# a string, so they all map to ``String``.  An ``EPOCH`` datetime is
+# converted to its epoch integer before the lookup, so the ``datetime``
+# entry only ever resolves an ISO datetime.
+_CRYSTAL_SCALAR_FIELD_TYPE: Mapping[type, str] = MappingProxyType(
+    mapping={
+        type(None): "Nil",
+        float: "Float64",
+        str: "String",
+        bytes: "String",
+        datetime.date: "String",
+        datetime.datetime: "String",
+        datetime.time: "String",
+    },
+)
+
+
+@beartype
+def _crystal_union(parts: set[str], /) -> str:
+    """Join Crystal type names into a union the way the compiler prints
+    one for an inferred container literal.
+
+    The compiler orders union members by ascending type name with
+    ``Nil`` forced last (``Int32 | String``, ``Bool | Int32 |
+    String``, ``Int32 | String | Nil``), and a single member is printed
+    without a ``|``.  An ``Array``/``Hash`` field is invariant in its
+    element type, so the declared element union must match the
+    literal's inferred one exactly.
+    """
+    return " | ".join(
+        sorted(parts, key=lambda part: (part == "Nil", part)),
+    )
+
+
+@beartype
+def _crystal_int_field_type(*, value: int) -> str:
+    """Return the Crystal ``record`` field type for an integer value.
+
+    Mirrors the literal :attr:`Crystal.format_integer` emits: a value
+    inside signed 32-bit range is a bare ``Int32`` literal, one only
+    inside signed 64-bit range is a bare ``Int64`` literal, and a value
+    beyond signed 64-bit range carries the ``_i128`` overflow-fallback
+    suffix and is therefore ``Int128``.
+    """
+    if _CRYSTAL_I32_MIN <= value <= _CRYSTAL_I32_MAX:
+        return "Int32"
+    if I64_MIN <= value <= I64_MAX:
+        return "Int64"
+    return "Int128"
+
+
+@beartype
+def _crystal_record_field_identifier(key: str, /) -> str:
+    """Return the Crystal ``record`` field name for a dict *key*.
+
+    Crystal field identifiers are the dict keys verbatim (no case
+    conversion); the literal is the positional ``Record0.new(...)``
+    constructor the ``record`` macro generates, so the field names
+    appear only in the declaration.
+    """
+    return key
+
+
+@beartype
+def _crystal_record_literal(
+    name: str,
+    fields: Sequence[RecordLiteralField],
+    /,
+) -> RenderedRecordLiteral:
+    """Render a Crystal ``Name.new(value, ...)`` constructor call as
+    structured pieces for the shared compact/multiline layout code.
+
+    The ``record`` macro generates a positional initializer in
+    declaration order; the shared strategy iterates the shape's keys in
+    document order for both the declaration and the literal, so the
+    argument order always matches the field order.  A trailing comma
+    after the last argument is valid in a Crystal call, so the
+    language-wide trailing-comma config applies unchanged.
+    """
+    return RenderedRecordLiteral(
+        head=f"{name}.new(",
+        entries=tuple(field.formatted for field in fields),
+        closer=")",
+        compact_pad="",
+    )
+
+
+@beartype
+def _crystal_render_record_declaration(
+    name: str,
+    fields: Sequence[RecordDeclarationField],
+    /,
+) -> str:
+    """Render a Crystal ``record Name, field : Type, ...`` declaration.
+
+    The ``record`` macro expands to a ``struct`` with a positional
+    initializer and one getter per field, which is exactly what the
+    generated ``Name.new(...)`` literal needs.
+    """
+    members = ", ".join(
+        f"{field.identifier} : {field.type_name}" for field in fields
+    )
+    return f"record {name}, {members}"
 
 
 @beartype
@@ -213,7 +351,7 @@ class Crystal(metaclass=LanguageCls):
     supports_default_sequence_element_type = False
     supports_default_set_element_type = True
     supports_default_ordered_map_value_type = False
-    supports_record_struct_name_prefix = False
+    supports_record_struct_name_prefix = True
     supports_record_shape_names = False
     supports_non_string_dict_keys = True
 
@@ -475,11 +613,19 @@ class Crystal(metaclass=LanguageCls):
     modifiers = Modifiers
 
     class HeterogeneousStrategies(enum.Enum):
-        """Heterogeneous-scalar strategy options — this language only
-        supports raising.
+        """Heterogeneous-scalar strategy options.
+
+        ``ERROR`` raises for any record-shaped dict that mixes scalars
+        with a container (``Hash`` requires a homogeneous value type).
+        ``RECORD`` instead renders each record-shaped dict (non-empty,
+        string-keyed) as a generated ``record`` struct declared in the
+        per-fixture module body plus a matching positional
+        ``Record0.new(value, ...)`` literal, so such fields are
+        representable.
         """
 
-        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+        ERROR = enum.auto()
+        RECORD = enum.auto()
 
     heterogeneous_strategies = HeterogeneousStrategies
 
@@ -573,6 +719,7 @@ class Crystal(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    record_struct_name_prefix: str = "Record"
     # Keep in sync with the ``crystal:`` pin passed to
     # ``crystal-lang/install-crystal`` in the ``lint-crystal`` job of
     # ``.github/workflows/lint.yml``.
@@ -615,13 +762,107 @@ class Crystal(metaclass=LanguageCls):
 
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
-        """Return data-dependent preamble lines."""
+        """Return data-dependent preamble lines.
+
+        The ``RECORD`` strategy's generated ``record`` declarations are
+        not emitted here (file scope): Crystal compiles every fixture in
+        one ``crystal run`` invocation, so a file-scope ``record
+        Record0`` would collide across cases.  They are emitted into the
+        per-fixture module body instead; see
+        :attr:`compute_body_preamble`.
+        """
         return no_data_preamble
 
     @cached_property
+    def _record_strategy_active(self) -> bool:
+        """Return whether the ``RECORD`` heterogeneous strategy is set."""
+        return self.heterogeneous_strategy.name == "RECORD"
+
+    def _crystal_type_for_value(self, value: Value, /) -> str:
+        """Return the Crystal type the rendered literal for *value*
+        compiles to.
+
+        Scalars map to their Crystal type (an integer sized by
+        magnitude to match the rendered literal -- ``Int32`` /
+        ``Int64`` / the ``_i128``-suffixed ``Int128``; an ``EPOCH``
+        datetime renders as its epoch integer and is sized the same
+        way, while every other date/datetime/time/bytes format renders
+        a string).  A list compiles to ``Array`` of the union of its
+        items' types (empty -> ``[] of Nil`` -> ``Array(Nil)``); an
+        ordered map compiles to ``Hash(String, ...)`` of the union of
+        its value types.  The union is built to match the compiler's
+        own canonical ordering so the invariant ``Array`` / ``Hash``
+        field type accepts the inferred literal.
+        """
+        if (
+            isinstance(value, datetime.datetime)
+            and self.datetime_format.value.type_produced is int
+        ):
+            value = datetime_epoch_seconds(value=value)
+        match value:
+            case bool():
+                return "Bool"
+            case int():
+                return _crystal_int_field_type(value=value)
+            case list() if not value:
+                return "Array(Nil)"
+            case list():
+                parts = {self._crystal_type_for_value(item) for item in value}
+                return f"Array({_crystal_union(parts)})"
+            case OrderedMap():
+                parts = {
+                    self._crystal_type_for_value(item)
+                    for item in value.values()
+                }
+                return f"Hash(String, {_crystal_union(parts)})"
+            case _:
+                # A set or non-record dict field is out of scope for
+                # the base ``RECORD`` port (#2317) and is not reached
+                # by any record golden; the ``or`` widens it to ``Nil``.
+                return _CRYSTAL_SCALAR_FIELD_TYPE.get(type(value)) or "Nil"
+
+    def _crystal_record_field_type(self, request: RecordFieldType, /) -> str:
+        """Return the Crystal ``record`` field type for a record field.
+
+        A field whose value is itself a nested record-shaped dict uses
+        that record's generated name; every other value is typed by
+        :meth:`_crystal_type_for_value`.  A set or non-record dict
+        field is out of scope for the base ``RECORD`` port (the
+        cross-language decision is tracked in #2317) and is not reached
+        by any record golden.
+        """
+        if request.record_name is not None:
+            return request.record_name
+        return self._crystal_type_for_value(request.value)
+
+    @cached_property
+    def _record_renderer(self) -> RecordRenderer:
+        """Crystal syntax hooks for the ``RECORD`` strategy."""
+        return RecordRenderer(
+            name_prefix=self.record_struct_name_prefix,
+            record_shape_names=_CRYSTAL_NO_RECORD_SHAPE_NAMES,
+            field_identifier=_crystal_record_field_identifier,
+            field_type=self._crystal_record_field_type,
+            render_declaration=_crystal_render_record_declaration,
+            render_literal=_crystal_record_literal,
+        )
+
+    @cached_property
+    def _record_strategy(self) -> RecordStrategy:
+        """Behavior + ``record``-declaration preamble for ``RECORD``."""
+        return build_record_strategy(renderer=self._record_renderer)
+
+    @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
-        """Return the heterogeneous-behavior config."""
-        return self.heterogeneous_strategy.value
+        """Return the heterogeneous-behavior config.
+
+        ``RECORD`` resolves to the shared record behavior (its value
+        needs the per-instance renderer, so it cannot be stored on the
+        enum member); ``ERROR`` raises.
+        """
+        if self._record_strategy_active:
+            return self._record_strategy.behavior
+        return NO_HETEROGENEOUS_BEHAVIOR
 
     @cached_property
     def call_data_dependent_preamble(
@@ -821,11 +1062,35 @@ class Crystal(metaclass=LanguageCls):
     def compute_body_preamble(
         self,
     ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
-        """Compute body-preamble lines from the scalar map."""
-        return body_preamble_from_scalars(
+        """Compute body-preamble lines from the scalar map, prefixed
+        with the ``RECORD`` strategy's generated ``record``
+        declarations.
+
+        Crystal compiles every fixture in one ``crystal run``
+        invocation, so a file-scope ``record Record0`` would collide
+        across cases.  Emitting the declarations into the body preamble
+        (which :meth:`wrap_in_file` places inside the per-fixture
+        module, ahead of the value) scopes each ``RecordN`` to its own
+        fixture; the declarations precede the scalar body lines so a
+        record type is in scope before its literal.
+        """
+        scalar_body = body_preamble_from_scalars(
             scalar_body_preamble=self.scalar_body_preamble,
             format_lines=tuple,
         )
+        if not self._record_strategy_active:
+            return scalar_body
+        record_preamble = self._record_strategy.preamble
+
+        def _compute(
+            types: frozenset[type],
+            data: Value,
+            /,
+        ) -> tuple[str, ...]:
+            """Record declaration lines precede scalar body lines."""
+            return record_preamble(data) + scalar_body(types, data)
+
+        return _compute
 
     @cached_property
     def call_style_config(self) -> CallStyle:

--- a/tests/integration/cases/call_deep_dotted_method/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_deep_dotted_method/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,10 @@
+module Fixture_call_deep_dotted_method_Crystal_heterogeneous_strategy_record_call
+extend self
+class ClientType_; def post(data = nil); 0; end; end
+class ApiType_; def client; ClientType_.new; end; end
+class ObjType_; def api; ApiType_.new; end; end
+obj = ObjType_.new
+obj.api.client.post(data: "hello");
+obj.api.client.post(data: 42);
+obj.api.client.post(data: true);
+end

--- a/tests/integration/cases/call_deep_dotted_transformed/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_deep_dotted_transformed/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,10 @@
+module Fixture_call_deep_dotted_transformed_Crystal_heterogeneous_strategy_record_call
+extend self
+class ClientType_; def fetch(payload = nil); 0; end; end
+class AppType_; def client; ClientType_.new; end; end
+app = AppType_.new
+def emit(_arg = nil); 0; end
+emit(app.client.fetch(payload: "hello"));
+emit(app.client.fetch(payload: 42));
+emit(app.client.fetch(payload: true));
+end

--- a/tests/integration/cases/call_dotted_method/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_dotted_method/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,9 @@
+module Fixture_call_dotted_method_Crystal_heterogeneous_strategy_record_call
+extend self
+class ClientType_; def fetch(payload = nil); 0; end; end
+class AppType_; def client; ClientType_.new; end; end
+app = AppType_.new
+app.client.fetch(payload: "hello");
+app.client.fetch(payload: 42);
+app.client.fetch(payload: true);
+end

--- a/tests/integration/cases/call_dotted_transform_stub/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_dotted_transform_stub/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,9 @@
+module Fixture_call_dotted_transform_stub_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(value = nil); 0; end
+class TracerType_; def emit(_arg = nil); 0; end; end
+tracer = TracerType_.new
+tracer.emit(process(value: "hello"));
+tracer.emit(process(value: 42));
+tracer.emit(process(value: true));
+end

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,17 @@
+module Fixture_call_ref_args_heterogeneous_list_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(data = nil, count = nil); 0; end
+my_ints = [
+    1,
+    2,
+    3,
+]
+my_strings = [
+    "a",
+    "b",
+]
+my_empty = [] of Nil
+process(data: my_ints, count: 42);
+process(data: my_strings, count: 7);
+process(data: my_empty, count: 99);
+end

--- a/tests/integration/cases/call_ref_args_reused/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_ref_args_reused/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,13 @@
+module Fixture_call_ref_args_reused_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(data = nil, count = nil); 0; end
+single_var = [
+    4,
+    5,
+    6,
+]
+repeated_var = 1
+process(data: repeated_var, count: 1);
+process(data: single_var, count: 0);
+process(data: repeated_var, count: 8);
+end

--- a/tests/integration/cases/call_ref_args_trivial_register/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_ref_args_trivial_register/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,16 @@
+module Fixture_call_ref_args_trivial_register_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(value = nil, count = nil); 0; end
+my_int = 1
+my_bool = true
+my_float = 3.14
+my_list = [
+    1,
+    2,
+    3,
+]
+process(value: my_int, count: 42);
+process(value: my_bool, count: 7);
+process(value: my_float, count: 9);
+process(value: my_list, count: 1);
+end

--- a/tests/integration/cases/call_scalar_args/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_scalar_args/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_call_scalar_args_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(value = nil); 0; end
+process(value: "hello");
+process(value: 42);
+process(value: true);
+end

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_call_scalar_args_uniform_second_slot_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(value = nil, label = nil); 0; end
+process(value: "hello", label: "a");
+process(value: 42, label: "b");
+process(value: true, label: "c");
+end

--- a/tests/integration/cases/call_scalar_args_with_null/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_scalar_args_with_null/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,6 @@
+module Fixture_call_scalar_args_with_null_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(value = nil); 0; end
+process(value: nil);
+process(value: "hello");
+end

--- a/tests/integration/cases/call_snake_dotted_method/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_snake_dotted_method/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,9 @@
+module Fixture_call_snake_dotted_method_Crystal_heterogeneous_strategy_record_call
+extend self
+class HttpClientType_; def fetch(payload = nil); 0; end; end
+class MyAppType_; def http_client; HttpClientType_.new; end; end
+my_app = MyAppType_.new
+my_app.http_client.fetch(payload: "hello");
+my_app.http_client.fetch(payload: 42);
+my_app.http_client.fetch(payload: true);
+end

--- a/tests/integration/cases/call_transform_no_wrapper/Crystal_heterogeneous_strategy_record_call@v1.cr
+++ b/tests/integration/cases/call_transform_no_wrapper/Crystal_heterogeneous_strategy_record_call@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_call_transform_no_wrapper_Crystal_heterogeneous_strategy_record_call
+extend self
+def process(value = nil); 0; end
+process(value: "hello");
+process(value: 42);
+process(value: true);
+end

--- a/tests/integration/cases/dict_all_scalar_types/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/dict_all_scalar_types/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,14 @@
+module Fixture_dict_all_scalar_types_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, s : String, i : Int32, f : Float64, b : Bool, n : Nil, d : String, dt : String, by : String
+my_data = Record0.new(
+    "string",
+    1,
+    1.5,
+    true,
+    nil,
+    "2024-01-15",
+    "2024-01-15T12:00:00",
+    "48656c6c6f",
+)
+end

--- a/tests/integration/cases/dict_all_scalar_types/Crystal_heterogeneous_strategy_record_datetime_epoch@v1.cr
+++ b/tests/integration/cases/dict_all_scalar_types/Crystal_heterogeneous_strategy_record_datetime_epoch@v1.cr
@@ -1,0 +1,14 @@
+module Fixture_dict_all_scalar_types_Crystal_heterogeneous_strategy_record_datetime_epoch
+extend self
+record Record0, s : String, i : Int32, f : Float64, b : Bool, n : Nil, d : String, dt : Int32, by : String
+my_data = Record0.new(
+    "string",
+    1,
+    1.5,
+    true,
+    nil,
+    "2024-01-15",
+    1705320000,
+    "48656c6c6f",
+)
+end

--- a/tests/integration/cases/dict_mixed_int_widths/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/dict_mixed_int_widths/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,9 @@
+module Fixture_dict_mixed_int_widths_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, a : Int32, b : Int64, c : String
+my_data = Record0.new(
+    1,
+    3000000000,
+    "x",
+)
+end

--- a/tests/integration/cases/dict_mixed_scalars/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/dict_mixed_scalars/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,8 @@
+module Fixture_dict_mixed_scalars_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, a : Int32, b : String
+my_data = Record0.new(
+    1,
+    "x",
+)
+end

--- a/tests/integration/cases/dict_mixed_scalars/Crystal_heterogeneous_strategy_record_combined@v1.cr
+++ b/tests/integration/cases/dict_mixed_scalars/Crystal_heterogeneous_strategy_record_combined@v1.cr
@@ -1,0 +1,12 @@
+module Fixture_dict_mixed_scalars_Crystal_heterogeneous_strategy_record_combined
+extend self
+record Record0, a : Int32, b : String
+my_data = Record0.new(
+    1,
+    "x",
+)
+my_data = Record0.new(
+    1,
+    "x",
+)
+end

--- a/tests/integration/cases/dict_with_list_value/Crystal_heterogeneous_strategy_record_list_val@v1.cr
+++ b/tests/integration/cases/dict_with_list_value/Crystal_heterogeneous_strategy_record_list_val@v1.cr
@@ -1,0 +1,12 @@
+module Fixture_dict_with_list_value_Crystal_heterogeneous_strategy_record_list_val
+extend self
+record Record0, name : String, scores : Array(Int32)
+my_data = Record0.new(
+    "Alice",
+    [
+        10,
+        20,
+        30,
+    ],
+)
+end

--- a/tests/integration/cases/empty_dict/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/empty_dict/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,4 @@
+module Fixture_empty_dict_Crystal_heterogeneous_strategy_record
+extend self
+my_data = {} of String => String
+end

--- a/tests/integration/cases/heterogeneous_list_with_string/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/heterogeneous_list_with_string/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_heterogeneous_list_with_string_Crystal_heterogeneous_strategy_record
+extend self
+my_data = [
+    "hello",
+    42,
+]
+end

--- a/tests/integration/cases/int_key_dict/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/int_key_dict/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,8 @@
+module Fixture_int_key_dict_Crystal_heterogeneous_strategy_record
+extend self
+my_data = {
+    1 => "one",
+    2 => "two",
+    42 => "answer",
+}
+end

--- a/tests/integration/cases/multiline_sibling_list_widening/Crystal_heterogeneous_strategy_record_sibling_widening@v1.cr
+++ b/tests/integration/cases/multiline_sibling_list_widening/Crystal_heterogeneous_strategy_record_sibling_widening@v1.cr
@@ -1,0 +1,24 @@
+module Fixture_multiline_sibling_list_widening_Crystal_heterogeneous_strategy_record_sibling_widening
+extend self
+record Record1, numbers : Array(Int32), strings : Array(String)
+record Record0, omap_value : Hash(String, Int32), sibling_lists : Record1, ref_marker_present : Array(String)
+my_data = Record0.new(
+    {
+        "first" => 1,
+    },
+    Record1.new(
+        [
+            1,
+            2,
+        ],
+        [
+            "x",
+            "y",
+        ],
+    ),
+    [
+        "$keep",
+        "z",
+    ],
+)
+end

--- a/tests/integration/cases/nested_mixed_dict/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/nested_mixed_dict/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,12 @@
+module Fixture_nested_mixed_dict_Crystal_heterogeneous_strategy_record
+extend self
+record Record1, a : Int32, b : String, c : Nil
+record Record0, outer : Record1
+my_data = Record0.new(
+    Record1.new(
+        1,
+        "x",
+        nil,
+    ),
+)
+end

--- a/tests/integration/cases/nested_mixed_inner/Crystal_heterogeneous_strategy_record_inner@v1.cr
+++ b/tests/integration/cases/nested_mixed_inner/Crystal_heterogeneous_strategy_record_inner@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_nested_mixed_inner_Crystal_heterogeneous_strategy_record_inner
+extend self
+my_data = [
+    [1, "a"],
+    [2, "b"],
+]
+end

--- a/tests/integration/cases/nested_mixed_types/Crystal_heterogeneous_strategy_record_sibling@v1.cr
+++ b/tests/integration/cases/nested_mixed_types/Crystal_heterogeneous_strategy_record_sibling@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_nested_mixed_types_Crystal_heterogeneous_strategy_record_sibling
+extend self
+my_data = [
+    [1, 2],
+    ["a", "b"],
+]
+end

--- a/tests/integration/cases/nested_sequences/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/nested_sequences/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_nested_sequences_Crystal_heterogeneous_strategy_record
+extend self
+my_data = [
+    [[1, 2], [3, 4]],
+    [[5]],
+]
+end

--- a/tests/integration/cases/ordered_map/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/ordered_map/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,8 @@
+module Fixture_ordered_map_Crystal_heterogeneous_strategy_record
+extend self
+my_data = {
+    "name" => "Alice",
+    "age" => 30,
+    "active" => true,
+}
+end

--- a/tests/integration/cases/record_basic/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/record_basic/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,14 @@
+module Fixture_record_basic_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, id : Int32, description : String, is_done : Bool, blocks : Array(Int32)
+my_data = Record0.new(
+    1,
+    "She said \"hello\", then waved",
+    false,
+    [
+        1,
+        2,
+        3,
+    ],
+)
+end

--- a/tests/integration/cases/record_epoch_datetime_i32_overflow/Crystal_record_epoch_i32_overflow@v1.cr
+++ b/tests/integration/cases/record_epoch_datetime_i32_overflow/Crystal_record_epoch_i32_overflow@v1.cr
@@ -1,0 +1,8 @@
+module Fixture_record_epoch_datetime_i32_overflow_Crystal_record_epoch_i32_overflow
+extend self
+record Record0, within_i32 : Int32, beyond_i32 : Int64
+my_data = Record0.new(
+    1705320000,
+    4085195400,
+)
+end

--- a/tests/integration/cases/record_nested_container/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/record_nested_container/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,13 @@
+module Fixture_record_nested_container_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, title : String, tags : Array(String), priority : Int32
+my_data = Record0.new(
+    "report",
+    [
+        "draft",
+        "urgent",
+        "review",
+    ],
+    2,
+)
+end

--- a/tests/integration/cases/record_nested_record/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/record_nested_record/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,12 @@
+module Fixture_record_nested_record_Crystal_heterogeneous_strategy_record
+extend self
+record Record1, name : String, age : Int32
+record Record0, id : Int32, owner : Record1
+my_data = Record0.new(
+    1,
+    Record1.new(
+        "Alice",
+        30,
+    ),
+)
+end

--- a/tests/integration/cases/record_pure_scalars/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/record_pure_scalars/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,10 @@
+module Fixture_record_pure_scalars_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, name : String, age : Int32, active : Bool, score : Float64
+my_data = Record0.new(
+    "Alice",
+    30,
+    true,
+    4.5,
+)
+end

--- a/tests/integration/cases/record_sequence/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/record_sequence/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,9 @@
+module Fixture_record_sequence_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, id : Int32, label : String, tags : Array(Nil)
+my_data = [
+    Record0.new(1, "first", [] of Nil),
+    Record0.new(2, "second", [] of Nil),
+    Record0.new(3, "third", [] of Nil),
+]
+end

--- a/tests/integration/cases/record_two_shapes/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/record_two_shapes/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,16 @@
+module Fixture_record_two_shapes_Crystal_heterogeneous_strategy_record
+extend self
+record Record1, count : Int32, rate : Int32
+record Record2, retries : Int32, timeout : Int32
+record Record0, metrics : Record1, flags : Record2
+my_data = Record0.new(
+    Record1.new(
+        100,
+        50,
+    ),
+    Record2.new(
+        3,
+        30,
+    ),
+)
+end

--- a/tests/integration/cases/record_wide_int/Crystal_heterogeneous_strategy_record_separator_underscore@v1.cr
+++ b/tests/integration/cases/record_wide_int/Crystal_heterogeneous_strategy_record_separator_underscore@v1.cr
@@ -1,0 +1,11 @@
+module Fixture_record_wide_int_Crystal_heterogeneous_strategy_record_separator_underscore
+extend self
+record Record0, quantity : Int32, big : Int128, ratio : Float64, label : String, ok : Bool
+my_data = Record0.new(
+    1_000_000,
+    18446744073709551615_i128,
+    2.5,
+    "tag",
+    true,
+)
+end

--- a/tests/integration/cases/tuple_int_key_dict_value/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_int_key_dict_value/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,6 @@
+module Fixture_tuple_int_key_dict_value_Crystal_heterogeneous_strategy_record
+extend self
+my_data = {
+    1 => [1, "email", "a@gmail.com", 100],
+}
+end

--- a/tests/integration/cases/tuple_pair_record_field/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_pair_record_field/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,11 @@
+module Fixture_tuple_pair_record_field_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, call : String, args : Array(Int32 | String)
+my_data = Record0.new(
+    "send",
+    [
+        1,
+        "email",
+    ],
+)
+end

--- a/tests/integration/cases/tuple_pair_top_level/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_pair_top_level/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,7 @@
+module Fixture_tuple_pair_top_level_Crystal_heterogeneous_strategy_record
+extend self
+my_data = [
+    1,
+    "email",
+]
+end

--- a/tests/integration/cases/tuple_record_field/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_record_field/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,13 @@
+module Fixture_tuple_record_field_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, call : String, args : Array(Int32 | String)
+my_data = Record0.new(
+    "send",
+    [
+        1,
+        "email",
+        "a@gmail.com",
+        100,
+    ],
+)
+end

--- a/tests/integration/cases/tuple_record_seq_sibling/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_record_seq_sibling/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,17 @@
+module Fixture_tuple_record_seq_sibling_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, scores : Array(Int32), args : Array(Int32 | String)
+my_data = Record0.new(
+    [
+        10,
+        20,
+        30,
+    ],
+    [
+        1,
+        "email",
+        "a@gmail.com",
+        100,
+    ],
+)
+end

--- a/tests/integration/cases/tuple_record_sequence/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_record_sequence/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,8 @@
+module Fixture_tuple_record_sequence_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, call : String, args : Array(Int32 | String)
+my_data = [
+    Record0.new("send", [1, "email", "a@gmail.com", 100]),
+    Record0.new("recv", [2, "sms", "b@example.com", 200]),
+]
+end

--- a/tests/integration/cases/tuple_top_level/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_top_level/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,9 @@
+module Fixture_tuple_top_level_Crystal_heterogeneous_strategy_record
+extend self
+my_data = [
+    1,
+    "email",
+    "a@gmail.com",
+    100,
+]
+end

--- a/tests/integration/cases/tuple_triple_record_field/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_triple_record_field/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,12 @@
+module Fixture_tuple_triple_record_field_Crystal_heterogeneous_strategy_record
+extend self
+record Record0, call : String, args : Array(Bool | Int32 | String)
+my_data = Record0.new(
+    "send",
+    [
+        1,
+        "email",
+        true,
+    ],
+)
+end

--- a/tests/integration/cases/tuple_triple_top_level/Crystal_heterogeneous_strategy_record@v1.cr
+++ b/tests/integration/cases/tuple_triple_top_level/Crystal_heterogeneous_strategy_record@v1.cr
@@ -1,0 +1,8 @@
+module Fixture_tuple_triple_top_level_Crystal_heterogeneous_strategy_record
+extend self
+my_data = [
+    1,
+    "email",
+    true,
+]
+end


### PR DESCRIPTION
Ports the `RECORD` heterogeneous strategy to Crystal (#2482, sub-issue of #2420), following the C++ reference port pattern: each record-shaped dict becomes a generated `record` struct plus a positional `RecordN.new(value, ...)` literal, so a dict mixing scalars with a container is representable even though Crystal's `Hash` requires a homogeneous value type. Declarations are emitted into the per-fixture module body (not file scope) because the `lint-crystal` job compiles every fixture in one `crystal run`; field types are derived structurally from the raw value, with integers sized `Int32`/`Int64`/`Int128` to match the rendered literal and invariant `Array`/`Hash` element unions built in Crystal's canonical ordering. Adds the `record_struct_name_prefix` constructor parameter, flips `supports_record_struct_name_prefix` to `True`, and a CHANGELOG entry; scope is `crystal.py` + CHANGELOG + 44 new `Crystal_*` goldens with zero churn elsewhere. All 508 `.cr` fixtures compile and run under Crystal 1.20.0 (the CI pin) via the CI's single-`crystal run` driver, and the full pytest suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new heterogeneous rendering behavior for Crystal and changes how some dicts are emitted (generated `record` declarations + typed fields), which could affect output compatibility and fixture compilation if type inference is off.
> 
> **Overview**
> Adds a Crystal `heterogeneous_strategy=RECORD` option that renders record-shaped dicts as generated `record` declarations plus positional `RecordN.new(...)` literals, enabling mixed scalar/container dict values that Crystal `Hash` literals can’t type.
> 
> Implements Crystal-specific record typing (including `Int32`/`Int64`/`Int128` sizing, `Array`/`Hash` invariant union element typing, and `record_struct_name_prefix` configuration) and emits record declarations in the per-fixture module body to avoid cross-fixture name collisions. Updates the changelog and adds extensive new Crystal golden fixtures covering record output and call scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a8649be524cad663acccde3ade9567dd6f3585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->