### PR TITLE
Support literalize_call variable_form for SystemVerilog (#2507)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,29 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.SystemVerilog` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  A SystemVerilog literal
+  binding wraps the right-hand side in a named ``_VVal`` struct literal
+  derived from the parsed value's runtime type, which is wrong for a
+  call whose return type is opaque to the renderer; the call result is
+  now bound directly as
+  ``static _VVal my_data = make_widget(...);``.  SystemVerilog
+  declarations are typed and have no inference, so the binding needs an
+  explicit declared type; no caller-supplied return-type hint is
+  required because every generated value-returning call stub returns
+  the universal tagged ``_VVal`` struct, so the binding's declared type
+  is always ``_VVal`` (the same type a SystemVerilog scalar literal
+  binding declares).  The call stub is emitted at module scope rather
+  than inside ``initial begin``, where a ``function`` declaration is
+  illegal.  Because the binding is a typed declaration while the
+  :class:`~literalizer.ExistingVariable` form is a bare assignment to an
+  already-declared name, only the :class:`~literalizer.NewVariable`
+  form is golden-covered.  Its ``supports_call_variable_binding``
+  language-class flag is now ``True``; existing literal-binding and
+  call-without-binding output is unchanged.  Follow-up to #1961.  See
+  #2507.
 - :class:`~literalizer.C` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -57,8 +57,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_ref_identifier,
@@ -235,13 +233,55 @@ def _sv_call_stub(
 
 
 @beartype
+def _format_systemverilog_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a SystemVerilog declaration binding a call result.
+
+    A literal binding wraps the right-hand side in a named ``_VVal``
+    (or ``_VKV``) struct literal derived from the parsed value's runtime
+    type.  That is wrong for a call, whose return type is opaque to the
+    renderer and is never a ``_VVal`` struct-literal projection.
+
+    SystemVerilog declarations are typed and have no inference, so the
+    binding still needs an explicit declared type.  No caller-supplied
+    return-type hint is required: every generated SystemVerilog call
+    stub that yields a value returns the universal tagged ``_VVal``
+    struct (a ``StubReturn.VALUE`` stub is ``function _VVal name(...)``),
+    so the call result's static type is always ``_VVal`` -- exactly the
+    type a SystemVerilog scalar literal binding already declares.  The
+    only call-vs-literal difference is dropping the value-wrapping
+    struct literal, so the call result is bound directly with a plain
+    ``static _VVal`` declaration regardless of the source data type.
+    """
+    return f"static _VVal {name} = {value};"
+
+
+@beartype
+def _format_systemverilog_call_assignment(
+    name: str,
+    value: str,
+    _data: Value,
+) -> str:
+    """Format a SystemVerilog reassignment binding a call result.
+
+    The call-expression counterpart of
+    :func:`_format_systemverilog_call_declaration`; the variable is
+    already declared ``_VVal``, so the call result is assigned directly
+    with no ``_VVal`` struct-literal wrapping.
+    """
+    return f"{name} = {value};"
+
+
+@beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SystemVerilog(metaclass=LanguageCls):
     """SystemVerilog language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -254,7 +294,13 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    # A call result is bound directly with an explicit ``_VVal`` type
+    # (every generated SystemVerilog call stub that yields a value
+    # returns the universal tagged ``_VVal`` struct, so no
+    # caller-supplied return-type hint is needed); the value-wrapping
+    # ``_VVal`` struct literal a SystemVerilog literal binding uses is
+    # dropped.  See :func:`_format_systemverilog_call_declaration`.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     allows_empty_call_parens = True
@@ -554,6 +600,34 @@ class SystemVerilog(metaclass=LanguageCls):
             content=declaration + "\n" + assignment,
             variable_name=variable_name,
             body_preamble=body_preamble,
+        )
+
+    def wrap_call_variable_in_file(
+        self,
+        content: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap a call-result variable binding in a SystemVerilog module.
+
+        In :meth:`wrap_in_file`'s ``variable_name`` branch,
+        *body_preamble* is prepended inside ``initial begin`` (where,
+        for a literal binding, it is data-dependent preamble).  For a
+        call binding
+        those lines are instead the module-scope ``task``/``function``/
+        ``class`` stubs emitted by :func:`_sv_call_stub`, and a
+        ``function`` declared inside ``initial begin`` is illegal.  Place
+        the stubs at module scope (matching the call-without-binding
+        branch of :meth:`wrap_in_file`) while keeping the
+        ``static _VVal my_data = make_widget(...);`` binding inside
+        ``initial begin``.
+        """
+        del variable_name
+        stubs_block = "".join(f"{s}\n" for s in body_preamble)
+        return (
+            f"module {self.module_name};\n"
+            f"{stubs_block}"
+            f"initial begin\n{content}\nend\nendmodule"
         )
 
     date_format: DateFormats = DateFormats.ISO
@@ -882,6 +956,34 @@ class SystemVerilog(metaclass=LanguageCls):
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a new variable declaration."""
         return self.declaration_style.value.formatter
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        A literal binding wraps the right-hand side in a named ``_VVal``
+        struct literal derived from the parsed value's runtime type; a
+        call's return type is opaque to the renderer and is always the
+        universal ``_VVal`` struct (the type every generated
+        value-returning call stub returns), so the call result is bound
+        directly with a plain ``static _VVal`` declaration and no
+        struct-literal wrapping.
+        """
+        return _format_systemverilog_call_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_variable_assignment`; the ``_VVal`` struct-literal
+        wrapping is dropped since the call already yields a ``_VVal``.
+        """
+        return _format_systemverilog_call_assignment
 
     @cached_property
     def compute_body_preamble(

--- a/tests/integration/cases/call_variable_form_new/SystemVerilog_call@ieee_1800_2017.sv
+++ b/tests/integration/cases/call_variable_form_new/SystemVerilog_call@ieee_1800_2017.sv
@@ -1,0 +1,19 @@
+typedef enum int {_VVAL_INT, _VVAL_REAL, _VVAL_STR} _VTag;
+typedef struct {
+    _VTag tag;
+    longint i;
+    real r;
+    string s;
+} _VVal;
+typedef struct {
+    string k;
+    _VVal v;
+} _VKV;
+module main;
+function _VVal make_widget(input _VVal count);
+    make_widget = _VVal'{tag: _VVAL_STR, i: 0, r: 0.0, s: ""};
+endfunction
+initial begin
+static _VVal my_data = make_widget(_VVal'{tag: _VVAL_INT, i: 42, r: 0.0, s: ""});
+end
+endmodule


### PR DESCRIPTION
Closes #2507. Follow-up to #1961; split out from #2225. Sibling of #2506 (C), #2226 (Elixir), #2455 (Nim), #2222 (Tcl/Bash).

## Problem

SystemVerilog rejected `variable_form` for `literalize_call` (`supports_call_variable_binding = False`) because its binding template wraps the RHS in a named `_VVal` struct literal derived from the parsed literal's runtime type. For a call RHS the result is not a `_VVal` literal, so that wrapping produces invalid code.

## Change

- Added `_format_systemverilog_call_declaration` (`static _VVal {name} = {value};`) and `_format_systemverilog_call_assignment` (`{name} = {value};`), exposed via `@cached_property` `format_call_variable_declaration` / `format_call_variable_assignment` (replacing the removed class-level `default_*` bindings).
- Added `wrap_call_variable_in_file`: the call stub is hoisted to module scope, since `wrap_in_file`'s `variable_name` branch would otherwise nest the `function`/`task` inside `initial begin`, which is illegal.
- Flipped `supports_call_variable_binding` `False -> True` with an explanatory comment.

## Decision: declared binding type

SystemVerilog declarations are typed and have no inference. **No caller-supplied return-type hint is required:** every generated value-returning SystemVerilog call stub is `function _VVal name(...)`, so a call result's static type is always the universal tagged `_VVal` struct -- exactly the type a SystemVerilog scalar literal binding already declares. Only the value-wrapping struct literal is dropped.

## Coverage

Only the `NewVariable` form is golden-covered (`call_variable_form_new/SystemVerilog_call@ieee_1800_2017.sv`). The `ExistingVariable` form is a bare assignment that diverges from the typed `NewVariable` declaration, so the `self_contained_mirror_variable_form` gate skips its golden (consistent with Rust/Go/Cpp/ObjectiveC/C and the #2375 gate); the assignment formatter is still exercised for coverage.

## Verification

- Full suite: 4898 passed, 100% coverage (`systemverilog.py` 100%, 0 missing).
- Existing SystemVerilog literal-binding and call-without-binding goldens unchanged (44 passed / 1 skipped for SystemVerilog call tests).
- New golden compiles under `verilator --lint-only --language 1800-2017 -Wno-REALCVT` (matching the lint CI step).
- `tests/errors/test_call_errors.py` 38 passed (the incompatible-template test uses `D`, still `False`, unaffected).
- ruff / mypy / ty / pyright / pyrefly clean; pylint manual + Sphinx spelling + sphinx-lint show only pre-existing baseline noise (no new words in changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables SystemVerilog `literalize_call(..., variable_form=...)` by changing how call results are declared and how stubs are scoped; mistakes here would surface as invalid generated SV or broken golden fixtures, but changes are localized to the SystemVerilog backend.
> 
> **Overview**
> Adds SystemVerilog support for `literalize_call(..., variable_form=NewVariable|ExistingVariable)` by introducing call-specific binding formatters that **do not wrap** the RHS in a `_VVal` struct literal, instead emitting `static _VVal name = call(...);` (and direct assignment for existing vars).
> 
> Updates the SystemVerilog wrapper path for call-result bindings to place generated `task`/`function`/`class` stubs at **module scope** (not inside `initial begin`, where `function` is illegal), flips `supports_call_variable_binding` to `True`, and adds a new golden fixture covering the new-variable call-binding output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f650585a7d8c85d786d35060591043bed7984879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->