### PR TITLE
Support literalize_call variable_form for D (#2511)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,24 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.D` now accepts ``variable_form`` on
+  :func:`~literalizer.literalize_call` for both
+  :class:`~literalizer.NewVariable` and
+  :class:`~literalizer.ExistingVariable`.  A D literal binding wraps
+  the right-hand side to encode the parsed value's runtime type (a
+  ``JSONValue(...)`` projection, or a positional ``Record0(...)``
+  struct-constructor literal under the ``RECORD`` strategy), which is
+  wrong for a call whose return type is opaque to the renderer; the
+  call result is now bound directly as ``auto my_data =
+  make_widget(...);``.  No caller-supplied return-type hint is
+  required: D infers the binding type from the initializer.  Because
+  the binding is an ``auto`` declaration while the
+  :class:`~literalizer.ExistingVariable` form is a bare assignment to
+  an already-declared name, only the :class:`~literalizer.NewVariable`
+  form is golden-covered.  Its ``supports_call_variable_binding``
+  language-class flag is now ``True``; existing literal-binding and
+  call-without-binding output is unchanged.  Follow-up to #1961.  See
+  #2511.
 - :class:`~literalizer.C` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -73,8 +73,6 @@ from literalizer._language import (
     StubReturn,
     TrailingCommaConfig,
     body_preamble_from_scalars,
-    default_format_call_variable_assignment,
-    default_format_call_variable_declaration,
     default_sequence_binding_declarations,
     default_wrap_calls_with_declarations,
     identity_call_arg,
@@ -327,13 +325,46 @@ def _d_int_field_type(value: int, /) -> str:
 
 
 @beartype
+def _format_d_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a D declaration binding a call result.
+
+    A literal binding wraps the right-hand side to encode the parsed
+    value's runtime type: a ``JSONValue(...)`` projection under the
+    default strategy, or a positional ``Record0(value, ...)``
+    struct-constructor literal under the ``RECORD`` strategy.  That is
+    wrong for a call, whose return type is opaque to the renderer and is
+    neither a ``JSONValue`` nor a generated ``struct``.
+
+    D infers the binding type from the initializer, so no caller-supplied
+    return-type hint is required: the call result is bound directly with
+    a plain inferred ``auto`` declaration and no value-wrapping.
+    """
+    return f"auto {name} = {value};"
+
+
+@beartype
+def _format_d_call_assignment(name: str, value: str, _data: Value) -> str:
+    """Format a D reassignment binding a call result.
+
+    The call-expression counterpart of
+    :func:`_format_d_call_declaration`; the variable is already
+    declared, so the call result is assigned directly with no
+    ``JSONValue`` or struct-constructor wrapping.
+    """
+    return f"{name} = {value};"
+
+
+@beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class D(metaclass=LanguageCls):
     """D language specification."""
 
     format_integer_widened = no_format_integer_widened
-    format_call_variable_declaration = default_format_call_variable_declaration
-    format_call_variable_assignment = default_format_call_variable_assignment
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble
     format_call_binding_file_pragmas = no_call_binding_file_pragmas
@@ -346,7 +377,13 @@ class D(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = False
+    # A call result is bound with a plain inferred ``auto`` declaration
+    # (D infers the binding type from the initializer, so no caller-
+    # supplied return-type hint is needed); the value-wrapping
+    # ``JSONValue(...)`` projection / positional ``Record0(...)``
+    # struct-constructor literal a D literal binding uses is dropped.
+    # See :func:`_format_d_call_declaration`.
+    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True
@@ -922,6 +959,34 @@ class D(metaclass=LanguageCls):
             return _decl
 
         return self.declaration_style.value.formatter
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        A literal binding wraps the right-hand side to encode the parsed
+        value's runtime type (a ``JSONValue(...)`` projection, or a
+        positional ``Record0(...)`` struct-constructor literal under
+        ``RECORD``); a call's return type is opaque to the renderer, so
+        the call result is bound directly with a plain inferred ``auto``
+        declaration and no value-wrapping.
+        """
+        return _format_d_call_declaration
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_variable_assignment`; the ``JSONValue`` /
+        struct-constructor wrapping is dropped since the variable is
+        already declared.
+        """
+        return _format_d_call_assignment
 
     @cached_property
     def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:

--- a/tests/errors/test_call_errors.py
+++ b/tests/errors/test_call_errors.py
@@ -37,7 +37,6 @@ from literalizer.exceptions import (
 from literalizer.languages import (
     Bash,
     Cobol,
-    D,
     Dhall,
     Elm,
     Haskell,
@@ -49,6 +48,7 @@ from literalizer.languages import (
     Racket,
     Tcl,
     Yaml,
+    Zig,
 )
 
 
@@ -741,8 +741,8 @@ def test_literalize_call_both_variable_forms_unsupported_raises() -> None:
 def test_literalize_call_variable_form_template_incompatible_raises() -> None:
     """``variable_form`` is rejected for languages whose declaration
     template wraps the right-hand side incompatibly with call expressions
-    (D wraps a scalar in ``JSONValue(...)``; tagged-enum heterogeneous
-    languages prepend a constructor; etc.).
+    (Zig projects a scalar into a ``ZVal`` tagged union; tagged-enum
+    heterogeneous languages prepend a constructor; etc.).
     """
     with pytest.raises(
         expected_exception=UnsupportedCallShapeError,
@@ -754,7 +754,7 @@ def test_literalize_call_variable_form_template_incompatible_raises() -> None:
         literalize_call(
             source="42",
             input_format=InputFormat.JSON,
-            language=D(),
+            language=Zig(),
             target_function="make_widget",
             parameter_names=["count"],
             per_element=False,

--- a/tests/integration/cases/call_variable_form_new/D_call@v2.d
+++ b/tests/integration/cases/call_variable_form_new/D_call@v2.d
@@ -1,0 +1,5 @@
+import std.json;
+void main() {
+int make_widget(T...)(T args) { return 0; }
+auto my_data = make_widget(42);
+}


### PR DESCRIPTION
Closes #2511. Follow-up to #1961; split from #2225. Sibling of the C (#2506), Nim (#2455), Elixir (#2226), Forth (#2456) and Tcl/Bash (#2222) ports.

## What

D rejected `variable_form` for `literalize_call` because its literal-binding template wraps the RHS to encode the parsed value's runtime type (a `JSONValue(...)` projection under the default strategy, or a positional `Record0(...)` struct-constructor literal under `RECORD`). That is wrong for a call, whose return type is opaque to the renderer and is neither a `JSONValue` nor a generated `struct`.

D infers the binding type from the initializer (`auto`), so **no caller-supplied return-type hint is required**. A call result is now bound directly:

- `NewVariable`: `auto my_data = make_widget(...);`
- `ExistingVariable`: `my_data = make_widget(...);`

`supports_call_variable_binding` flipped `False` -> `True`. The value-wrapping is dropped only for call expressions; existing literal-binding and call-without-binding output is unchanged (full suite green, no other goldens touched).

## Acceptance criteria

- [x] Decision recorded that D needs no return-type hint (uses `auto` inference) — in code comment, docstrings and CHANGELOG.
- [x] New golden `tests/integration/cases/call_variable_form_new/D_call@v2.d`. `ExistingVariable` is a bare assignment (not self-contained vs `NewVariable`), so it gets no golden — same as the C/Rust/Go/Cpp/ObjectiveC/Nim ports.
- [x] Existing D literal-binding and call-without-binding output unchanged.
- [x] `supports_call_variable_binding = False` / raise site removed for D. The incompatible-template error test swapped D -> Zig (D is no longer a still-False language; Zig projects a scalar into a `ZVal` tagged union).

## Verification

- Full suite: 4894 passed, 0 failed, **100% coverage** (0 missing).
- Golden compiles and runs under `ldc2` (CI uses `dmd -o- -c` then compile+run).
- ruff / mypy / ty / pyright / pyrefly / vulture / pylint (10.00) / doc8 / sphinx-lint clean; remaining Sphinx-spelling / pylint-spelling hits are pre-existing baseline noise in `cpp.py` / `mojo.py` / etc., not in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes D call code generation to emit variable bindings/assignments without the usual literal-wrapping, which could affect downstream D fixture output and compilation for call scenarios, but is scoped to `literalize_call` + `variable_form` paths.
> 
> **Overview**
> `literalize_call(..., variable_form=...)` is now supported for **D** by binding call results directly (`auto name = call(...);` / `name = call(...);`) instead of reusing the literal-binding templates that wrap values in `JSONValue(...)` or `RecordN(...)` constructors.
> 
> The D language flag `supports_call_variable_binding` is flipped to `True`, call-specific declaration/assignment formatters are introduced, a new D golden fixture is added for the `NewVariable` case, and the negative-path test for “incompatible variable declaration template” is updated to use `Zig` instead of `D`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ae8b7fc055f8196d868e269f98fafb79226320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->