### PR TITLE
Support literalize_call variable_form for Fortran (#2508)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,29 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.Fortran` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  A Fortran literal binding
+  wraps the right-hand side in the ``fval_t`` constructor matching the
+  parsed literal's type (the integer, real, or string constructor),
+  which is wrong for a call whose return type is opaque to the
+  renderer; the call result is now bound directly as
+  ``type(fval_t) :: my_data`` followed by
+  ``my_data = make_widget(...)``.  No caller-supplied return-type hint
+  is required: every generated Fortran call stub returns
+  ``type(fval_t)``, so the binding's declared type is always
+  ``type(fval_t)`` (the same type a Fortran literal binding declares).
+  The call stub is emitted in the program's ``contains`` section, after
+  the binding, so a value-returning call no longer needs an inline
+  procedure body.  Because the :class:`~literalizer.NewVariable` binding
+  is a typed declaration while the
+  :class:`~literalizer.ExistingVariable` form is a bare assignment to an
+  already-declared name, only the :class:`~literalizer.NewVariable`
+  form is golden-covered.  Its ``supports_call_variable_binding``
+  language-class flag is now ``True``; existing literal-binding and
+  call-without-binding output is unchanged.  Follow-up to #1961.  See
+  #2508.
 - :class:`~literalizer.C` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -57,8 +57,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     identity_call_ref_identifier,
     never_inhibits_consuming_form,
     no_call_binding_body_preamble,
@@ -256,6 +254,52 @@ def _build_format_variable_assignment(
 
 
 @beartype
+def _format_fortran_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a Fortran declaration binding a call result.
+
+    A literal binding wraps the right-hand side in the ``fval_t``
+    constructor matching the parsed literal's type (the integer, real,
+    or string constructor).  That is wrong for a call: the call's
+    return type is opaque to the renderer and the result is not the
+    constructed type.
+
+    Fortran has no type inference, so the binding still needs an
+    explicit declared type.  No caller-supplied return-type hint is
+    required: every generated Fortran call stub returns ``type(fval_t)``
+    -- a ``StubReturn.VALUE`` stub is a ``function ... result(r)`` whose
+    ``r`` is declared ``type(fval_t)`` -- so the call result's static
+    type is always ``type(fval_t)``, exactly the type a Fortran literal
+    binding already declares.  The only call-vs-literal difference is
+    dropping the value-wrapping constructor, so the call result is bound
+    directly to a plain ``type(fval_t)`` declaration.
+    """
+    continued = _add_continuation(value=value)
+    return f"type(fval_t) :: {name}\n{name} = {continued}"
+
+
+@beartype
+def _format_fortran_call_assignment(
+    name: str,
+    value: str,
+    _data: Value,
+) -> str:
+    """Format a Fortran reassignment binding a call result.
+
+    The call-expression counterpart of
+    :func:`_format_fortran_call_declaration`; the variable is already
+    declared ``type(fval_t)``, so the call result is assigned directly
+    with no ``fval_t``-constructor wrapping.
+    """
+    continued = _add_continuation(value=value)
+    return f"{name} = {continued}"
+
+
+@beartype
 def _fortran_call_target(parts: Sequence[str], /) -> str:
     """Return the last component of a dotted call target as the Fortran
     procedure name.
@@ -331,8 +375,6 @@ class Fortran(metaclass=LanguageCls):
     """Fortran language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
 
@@ -344,7 +386,13 @@ class Fortran(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    # A call result is bound directly with an explicit ``type(fval_t)``
+    # declaration (every generated Fortran call stub returns
+    # ``type(fval_t)``, so no caller-supplied return-type hint is
+    # needed); the value-wrapping ``fval_t`` constructor a Fortran
+    # literal binding uses is dropped.  See
+    # :func:`_format_fortran_call_declaration`.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     allows_empty_call_parens = True
@@ -679,6 +727,32 @@ class Fortran(metaclass=LanguageCls):
             "end program main"
         )
 
+    def wrap_call_variable_in_file(
+        self,
+        content: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap a call-result variable binding in a Fortran program.
+
+        The literal-binding :meth:`wrap_in_file` variable branch places
+        *body_preamble* directly in the program body, but a call stub
+        (an internal ``function``/``subroutine``) cannot be a
+        plain executable statement: it must live in the ``contains``
+        section after the executable statements.  *content* already
+        carries the ``type(fval_t) :: name`` specification line followed
+        by the binding assignment in the order Fortran requires, so this
+        delegates to the empty-``variable_name`` (call-mode) branch of
+        :meth:`wrap_in_file`, which places *content* in the program body
+        and the stubs in ``contains``.
+        """
+        del variable_name  # the binding text already carries the name
+        return self.wrap_in_file(
+            content=content,
+            variable_name="",
+            body_preamble=body_preamble,
+        )
+
     date_format: DateFormats = DateFormats.ISO
     datetime_format: DatetimeFormats = DatetimeFormats.ISO
     bytes_format: BytesFormats = BytesFormats.HEX
@@ -788,6 +862,34 @@ class Fortran(metaclass=LanguageCls):
     ]:
         """Return file-scope stubs for a call expression."""
         return no_call_stub
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        A literal binding wraps the right-hand side in a ``fval_t``
+        constructor chosen from the parsed literal's type; a call's
+        return type is opaque to the renderer and is always
+        ``type(fval_t)`` (the type every generated call stub returns),
+        so the call result is bound directly to a plain ``type(fval_t)``
+        declaration with no constructor wrapping.
+        """
+        return _format_fortran_call_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_variable_assignment`; the ``fval_t``-constructor
+        wrapping is dropped since the call already yields a
+        ``type(fval_t)``.
+        """
+        return _format_fortran_call_assignment
 
     @cached_property
     def format_call_target(self) -> Callable[[Sequence[str]], str]:

--- a/tests/integration/cases/call_variable_form_new/Fortran_call@v2003.f90
+++ b/tests/integration/cases/call_variable_form_new/Fortran_call@v2003.f90
@@ -1,0 +1,30 @@
+module fval_m
+  implicit none
+  integer, parameter :: int64 = selected_int_kind(18)
+  type :: fval_t
+    integer :: t = 0
+  end type fval_t
+contains
+  function fnull() result(v); type(fval_t) :: v; end function
+  function fbool(b) result(v); logical, intent(in) :: b; type(fval_t) :: v; end function
+  function fint(n) result(v); integer(kind=int64), intent(in) :: n; type(fval_t) :: v; end function
+  function freal(x) result(v); real, intent(in) :: x; type(fval_t) :: v; end function
+  function fstr(s) result(v); character(len=*), intent(in) :: s; type(fval_t) :: v; end function
+  function flist(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fmap(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fset(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fentry(k, u) result(v); character(len=*), intent(in) :: k; type(fval_t), intent(in) :: u; type(fval_t) :: v; end function
+end module fval_m
+program main
+    use fval_m
+    implicit none
+    type(fval_t) :: my_data
+    my_data = make_widget(fint(42_int64))
+contains
+    function make_widget(count) result(r)
+        implicit none
+        type(fval_t), intent(in) :: count
+        type(fval_t) :: r
+        r = fnull()
+    end function make_widget
+end program main

--- a/tests/integration/cases/call_variable_form_new/Fortran_call@v2008.f90
+++ b/tests/integration/cases/call_variable_form_new/Fortran_call@v2008.f90
@@ -1,0 +1,30 @@
+module fval_m
+  use, intrinsic :: iso_fortran_env, only: int64
+  implicit none
+  type :: fval_t
+    integer :: t = 0
+  end type fval_t
+contains
+  function fnull() result(v); type(fval_t) :: v; end function
+  function fbool(b) result(v); logical, intent(in) :: b; type(fval_t) :: v; end function
+  function fint(n) result(v); integer(kind=int64), intent(in) :: n; type(fval_t) :: v; end function
+  function freal(x) result(v); real, intent(in) :: x; type(fval_t) :: v; end function
+  function fstr(s) result(v); character(len=*), intent(in) :: s; type(fval_t) :: v; end function
+  function flist(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fmap(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fset(a) result(v); type(fval_t), intent(in) :: a(:); type(fval_t) :: v; end function
+  function fentry(k, u) result(v); character(len=*), intent(in) :: k; type(fval_t), intent(in) :: u; type(fval_t) :: v; end function
+end module fval_m
+program main
+    use fval_m
+    implicit none
+    type(fval_t) :: my_data
+    my_data = make_widget(fint(42_int64))
+contains
+    function make_widget(count) result(r)
+        implicit none
+        type(fval_t), intent(in) :: count
+        type(fval_t) :: r
+        r = fnull()
+    end function make_widget
+end program main


### PR DESCRIPTION
Follow-up to #1961; split out from #2225. Closes #2508.

## Problem

Fortran rejected `variable_form` for `literalize_call`
(`supports_call_variable_binding = False`) because the literal-binding
declaration wraps the RHS in an `fval_t` constructor chosen from the
parsed literal's type (`fint(...)`/`freal(...)`/`fstr(...)`). For a call
RHS this is wrong: the call's return type is opaque to the renderer and
the result is not that constructed type.

## Change

When the RHS is a call expression, emit a plain typed binding to the
call result with no constructor wrapping:

```fortran
type(fval_t) :: my_data
my_data = make_widget(fint(42_int64))
```

**Return-type-hint decision (recorded):** none is required. Every
generated Fortran call stub returns `type(fval_t)` (a `StubReturn.VALUE`
stub is a `function ... result(r)` whose `r` is declared
`type(fval_t)`), so the call result's static type is always
`type(fval_t)` -- exactly the type a Fortran literal binding already
declares. Only the value-wrapping constructor is dropped.

A `wrap_call_variable_in_file` hook (the `_SupportsCallVariableWrapInFile`
opt-in) routes the call stub into the program's `contains` section,
since the literal-binding variable scaffold has no `contains` section.

## Acceptance criteria

- [x] Decision recorded on the return-type hint (docstrings + CHANGELOG: none needed).
- [x] New golden under `tests/integration/cases/call_variable_form_new/` for Fortran (`Fortran_call@v2003.f90`, `Fortran_call@v2008.f90`).
- [x] `ExistingVariable` equivalent: a bare assignment to an undeclared name, so it diverges from the compilable `NewVariable` form and the `self_contained_mirror_variable_form` gate emits no golden (matches C/Rust/Go).
- [x] Existing Fortran literal-binding and call-without-binding output unchanged.
- [x] The `supports_call_variable_binding = False` raise site for Fortran removed (flipped to `True`).

## Verification

- Full suite: 4898 passed, coverage gate satisfied; `tests/errors/test_call_errors.py` green (incompatible-template test still uses `D`).
- Both goldens compile **and run** (exit 0) under `gfortran -std=f2003`/`-std=f2008 -ffree-line-length-none`, matching lint CI.
- ruff / pylint / mypy / ty / pyright / pyrefly clean; Sphinx spelling + sphinx-lint only pre-existing baseline noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Fortran call code generation and wrapping logic for `variable_form`, which could affect emitted Fortran syntax/ordering and stub placement across call fixtures. Scope is limited to Fortran and covered by new golden integration cases.
> 
> **Overview**
> Enables Fortran `literalize_call(..., variable_form=NewVariable|ExistingVariable)` by adding call-specific variable binding templates that **bind call results directly** as `type(fval_t)` without wrapping the RHS in a literal constructor.
> 
> Adds a Fortran-only `wrap_call_variable_in_file` path to ensure generated call stubs are emitted under `contains` (after executable statements), and flips `Fortran.supports_call_variable_binding` to `True`. New `@v2003`/`@v2008` golden fixtures cover the `NewVariable` call-binding output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32f7c6c511176fba2580cbc696ce2af8cf15836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->