### PR TITLE
Accept Forth deferred colon-word call binding (#2456)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,21 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Forth` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`, binding the call result with
+  the same colon definition Forth already uses for literal bindings:
+  ``: my_data 42 make_widget ;``.  This is a deferred word that
+  re-executes ``make_widget`` on every invocation, and (because Forth
+  has no reassignment in this model) the
+  :class:`~literalizer.ExistingVariable` output is identical to the
+  :class:`~literalizer.NewVariable` output; Forth's ``VALUE``/``TO``
+  idiom was rejected because it holds only a single cell and cannot
+  represent the string/dict/sequence values the colon form already
+  covers.  Its ``supports_call_variable_binding`` language-class flag
+  is now ``True``; existing literal-binding output is unchanged.
+  Follow-up to #1961.  See #2456.
 - :class:`~literalizer.Zig` gains the ``RECORD``
   ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
   :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -224,7 +224,15 @@ class Forth(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = False
+    # A call-result binding reuses the literal-binding colon definition
+    # unchanged: ``: my_data 42 make_widget ;`` is a deferred word that
+    # re-executes ``make_widget`` on every invocation.  Forth has no
+    # eager general-purpose value binding (``VALUE``/``TO`` holds only a
+    # single cell, not strings/dicts/sequences), so this is the same
+    # idiom already used for literal bindings, and ``ExistingVariable``
+    # is necessarily identical to ``NewVariable`` (no reassignment in
+    # this model).  See #2456.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/tests/integration/cases/call_variable_form_existing/Forth_call@ans.fth
+++ b/tests/integration/cases/call_variable_form_existing/Forth_call@ans.fth
@@ -1,0 +1,2 @@
+: make_widget ;
+: my_data 42 make_widget ;

--- a/tests/integration/cases/call_variable_form_new/Forth_call@ans.fth
+++ b/tests/integration/cases/call_variable_form_new/Forth_call@ans.fth
@@ -1,0 +1,2 @@
+: make_widget ;
+: my_data 42 make_widget ;


### PR DESCRIPTION
Resolves #2456 (follow-up to #1961; split out from triage #2227).

## Decision: Option 1 — accept the deferred colon-word form

Forth's `literalize_call(..., variable_form=...)` now binds the call result with the same colon definition Forth already uses for literal bindings:

```forth
: make_widget ;
: my_data 42 make_widget ;
```

### Rationale

- **Option 2 (`VALUE`/`TO`) rejected.** ANS Forth `VALUE` holds a single cell; the literalizer's value space includes strings (`s\" ..."` → addr+len), dicts and sequences that a single-cell `VALUE` cannot hold. The colon-definition form was chosen for *literal* binding precisely because Forth has no general eager binding for arbitrary-shape values; switching to `VALUE`/`TO` would only work for single-cell scalars and would break/inconsistently change the existing literal-binding output.
- **Option 3 (keep unsupported) rejected.** Forth already binds *literals* to names with exactly this deferred colon-word form; rejecting an identically-shaped call-result binding is an arbitrary asymmetry.
- **Option 1 chosen.** Smallest change — the default call-binding formatters already reuse the literal-binding declaration/assignment formatters, so only the `supports_call_variable_binding = False` gate blocked it. The caveats (deferred re-execution; `ExistingVariable` identical to `NewVariable` because Forth has no reassignment in this model) are inherent to Forth's model and already apply to its literal binding.

## Changes

- `Forth.supports_call_variable_binding` is now `True`, with a code comment documenting the deferred-word semantics and New/Existing equivalence.
- Golden cases added: `call_variable_form_new/Forth_call@ans.fth` and `call_variable_form_existing/Forth_call@ans.fth` (the existing-variable golden self-contained-mirrors the new-variable form since Forth's assignment formatter equals its declaration formatter).
- CHANGELOG entry added under *Next*.

## Verification

- All 44 Forth call goldens pass; existing literal-binding / call-without-binding output unchanged.
- 38 call-error tests pass; `test_literalize_call_variable_form_template_incompatible_raises` still uses `D`, unaffected.
- `pylint` (manual hook) 10/10 on the changed module; `ruff check`/`format` clean; the Sphinx spelling failures are pre-existing baseline noise unrelated to this diff.

The decision is also recorded as a comment on #2456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: enables an already-existing Forth binding idiom for `literalize_call` results behind a capability flag, with golden tests covering the new output shape.
> 
> **Overview**
> Enables `literalize_call(..., variable_form=...)` for `Forth` by flipping `supports_call_variable_binding` to `True`, so call results can be bound using the existing deferred colon-definition form (same output for `NewVariable` and `ExistingVariable`).
> 
> Adds integration goldens for both new/existing variable call binding and documents the behavior and rationale in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a449f5df84f4ca2993b2186afee5a5bf295cf2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->