### PR TITLE
Support literalize_call variable_form for Zig (#2510)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,26 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Zig` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  A Zig literal binding wraps
+  the right-hand side in a designated-initializer struct literal that
+  encodes the value's runtime type (a tagged ``ZVal`` union projection,
+  or a generated ``Record0`` struct literal under the ``RECORD``
+  strategy) and declares an explicit ``ZVal`` value type, which is
+  wrong for a call whose return type is opaque to the renderer; the
+  call result is now bound with a plain inferred declaration,
+  ``const my_data = make_widget(...);``.  No caller-supplied return-type
+  hint is required: the Zig ``const``/``var`` type inference supplies
+  the binding's type.  Because the binding is a keyword declaration
+  while
+  the :class:`~literalizer.ExistingVariable` form is a bare assignment
+  to an already-declared name, only the
+  :class:`~literalizer.NewVariable` form is golden-covered.  Its
+  ``supports_call_variable_binding`` language-class flag is now
+  ``True``; existing literal-binding and call-without-binding output is
+  unchanged.  Follow-up to #1961.  See #2510.
 - :class:`~literalizer.C` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -77,8 +77,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
@@ -349,13 +347,24 @@ def _zig_render_record_declaration(
 
 
 @beartype
+def _format_zig_call_assignment(name: str, value: str, _data: Value) -> str:
+    """Format a Zig reassignment binding a call result.
+
+    The call-expression counterpart of
+    :attr:`Zig.format_call_variable_declaration`; the variable already
+    exists, so the call result is assigned directly with none of the
+    ``ZVal`` union tagging a literal-binding assignment applies (a call
+    result is not a ``ZVal`` union literal).
+    """
+    return f"{name} = {value};"
+
+
+@beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Zig(metaclass=LanguageCls):
     """Zig language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -366,7 +375,15 @@ class Zig(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    # A call result is bound with a plain inferred declaration
+    # (``const my_data = make_widget(...);``); the Zig ``const``/``var``
+    # type inference means no caller-supplied return-type hint is
+    # needed.  The value-type ``: ZVal`` annotation and the
+    # ``Name{ .field = value, ... }`` struct-literal wrapping a Zig
+    # literal binding uses are both dropped (a call result is neither a
+    # ``ZVal`` projection nor a generated ``struct`` literal).  See
+    # :attr:`format_call_variable_declaration`.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -1324,6 +1341,51 @@ class Zig(metaclass=LanguageCls):
             return f"{keyword} {name}: ZVal = {wrapped};"
 
         return _format_decl
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        A Zig literal binding wraps the right-hand side in a
+        designated-initializer ``ZVal`` projection (``.{ .int = 42 }``),
+        or a generated ``Record0{ .field = value, ... }`` struct literal
+        under the ``RECORD`` strategy, and declares an explicit value
+        type (``: ZVal``).  A call's return type is opaque to the
+        renderer and is neither, so the call result is bound with a
+        plain inferred declaration (``const my_data = make_widget(...);``
+        / ``var my_data = make_widget(...);``): the Zig ``const``/``var``
+        type inference means no caller-supplied return-type hint is
+        needed, and the value-wrapping and ``: ZVal`` annotation are
+        dropped.
+        """
+        keyword = self.declaration_style.value.keyword
+
+        @beartype
+        def _format_call_decl(
+            name: str,
+            value: str,
+            _data: Value,
+            _modifiers: frozenset[enum.Enum],
+        ) -> str:
+            """Format an inferred Zig declaration binding a call."""
+            return f"{keyword} {name} = {value};"
+
+        return _format_call_decl
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_call_variable_declaration`; the ``ZVal`` tagging a
+        literal-binding assignment applies is dropped since a call
+        result is not a ``ZVal`` union literal.
+        """
+        return _format_zig_call_assignment
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:

--- a/tests/integration/cases/call_variable_form_new/Zig_call@v0_12.zig
+++ b/tests/integration/cases/call_variable_form_new/Zig_call@v0_12.zig
@@ -1,0 +1,17 @@
+const ZVal = union(enum) {
+    nil,
+    bool: bool,
+    int: i64,
+    uint: u64,
+    float: f64,
+    str: []const u8,
+    arr: []const ZVal,
+    map: []const ZKV,
+    set: []const ZVal,
+};
+const ZKV = struct { key: []const u8, val: ZVal };
+fn make_widget(count: ZVal) void { _ = count; }
+pub fn main() void {
+    const my_data = make_widget(.{ .int = 42 });
+    _ = my_data;
+}


### PR DESCRIPTION
Closes #2510. Follow-up to #1961; split out from #2225.

## Problem

Zig rejected `variable_form` for `literalize_call` (`supports_call_variable_binding = False`) because its declaration template wraps the RHS in a designated-initializer struct literal encoding the literal's runtime type (a tagged `ZVal` union projection, or a generated `Record0` struct under the `RECORD` strategy) and declares an explicit `: ZVal` value type. For a call RHS that is wrong: the call result is neither a `ZVal` projection nor a generated struct literal.

## Change

Bind a call result with a plain inferred declaration: `const my_data = make_widget(...);` (or `var ...` per declaration style). The `const`/`var` type inference supplies the binding's type, so **no caller-supplied return-type hint is required** and both the value-wrapping and the `: ZVal` annotation are dropped. This mirrors the C (#2506) / Nim (#2455) pattern: dedicated `format_call_variable_declaration` / `format_call_variable_assignment` `cached_property`s, the `default_format_call_variable_*` class assignments and imports removed, and `supports_call_variable_binding` flipped `False -> True` with an explanatory comment.

## Acceptance criteria

- [x] Decision recorded (code comment, docstring, CHANGELOG): Zig needs no return-type hint, uses `const`/`var` inference.
- [x] New golden `tests/integration/cases/call_variable_form_new/Zig_call@v0_12.zig`. The `ExistingVariable` equivalent is a bare assignment to an already-declared name, diverges from the keyword declaration, and is skipped by the `self_contained_mirror_variable_form` gate (no golden) -- consistent with C/Rust/Go/Nim and the issue's "if covered".
- [x] Existing Zig literal-binding and call-without-binding output unchanged (full suite green; only the new golden added).
- [x] The `supports_call_variable_binding = False` raise site for Zig removed.

## Verification

- Full suite: 4898 passed, 100% coverage (`zig.py` 513/513).
- All 38 `tests/errors/test_call_errors.py` green (the incompatible-template test uses `D`, still `False`, unaffected).
- New golden compiles + runs clean under `zig run` (locally 0.16; CI pins 0.14, construct is fundamental).
- ruff / pylint 10.00 / mypy / ty / pyright / pyrefly clean; Sphinx spelling + sphinx-lint only pre-existing baseline noise (no new flagged words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Zig codegen for `literalize_call(..., variable_form=...)` by enabling call-result bindings and introducing call-specific declaration/assignment formatters; risk is limited to Zig output paths but could affect downstream consumers relying on previous UnsupportedCallShapeError behavior.
> 
> **Overview**
> Enables Zig `literalize_call` to accept `variable_form` by flipping `supports_call_variable_binding` to `True` and adding call-specific binding formatters.
> 
> Call-result bindings now emit plain inferred declarations/assignments (e.g. `const my_data = make_widget(...);` / `my_data = make_widget(...);`) instead of reusing literal-binding templates that wrap values as `ZVal`/record literals and annotate `: ZVal`.
> 
> Adds a new Zig golden integration fixture covering the `NewVariable` call-binding output, and documents the behavior change in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04de72aca0624dbdeb61f2edf14cd21eb140ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->