### PR TITLE
Support literalize_call variable_form for C (#2506)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,26 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.C` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  A C literal binding wraps
+  the right-hand side in a designated-initializer compound literal that
+  encodes the value's runtime type (a tagged-union projection, or a
+  ``struct Record0 my_data = (struct Record0){...};`` aggregate under
+  the ``RECORD`` strategy), which is wrong for a call whose return type
+  is opaque to the renderer; the call result is now bound directly as
+  ``CVal my_data = make_widget(...);``.  No caller-supplied return-type
+  hint is required: every generated call stub returns the universal
+  tagged ``CVal`` union, so the binding's declared type is always
+  ``CVal`` (the same type a C literal binding declares).  Because the
+  binding is a typed
+  declaration while the :class:`~literalizer.ExistingVariable` form is a
+  bare assignment to an already-declared name, only the
+  :class:`~literalizer.NewVariable` form is golden-covered.  Its
+  ``supports_call_variable_binding`` language-class flag is now
+  ``True``; existing literal-binding and call-without-binding output is
+  unchanged.  Follow-up to #1961.  See #2506.
 - :class:`~literalizer.Elixir` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -73,8 +73,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
@@ -605,13 +603,51 @@ def _c_call_stub(
 
 
 @beartype
+def _format_c_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a C declaration binding a call result.
+
+    A literal binding wraps the right-hand side in a designated-
+    initializer compound literal that encodes the value's runtime type:
+    a tagged-union projection for the default strategy, or
+    ``struct Record0 my_data = (struct Record0){...};`` under the
+    ``RECORD`` strategy.  That is wrong for a call, whose return type is
+    opaque to the renderer and is neither a union-field projection nor a
+    generated ``struct``.
+
+    C has no type inference, so the binding still needs an explicit
+    declared type.  No caller-supplied return-type hint is required:
+    every generated call stub returns the universal tagged ``CVal``
+    union (a ``StubReturn.VALUE`` stub returns ``CVal``), so the call
+    result's static type is always ``CVal`` -- exactly the type a C
+    literal binding already declares.  The only call-vs-literal
+    difference is dropping the value-wrapping compound literal, so the
+    call result is bound directly with a plain ``CVal`` declaration.
+    """
+    return f"CVal {name} = {value};"
+
+
+@beartype
+def _format_c_call_assignment(name: str, value: str, _data: Value) -> str:
+    """Format a C reassignment binding a call result.
+
+    The call-expression counterpart of :func:`_format_c_call_declaration`;
+    the variable is already declared ``CVal``, so the call result is
+    assigned directly with no compound-literal wrapping.
+    """
+    return f"{name} = {value};"
+
+
+@beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class C(metaclass=LanguageCls):
     """C language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -624,7 +660,12 @@ class C(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    # A call result is bound directly with an explicit ``CVal`` type
+    # (every generated call stub returns the universal tagged ``CVal``
+    # union, so no caller-supplied return-type hint is needed); the
+    # value-wrapping designated-initializer compound literal a C literal
+    # binding uses is dropped.  See :func:`_format_c_call_declaration`.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -1550,6 +1591,33 @@ class C(metaclass=LanguageCls):
             return f"{name} = {wrapped};"
 
         return _format_assign
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        A literal binding wraps the right-hand side in a designated-
+        initializer compound literal that encodes the value's runtime
+        type; a call's return type is opaque to the renderer and is
+        always the universal ``CVal`` union (the type every generated
+        call stub returns), so the call result is bound directly with a
+        plain ``CVal`` declaration and no compound-literal wrapping.
+        """
+        return _format_c_call_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_variable_assignment`; the compound-literal
+        wrapping is dropped since the call already yields a ``CVal``.
+        """
+        return _format_c_call_assignment
 
     @cached_property
     def static_preamble(self) -> Sequence[str]:

--- a/tests/integration/cases/call_variable_form_new/C_call@c99.c
+++ b/tests/integration/cases/call_variable_form_new/C_call@c99.c
@@ -1,0 +1,22 @@
+#include <stdbool.h>
+#include <stddef.h>
+typedef struct CVal CVal;
+typedef struct CKV CKV;
+struct CVal {
+    union {
+        _Bool b;
+        long long i;
+        unsigned long long u;
+        double f;
+        const char *s;
+        const CVal *a;
+        const CKV *m;
+    };
+};
+struct CKV { const char *k; CVal v; };
+static CVal make_widget(CVal _a0) { (void)_a0; return (CVal){0}; }
+int main(void) {
+CVal my_data = make_widget(((CVal){.i = 42}));
+    (void)my_data;
+    return 0;
+}


### PR DESCRIPTION
Closes #2506. Follow-up to #1961; split out from #2225.

## What

C rejected `variable_form` for `literalize_call` (`supports_call_variable_binding = False`) because its declaration template wraps the RHS in a designated-initializer compound literal that encodes the literal's runtime type (`CVal name = ((CVal){.i = 42});`, or `struct Record0 name = (struct Record0){...};` under `RECORD`). That is wrong for a call, whose return type is opaque to the renderer and is neither a union-field projection nor a generated `struct`.

A call result is now bound directly with a plain typed declaration:

```c
static CVal make_widget(CVal _a0) { (void)_a0; return (CVal){0}; }
int main(void) {
CVal my_data = make_widget(((CVal){.i = 42}));
    (void)my_data;
    return 0;
}
```

## Decision recorded: return-type hint

No caller-supplied return-type hint is required. Every generated C call stub returns the universal tagged `CVal` union (a `StubReturn.VALUE` stub returns `CVal`), so a call result's static type is always `CVal` — exactly the type every C literal binding already declares. The only call-vs-literal difference is dropping the value-wrapping compound literal. This is documented in `_format_c_call_declaration`, the `supports_call_variable_binding` comment, and the changelog.

## Acceptance criteria

- [x] Decision recorded on whether/how a return-type hint is supplied for C (no hint needed; stubs return `CVal`).
- [x] New golden `tests/integration/cases/call_variable_form_new/C_call@c99.c`. The `ExistingVariable` form is a bare assignment to an already-declared name and diverges from the compilable `NewVariable` form, so it is skipped with no golden (consistent with Rust/Go/Cpp/ObjectiveC and the #2375 self-contained-mirror gate).
- [x] Existing C literal-binding and call-without-binding output unchanged (no other golden changed; full suite green).
- [x] `supports_call_variable_binding = False` / `UnsupportedCallShapeError` raise site for C removed (flag flipped to `True`).

## Verification

- Full test suite: 4894 passed, 0 failed; project coverage 100% (0 missing).
- New golden compiles and runs clean under `clang -std=c99 -Wall -Wextra -Werror` and passes `clang-tidy --config-file=.clang-tidy -- -std=c99` (exit 0).
- ruff / pylint 10.00 / mypy / ty / pyright / pyrefly clean on the changed module. Sphinx spelling and sphinx-lint introduce no new failures (only pre-existing baseline words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to C call rendering: call results are now bound with a plain `CVal` declaration/assignment instead of the literal-wrapping template, with a new integration golden to lock output.
> 
> **Overview**
> Enables `literalize_call(..., variable_form=...)` for the `C` backend by flipping `supports_call_variable_binding` to `True` and introducing call-specific binding formatters that **bind call results directly** as `CVal name = call(...);` / `name = call(...);` (dropping the compound-literal wrapping used for literal values).
> 
> Adds a new C99 golden integration fixture covering the `NewVariable` call-binding form, and documents the behavior/return-type rationale in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d47dd17492e1bda99ab89a6262bf8206a229690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->