### PR TITLE
Support variable_form for Nim literalize_call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,20 @@ Next
   covers.  Its ``supports_call_variable_binding`` language-class flag
   is now ``True``; existing literal-binding output is unchanged.
   Follow-up to #1961.  See #2456.
+- :class:`~literalizer.Nim` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call`, binding the call result
+  directly: ``var my_data = make_widget(42)``.  The literal-binding
+  declaration template prefixes the right-hand side with the ``%*``
+  json macro (or ``@`` for sequences) chosen from the parsed literal's
+  type, which JSON-constructs a literal rather than invoking a call;
+  the new call-specific declaration and assignment templates drop that
+  wrapping regardless of the source data type.  Its
+  ``supports_call_variable_binding`` language-class flag is now
+  ``True``; existing literal-binding and call-without-binding output is
+  unchanged.  Only the :class:`~literalizer.NewVariable` form emits a
+  golden because the :class:`~literalizer.ExistingVariable` bare
+  assignment (``my_data = make_widget(42)``) to an undeclared name is
+  not self-contained.  Follow-up to #1961.  See #2455.
 - :class:`~literalizer.Zig` gains the ``RECORD``
   ``heterogeneous_strategy`` (already on :class:`~literalizer.Rust`,
   :class:`~literalizer.Go`, :class:`~literalizer.Kotlin`,

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -78,8 +78,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_arg,
@@ -217,6 +215,47 @@ def _make_variable_assignment(
         )
 
     return _format
+
+
+@beartype
+def _make_nim_call_variable_declaration(
+    *,
+    keyword: str,
+) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+    """Create a Nim declaration formatter for a call-expression binding.
+
+    The literal-binding declaration prefixes the right-hand side with
+    the ``%*`` json macro (or ``@`` for sequences) chosen from the
+    parsed literal's type, which JSON-constructs a literal rather than
+    invoking a call.  A call result is bound directly with no wrapping,
+    regardless of the source data type.
+    """
+
+    def _format(
+        name: str,
+        value: str,
+        _data: Value,
+        _modifiers: frozenset[enum.Enum],
+    ) -> str:
+        """Emit ``<keyword> <name> = <call>`` with no ``%*``/``@``."""
+        return f"{keyword} {name} = {value}"
+
+    return _format
+
+
+@beartype
+def _format_nim_call_variable_assignment(
+    name: str,
+    value: str,
+    _data: Value,
+) -> str:
+    """Format an existing-variable assignment binding a call result.
+
+    The call-expression counterpart of the literal-binding assignment
+    formatter; the ``%*``/``@`` wrapping is dropped since a call result
+    is bound directly.
+    """
+    return f"{name} = {value}"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -640,8 +679,6 @@ class Nim(metaclass=LanguageCls):
     """
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -652,7 +689,13 @@ class Nim(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    # The literal-binding declaration template prefixes the right-hand
+    # side with the ``%*`` json macro (or ``@`` for sequences), which is
+    # only valid for literal values.  ``format_call_variable_declaration``
+    # / ``format_call_variable_assignment`` supply call-specific
+    # templates that bind the call result directly with no wrapping, so
+    # call-result bindings are supported.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = False
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -1749,6 +1792,34 @@ class Nim(metaclass=LanguageCls):
             ),
             uses_json_wrap=not self._uses_native_nim_collections,
         )
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        The literal-binding declaration prefixes the right-hand side
+        with the ``%*`` json macro (or ``@`` for sequences) chosen from
+        the parsed literal's type; that JSON-constructs a literal and is
+        invalid for a call result, so the call expression is bound
+        directly with no wrapping.
+        """
+        return _make_nim_call_variable_declaration(
+            keyword=self.declaration_style.name.lower(),
+        )
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_variable_assignment`; the ``%*``/``@`` wrapping is
+        dropped since a call result is bound directly.
+        """
+        return _format_nim_call_variable_assignment
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -28,6 +28,7 @@ from literalizer._formatters.format_entries import (
     passthrough_sequence_entry,
     passthrough_set_entry,
     variable_declaration_formatter,
+    variable_formatter,
 )
 from literalizer._formatters.format_floats import (
     format_float_fixed,
@@ -215,47 +216,6 @@ def _make_variable_assignment(
         )
 
     return _format
-
-
-@beartype
-def _make_nim_call_variable_declaration(
-    *,
-    keyword: str,
-) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
-    """Create a Nim declaration formatter for a call-expression binding.
-
-    The literal-binding declaration prefixes the right-hand side with
-    the ``%*`` json macro (or ``@`` for sequences) chosen from the
-    parsed literal's type, which JSON-constructs a literal rather than
-    invoking a call.  A call result is bound directly with no wrapping,
-    regardless of the source data type.
-    """
-
-    def _format(
-        name: str,
-        value: str,
-        _data: Value,
-        _modifiers: frozenset[enum.Enum],
-    ) -> str:
-        """Emit ``<keyword> <name> = <call>`` with no ``%*``/``@``."""
-        return f"{keyword} {name} = {value}"
-
-    return _format
-
-
-@beartype
-def _format_nim_call_variable_assignment(
-    name: str,
-    value: str,
-    _data: Value,
-) -> str:
-    """Format an existing-variable assignment binding a call result.
-
-    The call-expression counterpart of the literal-binding assignment
-    formatter; the ``%*``/``@`` wrapping is dropped since a call result
-    is bound directly.
-    """
-    return f"{name} = {value}"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1802,12 +1762,11 @@ class Nim(metaclass=LanguageCls):
         The literal-binding declaration prefixes the right-hand side
         with the ``%*`` json macro (or ``@`` for sequences) chosen from
         the parsed literal's type; that JSON-constructs a literal and is
-        invalid for a call result, so the call expression is bound
+        invalid for a call result.  The plain ``<keyword> <name> =
+        <value>`` declaration-style formatter binds the call result
         directly with no wrapping.
         """
-        return _make_nim_call_variable_declaration(
-            keyword=self.declaration_style.name.lower(),
-        )
+        return self.declaration_style.value.formatter
 
     @cached_property
     def format_call_variable_assignment(
@@ -1817,9 +1776,11 @@ class Nim(metaclass=LanguageCls):
 
         The call-expression counterpart of
         :attr:`format_variable_assignment`; the ``%*``/``@`` wrapping is
-        dropped since a call result is bound directly.
+        dropped since a call result is bound directly.  Unlike the
+        declaration form this carries no ``var``/``let``/``const``
+        keyword, so it does not reuse the declaration-style formatter.
         """
-        return _format_nim_call_variable_assignment
+        return variable_formatter(template="{name} = {value}")
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/tests/integration/cases/call_variable_form_new/Nim_call@v2.nim
+++ b/tests/integration/cases/call_variable_form_new/Nim_call@v2.nim
@@ -1,0 +1,2 @@
+proc make_widget[T0](count: T0): int {.discardable.} = 0
+var my_data = make_widget(42)


### PR DESCRIPTION
Follow-up to #1961; resolves #2455.

## Problem

Nim rejected `variable_form` for `literalize_call`. Its literal-binding
declaration template prefixes the right-hand side with the `%*` json
macro (or `@` for sequences) chosen from the parsed literal's type. For
a call RHS this produces invalid code:

```nim
var my_data = %* make_widget(42)   # %* JSON-constructs a literal, not a call result
```

## Change

- Added module-level `_make_nim_call_variable_declaration` /
  `_format_nim_call_variable_assignment` and `@cached_property`
  `format_call_variable_declaration` / `format_call_variable_assignment`
  overrides that emit `var my_data = make_widget(42)` /
  `my_data = make_widget(42)` with no `%*`/`@` wrapping, regardless of
  the source data type (mirrors the Tcl/Objective-C/Haskell pattern).
- Removed the `default_format_call_variable_*` reuse and flipped
  `supports_call_variable_binding` from `False` to `True`, removing the
  `UnsupportedCallShapeError` raise site for Nim.

## Acceptance criteria

- [x] New golden `tests/integration/cases/call_variable_form_new/Nim_call@v2.nim`:
  `var my_data = make_widget(42)`.
- [x] The `ExistingVariable` equivalent is **not** covered: the bare
  assignment to an undeclared name is not self-contained, so the
  existing mirror gate skips it (no golden) — consistent with Bash and
  the imperative compiled languages.
- [x] Existing Nim literal-binding and call-without-binding output
  unchanged (only one new file added; no other Nim golden changed).
- [x] `supports_call_variable_binding = True`; raise site removed.

## Verification

- `uv run --extra dev pytest` Nim integration suite + full
  `tests/errors/test_call_errors.py` green (including
  `test_literalize_call_variable_form_template_incompatible_raises`,
  which uses `D`).
- New fixture compiles+runs clean under pinned Nim 2.2.10 with the full
  `--warningAsError` catalogue (68 flags) from `lint.yml`.
- ruff, pylint (10.00/10), mypy, ty, pyright clean on `nim.py`; Sphinx
  spelling reports only pre-existing baseline words (none from this
  diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to Nim call-result variable binding templates and adds a single new integration golden, with existing literal rendering paths intended to remain unchanged.
> 
> **Overview**
> Enables `literalize_call(..., variable_form=...)` for **Nim** by introducing call-specific variable declaration/assignment formatters that bind the call result directly (dropping the `%*`/`@` literal wrappers used for value literals), and flipping `supports_call_variable_binding` to `True`.
> 
> Adds a new Nim golden fixture covering the `NewVariable` call-binding form (`var my_data = make_widget(42)`), and documents the change in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269cb30aa37f8f23796df79c60281d93de1c5b5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->