### PR TITLE
C#: array literals no longer over-emit 'using System;' / 'using System.Collections.Generic;' (#2524)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,18 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.CSharp` array sequence-format no longer emits
+  ``using System;`` or ``using System.Collections.Generic;``.  A C#
+  array literal (``new T[] {...}``) is a built-in language feature and
+  requires no ``using`` directives, so those lines were dead noise on
+  the array path (for example a ``Dictionary`` whose values are arrays
+  picked up a spurious ``using System;``).  ``using
+  System.Collections.Generic;`` is still emitted for the collection
+  types that need it (``List<T>``, ``Dictionary<TKey, TValue>``, and
+  the set types), and ``using System;`` for ``System`` scalar types
+  such as ``DateOnly``.  The array empty form is now the typed
+  literal ``new T[] {}`` rather than ``Array.Empty<T>()``, keeping the
+  array path free of any ``System`` reference.  See #2524.
 - :func:`~literalizer.literalize_call` now accepts a ``bound_refs``
   argument, the call-side counterpart of
   :func:`~literalizer.literalize`'s own ``bound_refs``.  With

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -625,11 +625,8 @@ class CSharp(metaclass=LanguageCls):
                 supports_heterogeneity=True,
                 single_element_trailing_comma=False,
                 supports_trailing_comma=True,
-                empty_template="Array.Empty<{type}>()",
-                preamble_lines=(
-                    "using System;",
-                    "using System.Collections.Generic;",
-                ),
+                empty_template="new {type}[] {{}}",
+                preamble_lines=(),
                 format_entry=passthrough_sequence_entry,
                 typed_opener_fallback_template=("new {type}[] {{"),
             )
@@ -1372,14 +1369,17 @@ class CSharp(metaclass=LanguageCls):
         """Configuration for the chosen sequence format.
 
         ``()`` parses as an invalid expression in C#; the language's
-        ``ValueTuple.Create()`` (or ``Array.Empty<T>()`` for the array
-        format) is the syntactically valid empty form, so prefer it
-        whenever an empty inner list sits beside non-empty siblings.
+        ``ValueTuple.Create()`` (or a typed empty array literal
+        ``new T[] {}`` for the array format) is the syntactically valid
+        empty form, so prefer it whenever an empty inner list sits
+        beside non-empty siblings.  The array empty form is a plain
+        language-level array literal, never ``Array.Empty<T>()``, so the
+        array path needs no ``using System;``.
         """
         element_type = self.default_sequence_element_type
         base = self.sequence_format(default_type=element_type)
         empty = (
-            f"Array.Empty<{element_type}>()"
+            f"new {element_type}[] {{}}"
             if self.sequence_format.name == "ARRAY"
             else "ValueTuple.Create()"
         )

--- a/tests/integration/cases/binary_list/CSharp_sequence_array_binary@v10.cs
+++ b/tests/integration/cases/binary_list/CSharp_sequence_array_binary@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new string[] {
     "48656c6c6f"
 };

--- a/tests/integration/cases/bool_list/CSharp_type_hints_safe_seq_array@v10.cs
+++ b/tests/integration/cases/bool_list/CSharp_type_hints_safe_seq_array@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new bool[] {
     true,
     false,

--- a/tests/integration/cases/call_deep_dotted_method/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_deep_dotted_method/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 class ClientType_ { public object post(object data = null) => null; }
 class ApiType_ { public ClientType_ client = new ClientType_(); }

--- a/tests/integration/cases/call_deep_dotted_transformed/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_deep_dotted_transformed/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 class ClientType_ { public object fetch(object payload = null) => null; }
 class AppType_ { public ClientType_ client = new ClientType_(); }

--- a/tests/integration/cases/call_dotted_method/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_dotted_method/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 class ClientType_ { public object fetch(object payload = null) => null; }
 class AppType_ { public ClientType_ client = new ClientType_(); }

--- a/tests/integration/cases/call_dotted_transform_stub/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_dotted_transform_stub/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object value = null) => null;
 class TracerType_ { public object emit(object _arg = null) => null; }

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object data = null, object count = null) => null;
     public static void Main() {
@@ -12,7 +10,7 @@ var my_strings = new string[] {
     "a",
     "b"
 };
-var my_empty = Array.Empty<object>();
+var my_empty = new object[] {};
 process(my_ints, 42);
 process(my_strings, 7);
 process(my_empty, 99);

--- a/tests/integration/cases/call_ref_args_reused/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_ref_args_reused/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object data = null, object count = null) => null;
     public static void Main() {

--- a/tests/integration/cases/call_ref_args_trivial_register/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_ref_args_trivial_register/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object value = null, object count = null) => null;
     public static void Main() {

--- a/tests/integration/cases/call_scalar_args/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_scalar_args/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object value = null) => null;
     public static void Main() {

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object value = null, object label = null) => null;
     public static void Main() {

--- a/tests/integration/cases/call_scalar_args_with_null/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_scalar_args_with_null/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object value = null) => null;
     public static void Main() {

--- a/tests/integration/cases/call_snake_dotted_method/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_snake_dotted_method/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 class Http_ClientType_ { public object fetch(object payload = null) => null; }
 class My_AppType_ { public Http_ClientType_ http_client = new Http_ClientType_(); }

--- a/tests/integration/cases/call_transform_no_wrapper/CSharp_heterogeneous_strategy_record_call@v10.cs
+++ b/tests/integration/cases/call_transform_no_wrapper/CSharp_heterogeneous_strategy_record_call@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 static object process(object value = null) => null;
     public static void Main() {

--- a/tests/integration/cases/dict_with_list_value/CSharp_heterogeneous_strategy_record_list_val@v10.cs
+++ b/tests/integration/cases/dict_with_list_value/CSharp_heterogeneous_strategy_record_list_val@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(string Name, int[] Scores);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/empty_list/CSharp_type_hints_safe_seq_array@v10.cs
+++ b/tests/integration/cases/empty_list/CSharp_type_hints_safe_seq_array@v10.cs
@@ -1,3 +1,1 @@
-using System;
-using System.Collections.Generic;
-var my_data = Array.Empty<object>();
+var my_data = new object[] {};

--- a/tests/integration/cases/float_list/CSharp_sequence_array_float@v10.cs
+++ b/tests/integration/cases/float_list/CSharp_sequence_array_float@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new double[] {
     1.1,
     -2.2,

--- a/tests/integration/cases/float_list/CSharp_type_hints_safe_seq_array@v10.cs
+++ b/tests/integration/cases/float_list/CSharp_type_hints_safe_seq_array@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new double[] {
     1.1,
     -2.2,

--- a/tests/integration/cases/heterogeneous_list_with_string/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/heterogeneous_list_with_string/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
     public static void Main() {
 var my_data = new object[] {

--- a/tests/integration/cases/int_list/CSharp_type_hints_safe_seq_array@v10.cs
+++ b/tests/integration/cases/int_list/CSharp_type_hints_safe_seq_array@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new int[] {
     1,
     2,

--- a/tests/integration/cases/int_list_large/CSharp_type_hints_safe_seq_array@v10.cs
+++ b/tests/integration/cases/int_list_large/CSharp_type_hints_safe_seq_array@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new int[] {
     1000000,
     -1234,

--- a/tests/integration/cases/mixed_number_list/CSharp_modifiers_readonly_mixed_numbers@v10.cs
+++ b/tests/integration/cases/mixed_number_list/CSharp_modifiers_readonly_mixed_numbers@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 readonly double[] my_data = new double[] {
     1,

--- a/tests/integration/cases/multiline_sibling_list_widening/CSharp_heterogeneous_strategy_record_sibling_widening@v10.cs
+++ b/tests/integration/cases/multiline_sibling_list_widening/CSharp_heterogeneous_strategy_record_sibling_widening@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record1(int[] Numbers, string[] Strings);
 record Record0(Dictionary<string, object> OmapValue, Record1 SiblingLists, string[] RefMarkerPresent);
 class Check {

--- a/tests/integration/cases/nested_mixed_inner/CSharp_heterogeneous_strategy_record_inner@v10.cs
+++ b/tests/integration/cases/nested_mixed_inner/CSharp_heterogeneous_strategy_record_inner@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
     public static void Main() {
 var my_data = new object[] {

--- a/tests/integration/cases/nested_mixed_types/CSharp_heterogeneous_strategy_record_sibling@v10.cs
+++ b/tests/integration/cases/nested_mixed_types/CSharp_heterogeneous_strategy_record_sibling@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
     public static void Main() {
 var my_data = new object[] {

--- a/tests/integration/cases/nested_sequences/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/nested_sequences/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
     public static void Main() {
 var my_data = new int[][][] {

--- a/tests/integration/cases/null_list/CSharp_sequence_array_null@v10.cs
+++ b/tests/integration/cases/null_list/CSharp_sequence_array_null@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new object[] {
     (object?)null,
     (object?)null

--- a/tests/integration/cases/pair_sequence/CSharp_sequence_array_pair@v10.cs
+++ b/tests/integration/cases/pair_sequence/CSharp_sequence_array_pair@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new object[] {
     1,
     "hello"

--- a/tests/integration/cases/pair_sequence/CSharp_type_hints_safe_seq_array@v10.cs
+++ b/tests/integration/cases/pair_sequence/CSharp_type_hints_safe_seq_array@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new object[] {
     1,
     "hello"

--- a/tests/integration/cases/record_basic/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/record_basic/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(int Id, string Description, bool IsDone, int[] Blocks);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/record_list_of_records/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/record_list_of_records/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record1(int Id, string Label);
 record Record0(string Name, Record1[] Items);
 class Check {

--- a/tests/integration/cases/record_nested_container/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/record_nested_container/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(string Title, string[] Tags, int Priority);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/record_sequence/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/record_sequence/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
-using System;
 record Record0(int Id, string Label, object[] Tags);
 class Check {
     public static void Main() {
 var my_data = new[] {
-    new Record0(1, "first", Array.Empty<object>()),
-    new Record0(2, "second", Array.Empty<object>()),
-    new Record0(3, "third", Array.Empty<object>())
+    new Record0(1, "first", new object[] {}),
+    new Record0(2, "second", new object[] {}),
+    new Record0(3, "third", new object[] {})
 };
     }
 }

--- a/tests/integration/cases/simple_sequence/CSharp_modifiers_readonly_array@v10.cs
+++ b/tests/integration/cases/simple_sequence/CSharp_modifiers_readonly_array@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
 readonly object[] my_data = new object[] {
     1,

--- a/tests/integration/cases/simple_sequence/CSharp_sequence_array@v10.cs
+++ b/tests/integration/cases/simple_sequence/CSharp_sequence_array@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new object[] {
     1,
     "hello",

--- a/tests/integration/cases/simple_sequence/CSharp_sequence_array_varname@v10.cs
+++ b/tests/integration/cases/simple_sequence/CSharp_sequence_array_varname@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new object[] {
     1,
     "hello",

--- a/tests/integration/cases/triple_sequence/CSharp_sequence_array_triple@v10.cs
+++ b/tests/integration/cases/triple_sequence/CSharp_sequence_array_triple@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 var my_data = new object[] {
     1,
     "hello",

--- a/tests/integration/cases/tuple_pair_record_field/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_pair_record_field/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(string Call, object[] Args);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/tuple_pair_top_level/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_pair_top_level/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
     public static void Main() {
 var my_data = new object[] {

--- a/tests/integration/cases/tuple_record_field/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_record_field/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(string Call, object[] Args);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/tuple_record_seq_sibling/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_record_seq_sibling/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(int[] Scores, object[] Args);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/tuple_record_sequence/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_record_sequence/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(string Call, object[] Args);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/tuple_top_level/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_top_level/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
     public static void Main() {
 var my_data = new object[] {

--- a/tests/integration/cases/tuple_triple_record_field/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_triple_record_field/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System;
 record Record0(string Call, object[] Args);
 class Check {
     public static void Main() {

--- a/tests/integration/cases/tuple_triple_top_level/CSharp_heterogeneous_strategy_record@v10.cs
+++ b/tests/integration/cases/tuple_triple_top_level/CSharp_heterogeneous_strategy_record@v10.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 class Check {
     public static void Main() {
 var my_data = new object[] {


### PR DESCRIPTION
Fixes #2524.

## Problem

The C# array sequence-format unconditionally contributed `using System;` and `using System.Collections.Generic;`. A plain C# array literal (`new T[] {...}`) is a built-in language feature requiring zero `using` directives, so both lines were dead noise on the array path. A nested input such as a `Dictionary<string, string[]>` (dict whose values are arrays) tripped the array path and got a spurious `using System;`.

## Fix

- `CSharp.SequenceFormats.ARRAY`: `preamble_lines=()` (was `using System;` + `using System.Collections.Generic;`).
- Replace the empty-array form `Array.Empty<T>()` (which references `System.Array`) with the typed literal `new T[] {}`, so the array path carries no `System` reference at all. Updated `sequence_format_config` empty-form and its docstring accordingly.

`using System.Collections.Generic;` is still emitted by the dict/set/list configs that need it (`List<T>`, `Dictionary<TKey,TValue>`, the set types), and `using System;` by the date/datetime/time scalar preambles, so mixed inputs (e.g. a time inside an array) keep every directive they actually require. Scans over the regenerated goldens confirm no fixture lost a `using` it still needs.

## Verification

- 45 C# goldens regenerated; no golden lost a needed `System` / `System.Collections.Generic` directive.
- Full suite green (`uv run --extra dev pytest`): 4760 passed.
- ruff check/format, sphinx-lint, doc8 clean; pylint `manual` and Sphinx `spelling` show no new findings (only pre-existing baseline noise).
- CHANGELOG `Next` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to C# array sequence rendering (imports + empty-array syntax) and updates goldens accordingly, with minimal impact outside codegen output formatting.
> 
> **Overview**
> Removes `using System;` and `using System.Collections.Generic;` emission from the C# `SequenceFormats.ARRAY` path, so array literals no longer drag in unrelated imports (while other collection formats still emit `System.Collections.Generic` as needed).
> 
> Switches empty-array rendering from `Array.Empty<T>()` to the typed literal `new T[] {}`, keeping the array format free of any `System` reference, and updates documentation + regenerated C# integration goldens to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7abbc4167beefac557e84fc10579e12cc89da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->