### PR TITLE
Remove vestigial supports_call_variable_binding flag (#2521)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Changelog
 Next
 ----
 
+- The ``supports_call_variable_binding`` language-class flag has been
+  removed.  Every language now binds a :func:`~literalizer.literalize_call`
+  result directly with no literal-only wrapping, so the flag was
+  ``True`` for all languages and its
+  :class:`~literalizer.exceptions.UnsupportedCallShapeError` rejection
+  path was unreachable.  No generated output changes.  See #2521.
+
 2026.05.17
 ----------
 

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -750,7 +750,6 @@ class LanguageCls(type):
     supports_special_floats: bool
     supports_variable_names: bool
     supports_no_variable_wrap_in_file: bool
-    supports_call_variable_binding: bool
     supports_dotted_calls: bool
     has_free_function_calls: bool
     reserved_identifiers: frozenset[str]
@@ -1068,25 +1067,6 @@ class Language(Protocol):
     Languages with no variable-name syntax at all
     (:attr:`supports_variable_names` is ``False``) must set this to
     ``True``: their ``wrap_in_file`` output has no other shape.
-    """
-
-    supports_call_variable_binding: bool
-    """Whether the language's ``format_variable_declaration`` /
-    ``format_variable_assignment`` template can safely host a *call
-    expression* on the right-hand side.
-
-    When ``False``, the language's binding template wraps or
-    transforms the right-hand side in a way that is only valid for
-    *literal* values (e.g. Tcl's bare command words that need
-    ``[...]`` substitution; Objective-C's ``@(...)`` boxing of
-    primitives; tagged-enum heterogeneous-strategy languages that
-    prepend a value-type constructor; languages whose declaration
-    template encodes the value's literal type as a struct-initializer
-    field).  ``literalize_call`` rejects ``variable_form`` for such
-    languages with
-    :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
-    Ignored by :func:`~literalizer.literalize`, whose right-hand side
-    is always a literal value.
     """
 
     dict_supports_heterogeneous_values: bool

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -3920,15 +3920,6 @@ def _validate_call_variable_form(
                 "so the call result cannot be bound to a variable"
             ),
         )
-    if not language.supports_call_variable_binding:
-        raise UnsupportedCallShapeError(
-            language_name=type(language).__name__,
-            reason=(
-                "this language's variable-declaration template wraps or "
-                "transforms the right-hand side in a way that is only "
-                "valid for literal values, not call expressions"
-            ),
-        )
 
 
 @beartype

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -279,12 +279,6 @@ class Ada(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    # A call result is bound directly with an explicit ``A_Val`` type
-    # (every generated Ada call stub returns ``A_Val``, so no
-    # caller-supplied return-type hint is needed); the value-wrapping
-    # ``A_Val`` constructor an Ada literal binding uses is dropped.  See
-    # :func:`_format_ada_call_declaration`.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     allows_empty_call_parens = False

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -227,7 +227,6 @@ class Bash(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -660,12 +660,6 @@ class C(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    # A call result is bound directly with an explicit ``CVal`` type
-    # (every generated call stub returns the universal tagged ``CVal``
-    # union, so no caller-supplied return-type hint is needed); the
-    # value-wrapping designated-initializer compound literal a C literal
-    # binding uses is dropped.  See :func:`_format_c_call_declaration`.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -124,7 +124,6 @@ class Clojure(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -350,7 +350,6 @@ class Cobol(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -133,7 +133,6 @@ class CommonLisp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1310,7 +1310,6 @@ class Cpp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -334,7 +334,6 @@ class Crystal(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -504,7 +504,6 @@ class CSharp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -377,13 +377,6 @@ class D(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    # A call result is bound with a plain inferred ``auto`` declaration
-    # (D infers the binding type from the initializer, so no caller-
-    # supplied return-type hint is needed); the value-wrapping
-    # ``JSONValue(...)`` projection / positional ``Record0(...)``
-    # struct-constructor literal a D literal binding uses is dropped.
-    # See :func:`_format_d_call_declaration`.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -357,7 +357,6 @@ class Dart(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -577,7 +577,6 @@ class Dhall(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = False
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -221,7 +221,6 @@ class Elixir(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -567,7 +567,6 @@ class Elm(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -216,7 +216,6 @@ class Erlang(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -226,15 +226,6 @@ class Forth(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    # A call-result binding reuses the literal-binding colon definition
-    # unchanged: ``: my_data 42 make_widget ;`` is a deferred word that
-    # re-executes ``make_widget`` on every invocation.  Forth has no
-    # eager general-purpose value binding (``VALUE``/``TO`` holds only a
-    # single cell, not strings/dicts/sequences), so this is the same
-    # idiom already used for literal bindings, and ``ExistingVariable``
-    # is necessarily identical to ``NewVariable`` (no reassignment in
-    # this model).  See #2456.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -386,13 +386,6 @@ class Fortran(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    # A call result is bound directly with an explicit ``type(fval_t)``
-    # declaration (every generated Fortran call stub returns
-    # ``type(fval_t)``, so no caller-supplied return-type hint is
-    # needed); the value-wrapping ``fval_t`` constructor a Fortran
-    # literal binding uses is dropped.  See
-    # :func:`_format_fortran_call_declaration`.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     allows_empty_call_parens = True

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -337,7 +337,6 @@ class FSharp(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -573,7 +573,6 @@ class Gleam(metaclass=LanguageCls):
     supports_special_floats = False
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -319,7 +319,6 @@ class Go(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -160,7 +160,6 @@ class Groovy(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1140,7 +1140,6 @@ class Haskell(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -171,7 +171,6 @@ class Hcl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = False
     has_free_function_calls = True

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -672,7 +672,6 @@ class Java(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -144,7 +144,6 @@ class JavaScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -135,7 +135,6 @@ class Json5(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -154,7 +154,6 @@ class Jsonnet(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -172,7 +172,6 @@ class Julia(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -658,7 +658,6 @@ class Kotlin(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -157,7 +157,6 @@ class Lua(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -224,7 +224,6 @@ class Matlab(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -939,7 +939,6 @@ class Mojo(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = False
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -649,13 +649,6 @@ class Nim(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    # The literal-binding declaration template prefixes the right-hand
-    # side with the ``%*`` json macro (or ``@`` for sequences), which is
-    # only valid for literal values.  ``format_call_variable_declaration``
-    # / ``format_call_variable_assignment`` supply call-specific
-    # templates that bind the call result directly with no wrapping, so
-    # call-result bindings are supported.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = False
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -201,7 +201,6 @@ class Nix(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -107,7 +107,6 @@ class Norg(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -336,7 +336,6 @@ class ObjectiveC(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -296,7 +296,6 @@ class OCaml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -152,7 +152,6 @@ class Occam(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -325,7 +325,6 @@ class Odin(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -169,7 +169,6 @@ class Perl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -169,7 +169,6 @@ class Php(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -182,7 +182,6 @@ class PowerShell(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -729,7 +729,6 @@ class PureScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -790,7 +790,6 @@ class Python(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -181,7 +181,6 @@ class R(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -125,7 +125,6 @@ class Racket(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -201,7 +201,6 @@ class Raku(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -573,7 +573,6 @@ class Roc(metaclass=LanguageCls):
     pygments_name = "text"
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -205,7 +205,6 @@ class Ruby(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1276,7 +1276,6 @@ class Rust(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = False
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -396,7 +396,6 @@ class Scala(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -120,7 +120,6 @@ class Scheme(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -374,7 +374,6 @@ class Sml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -492,7 +492,6 @@ class Swift(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -294,13 +294,6 @@ class SystemVerilog(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    # A call result is bound directly with an explicit ``_VVal`` type
-    # (every generated SystemVerilog call stub that yields a value
-    # returns the universal tagged ``_VVal`` struct, so no
-    # caller-supplied return-type hint is needed); the value-wrapping
-    # ``_VVal`` struct literal a SystemVerilog literal binding uses is
-    # dropped.  See :func:`_format_systemverilog_call_declaration`.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     allows_empty_call_parens = True

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -181,7 +181,6 @@ class Tcl(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -140,7 +140,6 @@ class Toml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -392,7 +392,6 @@ class TypeScript(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -539,7 +539,6 @@ class V(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = False
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -286,7 +286,6 @@ class VisualBasic(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -182,7 +182,6 @@ class Wren(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = False

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -109,7 +109,6 @@ class Yaml(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = False
     supports_no_variable_wrap_in_file = True
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -375,15 +375,6 @@ class Zig(metaclass=LanguageCls):
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False
-    # A call result is bound with a plain inferred declaration
-    # (``const my_data = make_widget(...);``); the Zig ``const``/``var``
-    # type inference means no caller-supplied return-type hint is
-    # needed.  The value-type ``: ZVal`` annotation and the
-    # ``Name{ .field = value, ... }`` struct-literal wrapping a Zig
-    # literal binding uses are both dropped (a call result is neither a
-    # ``ZVal`` projection nor a generated ``struct`` literal).  See
-    # :attr:`format_call_variable_declaration`.
-    supports_call_variable_binding = True
     dict_supports_heterogeneous_values = True
     supports_dotted_calls = True
     has_free_function_calls = True

--- a/tests/errors/test_call_errors.py
+++ b/tests/errors/test_call_errors.py
@@ -48,7 +48,6 @@ from literalizer.languages import (
     Racket,
     Tcl,
     Yaml,
-    Zig,
 )
 
 
@@ -735,28 +734,4 @@ def test_literalize_call_both_variable_forms_unsupported_raises() -> None:
             parameter_names=["count"],
             per_element=False,
             variable_form=BothVariableForms(name="result"),
-        )
-
-
-def test_literalize_call_variable_form_template_incompatible_raises() -> None:
-    """``variable_form`` is rejected for languages whose declaration
-    template wraps the right-hand side incompatibly with call expressions
-    (Zig projects a scalar into a ``ZVal`` tagged union; tagged-enum
-    heterogeneous languages prepend a constructor; etc.).
-    """
-    with pytest.raises(
-        expected_exception=UnsupportedCallShapeError,
-        match=(
-            r"this language's variable-declaration template wraps or "
-            r"transforms the right-hand side"
-        ),
-    ):
-        literalize_call(
-            source="42",
-            input_format=InputFormat.JSON,
-            language=Zig(),
-            target_function="make_widget",
-            parameter_names=["count"],
-            per_element=False,
-            variable_form=NewVariable(name="result"),
         )

--- a/tests/integration/call_cases.py
+++ b/tests/integration/call_cases.py
@@ -1482,8 +1482,6 @@ def _variable_form_expected_exception(
         return VariableNameNotSupportedError
     if not lang_cls.call_returns_expression:
         return UnsupportedCallShapeError
-    if not lang_cls.supports_call_variable_binding:
-        return UnsupportedCallShapeError
     return None
 
 


### PR DESCRIPTION
Fixes #2521. After the recent `literalize_call` call-binding work, every one of the 63 languages had `supports_call_variable_binding = True`, so the flag, its `UnsupportedCallShapeError` rejection branch in `_validate_call_variable_form`, the mirror branch in `_variable_form_expected_exception`, and the stale Zig-based test `test_literalize_call_variable_form_template_incompatible_raises` were all dead — leaving the test failing and total coverage at 99.99%. This removes the base-class attribute, the per-language flag (plus the 8 orphaned explanatory comments, whose rationale is already documented on each `_format_*_call_declaration`), the two dead branches, and the stale test. No generated output changes; the full suite passes with the 100% coverage gate restored (4893 passed, coverage 100.00%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor removing an always-true capability flag and its unreachable error path; behavior should be unchanged aside from eliminating a stale negative test.
> 
> **Overview**
> Removes the `supports_call_variable_binding` language capability flag across the codebase, along with the now-unreachable `UnsupportedCallShapeError` validation branch in `literalize_call`.
> 
> Cleans up all per-language declarations/comments for the flag and updates tests by deleting the obsolete Zig-based rejection test and simplifying integration case expectation logic. Adds a changelog entry noting no generated output changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbabd7bfbf256af6d60cadca7cc4af8d9ccad3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->