### PR TITLE
Support literalize_call variable_form for Elixir (#2226)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,18 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Elixir` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  The call stub is emitted at
+  module scope and the binding lives inside the generated ``def x do``
+  entry function, so ``my_data = make_widget(42)`` no longer needs a
+  ``def`` nested inside another ``def``.  Because Elixir rebinds names
+  with ``=``, the :class:`~literalizer.ExistingVariable` output is
+  identical to the :class:`~literalizer.NewVariable` output.  Its
+  ``supports_call_variable_binding`` language-class flag is now
+  ``True``; existing literal-binding and call-without-binding output is
+  unchanged.  Follow-up to #1961.  See #2226.
 - :class:`~literalizer.Python` now emits ``from __future__ import
   annotations`` only when the rendered code actually contains an
   annotation: a ``RECORD``-strategy ``@dataclasses.dataclass`` block

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -221,7 +221,7 @@ class Elixir(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = False
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -574,6 +574,45 @@ class Elixir(metaclass=LanguageCls):
         parts.extend(f"  {stub}" for stub in module_defs)
         parts.append("  def x do")
         parts.append(indented_body)
+        parts.append("  end")
+        parts.append("end")
+        return "\n".join(parts)
+
+    def wrap_call_variable_in_file(
+        self,
+        content: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap a call-result variable binding in an Elixir module.
+
+        :meth:`wrap_in_file`'s variable branch places *body_preamble*
+        inside ``def x do``, but for a call binding those lines are the
+        module-level stub function definitions emitted by
+        :func:`_elixir_call_stub`; nesting a ``def`` inside ``def x do``
+        is a syntax error.  This hook hoists the ``def ``-prefixed
+        preamble lines to module scope (matching the
+        call-without-binding branch of :meth:`wrap_in_file`) while
+        keeping the ``my_data = make_widget(...)`` binding, any non-stub
+        preamble lines (e.g. the dotted-call ``root = RootType_`` alias),
+        and the trailing ``_ = my_data`` use inside ``def x do``.
+        """
+        module_defs = [
+            line for line in body_preamble if line.startswith("def ")
+        ]
+        body_assigns = tuple(
+            line for line in body_preamble if not line.startswith("def ")
+        )
+        body = prepend_body_preamble(
+            content=content, body_preamble=body_assigns
+        )
+        indented_body = textwrap.indent(text=body, prefix=self.indent)
+        use_line = f"{self.indent}_ = {variable_name}"
+        parts: list[str] = ["defmodule Check do"]
+        parts.extend(f"  {stub}" for stub in module_defs)
+        parts.append("  def x do")
+        parts.append(indented_body)
+        parts.append(use_line)
         parts.append("  end")
         parts.append("end")
         return "\n".join(parts)

--- a/tests/integration/cases/call_variable_form_existing/Elixir_call@v1_14.ex
+++ b/tests/integration/cases/call_variable_form_existing/Elixir_call@v1_14.ex
@@ -1,0 +1,7 @@
+defmodule Check do
+  def make_widget(_count), do: nil
+  def x do
+    my_data = make_widget(42)
+    _ = my_data
+  end
+end

--- a/tests/integration/cases/call_variable_form_new/Elixir_call@v1_14.ex
+++ b/tests/integration/cases/call_variable_form_new/Elixir_call@v1_14.ex
@@ -1,0 +1,7 @@
+defmodule Check do
+  def make_widget(_count), do: nil
+  def x do
+    my_data = make_widget(42)
+    _ = my_data
+  end
+end


### PR DESCRIPTION
Closes #2226 (follow-up to #1961). `literalize_call(..., variable_form=...)` now works for Elixir for both `NewVariable` and `ExistingVariable`: a new `wrap_call_variable_in_file` hook emits the call stub at module scope while keeping the binding inside the generated `def x do` entry function, resolving the structural conflict where a `def` stub cannot be nested inside another `def`. `supports_call_variable_binding` is flipped to `True`, so Elixir no longer hits the shared `UnsupportedCallShapeError` raise site. The two outputs are byte-identical (Elixir `=` rebinds), so both `call_variable_form_new` and `call_variable_form_existing` goldens are added while existing literal-binding and call-without-binding output is unchanged. Verified: full `test_calls.py` (2893 passed), `test_call_errors.py` (38 passed), and the generated fixture compiles + `Check.x()` runs warning-free under Elixir 1.18/1.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a previously-unsupported `literalize_call(..., variable_form=...)` shape for Elixir by changing file-wrapping behavior and flipping a capability flag, which could affect call-mode output and integration fixtures but is isolated to the Elixir backend.
> 
> **Overview**
> Adds Elixir support for binding `literalize_call` results to a variable (`NewVariable`/`ExistingVariable`) by introducing `Elixir.wrap_call_variable_in_file`, which **hoists generated `def` call stubs to module scope** while keeping the assignment (and `_ = my_data` use) inside `def x do`.
> 
> Flips `Elixir.supports_call_variable_binding` to `True` so this call shape no longer raises `UnsupportedCallShapeError`, and adds new golden integration fixtures for both “new” and “existing” variable forms (byte-identical in Elixir).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1918e870645ce15e657d42064957ecd0a9b211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->