### PR TITLE
Add literalize_call(bound_refs=) for declaration+call composition (#1946)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,28 @@ Changelog
 Next
 ----
 
+- :func:`~literalizer.literalize_call` now accepts a ``bound_refs``
+  argument, the call-side counterpart of
+  :func:`~literalizer.literalize`'s own ``bound_refs``.  With
+  ``wrap_in_file=True`` it renders a complete, self-contained file:
+  each ref is declared (cased via ``ref_case``) ahead of the calls, a
+  no-op stub for the target function is injected, and one reconciled
+  preamble (header and body) is placed in front, so callers no longer
+  hand-roll a duplicate-removal pass.  Entries double as ``ref_values``
+  and are emitted in iteration order.
+- Added :func:`~literalizer.literalize_call_with_declarations`, the
+  lower-level building block ``bound_refs`` is built on, for callers
+  that must interleave their own definitions (e.g. a ``call_transform``
+  wrapper) between the declarations and the calls.  It takes the
+  already-rendered declaration and call
+  :class:`~literalizer.LiteralizeResult` objects (plus optional
+  ``extra_body_preamble`` / ``extra_preamble``), recomputes the body
+  preamble across the union of types, reconciles the data-dependent
+  header block into a single copy covering every type, wraps the
+  pieces through the language's call-with-declarations wrapper, and
+  returns a :class:`~literalizer.LiteralizeResult` whose
+  :attr:`~literalizer.LiteralizeResult.code` is the finished file.
+  See #1946.
 - :class:`~literalizer.D` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,20 +20,10 @@ Next
   no-op stub for the target function is injected, and one reconciled
   preamble (header and body) is placed in front, so callers no longer
   hand-roll a duplicate-removal pass.  Entries double as ``ref_values``
-  and are emitted in iteration order.
-- Added :func:`~literalizer.literalize_call_with_declarations`, the
-  lower-level building block ``bound_refs`` is built on, for callers
-  that must interleave their own definitions (e.g. a ``call_transform``
-  wrapper) between the declarations and the calls.  It takes the
-  already-rendered declaration and call
-  :class:`~literalizer.LiteralizeResult` objects (plus optional
-  ``extra_body_preamble`` / ``extra_preamble``), recomputes the body
-  preamble across the union of types, reconciles the data-dependent
-  header block into a single copy covering every type, wraps the
-  pieces through the language's call-with-declarations wrapper, and
-  returns a :class:`~literalizer.LiteralizeResult` whose
-  :attr:`~literalizer.LiteralizeResult.code` is the finished file.
-  See #1946.
+  and are emitted in iteration order.  Recomputing the body preamble
+  across the union of types and reconciling the data-dependent header
+  block into a single copy covering every type replaces the previous
+  multi-line preamble-filter heuristic.  See #1946.
 - :class:`~literalizer.D` now accepts ``variable_form`` on
   :func:`~literalizer.literalize_call` for both
   :class:`~literalizer.NewVariable` and

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -207,61 +207,48 @@ declarations; D rejects duplicate ``import`` lines) and a linter flags
 it (``ruff`` and ``pylint`` warn about repeated ``from typing import
 Any`` lines).
 
-Remove the duplicate preamble lines in first-seen order before
-emitting the file:
+Pass the ref values through the ``bound_refs`` argument of
+:func:`~literalizer.literalize_call` (with ``wrap_in_file=True``) and
+it renders the whole file for you: each ref is declared ahead of the
+calls, a no-op stub for the target function is injected, and one
+reconciled preamble is placed in front.  This is the call-side
+counterpart of :func:`~literalizer.literalize`'s own ``bound_refs``
+argument; the returned :attr:`~literalizer.LiteralizeResult.code` is
+the finished file:
 
 .. code-block:: python
 
-   """Compose a declaration and a call into one Haskell source file."""
+   """Render a call that declares its refs into one Haskell file."""
 
-   from literalizer import InputFormat, NewVariable, literalize, literalize_call
+   from literalizer import InputFormat, literalize_call
    from literalizer.languages import Haskell
 
-   language = Haskell()
-
-   declaration = literalize(
-       source="[1, 2, 3]",
+   composed = literalize_call(
+       source='[[{"$ref": "my_list"}, 42]]',
        input_format=InputFormat.JSON,
-       language=language,
-       variable_form=NewVariable(name="myList"),
-   )
-   call = literalize_call(
-       source='[[{"$ref": "myList"}, 42]]',
-       input_format=InputFormat.JSON,
-       language=language,
+       language=Haskell(),
        target_function="process",
        parameter_names=["data", "count"],
-       ref_values={"myList": declaration.source_data},
+       wrap_in_file=True,
+       bound_refs={"my_list": [1, 2, 3]},
    )
 
-   seen: set[str] = set()
-   merged_body_preamble: list[str] = []
-   for block in (*declaration.body_preamble, *call.body_preamble):
-       if block in seen:
-           continue
-       seen.add(block)
-       merged_body_preamble.append(block)
+   assert composed.code.count("data Val = HInt Integer | HList [Val]") == 1
 
-   # ``declaration_code`` is the bare text without ``body_preamble``
-   # prepended; ``code`` includes the body_preamble, which would
-   # reintroduce duplicates.
-   composed = "\n".join(
-       [
-           *merged_body_preamble,
-           declaration.declaration_code,
-           call.declaration_code,
-       ],
-   )
+``bound_refs`` entries double as ``ref_values``, so a name need not be
+repeated in both mappings, and they are emitted in iteration order
+ahead of their first use.
 
-   assert composed.count("data Val = HInt Integer | HList [Val]") == 1
-
-The same pattern applies to :attr:`~literalizer.LiteralizeResult.preamble`
-when ``wrap_in_file=False`` and the caller is assembling the file
-manually: concatenate the preamble tuples from both results, drop
-duplicates while preserving order, and prepend the result.
-
-A first-class composition helper is tracked separately; until then,
-this duplicate-removal step is a required part of the workflow.
+When you need to interleave your own definitions between the
+declarations and the calls — for example a ``call_transform`` wrapper
+the generated file must also define —
+:func:`~literalizer.literalize_call_with_declarations` is the
+lower-level building block ``bound_refs`` is built on.  It takes the
+already-rendered declaration and call
+:class:`~literalizer.LiteralizeResult` objects plus optional
+``extra_body_preamble`` / ``extra_preamble`` lines and performs the
+same reconciliation, returning the finished
+:attr:`~literalizer.LiteralizeResult.code`.
 
 Snake case is the recommended authoring convention for ``$ref`` names:
 ``pyhumps`` converts ``snake_case`` to every other case without loss.

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -239,17 +239,6 @@ the finished file:
 repeated in both mappings, and they are emitted in iteration order
 ahead of their first use.
 
-When you need to interleave your own definitions between the
-declarations and the calls — for example a ``call_transform`` wrapper
-the generated file must also define —
-:func:`~literalizer.literalize_call_with_declarations` is the
-lower-level building block ``bound_refs`` is built on.  It takes the
-already-rendered declaration and call
-:class:`~literalizer.LiteralizeResult` objects plus optional
-``extra_body_preamble`` / ``extra_preamble`` lines and performs the
-same reconciliation, returning the finished
-:attr:`~literalizer.LiteralizeResult.code`.
-
 Snake case is the recommended authoring convention for ``$ref`` names:
 ``pyhumps`` converts ``snake_case`` to every other case without loss.
 Inputs in other conventions are normalized to ``snake_case`` first, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,6 +355,7 @@ typeCheckingMode = "strict"
 executionEnvironments = [
     { root = "tests/integration/cases", reportUnusedExpression = false, reportUndefinedVariable = false, reportUnknownVariableType = false },
     { root = "tests/errors/test_non_string_dict_key_guard.py", reportPrivateUsage = false },
+    { root = "tests/integration/call_cases.py", reportPrivateUsage = false },
 ]
 
 [tool.ty]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,11 @@ lint.per-file-ignores."tests/**/test_*.py" = [
     # Allow 'assert' as we use it for tests.
     "S101",
 ]
+lint.per-file-ignores."tests/integration/call_cases.py" = [
+    # Test-support module (imported only by golden-file test modules,
+    # never run under ``-O``); allow 'assert' as we use it for tests.
+    "S101",
+]
 lint.per-file-ignores."tests/integration/cases/**/*.py" = [
     # These are generated fixture files; suppress everything except
     # unused-import checks (F401) so we catch stale imports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,11 +140,6 @@ lint.per-file-ignores."tests/**/test_*.py" = [
     # Allow 'assert' as we use it for tests.
     "S101",
 ]
-lint.per-file-ignores."tests/integration/call_cases.py" = [
-    # Test-support module (imported only by golden-file test modules,
-    # never run under ``-O``); allow 'assert' as we use it for tests.
-    "S101",
-]
 lint.per-file-ignores."tests/integration/cases/**/*.py" = [
     # These are generated fixture files; suppress everything except
     # unused-import checks (F401) so we catch stale imports.

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -37,7 +37,6 @@ from literalizer._literalize import (
     VariableForm,
     literalize,
     literalize_call,
-    literalize_call_with_declarations,
 )
 from literalizer._parsing import InputFormat
 
@@ -75,5 +74,4 @@ __all__ = [
     "fixed_open",
     "literalize",
     "literalize_call",
-    "literalize_call_with_declarations",
 ]

--- a/src/literalizer/__init__.py
+++ b/src/literalizer/__init__.py
@@ -37,6 +37,7 @@ from literalizer._literalize import (
     VariableForm,
     literalize,
     literalize_call,
+    literalize_call_with_declarations,
 )
 from literalizer._parsing import InputFormat
 
@@ -74,4 +75,5 @@ __all__ = [
     "fixed_open",
     "literalize",
     "literalize_call",
+    "literalize_call_with_declarations",
 ]

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4111,7 +4111,6 @@ def _compose_call_with_bound_ref_declarations(
     contains_standalone_comments: bool,
     data_for_preamble: Value,
     per_element: bool,
-    variable_form: NewVariable | ExistingVariable | None,
     target_function_parts: tuple[str, ...],
     parameter_names: Sequence[str],
     call_transform: Callable[[CallContext], str] | None,
@@ -4129,10 +4128,10 @@ def _compose_call_with_bound_ref_declarations(
     The refs are now real declarations, so the target stub's parameter
     types are inferred from the ref-substituted values
     (*data_for_preamble*), not from the raw ``$ref`` markers a call's
-    own ``arg_values`` still carries.  The stub return mode mirrors
-    :func:`_wrap_call_in_file`: a value is returned whenever the call
-    result is consumed (a ``call_transform`` or a ``variable_form``
-    binding); otherwise a void stub suffices.
+    own ``arg_values`` still carries.  ``variable_form`` is rejected
+    upstream for the ``bound_refs`` path, so the call result is never
+    consumed here: a value stub is emitted only for a ``call_transform``
+    wrapper; otherwise a void stub suffices.
     """
     call_result = LiteralizeResult(
         declaration_code=result,
@@ -4162,9 +4161,7 @@ def _compose_call_with_bound_ref_declarations(
         for name, value in bound_refs.items()
     ]
     stub_return = (
-        StubReturn.VALUE
-        if call_transform is not None or variable_form is not None
-        else StubReturn.VOID
+        StubReturn.VALUE if call_transform is not None else StubReturn.VOID
     )
     body_stubs = language.format_call_stub(
         target_function_parts, parameter_names, stub_return, stub_arg_values
@@ -4172,25 +4169,12 @@ def _compose_call_with_bound_ref_declarations(
     preamble_stubs = language.format_call_preamble_stub(
         target_function_parts, parameter_names, stub_return, stub_arg_values
     )
-    # An inference-bound call result may rely on module-internal
-    # preamble or file-level compiler directives the literal binding
-    # never needs (e.g. PureScript's ``import Prelude``, Haskell's
-    # missing-signature suppression); :func:`_wrap_call_in_file` adds
-    # these for the non-bound path, so add them here too when a
-    # variable binds the call result.
-    call_binding_body_preamble: tuple[str, ...] = ()
-    call_binding_pragmas: tuple[str, ...] = ()
-    if variable_form is not None:
-        call_binding_body_preamble = (
-            language.format_call_binding_body_preamble()
-        )
-        call_binding_pragmas = language.format_call_binding_file_pragmas()
     return _literalize_call_with_declarations(
         language=language,
         declarations=decl_results,
         call=call_result,
-        extra_body_preamble=call_binding_body_preamble + body_stubs,
-        extra_preamble=call_binding_pragmas + preamble_stubs,
+        extra_body_preamble=body_stubs,
+        extra_preamble=preamble_stubs,
     )
 
 
@@ -4223,6 +4207,24 @@ def _wrap_call_result_in_file(
     keeps that public entry point within its complexity budget.
     """
     if materialized_bound_refs:
+        if variable_form is not None:
+            # The ref declarations are composed through
+            # ``wrap_calls_with_declarations``, which routes to a
+            # language's plain ``wrap_in_file`` and so never applies
+            # the call-result variable-binding file scaffold a few
+            # languages need (the ``_SupportsCallVariableWrapInFile``
+            # protocol ``_wrap_call_in_file`` consults).  Rather than
+            # emit a silently wrong scaffold, reject the combination:
+            # ``bound_refs`` declares the call's inputs, not a binding
+            # for its result.
+            raise UnsupportedCallShapeError(
+                language_name=type(language).__name__,
+                reason=(
+                    "variable_form cannot be combined with bound_refs; "
+                    "bound_refs declares the call's input refs, not a "
+                    "binding for the call result"
+                ),
+            )
         # ``bound_refs`` requests a complete file that declares each
         # ref and then calls the target with it.  Reconcile the
         # declaration and call preambles through the shared composer so
@@ -4238,7 +4240,6 @@ def _wrap_call_result_in_file(
             contains_standalone_comments=contains_standalone_comments,
             data_for_preamble=data_for_preamble,
             per_element=per_element,
-            variable_form=variable_form,
             target_function_parts=target_function_parts,
             parameter_names=parameter_names,
             call_transform=call_transform,
@@ -4558,7 +4559,18 @@ def literalize_call(
             with a single reconciled preamble.  Declaration emission
             only happens when *wrap_in_file* is ``True``; otherwise
             *bound_refs* degrades to type information only, exactly like
-            *ref_values*, and the refs stay free identifiers.  Keys
+            *ref_values*, and the refs stay free identifiers.  Every
+            name should appear as a ``$ref`` marker in *source* (a ref
+            that is declared but never referenced is folded into
+            neither the call nor its preamble inference and so may
+            leave the declaration's data-dependent preamble entries
+            uncovered, besides being an unused binding); this mirrors
+            ``literalize``'s *bound_refs* contract.  Incompatible with
+            *variable_form* (which binds the call *result*): the two
+            are rejected together with
+            :class:`~literalizer.exceptions.UnsupportedCallShapeError`
+            because the declaration-composition path cannot apply a
+            language's call-result binding file scaffold.  Keys
             should match the identifiers used in *source* before any
             *ref_case* conversion.  Defaults to ``None`` (no bindings
             emitted; behavior is byte-identical to omitting this

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4108,6 +4108,79 @@ def _wrap_call_in_file(
 
 
 @beartype
+def _compose_call_with_bound_ref_declarations(
+    *,
+    language: Language,
+    bound_refs: Mapping[str, Value],
+    ref_case: IdentifierCase | None,
+    call_result: LiteralizeResult,
+    variable_form: NewVariable | ExistingVariable | None,
+    target_function_parts: tuple[str, ...],
+    parameter_names: Sequence[str],
+    arg_values: Sequence[Value],
+    call_transform: Callable[[CallContext], str] | None,
+) -> LiteralizeResult:
+    """Emit a binding for each bound ref before the calls.
+
+    Renders one :class:`NewVariable` declaration (via
+    :func:`_literalize_value_binding`) for every name in *bound_refs*,
+    in *bound_refs* iteration order, then composes them with
+    *call_result* and a no-op stub for the target function through
+    :func:`literalize_call_with_declarations` so the duplicate-preamble
+    reconciliation is shared with every other call/declaration caller.
+
+    The stub return mode mirrors :func:`_wrap_call_in_file`: a value is
+    returned whenever the call result is consumed (a ``call_transform``
+    or a ``variable_form`` binding); otherwise a void stub suffices.
+    """
+    decl_results = [
+        _literalize_value_binding(
+            value=value,
+            language=language,
+            variable_form=NewVariable(
+                name=(
+                    ref_case.convert(name=name)
+                    if ref_case is not None
+                    else name
+                ),
+            ),
+        )
+        for name, value in bound_refs.items()
+    ]
+    stub_return = (
+        StubReturn.VALUE
+        if call_transform is not None or variable_form is not None
+        else StubReturn.VOID
+    )
+    body_stubs = language.format_call_stub(
+        target_function_parts, parameter_names, stub_return, arg_values
+    )
+    preamble_stubs = language.format_call_preamble_stub(
+        target_function_parts, parameter_names, stub_return, arg_values
+    )
+    # An inference-bound call result may rely on module-internal
+    # preamble or file-level compiler directives the literal binding
+    # never needs (e.g. PureScript's ``import Prelude``, Haskell's
+    # missing-signature suppression); :func:`_wrap_call_in_file` adds
+    # these for the non-bound path, so add them here too when a
+    # variable binds the call result.
+    call_binding_body_preamble: tuple[str, ...] = ()
+    call_binding_pragmas: tuple[str, ...] = ()
+    if variable_form is not None:
+        call_binding_body_preamble = (
+            language.format_call_binding_body_preamble()
+        )
+        call_binding_pragmas = language.format_call_binding_file_pragmas()
+    return literalize_call_with_declarations(
+        language=language,
+        declarations=decl_results,
+        call=call_result,
+        extra_body_preamble=call_binding_body_preamble + body_stubs,
+        extra_preamble=call_binding_pragmas + preamble_stubs,
+    )
+
+
+@beartype
 def _materialize_value_input(*, value: ValueInput) -> Value:
     """Convert a user-supplied ``ValueInput`` into the internal ``Value``
     form, replacing any non-``list`` ``Sequence`` and non-``dict``
@@ -4252,6 +4325,7 @@ def literalize_call(
     ref_case: IdentifierCase | None = None,
     consumable_refs: frozenset[str] = frozenset(),
     ref_values: Mapping[str, ValueInput] | None = None,
+    bound_refs: Mapping[str, ValueInput] | None = None,
     ref_key: str = "$ref",
     collection_layout: CollectionLayout = CollectionLayout.COMPACT,
     variable_form: VariableForm | None = None,
@@ -4383,6 +4457,32 @@ def literalize_call(
             keep the historical behavior: their markers are omitted
             from preamble inference.  Keys should match the identifiers
             used in *source* before any *ref_case* conversion.
+        bound_refs: Optional mapping from ref identifier to the source
+            value that ref should be *declared* with.  The recommended
+            way to render a complete, self-contained file that declares
+            each ref and then calls the target with it: ``literalize``
+            exposes the same argument for the declaration-only case, and
+            this is its call-side counterpart.  Each entry is emitted as
+            a :class:`NewVariable` declaration (cased via *ref_case*) in
+            *bound_refs* iteration order ahead of the calls, the value
+            is folded into preamble inference exactly like *ref_values*
+            (so a name need not be repeated in both mappings; an
+            explicit *ref_values* entry for the same name wins), and the
+            declarations, calls, and a no-op stub for *target_function*
+            are wrapped into one file via
+            :meth:`~literalizer.Language.wrap_calls_with_declarations`
+            with a single reconciled preamble.  Declaration emission
+            only happens when *wrap_in_file* is ``True``; otherwise
+            *bound_refs* degrades to type information only, exactly like
+            *ref_values*, and the refs stay free identifiers.  Callers
+            that must interleave their own definitions (e.g. a
+            ``call_transform`` wrapper) can compose the pieces
+            explicitly with
+            :func:`literalize_call_with_declarations` instead.  Keys
+            should match the identifiers used in *source* before any
+            *ref_case* conversion.  Defaults to ``None`` (no bindings
+            emitted; behavior is byte-identical to omitting this
+            argument).
         ref_key: The dict key used to identify variable-reference
             markers in the input data.  A single-key dict whose key
             equals *ref_key* and whose value is a string is treated as
@@ -4423,9 +4523,10 @@ def literalize_call(
         data they see.  Concatenating the results into a single file
         can produce duplicate import lines or duplicate type
         declarations, which strict compilers (Haskell, D, …) reject
-        and a linter (``ruff``, ``pylint``, …) flags.  Remove the
-        duplicate preamble entries (preserving first-seen order) before
-        emitting the file.  The "Composing declarations and calls"
+        and a linter (``ruff``, ``pylint``, …) flags.  Use
+        :func:`literalize_call_with_declarations` to render the
+        declarations and the call into one coherent file with a single
+        reconciled preamble.  The "Composing declarations and calls"
         section of :doc:`/function-call-use-case` shows a worked example.
     """
     if isinstance(variable_form, BothVariableForms):
@@ -4510,9 +4611,21 @@ def literalize_call(
     )
     target_function = language.format_call_target(target_function_parts)
 
-    materialized_ref_values: Mapping[str, Value] = {
+    explicit_ref_values: dict[str, Value] = {
         name: _materialize_value_input(value=value)
         for name, value in (ref_values or {}).items()
+    }
+    materialized_bound_refs: dict[str, Value] = {
+        name: _materialize_value_input(value=value)
+        for name, value in (bound_refs or {}).items()
+    }
+    # ``bound_refs`` entries double as ``ref_values`` so a name need not
+    # be repeated in both mappings; an explicit ``ref_values`` entry for
+    # the same name wins (it is the caller's stated type intent).  This
+    # mirrors :func:`literalize`'s ``bound_refs``/``ref_values`` rule.
+    materialized_ref_values: Mapping[str, Value] = {
+        **materialized_bound_refs,
+        **explicit_ref_values,
     }
 
     data_for_preamble = _strip_call_arg_refs_for_preamble(
@@ -4586,6 +4699,40 @@ def literalize_call(
     )
 
     if wrap_in_file:
+        if materialized_bound_refs:
+            # ``bound_refs`` requests a complete file that declares
+            # each ref and then calls the target with it.  Reconcile
+            # the declaration and call preambles through the shared
+            # composer so the result matches every other
+            # call/declaration caller.
+            call_result = LiteralizeResult(
+                declaration_code=result,
+                preamble=preamble,
+                body_preamble=computed.body,
+                types_present=computed.types_present,
+                contains_standalone_comments=contains_standalone_comments,
+                source_data=data_for_preamble,
+            )
+            # The refs are now real declarations, so the target stub's
+            # parameter types must be inferred from the ref-substituted
+            # values (``data_for_preamble``), not from the raw ``$ref``
+            # markers ``arg_values`` still carries.
+            stub_arg_values: Sequence[Value] = (
+                data_for_preamble
+                if per_element and isinstance(data_for_preamble, list)
+                else [data_for_preamble]
+            )
+            return _compose_call_with_bound_ref_declarations(
+                language=language,
+                bound_refs=materialized_bound_refs,
+                ref_case=ref_case,
+                call_result=call_result,
+                variable_form=variable_form,
+                target_function_parts=target_function_parts,
+                parameter_names=parameter_names,
+                arg_values=stub_arg_values,
+                call_transform=call_transform,
+            )
         wrapped = _wrap_call_in_file(
             language=language,
             result=result,
@@ -4613,4 +4760,152 @@ def literalize_call(
         types_present=computed.types_present,
         contains_standalone_comments=contains_standalone_comments,
         source_data=data_for_preamble,
+    )
+
+
+@beartype
+def literalize_call_with_declarations(
+    *,
+    language: Language,
+    declarations: Sequence[LiteralizeResult],
+    call: LiteralizeResult,
+    extra_body_preamble: tuple[str, ...] = (),
+    extra_preamble: tuple[str, ...] = (),
+) -> LiteralizeResult:
+    r"""Render N ref declarations and a call into one coherent file.
+
+    Composes the per-ref :func:`literalize` results in *declarations*
+    (each a ``NewVariable`` binding for a ``$ref`` target) with the
+    :func:`literalize_call` result *call* (rendered with those refs
+    folded into ``ref_values``) into a single
+    :class:`LiteralizeResult` whose :attr:`~LiteralizeResult.code` is a
+    complete file: one coherent preamble (header *and* body) followed by
+    the declarations and the calls wrapped via
+    :meth:`Language.wrap_calls_with_declarations`.
+
+    This is the recommended way to emit a call beside its ref
+    declarations.  Concatenating the two halves' independently computed
+    preambles instead would emit overlapping type definitions (e.g.
+    Haskell's ``data Val = ...`` with disjoint constructor sets) that no
+    string-level duplicate filter can reconcile.  The body preamble is
+    recomputed across the union of types observed in every declaration
+    *and* the call (so e.g. Haskell's datetime microsecond-precision
+    check sees actual values).  The data-dependent header block (e.g.
+    Gleam's ``pub type GVal {...}``) is likewise recomputed once over
+    the combined source data of every declaration and the call, so a
+    single block covers every type in the file; each declaration's own
+    narrower block is dropped.
+
+    Args:
+        language: The :class:`Language` to render with.  Must be the
+            same instance used to produce *declarations* and *call*.
+        declarations: The per-ref :func:`literalize` results, in the
+            order they should appear, ahead of their first use in the
+            call.
+        call: The :func:`literalize_call` result.  It should have been
+            rendered with every ref in *declarations* supplied via
+            ``ref_values`` so its own preamble already covers the
+            ref-reachable types.
+        extra_body_preamble: Additional body-preamble lines to append
+            after the unified body preamble (e.g. a caller-supplied
+            no-op stub for the called function).  Defaults to ``()``.
+        extra_preamble: Additional header-preamble entries to append
+            after the unified header preamble (e.g. the stub's own
+            import lines).  Defaults to ``()``.
+
+    Returns:
+        A :class:`LiteralizeResult` whose
+        :attr:`~LiteralizeResult.declaration_code` (and therefore
+        :attr:`~LiteralizeResult.code`) is the full file with the
+        unified preamble already prepended;
+        :attr:`~LiteralizeResult.preamble` and
+        :attr:`~LiteralizeResult.body_preamble` are empty (their content
+        has been folded into the code).
+
+    Raises:
+        UnsupportedCallShapeError: If *call* carries standalone comments
+            but *language* cannot preserve them when wrapping calls.
+    """
+    if (
+        call.contains_standalone_comments
+        and not language.supports_standalone_comments_in_wrapped_calls
+    ):
+        raise UnsupportedCallShapeError(
+            language_name=type(language).__name__,
+            reason=(
+                "standalone comments cannot be preserved when wrapping "
+                "calls in this language"
+            ),
+        )
+    empty_types: frozenset[type] = frozenset()
+    union_types = empty_types.union(
+        *(d.types_present for d in declarations),
+        call.types_present,
+    )
+    declaration_source_data: list[Value] = [
+        d.source_data for d in declarations
+    ]
+    combined_source_data: list[Value] = [
+        *declaration_source_data,
+        call.source_data,
+    ]
+    unified_body_preamble = language.compute_body_preamble(
+        union_types, combined_source_data
+    )
+    wrapped = language.wrap_calls_with_declarations(
+        declarations=tuple(d.bare_code for d in declarations),
+        calls=call.bare_code,
+        body_preamble=unified_body_preamble + extra_body_preamble,
+    )
+    # Each declaration emitted its data-dependent block (e.g. Gleam's
+    # ``pub type GVal {...}``) from *its own* data alone, so the
+    # per-declaration blocks disagree on which constructors they
+    # declare.  How they are reconciled depends on whether the language
+    # renders call arguments and declarations through the *same*
+    # data-dependent construct:
+    #
+    # * When ``call_data_dependent_preamble`` and
+    #   ``data_dependent_preamble`` agree (Gleam, C++, ...), the call
+    #   was rendered with every ref folded into ``ref_values`` so
+    #   ``call.preamble`` already carries one block computed over the
+    #   ref-substituted union (declarations *and* call).  That is the
+    #   single canonical copy; drop the narrower per-declaration
+    #   copies.  ``data_dependent_preamble`` is a pure function of the
+    #   value, so the exact strings a declaration appended to its
+    #   ``preamble`` are reproducible by re-invoking it on that
+    #   declaration's ``source_data``.
+    # * When they diverge (Nim drops ``import json`` for call
+    #   arguments), ``call.preamble`` cannot carry the
+    #   declaration-side construct, so keep each declaration's own
+    #   block; duplicate-line filtering collapses the copies.  This
+    #   also keeps a *multi-line* declaration-only block, which the
+    #   previous "drop any entry containing a newline" heuristic
+    #   silently lost.
+    call_form_matches_declaration_form = language.data_dependent_preamble(
+        combined_source_data
+    ) == language.call_data_dependent_preamble(combined_source_data)
+    dropped_declaration_blocks: set[str] = set()
+    if call_form_matches_declaration_form:
+        for d in declarations:
+            dropped_declaration_blocks.update(
+                language.data_dependent_preamble(d.source_data)
+            )
+    declaration_preamble = tuple(
+        entry
+        for d in declarations
+        for entry in d.preamble
+        if entry not in dropped_declaration_blocks
+    )
+    all_preamble = deduplicate_preamble_entries(
+        entries=(declaration_preamble + call.preamble + extra_preamble)
+    )
+    if all_preamble:
+        wrapped = "\n".join(all_preamble) + "\n" + wrapped
+    return LiteralizeResult(
+        declaration_code=wrapped,
+        preamble=(),
+        body_preamble=(),
+        types_present=union_types,
+        contains_standalone_comments=call.contains_standalone_comments,
+        source_data=call.source_data,
     )

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4113,26 +4113,49 @@ def _compose_call_with_bound_ref_declarations(
     language: Language,
     bound_refs: Mapping[str, Value],
     ref_case: IdentifierCase | None,
-    call_result: LiteralizeResult,
+    result: str,
+    preamble: tuple[str, ...],
+    body_preamble: tuple[str, ...],
+    types_present: frozenset[type],
+    contains_standalone_comments: bool,
+    data_for_preamble: Value,
+    per_element: bool,
     variable_form: NewVariable | ExistingVariable | None,
     target_function_parts: tuple[str, ...],
     parameter_names: Sequence[str],
-    arg_values: Sequence[Value],
     call_transform: Callable[[CallContext], str] | None,
 ) -> LiteralizeResult:
     """Emit a binding for each bound ref before the calls.
 
-    Renders one :class:`NewVariable` declaration (via
-    :func:`_literalize_value_binding`) for every name in *bound_refs*,
-    in *bound_refs* iteration order, then composes them with
-    *call_result* and a no-op stub for the target function through
+    Reconstructs the call :class:`LiteralizeResult` from the rendered
+    *result* and its preamble pieces, renders one :class:`NewVariable`
+    declaration (via :func:`_literalize_value_binding`) for every name
+    in *bound_refs* in iteration order, then composes them with a no-op
+    stub for the target function through
     :func:`_literalize_call_with_declarations` so the duplicate-preamble
     reconciliation is shared with every other call/declaration caller.
 
-    The stub return mode mirrors :func:`_wrap_call_in_file`: a value is
-    returned whenever the call result is consumed (a ``call_transform``
-    or a ``variable_form`` binding); otherwise a void stub suffices.
+    The refs are now real declarations, so the target stub's parameter
+    types are inferred from the ref-substituted values
+    (*data_for_preamble*), not from the raw ``$ref`` markers a call's
+    own ``arg_values`` still carries.  The stub return mode mirrors
+    :func:`_wrap_call_in_file`: a value is returned whenever the call
+    result is consumed (a ``call_transform`` or a ``variable_form``
+    binding); otherwise a void stub suffices.
     """
+    call_result = LiteralizeResult(
+        declaration_code=result,
+        preamble=preamble,
+        body_preamble=body_preamble,
+        types_present=types_present,
+        contains_standalone_comments=contains_standalone_comments,
+        source_data=data_for_preamble,
+    )
+    stub_arg_values: Sequence[Value] = (
+        data_for_preamble
+        if per_element and isinstance(data_for_preamble, list)
+        else [data_for_preamble]
+    )
     decl_results = [
         _literalize_value_binding(
             value=value,
@@ -4153,10 +4176,10 @@ def _compose_call_with_bound_ref_declarations(
         else StubReturn.VOID
     )
     body_stubs = language.format_call_stub(
-        target_function_parts, parameter_names, stub_return, arg_values
+        target_function_parts, parameter_names, stub_return, stub_arg_values
     )
     preamble_stubs = language.format_call_preamble_stub(
-        target_function_parts, parameter_names, stub_return, arg_values
+        target_function_parts, parameter_names, stub_return, stub_arg_values
     )
     # An inference-bound call result may rely on module-internal
     # preamble or file-level compiler directives the literal binding
@@ -4177,6 +4200,76 @@ def _compose_call_with_bound_ref_declarations(
         call=call_result,
         extra_body_preamble=call_binding_body_preamble + body_stubs,
         extra_preamble=call_binding_pragmas + preamble_stubs,
+    )
+
+
+@beartype
+def _wrap_call_result_in_file(
+    *,
+    language: Language,
+    materialized_bound_refs: Mapping[str, Value],
+    ref_case: IdentifierCase | None,
+    result: str,
+    preamble: tuple[str, ...],
+    computed_body: tuple[str, ...],
+    types_present: frozenset[type],
+    contains_standalone_comments: bool,
+    data_for_preamble: Value,
+    per_element: bool,
+    variable_form: NewVariable | ExistingVariable | None,
+    target_function_parts: tuple[str, ...],
+    parameter_names: Sequence[str],
+    arg_values: Sequence[Value],
+    call_transform: Callable[[CallContext], str] | None,
+) -> LiteralizeResult:
+    """Assemble a ``wrap_in_file=True`` ``literalize_call`` result.
+
+    Routes through :func:`_compose_call_with_bound_ref_declarations`
+    when ``bound_refs`` were supplied (a complete file that declares
+    each ref before the calls) and through :func:`_wrap_call_in_file`
+    (calls plus a target stub, refs left as free identifiers)
+    otherwise.  Keeping this dispatch out of :func:`literalize_call`
+    keeps that public entry point within its complexity budget.
+    """
+    if materialized_bound_refs:
+        # ``bound_refs`` requests a complete file that declares each
+        # ref and then calls the target with it.  Reconcile the
+        # declaration and call preambles through the shared composer so
+        # the result matches every other call/declaration caller.
+        return _compose_call_with_bound_ref_declarations(
+            language=language,
+            bound_refs=materialized_bound_refs,
+            ref_case=ref_case,
+            result=result,
+            preamble=preamble,
+            body_preamble=computed_body,
+            types_present=types_present,
+            contains_standalone_comments=contains_standalone_comments,
+            data_for_preamble=data_for_preamble,
+            per_element=per_element,
+            variable_form=variable_form,
+            target_function_parts=target_function_parts,
+            parameter_names=parameter_names,
+            call_transform=call_transform,
+        )
+    wrapped = _wrap_call_in_file(
+        language=language,
+        result=result,
+        variable_form=variable_form,
+        target_function_parts=target_function_parts,
+        parameter_names=parameter_names,
+        arg_values=arg_values,
+        call_transform=call_transform,
+        preamble=preamble,
+        computed_body=computed_body,
+    )
+    return LiteralizeResult(
+        declaration_code=wrapped,
+        preamble=(),
+        body_preamble=(),
+        types_present=types_present,
+        contains_standalone_comments=contains_standalone_comments,
+        source_data=data_for_preamble,
     )
 
 
@@ -4696,58 +4789,22 @@ def literalize_call(
     )
 
     if wrap_in_file:
-        if materialized_bound_refs:
-            # ``bound_refs`` requests a complete file that declares
-            # each ref and then calls the target with it.  Reconcile
-            # the declaration and call preambles through the shared
-            # composer so the result matches every other
-            # call/declaration caller.
-            call_result = LiteralizeResult(
-                declaration_code=result,
-                preamble=preamble,
-                body_preamble=computed.body,
-                types_present=computed.types_present,
-                contains_standalone_comments=contains_standalone_comments,
-                source_data=data_for_preamble,
-            )
-            # The refs are now real declarations, so the target stub's
-            # parameter types must be inferred from the ref-substituted
-            # values (``data_for_preamble``), not from the raw ``$ref``
-            # markers ``arg_values`` still carries.
-            stub_arg_values: Sequence[Value] = (
-                data_for_preamble
-                if per_element and isinstance(data_for_preamble, list)
-                else [data_for_preamble]
-            )
-            return _compose_call_with_bound_ref_declarations(
-                language=language,
-                bound_refs=materialized_bound_refs,
-                ref_case=ref_case,
-                call_result=call_result,
-                variable_form=variable_form,
-                target_function_parts=target_function_parts,
-                parameter_names=parameter_names,
-                arg_values=stub_arg_values,
-                call_transform=call_transform,
-            )
-        wrapped = _wrap_call_in_file(
+        return _wrap_call_result_in_file(
             language=language,
+            materialized_bound_refs=materialized_bound_refs,
+            ref_case=ref_case,
             result=result,
+            preamble=preamble,
+            computed_body=computed.body,
+            types_present=computed.types_present,
+            contains_standalone_comments=contains_standalone_comments,
+            data_for_preamble=data_for_preamble,
+            per_element=per_element,
             variable_form=variable_form,
             target_function_parts=target_function_parts,
             parameter_names=parameter_names,
             arg_values=arg_values,
             call_transform=call_transform,
-            preamble=preamble,
-            computed_body=computed.body,
-        )
-        return LiteralizeResult(
-            declaration_code=wrapped,
-            preamble=(),
-            body_preamble=(),
-            types_present=computed.types_present,
-            contains_standalone_comments=contains_standalone_comments,
-            source_data=data_for_preamble,
         )
 
     return LiteralizeResult(

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -4126,7 +4126,7 @@ def _compose_call_with_bound_ref_declarations(
     :func:`_literalize_value_binding`) for every name in *bound_refs*,
     in *bound_refs* iteration order, then composes them with
     *call_result* and a no-op stub for the target function through
-    :func:`literalize_call_with_declarations` so the duplicate-preamble
+    :func:`_literalize_call_with_declarations` so the duplicate-preamble
     reconciliation is shared with every other call/declaration caller.
 
     The stub return mode mirrors :func:`_wrap_call_in_file`: a value is
@@ -4171,7 +4171,7 @@ def _compose_call_with_bound_ref_declarations(
             language.format_call_binding_body_preamble()
         )
         call_binding_pragmas = language.format_call_binding_file_pragmas()
-    return literalize_call_with_declarations(
+    return _literalize_call_with_declarations(
         language=language,
         declarations=decl_results,
         call=call_result,
@@ -4474,11 +4474,7 @@ def literalize_call(
             with a single reconciled preamble.  Declaration emission
             only happens when *wrap_in_file* is ``True``; otherwise
             *bound_refs* degrades to type information only, exactly like
-            *ref_values*, and the refs stay free identifiers.  Callers
-            that must interleave their own definitions (e.g. a
-            ``call_transform`` wrapper) can compose the pieces
-            explicitly with
-            :func:`literalize_call_with_declarations` instead.  Keys
+            *ref_values*, and the refs stay free identifiers.  Keys
             should match the identifiers used in *source* before any
             *ref_case* conversion.  Defaults to ``None`` (no bindings
             emitted; behavior is byte-identical to omitting this
@@ -4523,11 +4519,12 @@ def literalize_call(
         data they see.  Concatenating the results into a single file
         can produce duplicate import lines or duplicate type
         declarations, which strict compilers (Haskell, D, …) reject
-        and a linter (``ruff``, ``pylint``, …) flags.  Use
-        :func:`literalize_call_with_declarations` to render the
-        declarations and the call into one coherent file with a single
-        reconciled preamble.  The "Composing declarations and calls"
-        section of :doc:`/function-call-use-case` shows a worked example.
+        and a linter (``ruff``, ``pylint``, …) flags.  Pass the ref
+        values through *bound_refs* (with ``wrap_in_file=True``) instead
+        and this function renders the declarations and the calls into
+        one coherent file with a single reconciled preamble.  The
+        "Composing declarations and calls" section of
+        :doc:`/function-call-use-case` shows a worked example.
     """
     if isinstance(variable_form, BothVariableForms):
         # Rendering both halves would invoke the call twice -- a silent
@@ -4764,7 +4761,7 @@ def literalize_call(
 
 
 @beartype
-def literalize_call_with_declarations(
+def _literalize_call_with_declarations(
     *,
     language: Language,
     declarations: Sequence[LiteralizeResult],
@@ -4774,8 +4771,10 @@ def literalize_call_with_declarations(
 ) -> LiteralizeResult:
     r"""Render N ref declarations and a call into one coherent file.
 
-    Composes the per-ref :func:`literalize` results in *declarations*
-    (each a ``NewVariable`` binding for a ``$ref`` target) with the
+    Shared reconciliation core behind :func:`literalize_call`'s
+    *bound_refs* argument (and the call golden-file harness).  Composes
+    the per-ref :func:`literalize` results in *declarations* (each a
+    ``NewVariable`` binding for a ``$ref`` target) with the
     :func:`literalize_call` result *call* (rendered with those refs
     folded into ``ref_values``) into a single
     :class:`LiteralizeResult` whose :attr:`~LiteralizeResult.code` is a
@@ -4783,8 +4782,7 @@ def literalize_call_with_declarations(
     the declarations and the calls wrapped via
     :meth:`Language.wrap_calls_with_declarations`.
 
-    This is the recommended way to emit a call beside its ref
-    declarations.  Concatenating the two halves' independently computed
+    Concatenating the two halves' independently computed
     preambles instead would emit overlapping type definitions (e.g.
     Haskell's ``data Val = ...`` with disjoint constructor sets) that no
     string-level duplicate filter can reconcile.  The body preamble is

--- a/tests/errors/test_call_errors.py
+++ b/tests/errors/test_call_errors.py
@@ -735,3 +735,30 @@ def test_literalize_call_both_variable_forms_unsupported_raises() -> None:
             per_element=False,
             variable_form=BothVariableForms(name="result"),
         )
+
+
+def test_literalize_call_bound_refs_with_variable_form_raises() -> None:
+    """``bound_refs`` combined with ``variable_form`` is rejected:
+    ``bound_refs`` declares the call's input refs, not a binding for
+    the call result, and the declaration-composition path cannot apply
+    a language's call-result binding file scaffold.
+    """
+    with pytest.raises(
+        expected_exception=UnsupportedCallShapeError,
+        match=(
+            r"variable_form cannot be combined with bound_refs; "
+            r"bound_refs declares the call's input refs, not a "
+            r"binding for the call result"
+        ),
+    ):
+        literalize_call(
+            source='{"$ref": "my_list"}',
+            input_format=InputFormat.JSON,
+            language=Python(),
+            target_function="make_widget",
+            parameter_names=["data"],
+            per_element=False,
+            wrap_in_file=True,
+            bound_refs={"my_list": [1, 2, 3]},
+            variable_form=NewVariable(name="result"),
+        )

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -1857,13 +1857,11 @@ def run_call_golden_case(
                 for ref_name, ref_source in config.ref_declarations.items()
             },
         )
-        if bound.code != composed.code:
-            msg = (
-                "literalize_call(bound_refs=...) diverged from the "
-                "shared call/declaration composition for "
-                f"{lang_cls.__name__} / {config.case_dir_name}"
-            )
-            raise AssertionError(msg)
+        assert bound.code == composed.code, (
+            "literalize_call(bound_refs=...) diverged from the shared "
+            f"call/declaration composition for {lang_cls.__name__} / "
+            f"{config.case_dir_name}"
+        )
     check_golden(
         file_regression=file_regression,
         contents=composed.code + "\n",

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -10,6 +10,7 @@ import dataclasses
 import datetime
 import enum
 import functools
+import json
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -50,17 +51,6 @@ type _Scalar = (
     | bytes
 )
 type _Value = _Scalar | list[_Value] | dict[_Scalar, _Value] | set[_Scalar]
-
-
-@beartype
-def _prepend_preamble(
-    wrapped: str,
-    preamble: tuple[str, ...],
-) -> str:
-    """Prepend *preamble* lines before *wrapped*."""
-    if not preamble:
-        return wrapped
-    return "\n".join(preamble) + "\n" + wrapped
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1812,71 +1802,63 @@ def run_call_golden_case(
                 (),
             ),
         )
-    # Recompute the body preamble across the union of types observed in
-    # every declaration *and* the call.  Concatenating each piece's
-    # already-rendered body preamble would emit overlapping
-    # type-definition strings (e.g. Haskell's ``data Val = ...`` with
-    # different constructor sets) that no string-level duplicate
-    # filter can reconcile.  Combine ``source_data`` from every piece
-    # so ``compute_body_preamble`` can inspect actual values when it
-    # needs to (e.g. Haskell's datetime microsecond-precision check).
-    empty_types: frozenset[type] = frozenset()
-    union_types = empty_types.union(
-        *(d.types_present for d in decl_results),
-        result.types_present,
+    # One library entry point assembles the declarations and the call
+    # into a single coherent file: it recomputes the body preamble
+    # across the union of types in every declaration *and* the call,
+    # recomputes the data-dependent header block over their combined
+    # source data (so a single block covers every type, replacing the
+    # old multi-line filter heuristic), wraps the pieces via
+    # ``wrap_calls_with_declarations``, and places the deduplicated
+    # preamble in front.  The call-stub lines this harness synthesizes
+    # for the otherwise-undefined target/transform names are folded in
+    # as the ``extra_*`` arguments.
+    composed = literalizer.literalize_call_with_declarations(
+        language=spec,
+        declarations=decl_results,
+        call=result,
+        extra_body_preamble=tuple(body_stubs),
+        extra_preamble=tuple(preamble_stubs),
     )
-    combined_source_data: list[_Value] = [
-        *(d.source_data for d in decl_results),
-        result.source_data,
-    ]
-    unified_body_preamble = spec.compute_body_preamble(
-        union_types, combined_source_data
-    )
-    call_body_preamble = unified_body_preamble + tuple(body_stubs)
+    # Anchor the public ``literalize_call(bound_refs=...)`` path to this
+    # golden-verified composer output.  ``bound_refs`` injects only the
+    # target stub, so the equivalence holds exactly when this case
+    # synthesizes no extra (transform-wrapper) stubs and binds no
+    # variable; those cases are exercised through the composer call
+    # directly above.
     if (
-        result.contains_standalone_comments
-        and not spec.supports_standalone_comments_in_wrapped_calls
+        config.ref_declarations
+        and config.call_transform is None
+        and not config.transform_stub_names
+        and config.variable_form is None
     ):
-        raise UnsupportedCallShapeError(
-            language_name=lang_cls.__name__,
-            reason=(
-                "standalone comments cannot be preserved when wrapping "
-                "calls in this language"
-            ),
+        bound = literalizer.literalize_call(
+            source=yaml_string,
+            input_format=literalizer.InputFormat.YAML,
+            language=spec,
+            target_function=config.target_function,
+            parameter_names=config.parameter_names,
+            zip_source=config.zip_source,
+            zip_input_format=config.zip_input_format,
+            comment_source=config.comment_source,
+            per_element=config.per_element,
+            wrap_in_file=True,
+            ref_case=effective_ref_case,
+            consumable_refs=config.consumable_refs,
+            bound_refs={
+                ref_name: json.loads(s=ref_source)
+                for ref_name, ref_source in config.ref_declarations.items()
+            },
         )
-    declarations_bare_codes = tuple(d.bare_code for d in decl_results)
-    wrapped = spec.wrap_calls_with_declarations(
-        declarations=declarations_bare_codes,
-        calls=result.bare_code,
-        body_preamble=call_body_preamble,
-    )
-    # ``literalize_call`` substitutes ``ref_values`` into the data fed
-    # to its preamble computation, so ``result.preamble`` already
-    # contains the union version of any multi-line data-dependent block
-    # (e.g. Gleam's ``pub type GVal {...}``) covering every type
-    # observed across the declarations *and* the call.  Each
-    # declaration's own multi-line block, by contrast, was computed
-    # from that declaration's data alone and would conflict with the
-    # union version under string-level duplicate filtering.  Drop the
-    # multi-line entries from declaration preambles and keep their
-    # single-line entries (e.g. the Nim ``import json`` line);
-    # filtering duplicate lines handles the rest.
-    decl_preamble_lines = tuple(
-        entry
-        for d in decl_results
-        for entry in d.preamble
-        if "\n" not in entry
-    )
-    seen: set[str] = set()
-    all_preamble: tuple[str, ...] = ()
-    for entry in decl_preamble_lines + result.preamble + tuple(preamble_stubs):
-        if entry not in seen:
-            seen.add(entry)
-            all_preamble += (entry,)
-    wrapped = _prepend_preamble(wrapped=wrapped, preamble=all_preamble)
+        if bound.code != composed.code:
+            msg = (
+                "literalize_call(bound_refs=...) diverged from the "
+                "literalize_call_with_declarations composition for "
+                f"{lang_cls.__name__} / {config.case_dir_name}"
+            )
+            raise AssertionError(msg)
     check_golden(
         file_regression=file_regression,
-        contents=wrapped + "\n",
+        contents=composed.code + "\n",
         extension=lang_cls.extension,
         newline="",
         golden_path=golden_path,

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -1857,11 +1857,12 @@ def run_call_golden_case(
                 for ref_name, ref_source in config.ref_declarations.items()
             },
         )
-        assert bound.code == composed.code, (
+        divergence_message = (
             "literalize_call(bound_refs=...) diverged from the shared "
             f"call/declaration composition for {lang_cls.__name__} / "
             f"{config.case_dir_name}"
         )
+        assert bound.code == composed.code, divergence_message  # noqa: S101
     check_golden(
         file_regression=file_regression,
         contents=composed.code + "\n",

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -20,6 +20,14 @@ from pytest_regressions.file_regression import FileRegressionFixture
 
 import literalizer
 from literalizer import StubReturn
+
+# ``_literalize_call_with_declarations`` is the shared call/declaration
+# reconciliation core; it is intentionally not part of the public API
+# (the public surface is ``literalize_call(bound_refs=...)``).  This
+# golden-file harness must interpose its own transform-wrapper stubs
+# between rendering and composition, so it uses the internal core
+# directly.  See issue #1946.
+from literalizer._literalize import _literalize_call_with_declarations
 from literalizer.exceptions import (
     CallArgNotSupportedError,
     DottedCallTargetNotSupportedError,
@@ -1812,7 +1820,7 @@ def run_call_golden_case(
     # preamble in front.  The call-stub lines this harness synthesizes
     # for the otherwise-undefined target/transform names are folded in
     # as the ``extra_*`` arguments.
-    composed = literalizer.literalize_call_with_declarations(
+    composed = _literalize_call_with_declarations(
         language=spec,
         declarations=decl_results,
         call=result,
@@ -1852,7 +1860,7 @@ def run_call_golden_case(
         if bound.code != composed.code:
             msg = (
                 "literalize_call(bound_refs=...) diverged from the "
-                "literalize_call_with_declarations composition for "
+                "shared call/declaration composition for "
                 f"{lang_cls.__name__} / {config.case_dir_name}"
             )
             raise AssertionError(msg)


### PR DESCRIPTION
`literalize_call` gains a `bound_refs` argument (the call-side counterpart of `literalize`'s own `bound_refs`): with `wrap_in_file=True` it renders a complete, self-contained file that declares each ref ahead of the calls, injects a no-op target stub, and places one reconciled preamble in front. Internally this is the new private `_literalize_call_with_declarations` reconciliation core, which replaces the golden-file harness's `if "\n" not in entry` heuristic with a semantic `data_dependent`/`call_data_dependent` discriminator (drop per-declaration blocks only when the call already carries the canonical merged copy); the harness collapses onto that core and cross-checks the public `bound_refs` path against the golden-verified output for every applicable case and language. The public surface stays minimal — just the `bound_refs` parameter — and `literalize`'s separate `bound_refs` path (`_compose_bound_refs`) is deliberately untouched, so there is zero golden churn across the call and literalize-ref suites. Also updates the docs, CHANGELOG, and a scoped basedpyright `reportPrivateUsage` override for the harness's internal import. Full test suite passes except one pre-existing failure (`test_call_errors.py::test_literalize_call_variable_form_template_incompatible_raises`) that fails identically on a clean tree and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `literalize_call` wrapping/composition logic and preamble reconciliation, which could subtly change generated output across languages when `wrap_in_file=True`, though behavior is intended to be byte-identical when `bound_refs` is not used.
> 
> **Overview**
> `literalize_call` gains a `bound_refs` parameter that (when `wrap_in_file=True`) emits a complete file: declares each referenced value (respecting `ref_case`) ahead of the calls, injects a no-op target stub, and outputs a **single reconciled preamble**.
> 
> Internally this introduces a shared `_literalize_call_with_declarations` composer that recomputes body/header preambles over the union of declaration+call data (replacing prior newline-based duplicate filtering) and the integration golden harness is refactored to use it and to cross-check the public `bound_refs` path. Docs/CHANGELOG are updated, Pyright is configured to allow the harness’s private import, and a new error test asserts `bound_refs` cannot be combined with `variable_form`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec689e66756decd2c41b5170b90a8e1f10389b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->