### PR TITLE
Support literalize_call variable_form for Ada (#2509)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,23 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Ada` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  An Ada literal binding wraps
+  the right-hand side in the ``A_Val`` constructor chosen from the
+  parsed literal's runtime type, which is wrong for a call whose return
+  type is opaque to the renderer; the call result is now bound directly
+  as ``my_data : A_Val := Make_Widget (...);``.  No caller-supplied
+  return-type hint is required: every generated Ada call stub returns
+  ``A_Val``, so the binding's declared type is always ``A_Val`` (the
+  same type an Ada literal binding declares).  Because the binding is a
+  typed declaration while the :class:`~literalizer.ExistingVariable`
+  form is a bare assignment to an already-declared name, only the
+  :class:`~literalizer.NewVariable` form is golden-covered.  Its
+  ``supports_call_variable_binding`` language-class flag is now
+  ``True``; existing literal-binding and call-without-binding output is
+  unchanged.  Follow-up to #1961.  See #2509.
 - :class:`~literalizer.C` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -57,8 +57,6 @@ from literalizer._language import (
     SetFormatConfig,
     StubReturn,
     TrailingCommaConfig,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     identity_call_ref_identifier,
     identity_call_statement,
@@ -171,6 +169,51 @@ def _format_variable_assignment(name: str, value: str, data: Value) -> str:
 
 
 @beartype
+def _format_ada_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format an Ada object declaration binding a call result.
+
+    A literal binding wraps the right-hand side in the ``A_Val``
+    constructor chosen from the parsed literal's runtime type
+    (``AInt``/``AFloat``/``AStr``/...).  That is wrong for a call, whose
+    return type is opaque to the renderer and whose result is not an
+    ``A_Val`` projection of a known scalar.
+
+    Ada has no type inference for object declarations, so the binding
+    still needs an explicit declared type.  No caller-supplied
+    return-type hint is required: every generated Ada call stub returns
+    ``A_Val`` (see :func:`_ada_call_stub`), so the call result's static
+    type is always ``A_Val`` -- exactly the type a literal binding
+    already declares.  The only call-vs-literal difference is dropping
+    the value-wrapping ``A_Val`` constructor, so the call result is
+    bound directly with a plain ``A_Val`` declaration.
+
+    Example: ``"my_data"`` and ``"Make_Widget (AInt (42))"`` →
+    ``"my_data : A_Val := Make_Widget (AInt (42));"``
+    """
+    return f"{name} : A_Val := {value};"
+
+
+@beartype
+def _format_ada_call_assignment(name: str, value: str, _data: Value) -> str:
+    """Format an Ada assignment binding a call result.
+
+    The call-expression counterpart of
+    :func:`_format_ada_call_declaration`; the variable is already
+    declared ``A_Val``, so the call result is assigned directly with no
+    ``A_Val`` constructor wrapping.
+
+    Example: ``"my_data"`` and ``"Make_Widget (AInt (42))"`` →
+    ``"my_data := Make_Widget (AInt (42));"``
+    """
+    return f"{name} := {value};"
+
+
+@beartype
 def _ada_call_stub(
     parts: Sequence[str],
     params: Sequence[str],
@@ -224,8 +267,6 @@ class Ada(metaclass=LanguageCls):
     """Ada language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -238,7 +279,12 @@ class Ada(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    # A call result is bound directly with an explicit ``A_Val`` type
+    # (every generated Ada call stub returns ``A_Val``, so no
+    # caller-supplied return-type hint is needed); the value-wrapping
+    # ``A_Val`` constructor an Ada literal binding uses is dropped.  See
+    # :func:`_format_ada_call_declaration`.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     allows_empty_call_parens = False
@@ -646,6 +692,32 @@ class Ada(metaclass=LanguageCls):
     def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
         """Format an assignment to an existing variable."""
         return _format_variable_assignment
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        Unlike :attr:`format_variable_declaration`, the call result is
+        opaque (it is whatever the ``A_Val``-returning call stub
+        returns), so the call result is bound directly with a plain
+        ``A_Val`` declaration and no ``A_Val`` constructor wrapping.
+        """
+        return _format_ada_call_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_call_variable_declaration`; the ``A_Val``
+        constructor wrapping is dropped since the call already yields an
+        ``A_Val``.
+        """
+        return _format_ada_call_assignment
 
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:

--- a/tests/integration/cases/call_variable_form_new/Ada_call@ada_2022.adb
+++ b/tests/integration/cases/call_variable_form_new/Ada_call@ada_2022.adb
@@ -1,0 +1,7 @@
+with A_Stub; use A_Stub;
+procedure Main is
+    function Make_Widget (Count : A_Val) return A_Val is (ANull);
+    my_data : A_Val := Make_Widget(count => AInt (42));
+begin
+    null;
+end Main;


### PR DESCRIPTION
Closes #2509. Follow-up to #1961, split out from #2225. Sibling of #2506 (C), #2226 (Elixir), #2455 (Nim), #2456 (Forth).

## Problem

Ada rejected `variable_form` for `literalize_call` (`supports_call_variable_binding = False`) because its object-declaration template wraps the RHS in the `A_Val` constructor chosen from the parsed literal's runtime type (`AInt`/`AFloat`/`AStr`/...). For a call RHS that is wrong: the call's return type is opaque to the renderer and the result is not an `A_Val` projection of a known scalar.

## Decision: return-type hint

**None needed.** Every generated Ada call stub returns `A_Val` (`function Make_Widget (...) return A_Val is (ANull);`), so a call result's static type is always `A_Val` — exactly the type every Ada literal binding declares (`name : A_Val := ...;`). The only call-vs-literal difference is dropping the value-wrapping `A_Val` constructor, so the call result is bound directly:

```ada
my_data : A_Val := Make_Widget (count => AInt (42));
```

## Changes

- Added module-level `_format_ada_call_declaration` / `_format_ada_call_assignment` and `@cached_property` overrides returning them.
- Removed the class-level `default_format_call_variable_declaration` / `default_format_call_variable_assignment` assignments and their imports.
- Flipped `supports_call_variable_binding` `False` -> `True` with an explanatory comment; this removes the flag-driven `UnsupportedCallShapeError` raise for Ada.
- New `call_variable_form_new/Ada_call@ada_2022.adb` golden (`NewVariable`).

The `ExistingVariable` form is a bare assignment to an already-declared name (not a self-contained declaration), so the runner's `self_contained_mirror_variable_form` gate skips its golden — matching the C/Rust/Go precedent and the issue's "if covered". `_format_ada_call_assignment` is still covered because the runner computes the `ExistingVariable` wrap before skipping.

## Acceptance criteria

- [x] Decision recorded on the return-type hint (none required; documented in code + CHANGELOG).
- [x] New golden-file case under `tests/integration/cases/call_variable_form_new/` for Ada (`ExistingVariable` gated out per precedent).
- [x] Existing Ada literal-binding and call-without-binding output unchanged.
- [x] The `supports_call_variable_binding = False` / `UnsupportedCallShapeError` raise for Ada removed.

## Verification

- Full suite: 4898 passed, 100% coverage (incl. `ada.py` at 100%).
- `test_literalize_call_variable_form_template_incompatible_raises` (uses `D`, still `False`) green.
- ruff / mypy / ty / pyright / pyrefly clean on `ada.py`; pylint 10.00; pylint-docs + sphinx-lint clean on CHANGELOG. Sphinx spelling shows only the pre-existing `cpp.py` `copyable` baseline (no new words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Ada call-result variable binding formatting and add a single golden integration fixture; existing literal bindings and unbound call output should remain unchanged.
> 
> **Overview**
> Adds Ada support for `literalize_call(..., variable_form=...)` by enabling `supports_call_variable_binding` and introducing call-specific variable declaration/assignment formatters that **bind call results directly** (no `AInt`/`AFloat`/`AStr` constructor wrapping) while still declaring the variable as `A_Val`.
> 
> Updates documentation (CHANGELOG) and adds a new Ada golden integration fixture covering the `NewVariable` call-binding form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a42d8e013bcd80107fbdf0a27cbaf7e1fb409b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->