### PR TITLE
Reject same-shape C records with differing-length all-record-list fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -190,8 +190,14 @@ Next
   fixed-size ``struct`` array member.  Every other container (a scalar
   or heterogeneous list, or an empty list) is typed a pointer to
   ``CVal`` and rendered as a ``CVal`` array literal, reusing C's
-  existing tagged union for arbitrary heterogeneity.  The default
-  (``ERROR``) ``CVal`` output is unchanged.  See #2476.
+  existing tagged union for arbitrary heterogeneity.  Because that
+  fixed-size ``struct`` array is sized from the shape's first-seen
+  instance, two same-shape records whose shared all-record-list field
+  has differing lengths are rejected with
+  :class:`~literalizer.exceptions.UnrepresentableInputError` rather
+  than emitting C that fails to compile or misrepresents the input
+  (cf. the set / non-record-dict field boundary tracked in #2317).
+  The default (``ERROR``) ``CVal`` output is unchanged.  See #2476.
 - :class:`~literalizer.V` gains the ``RECORD``
   ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
   :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -302,11 +302,63 @@ _C_RECORD_IN_CVAL_MSG = (
 )
 
 
+_C_RECORD_ARRAY_LEN_MSG = (
+    "C cannot represent two record-shaped dicts of one shape whose "
+    "shared all-record-list field has differing lengths under the "
+    "RECORD heterogeneous strategy: that field becomes a fixed-size "
+    "struct RecordN [len] member sized from the shape's first-seen "
+    "instance, so a later instance with a different-length list would "
+    "overflow the array (excess initializers fail to compile) or "
+    "silently under-fill it -- neither faithfully represents the input "
+    "(cf. the set / non-record-dict field boundary tracked in #2317)"
+)
+
+
+@beartype
+def _check_c_record_array_field_lengths(
+    *,
+    node: dict[Scalar, Value],
+    array_lengths_by_shape: dict[tuple[Scalar, ...], dict[Scalar, int]],
+) -> None:
+    """Raise :class:`UnrepresentableInputError` if a record-shaped dict
+    shares a shape with an earlier one but its all-record-list field
+    has a different length.
+
+    An all-record-list record field becomes a fixed-size
+    ``struct RecordN[len]`` member sized from the shape's first-seen
+    instance (``record_strategy`` caches the first-seen field-type
+    request per shape, in document order).  A later same-shape instance
+    whose list has a different length would overflow that fixed array
+    (excess initializers fail to compile) or silently under-fill it, so
+    neither faithfully represents the data.  Rejecting it here keeps
+    the boundary explicit rather than emitting C that fails to compile
+    or misrepresents the input (cf. the set / non-record-dict field
+    boundary tracked in #2317).
+
+    A shape is keyed by its ordered key tuple: C does not unify record
+    shapes, so identical-keyed dicts (and only those) share one
+    generated ``struct``, exactly as
+    :func:`literalizer._formatters.type_inference.record_shape_for_dict`
+    deduces.  *array_lengths_by_shape* accumulates the first-seen
+    length per shape and field across the whole walk.
+    """
+    field_lengths = array_lengths_by_shape.setdefault(tuple(node), {})
+    for field_name, field_value in node.items():
+        if isinstance(field_value, list) and _all_record_shaped(field_value):
+            first_length = field_lengths.setdefault(
+                field_name,
+                len(field_value),
+            )
+            if first_length != len(field_value):
+                raise UnrepresentableInputError(_C_RECORD_ARRAY_LEN_MSG)
+
+
 @beartype
 def _check_c_record_nesting(  # noqa: C901
     *,
     node: Value,
     cval_context: bool,
+    array_lengths_by_shape: dict[tuple[Scalar, ...], dict[Scalar, int]],
 ) -> None:
     """Raise :class:`UnrepresentableInputError` if a record-shaped dict
     (or an all-record list) is reachable only through a ``CVal``
@@ -325,41 +377,79 @@ def _check_c_record_nesting(  # noqa: C901
     if _c_record_dict(node):
         if cval_context:
             raise UnrepresentableInputError(_C_RECORD_IN_CVAL_MSG)
+        _check_c_record_array_field_lengths(
+            node=node,
+            array_lengths_by_shape=array_lengths_by_shape,
+        )
         for field_value in node.values():
-            _check_c_record_field(field_value)
+            _check_c_record_field(
+                field_value,
+                array_lengths_by_shape=array_lengths_by_shape,
+            )
         return
     match node:
         case OrderedMap() | dict():
             for value in node.values():
-                _check_c_record_nesting(node=value, cval_context=True)
+                _check_c_record_nesting(
+                    node=value,
+                    cval_context=True,
+                    array_lengths_by_shape=array_lengths_by_shape,
+                )
         case list() if _all_record_shaped(node):
             if cval_context:
                 raise UnrepresentableInputError(_C_RECORD_IN_CVAL_MSG)
             for element in node:
-                _check_c_record_nesting(node=element, cval_context=False)
+                _check_c_record_nesting(
+                    node=element,
+                    cval_context=False,
+                    array_lengths_by_shape=array_lengths_by_shape,
+                )
         case list():
             for element in node:
-                _check_c_record_nesting(node=element, cval_context=True)
+                _check_c_record_nesting(
+                    node=element,
+                    cval_context=True,
+                    array_lengths_by_shape=array_lengths_by_shape,
+                )
         case _:
             return
 
 
 @beartype
-def _check_c_record_field(field_value: Value, /) -> None:
+def _check_c_record_field(
+    field_value: Value,
+    /,
+    *,
+    array_lengths_by_shape: dict[tuple[Scalar, ...], dict[Scalar, int]],
+) -> None:
     """Validate one field value of a record-shaped dict.
 
     A nested record dict stays a ``struct`` member and an all-record
     list a ``struct`` array (neither a ``CVal``), so those descend
     without entering a ``CVal`` context.  Every other field value is a
-    ``CVal`` slot.
+    ``CVal`` slot.  *array_lengths_by_shape* is threaded through so the
+    walk can reject same-shape records whose shared all-record-list
+    field has differing lengths.
     """
     if _c_record_dict(field_value):
-        _check_c_record_nesting(node=field_value, cval_context=False)
+        _check_c_record_nesting(
+            node=field_value,
+            cval_context=False,
+            array_lengths_by_shape=array_lengths_by_shape,
+        )
     elif isinstance(field_value, list) and _all_record_shaped(field_value):
         for element in field_value:
-            _check_c_record_nesting(node=element, cval_context=False)
+            _check_c_record_nesting(
+                node=element,
+                cval_context=False,
+                array_lengths_by_shape=array_lengths_by_shape,
+            )
     else:
-        _check_c_record_nesting(node=field_value, cval_context=True)
+        _check_c_record_nesting(
+            node=field_value,
+            cval_context=True,
+            array_lengths_by_shape=array_lengths_by_shape,
+        )
 
 
 @beartype
@@ -803,13 +893,20 @@ class C(metaclass=LanguageCls):
         all record-shaped dicts as a ``struct RecordN[]`` array); a
         ``struct`` is not a ``CVal`` union member, so a record reachable
         only through a non-record container would have to occupy a
-        ``CVal`` slot and cannot compile.  Rejecting it here keeps the
+        ``CVal`` slot and cannot compile.  The same walk rejects two
+        same-shape records whose shared all-record-list field has
+        differing lengths (the field's fixed-size ``struct`` array is
+        sized from the first-seen instance).  Rejecting here keeps the
         boundary explicit rather than emitting C that fails to build
         (cf. the set / non-record-dict field boundary tracked in
         #2317).  The default (``ERROR``) strategy is unconstrained.
         """
         if self._record_strategy_active:
-            _check_c_record_nesting(node=data, cval_context=False)
+            _check_c_record_nesting(
+                node=data,
+                cval_context=False,
+                array_lengths_by_shape={},
+            )
 
     @cached_property
     def validate_call_arg(self) -> Callable[[Value], None]:

--- a/tests/errors/test_c_record_strategy_record_array_length_mismatch.py
+++ b/tests/errors/test_c_record_strategy_record_array_length_mismatch.py
@@ -1,0 +1,61 @@
+"""Rejection of same-shape records with a differing-length all-record
+list field under the C ``RECORD`` strategy.
+
+Under C's ``RECORD`` strategy a record field whose value is a list of
+one-shape record dicts becomes a fixed-size ``struct RecordN [len]``
+member, sized from the shape's first-seen instance.  A later record of
+the same shape whose list has a different length would overflow that
+fixed array (excess initializers fail to compile) or silently
+under-fill it, so neither faithfully represents the input.
+``literalize`` raises
+:class:`~literalizer.exceptions.UnrepresentableInputError` rather than
+emitting C that fails to compile or misrepresents the data.  The
+integration framework only exercises golden output that compiles, so
+this contract has no golden-file surface and needs unit coverage.
+"""
+
+import pytest
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.exceptions import UnrepresentableInputError
+from literalizer.languages import C
+
+# A record field that is a list of same-shape record dicts whose own
+# all-record-list field (``sub``) has length 1 in the first instance
+# and length 2 in the second: the generated ``struct`` array member is
+# sized from the first instance, so the second overflows it.
+_RECORD_FIELD_LIST_LENGTH_MISMATCH_YAML = (
+    "items:\n- sub:\n  - x: 1\n- sub:\n  - x: 2\n  - x: 3\n"
+)
+
+# A top-level all-record list whose two same-shape elements carry an
+# all-record-list field (``group``) of differing length: the shape's
+# fixed-size ``struct`` array member is sized from the first element.
+_RECORD_ROOT_LIST_LENGTH_MISMATCH_YAML = (
+    "- group:\n  - x: 1\n- group:\n  - x: 1\n  - x: 2\n"
+)
+
+
+@pytest.mark.parametrize(
+    argnames="source",
+    argvalues=[
+        _RECORD_FIELD_LIST_LENGTH_MISMATCH_YAML,
+        _RECORD_ROOT_LIST_LENGTH_MISMATCH_YAML,
+    ],
+)
+def test_c_record_strategy_rejects_array_field_length_mismatch(
+    source: str,
+) -> None:
+    """Same-shape records whose shared all-record-list field has
+    differing lengths raise rather than emitting C that fails to
+    compile or misrepresents the data.
+    """
+    language = C(heterogeneous_strategy=C.heterogeneous_strategies.RECORD)
+    with pytest.raises(expected_exception=UnrepresentableInputError):
+        literalize(
+            source=source,
+            input_format=InputFormat.YAML,
+            language=language,
+            wrap_in_file=True,
+            variable_form=NewVariable(name="my_data"),
+        )


### PR DESCRIPTION
Addresses the outstanding [Bugbot review comment](https://github.com/adamtheturtle/literalizer/pull/2497#discussion_r3254178162) on the merged PR #2497 ("Fixed-size record array uses unchecked first-instance length").

## Problem

Under C's `RECORD` strategy a record field whose value is an all-record list becomes a fixed-size `struct RecordN[len]` member. `record_strategy` sizes that member from the shape's *first-seen* field-type request, so two sibling records of the same shape carrying all-record lists of different lengths produced invalid C:

```yaml
items:
- sub:
  - x: 1
- sub:
  - x: 2
  - x: 3
```

emitted `struct Record1 { struct Record2 sub[1]; };` while the second `Record1` literal supplied two `sub` elements — `excess elements in array initializer` (a hard compile error). The reverse (a shorter later list) compiled but silently zero-filled, misrepresenting the data.

## Fix

C's `RECORD` nesting validation walk (`validate_spec_for_data` → `_check_c_record_nesting`) now threads a per-shape accumulator and, for each record-shaped dict, records the first-seen length of every all-record-list field. A later same-shape instance whose list length differs raises `UnrepresentableInputError`, matching the codebase's established "raise rather than emit code that fails to compile or misrepresents the input" contract (cf. the set / non-record-dict field boundary tracked in #2317, and the sibling `record-in-CVal-context` guard added in #2497 itself).

A shape is keyed by its ordered key tuple — C does not unify record shapes, so identical-keyed dicts (and only those) share one generated `struct`, exactly as `record_shape_for_dict` deduces.

## Tests

All 44 existing C `RECORD` goldens are unaffected (none carry a same-shape divergent-length field). Added `tests/errors/test_c_record_strategy_record_array_length_mismatch.py` covering the record-field and root-list paths. Full suite green (4885 passed); ruff / pylint (10/10) / mypy / pyrefly / ty / Sphinx-spelling clean for the change. CHANGELOG `Next` C `RECORD` entry extended with the new boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a validation guard and targeted tests for an edge case in C `RECORD` rendering; changes only affect inputs that previously produced invalid or misleading C output.
> 
> **Overview**
> Prevents C `heterogeneous_strategy=RECORD` from emitting invalid/misleading code when two same-shape records contain an all-record-list field of different lengths.
> 
> The C `RECORD` validation walk now tracks first-seen per-shape list lengths and raises `UnrepresentableInputError` on mismatches, with a new unit test covering both record-field and root-list scenarios; the changelog documents this tightened boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15003dc7e8bd1b542aad3c17e2519b0f916a9bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->