### PR TITLE
Support variable_form call binding for Tcl and Bash (#2222)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,18 @@ Next
   nested it inside the ``x/0`` clause, producing invalid Erlang) while
   keeping the binding and the trailing ``My_data.`` return inside
   ``x()``.  See #2454.
+- :class:`~literalizer.Tcl` and :class:`~literalizer.Bash` now accept
+  ``variable_form`` on :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  Their literal-binding
+  templates treat the right-hand side as a value word, so a call result
+  is now bound through command substitution instead: Tcl emits ``set
+  my_data [make_widget 42]`` and Bash emits ``declare
+  my_data="$(make_widget 42)"`` (a bare ``my_data="$(...)"`` for an
+  :class:`~literalizer.ExistingVariable`).  Their
+  ``supports_call_variable_binding`` language-class flag is now
+  ``True``; existing literal-binding output is unchanged.  Follow-up to
+  #1961.  See #2222.
 
 2026.05.16.1
 ------------

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -56,8 +56,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_arg,
@@ -193,13 +191,31 @@ def _format_variable_declaration(
 
 
 @beartype
+def _format_call_variable_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a Bash ``declare`` binding whose right-hand side is a
+    call.
+
+    The literal-binding template assigns the right-hand side as a value
+    word (``declare name=42``); binding a call result instead requires
+    command substitution (``declare name="$(target arg1 arg2)"``) so
+    the shell runs the command and captures its output.  A call result
+    is a scalar string, so the associative-array ``-A`` flag never
+    applies.
+    """
+    return f'declare {name}="$({value})"'
+
+
+@beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Bash(metaclass=LanguageCls):
     """Bash language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -209,7 +225,7 @@ class Bash(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -777,6 +793,33 @@ class Bash(metaclass=LanguageCls):
     ) -> Callable[[str, str, Value], str]:
         """Callable that formats an assignment to an existing variable."""
         return variable_formatter(template="{name}={value}")
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call expression.
+
+        The literal-binding template assigns the right-hand side as a
+        value word; a call result must be command-substituted with
+        ``"$(...)"`` so the shell runs the command and captures its
+        output instead of assigning the command name verbatim.
+        """
+        return _format_call_variable_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call
+        expression.
+
+        The existing-variable counterpart of
+        :attr:`format_call_variable_declaration`: a bare
+        ``name="$(...)"`` with no ``declare`` keyword, matching the
+        literal-binding assignment template.
+        """
+        return variable_formatter(template='{name}="$({value})"')
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -54,8 +54,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_arg,
@@ -112,6 +110,26 @@ def _format_tcl_declaration(
 
 
 @beartype
+def _format_tcl_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a Tcl ``set`` binding whose right-hand side is a call.
+
+    The literal-binding template treats the right-hand side as a value
+    word (``set name 42``); binding a call result instead requires
+    command substitution (``set name [target arg1 arg2]``) so the
+    interpreter runs the command and assigns its result.  ``set`` is
+    the only binding form in this language, so an assignment to an
+    existing variable uses this same template.
+    """
+    continued = _add_tcl_continuation(value=value)
+    return f"set {name} [{continued}]"
+
+
+@beartype
 def _tcl_call_stub(
     parts: Sequence[str],
     _params: Sequence[str],
@@ -152,8 +170,6 @@ class Tcl(metaclass=LanguageCls):
     """Tcl language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -163,7 +179,7 @@ class Tcl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -714,6 +730,34 @@ class Tcl(metaclass=LanguageCls):
         """Callable that formats an assignment to an existing variable."""
         return assignment_formatter_from_declaration(
             formatter=self.declaration_style.value.formatter,
+        )
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call expression.
+
+        The literal-binding template emits the right-hand side as a
+        value word; a call result must be command-substituted with
+        ``[...]`` so Tcl runs the command instead of treating its name
+        and arguments as a literal list.
+        """
+        return _format_tcl_call_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call
+        expression.
+
+        ``set`` is the only binding form in this language, so an
+        existing-variable assignment shares the command-substitution
+        template with :attr:`format_call_variable_declaration`.
+        """
+        return assignment_formatter_from_declaration(
+            formatter=_format_tcl_call_declaration,
         )
 
     @cached_property

--- a/tests/errors/test_call_errors.py
+++ b/tests/errors/test_call_errors.py
@@ -37,6 +37,7 @@ from literalizer.exceptions import (
 from literalizer.languages import (
     Bash,
     Cobol,
+    D,
     Dhall,
     Elm,
     Haskell,
@@ -740,9 +741,8 @@ def test_literalize_call_both_variable_forms_unsupported_raises() -> None:
 def test_literalize_call_variable_form_template_incompatible_raises() -> None:
     """``variable_form`` is rejected for languages whose declaration
     template wraps the right-hand side incompatibly with call expressions
-    (Tcl needs ``[...]`` substitution; Objective-C wraps primitives in
-    ``@(...)``; tagged-enum heterogeneous languages prepend a
-    constructor; etc.).
+    (D wraps a scalar in ``JSONValue(...)``; tagged-enum heterogeneous
+    languages prepend a constructor; etc.).
     """
     with pytest.raises(
         expected_exception=UnsupportedCallShapeError,
@@ -754,7 +754,7 @@ def test_literalize_call_variable_form_template_incompatible_raises() -> None:
         literalize_call(
             source="42",
             input_format=InputFormat.JSON,
-            language=Tcl(),
+            language=D(),
             target_function="make_widget",
             parameter_names=["count"],
             per_element=False,

--- a/tests/integration/cases/call_variable_form_existing/Tcl_call@v8_6.tcl
+++ b/tests/integration/cases/call_variable_form_existing/Tcl_call@v8_6.tcl
@@ -1,0 +1,2 @@
+proc make_widget {args} {return {}}
+set my_data [make_widget 42]

--- a/tests/integration/cases/call_variable_form_new/Bash_call@v5_1.sh
+++ b/tests/integration/cases/call_variable_form_new/Bash_call@v5_1.sh
@@ -1,0 +1,2 @@
+make_widget() { :; }
+declare my_data="$(make_widget 42)"

--- a/tests/integration/cases/call_variable_form_new/Tcl_call@v8_6.tcl
+++ b/tests/integration/cases/call_variable_form_new/Tcl_call@v8_6.tcl
@@ -1,0 +1,2 @@
+proc make_widget {args} {return {}}
+set my_data [make_widget 42]


### PR DESCRIPTION
Follow-up to #1961. Closes #2222.

`literalize_call(..., variable_form=...)` previously rejected Tcl and
Bash with `UnsupportedCallShapeError` because their declaration
templates assume the right-hand side is a literal value. This teaches
both languages to bind a call result through command substitution.

## Output

- Tcl: `set my_data [make_widget 42]` (same for `NewVariable` /
  `ExistingVariable` — `set` is the only binding form)
- Bash `NewVariable`: `declare my_data="$(make_widget 42)"`
- Bash `ExistingVariable`: `my_data="$(make_widget 42)"`

## Changes

- `tcl.py` / `bash.py`: added a call-binding declaration formatter plus
  `format_call_variable_declaration` / `format_call_variable_assignment`
  `@cached_property` overrides (mirrors the Haskell/OCaml pattern);
  flipped `supports_call_variable_binding` to `True`. Literal-binding
  output is unchanged.
- New goldens: `call_variable_form_new/{Tcl,Bash}` and
  `call_variable_form_existing/Tcl`. Bash's `declare`-prefixed form is
  not self-contained against the bare-assignment mirror, so the runner
  correctly emits no `call_variable_form_existing` Bash golden.
- `test_literalize_call_variable_form_template_incompatible_raises`
  swapped its example language from the now-supported Tcl to `D`
  (which wraps scalars in `JSONValue(...)`).

## Acceptance criteria

- [x] New golden-file cases under `call_variable_form_new/` for Tcl and Bash
- [x] Existing literal-binding output for Tcl and Bash unchanged
- [x] `UnsupportedCallShapeError` raise sites for these two languages removed

## Verification

All call/error/meta/orphan tests pass; both fixtures execute under
`tclsh` / `bash -n`; `ruff`, `pylint` (10/10), `mypy`, `pyrefly` clean
on changed files; Sphinx spelling shows only pre-existing baseline noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds language-specific formatting for call-result variable bindings in Tcl/Bash plus new fixtures/tests, without altering existing literal-binding output.
> 
> **Overview**
> Enables `literalize_call(..., variable_form=...)` for **Tcl** and **Bash** by adding call-specific variable-binding formatters that use command substitution (`set x [cmd ...]` for Tcl; `declare x="$(cmd ...)"` / `x="$(cmd ...)"` for Bash) and flipping `supports_call_variable_binding` to `True` for both languages.
> 
> Updates the negative-path test to use `D` as the example of an incompatible declaration template, adds new integration golden cases for Tcl/Bash call bindings, and documents the new behavior in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e283d940c733e4e474eb4e65fd80417bbf7d78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->