### PR TITLE
Unify literalize(bound_refs=) preamble onto the semantic discriminator (#1946)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,11 @@ Next
   and are emitted in iteration order.  Recomputing the body preamble
   across the union of types and reconciling the data-dependent header
   block into a single copy covering every type replaces the previous
-  multi-line preamble-filter heuristic.  See #1946.
+  multi-line preamble-filter heuristic.  The same single-copy
+  reconciliation now also backs :func:`~literalizer.literalize`'s own
+  ``bound_refs`` declaration composition, removing the last
+  preamble-filter heuristic there with no change to generated output.
+  See #1946.
 - The ``supports_call_variable_binding`` language-class flag has been
   removed.  Every language now binds a :func:`~literalizer.literalize_call`
   result directly with no literal-only wrapping, so the flag was

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2632,11 +2632,11 @@ def _compose_bound_refs(
     # of the value, so the exact strings a declaration appended to its
     # ``preamble`` are reproducible by re-invoking it on that
     # declaration's ``source_data``.  Drop those reproduced
-    # per-declaration blocks and let first-seen deduplication collapse
-    # the shared single-line entries (imports, package lines).  Unlike
-    # the previous "drop any entry containing a newline" heuristic, a
-    # multi-line declaration-only block that the main binding does not
-    # reproduce is preserved.
+    # per-declaration blocks and let first-seen duplicate removal
+    # collapse the shared single-line entries (imports, package lines).
+    # Unlike the previous "drop any entry containing a newline"
+    # heuristic, a multi-line declaration-only block that the main
+    # binding does not reproduce is preserved.
     dropped_declaration_blocks: set[str] = set()
     for d in decl_results:
         dropped_declaration_blocks.update(

--- a/src/literalizer/_literalize.py
+++ b/src/literalizer/_literalize.py
@@ -2619,28 +2619,38 @@ def _compose_bound_refs(
         variable_name=composition.main_variable_name,
         body_preamble=unified_body_preamble,
     )
-    # The main binding's preamble was computed with every bound ref
-    # resolved into its data, so its multi-line data-dependent block
-    # (e.g. Gleam's ``pub type GVal {...}``) already covers every type
-    # across the declarations and the main binding.  Each declaration's
-    # own multi-line block, by contrast, was computed from that
-    # declaration's data alone and would conflict with the unified
-    # version once duplicate lines are dropped.  Drop the multi-line
-    # entries from declaration preambles and keep their single-line
-    # entries (imports, package lines); dropping repeated lines in
-    # first-seen order handles the rest.
-    decl_preamble_lines = tuple(
+    # Each declaration emitted its data-dependent block (e.g. Gleam's
+    # ``pub type GVal {...}``) from *its own* data alone, so the
+    # per-declaration blocks disagree on which constructors they
+    # declare.  The main binding was rendered with every bound ref
+    # resolved into its data, so ``main_result.preamble`` already
+    # carries one block computed over that full union (declarations
+    # *and* the main binding); it is the single canonical copy.  Unlike
+    # the call composer there is no divergent form to reconcile: every
+    # binding renders its data-dependent construct through
+    # :meth:`Language.data_dependent_preamble`, which is a pure function
+    # of the value, so the exact strings a declaration appended to its
+    # ``preamble`` are reproducible by re-invoking it on that
+    # declaration's ``source_data``.  Drop those reproduced
+    # per-declaration blocks and let first-seen deduplication collapse
+    # the shared single-line entries (imports, package lines).  Unlike
+    # the previous "drop any entry containing a newline" heuristic, a
+    # multi-line declaration-only block that the main binding does not
+    # reproduce is preserved.
+    dropped_declaration_blocks: set[str] = set()
+    for d in decl_results:
+        dropped_declaration_blocks.update(
+            language.data_dependent_preamble(d.source_data)
+        )
+    declaration_preamble = tuple(
         entry
         for d in decl_results
         for entry in d.preamble
-        if "\n" not in entry
+        if entry not in dropped_declaration_blocks
     )
-    seen: set[str] = set()
-    all_preamble: tuple[str, ...] = ()
-    for entry in decl_preamble_lines + main_result.preamble:
-        if entry not in seen:
-            seen.add(entry)
-            all_preamble += (entry,)
+    all_preamble = deduplicate_preamble_entries(
+        entries=declaration_preamble + main_result.preamble
+    )
     if all_preamble:
         wrapped = "\n".join(all_preamble) + "\n" + wrapped
     return LiteralizeResult(


### PR DESCRIPTION
## What

Completes #1946 by retiring the last `if "\n" not in entry`
declaration-preamble heuristic.

v1 (PR #2520, merged) delivered the public entry point
(`literalize_call(bound_refs=)` / `literalize_call_with_declarations`)
and replaced the call-side harness filter with a semantic rule. It
**deliberately scoped out** `_compose_bound_refs` (the
`literalize(bound_refs=)` *declaration* path), which still carried the
identical `\n` heuristic.

This PR applies the same reconciliation there:

- Reproduce each declaration's `data_dependent_preamble` over its own
  `source_data` and drop those exact strings (the main result, rendered
  with every ref resolved into its data, already carries one block over
  the full union, the single canonical copy).
- Reuse `deduplicate_preamble_entries` for the first-seen dedup the
  hand-rolled loop did.

The declaration path is *simpler* than the call path: every binding
renders its data-dependent construct through `data_dependent_preamble`,
so there is no divergent call form to discriminate against and the drop
is unconditional. The result is strictly more correct than the old
heuristic, which silently dropped any multi-line declaration-only block
even when the main binding did not reproduce it.

## Verification

- **Zero generated-output change.** Full literalize-ref golden suite
  (827 cases) and full pytest suite (4760 passed, 29059 subtests) are
  byte-identical, zero golden churn (Gleam/Nim included).
- ruff / ty clean. pylint manual + sphinx spelling + sphinx-lint: no
  new words; only pre-existing baseline noise in untouched files.

## Acceptance criteria (#1946)

- [x] Public entry point rendering N declarations + a call (v1).
- [x] `call_cases.py::run_call_golden_case` calls it (v1).
- [x] The `if "\n" not in entry` filter on declaration preambles is
  removed (v1 harness/call side; **this PR** the remaining
  `_compose_bound_refs` twin).

Closes #1946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core code-generation preamble composition for `literalize(bound_refs=...)`; while intended to be output-neutral, subtle differences in which multi-line blocks are dropped/deduped could affect compilation for some languages.
> 
> **Overview**
> Removes the last `"\n" not in entry` heuristic in the `literalize(bound_refs=...)` declaration composition path by *semantically* dropping each declaration’s own `data_dependent_preamble` block (recomputed from its `source_data`) and keeping the main binding’s unified block as the canonical copy.
> 
> Preamble assembly now reuses `deduplicate_preamble_entries` for first-seen deduplication, and preserves any multi-line declaration-only preamble content that isn’t reproduced by the main binding. The changelog is updated to document this reconciliation as part of the #1946 work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd530b27665baf9f9466ca5d676cca83ee267071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->