### PR TITLE
Cancel superseded PR CI runs via PR-number concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,11 @@ on:
 
 permissions: {}
 
+# We often have a long CI queue, so cancel superseded runs for a PR as soon
+# as a new commit is pushed. Non-PR runs (push/schedule on main) fall back to
+# the unique run ID so they never cancel each other.
 concurrency:
-  group: ci-${{ github.head_ref || github.run_id }}
+  group: ci-pr-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,11 @@ on:
 
 permissions: {}
 
+# We often have a long CI queue, so cancel superseded runs for a PR as soon
+# as a new commit is pushed. Non-PR runs (push/schedule on main) fall back to
+# the unique run ID so they never cancel each other.
 concurrency:
-  group: lint-${{ github.head_ref || github.run_id }}
+  group: lint-pr-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -7,8 +7,11 @@ on:
   pull_request:
     branches: [main]
 
+# We often have a long CI queue, so cancel superseded runs for a PR as soon
+# as a new commit is pushed. Non-PR runs (push on main) fall back to the
+# unique run ID so they never cancel each other.
 concurrency:
-  group: deploy-docs-${{ github.head_ref || github.run_id }}
+  group: deploy-docs-pr-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We often have a long CI queue, so this groups the CI, Lint, and docs-deploy workflow runs by PR number, meaning a new commit cancels the previous in-progress run for that PR. Non-PR runs (push/schedule on `main`) fall back to the unique run ID so they never cancel each other, and each workflow keeps a distinct group prefix so they don't cancel across workflows. A comment in each workflow explains the long-queue rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that affects CI scheduling by canceling in-progress runs for the same PR when new commits are pushed.
> 
> **Overview**
> **Improves GitHub Actions queue behavior for PRs** by changing `concurrency.group` in `CI`, `Lint`, and docs deployment workflows to key off `github.event.pull_request.number` (falling back to `github.run_id` for non-PR runs).
> 
> This makes newer PR commits automatically cancel older in-progress runs for that PR, while ensuring `main` push/scheduled runs don’t cancel each other, and adds an explanatory comment in each workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e675ae9bafd327446246b82f78333f1b9098d4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->