### PR TITLE
Add support for Haxe as a new output language

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1394,6 +1394,46 @@ jobs:
           printf '}\n' >> "$main"
           scala-cli run "$workspace" -S 3 --main-class __run
 
+  lint-haxe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Find files to lint
+        shell: bash
+        run: find tests/integration/cases -name '*.hx' -print0 > /tmp/files-to-lint
+          && test -s /tmp/files-to-lint
+      # `haxe-version: 4.3.6` matches the major version of
+      # `Haxe.language_version` (`V4`) in
+      # `src/literalizer/languages/haxe.py`; keep them in sync.
+      - name: Install Haxe
+        uses: krdlab/setup-haxe@v1
+        with:
+          haxe-version: 4.3.6
+      # Each fixture already carries a unique class name derived from
+      # its case directory and stem (`Fixture_<dir>_<stem>`), so a plain
+      # copy to `<class>.hx` suffices; no sed rewriting needed. The
+      # fixtures are compiled and run in a single `haxe --interp`
+      # invocation via a generated `Driver` that calls every fixture's
+      # `main()`, paying Haxe compiler startup once across all fixtures.
+      - name: Check Haxe syntax and run fixtures
+        run: |-
+          workspace=$(mktemp -d)
+          driver="$workspace/Driver.hx"
+          printf 'class Driver {\n  public static function main() {\n' > "$driver"
+          while IFS= read -r -d '' f; do
+            dir=$(basename "$(dirname "$f")")
+            stem=$(basename "$f" .hx)
+            stem="${stem%@*}"  # strip @version so the Haxe class name is a valid identifier
+            name="Fixture_${dir}_${stem}"
+            cp "$f" "$workspace/${name}.hx"
+            printf '%s.hx <- %s\n' "$name" "$f"
+            printf '    %s.main();\n' "$name" >> "$driver"
+          done < /tmp/files-to-lint
+          printf '  }\n}\n' >> "$driver"
+          haxe -p "$workspace" --main Driver --interp
+
   lint-dart:
     runs-on: ubuntu-latest
     steps:
@@ -2111,6 +2151,7 @@ jobs:
       - lint-ocaml
       - lint-commonlisp
       - lint-scala
+      - lint-haxe
       - lint-dart
       - lint-go
       - lint-julia

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Changelog
 Next
 ----
 
+- Added support for Haxe as a new output language.  ``Haxe`` renders
+  every collection literal with an explicit ``(... : Array<Dynamic>)``
+  or ``(... : Map<String, Dynamic>)`` cast, so heterogeneous and empty
+  collections type-check without per-variable annotations.  Maps use
+  Haxe's ``["key" => value]`` literal syntax and strings use the
+  double-quoted form (no interpolation).  Calls use positional syntax
+  with local-function and anonymous-structure-closure stubs emitted
+  inside ``static function main()``.  A new ``lint-haxe`` job in
+  ``.github/workflows/lint.yml`` compiles and runs every ``.hx``
+  fixture in a single ``haxe --interp`` invocation.
 - :class:`~literalizer.CSharp` array sequence-format no longer emits
   ``using System;`` or ``using System.Collections.Generic;``.  A C#
   array literal (``new T[] {...}``) is a built-in language feature and

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Supported languages
 -------------------
 
 Ada, Bash, C, C#, C++, Clojure, COBOL, Common Lisp, Crystal, D, Dart, Dhall,
-Elixir, Elm, Erlang, F#, Fortran, Gleam, Go, Groovy, Haskell, HCL, Java,
-JavaScript, JSON5, Jsonnet, Julia, Kotlin, Lua, MATLAB, Mojo, Nim, Norg,
+Elixir, Elm, Erlang, F#, Fortran, Gleam, Go, Groovy, Haskell, Haxe, HCL,
+Java, JavaScript, JSON5, Jsonnet, Julia, Kotlin, Lua, MATLAB, Mojo, Nim, Norg,
 Objective-C, OCaml, Occam-pi, Odin, Perl, PHP, PowerShell, PureScript, Python,
 R, Racket, Raku, Roc, Ruby, Rust, Scala, Scheme, Swift, SystemVerilog, TOML,
 TypeScript, Visual Basic, YAML, Zig.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -54,6 +54,7 @@ HNull
 HSet
 HStr
 HashiCorp
+Haxe
 Hcl
 JSONDecodeError
 Jsonnet

--- a/src/literalizer/languages/__init__.py
+++ b/src/literalizer/languages/__init__.py
@@ -24,6 +24,7 @@ from .gleam import Gleam
 from .go import Go
 from .groovy import Groovy
 from .haskell import Haskell
+from .haxe import Haxe
 from .hcl import Hcl
 from .java import Java
 from .javascript import JavaScript
@@ -90,6 +91,7 @@ ALL_LANGUAGES: frozenset[LanguageCls] = frozenset(
         Go,
         Groovy,
         Haskell,
+        Haxe,
         Hcl,
         Java,
         JavaScript,
@@ -158,6 +160,7 @@ __all__ = [
     "Go",
     "Groovy",
     "Haskell",
+    "Haxe",
     "Hcl",
     "Java",
     "JavaScript",

--- a/src/literalizer/languages/haxe.py
+++ b/src/literalizer/languages/haxe.py
@@ -1,0 +1,958 @@
+"""Haxe language specification."""
+
+import dataclasses
+import datetime
+import enum
+from collections.abc import Callable, Sequence
+from functools import cached_property
+from typing import ClassVar, assert_never
+
+from beartype import beartype
+
+from literalizer._formatters.collection_openers import fixed_open
+from literalizer._formatters.format_dates import (
+    format_date_iso,
+    format_datetime_epoch,
+    format_datetime_iso,
+    format_time_iso,
+)
+from literalizer._formatters.format_entries import (
+    dict_entry_with_separator,
+    format_bytes_base64,
+    format_bytes_hex,
+    passthrough_sequence_entry,
+    passthrough_set_entry,
+    variable_declaration_formatter,
+    variable_formatter,
+)
+from literalizer._formatters.format_factories import set_format_factory
+from literalizer._formatters.format_floats import (
+    format_float_fixed,
+    format_float_repr,
+    format_float_scientific,
+)
+from literalizer._formatters.format_integers import format_integer_hex
+from literalizer._formatters.format_strings import format_string_backslash
+from literalizer._language import (
+    NO_CALL_PARAMETER_LIMIT,
+    NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
+    CallStyle,
+    CommentConfig,
+    DateFormatConfig,
+    DatetimeFormatConfig,
+    DeclarationStyleConfig,
+    DictFormatConfig,
+    FloatSpecialsMixin,
+    HeterogeneousBehavior,
+    IdentifierCase,
+    LanguageCls,
+    ModifierCombination,
+    OrderedMapFormatConfig,
+    PositionalCallStyle,
+    SequenceFormatConfig,
+    SetFormatConfig,
+    StubReturn,
+    TrailingCommaConfig,
+    body_preamble_from_scalars,
+    default_format_call_variable_assignment,
+    default_format_call_variable_declaration,
+    default_sequence_binding_declarations,
+    default_wrap_calls_with_declarations,
+    identity_call_arg,
+    identity_call_ref_identifier,
+    identity_call_statement,
+    identity_call_target,
+    never_inhibits_consuming_form,
+    no_call_binding_body_preamble,
+    no_call_binding_file_pragmas,
+    no_call_stub,
+    no_data_preamble,
+    no_format_integer_widened,
+    no_leading_preamble,
+    no_type_hint_preamble,
+    no_validate_call_arg,
+    no_validate_spec_for_data,
+    prepend_body_preamble,
+)
+from literalizer._types import Scalar, Value
+from literalizer.exceptions import WrapCombinedInFileNotSupportedError
+
+# The Haxe ``Int`` is a 32-bit signed integer on static targets; only
+# values inside this range are guaranteed to round-trip as an ``Int``.
+# Wider values are annotated as ``Float`` (an ``Int`` literal converts
+# implicitly to ``Float``, so the annotation is always safe).
+_I32_MIN = -(2**31)
+_I32_MAX = 2**31 - 1
+
+
+@beartype
+def _haxe_scalar_hint(
+    *,
+    data: Scalar,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive the Haxe annotation for a scalar value."""
+    match data:
+        case bool():
+            hint = "Bool"
+        case int():
+            hint = "Int" if _I32_MIN <= data <= _I32_MAX else "Float"
+        case float():
+            hint = "Float"
+        case str() | bytes():
+            hint = "String"
+        case datetime.datetime():
+            hint = datetime_hint
+        case datetime.date():
+            hint = date_hint
+        case datetime.time():
+            hint = "String"
+        case None:
+            hint = "Dynamic"
+        case _ as unreachable:
+            assert_never(unreachable)
+    return hint
+
+
+@beartype
+def _haxe_type_hint(
+    *,
+    data: Value,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Derive a Haxe type annotation from *data*.
+
+    Every collection literal is rendered with an explicit
+    ``(... : Array<Dynamic>)`` / ``(... : Map<String, Dynamic>)`` cast,
+    so the matching variable annotation is the same coarse type
+    regardless of element types.
+    """
+    match data:
+        case dict():
+            return "Map<String, Dynamic>"
+        case list() | set():
+            return "Array<Dynamic>"
+        case _:
+            return _haxe_scalar_hint(
+                data=data,
+                date_hint=date_hint,
+                datetime_hint=datetime_hint,
+            )
+
+
+@beartype
+def _format_haxe_typed_declaration(
+    *,
+    name: str,
+    value: str,
+    data: Value,
+    _modifiers: frozenset[enum.Enum],
+    keyword: str,
+    date_hint: str,
+    datetime_hint: str,
+) -> str:
+    """Format a Haxe variable declaration with an explicit type."""
+    hint = _haxe_type_hint(
+        data=data,
+        date_hint=date_hint,
+        datetime_hint=datetime_hint,
+    )
+    return f"{keyword}{name}:{hint} = {value};"
+
+
+@beartype
+def _haxe_params(params: Sequence[str]) -> str:
+    """Render a stub parameter list, typing every parameter
+    ``Dynamic``.
+    """
+    return ", ".join(f"{param}:Dynamic" for param in params)
+
+
+@beartype
+def _haxe_call_stub(
+    parts: Sequence[str],
+    params: Sequence[str],
+    _stub_return: StubReturn,
+    _args: Sequence[Value],
+    /,
+) -> tuple[str, ...]:
+    """Return Haxe stub declarations for a call name.
+
+    Stubs are emitted as local declarations so they are valid inside the
+    ``static function main()`` body that :meth:`Haxe.wrap_in_file`
+    produces.  A bare name becomes a local function; a dotted name
+    becomes a local bound to a nested anonymous structure of closures
+    (``var app = { client: { fetch: function(...) ... } };``).
+    """
+    param_list = _haxe_params(params=params)
+    if len(parts) == 1:
+        return (f"function {parts[0]}({param_list}):Dynamic return null;",)
+    method = parts[-1]
+    fields = parts[1:-1]
+    closure = f"function({param_list}):Dynamic return null"
+    structure = f"{{ {method}: {closure} }}"
+    for field in reversed(fields):
+        structure = f"{{ {field}: {structure} }}"
+    return (f"var {parts[0]} = {structure};",)
+
+
+_HAXE_RESERVED: frozenset[str] = frozenset(
+    {
+        "abstract",
+        "break",
+        "case",
+        "cast",
+        "catch",
+        "class",
+        "continue",
+        "default",
+        "do",
+        "dynamic",
+        "else",
+        "enum",
+        "extends",
+        "extern",
+        "false",
+        "final",
+        "for",
+        "function",
+        "if",
+        "implements",
+        "import",
+        "in",
+        "inline",
+        "interface",
+        "macro",
+        "new",
+        "null",
+        "operator",
+        "overload",
+        "override",
+        "package",
+        "private",
+        "public",
+        "return",
+        "static",
+        "switch",
+        "this",
+        "throw",
+        "true",
+        "try",
+        "typedef",
+        "untyped",
+        "using",
+        "var",
+        "while",
+    }
+)
+
+
+@beartype
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Haxe(metaclass=LanguageCls):
+    """Haxe language specification.
+
+    Args:
+        date_format: How to format :class:`datetime.date` values.
+
+            * ``date_formats.ISO`` — ISO 8601 quoted string,
+              e.g. ``"2024-01-15"``.
+
+        datetime_format: How to format :class:`datetime.datetime` values.
+
+            * ``datetime_formats.ISO`` — ISO 8601 quoted string,
+              e.g. ``"2024-01-15T12:30:00"``.
+            * ``datetime_formats.EPOCH`` — Unix timestamp integer.
+    """
+
+    format_integer_widened = no_format_integer_widened
+    format_call_variable_declaration = default_format_call_variable_declaration
+    format_call_variable_assignment = default_format_call_variable_assignment
+    sequence_binding_declarations = default_sequence_binding_declarations
+    format_call_binding_body_preamble = no_call_binding_body_preamble
+    format_call_binding_file_pragmas = no_call_binding_file_pragmas
+
+    leading_preamble = no_leading_preamble
+    validate_spec_for_data = no_validate_spec_for_data
+    extension = ".hx"
+    pygments_name = "haxe"
+    supports_special_floats = True
+    supports_variable_names = True
+    supports_no_variable_wrap_in_file = False
+    dict_supports_heterogeneous_values = True
+    supports_dotted_calls = True
+    has_free_function_calls = True
+    reserved_identifiers: ClassVar[frozenset[str]] = _HAXE_RESERVED
+    allows_empty_call_parens = True
+    supports_dotted_call_stub = True
+    call_returns_expression = True
+    supports_zero_parameter_calls = True
+    max_call_parameters = NO_CALL_PARAMETER_LIMIT
+    supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_module_name = True
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
+    supports_non_string_dict_keys = False
+
+    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
+        staticmethod(
+            identity_call_arg,
+        )
+    )
+    """Callable that rewrites a formatted direct call argument."""
+
+    class DateFormats(enum.Enum):
+        """Date formatting options for Haxe."""
+
+        ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
+
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value.formatter(date_value)
+
+    class DatetimeFormats(enum.Enum):
+        """Datetime formatting options for Haxe."""
+
+        ISO = DatetimeFormatConfig(
+            formatter=format_datetime_iso,
+            type_produced=str,
+        )
+        EPOCH = DatetimeFormatConfig(
+            formatter=format_datetime_epoch,
+            type_produced=int,
+        )
+
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value.formatter(dt_value)
+
+    class BytesFormats(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+        BASE64 = enum.member(value=format_bytes_base64)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
+    class SequenceFormats(enum.Enum):
+        """Sequence type options for Haxe."""
+
+        ARRAY = SequenceFormatConfig(
+            sequence_open=fixed_open(open_str="(["),
+            close="] : Array<Dynamic>)",
+            supports_heterogeneity=True,
+            single_element_trailing_comma=False,
+            supports_trailing_comma=True,
+            empty_sequence=None,
+            preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
+            typed_opener_fallback=None,
+            uses_typed_literal_for_scalars=False,
+            requires_uniform_record_shapes=False,
+            declared_type=None,
+            narrowed_empty_form=None,
+        )
+
+    class SetFormats(enum.Enum):
+        """Set type options for Haxe.
+
+        Haxe has no native set literal, so a set is rendered as a
+        type-annotated ``Array`` literal.
+        """
+
+        SET = enum.member(
+            value=set_format_factory(
+                open_template="([",
+                close="] : Array<Dynamic>)",
+                empty_template="([] : Array<Dynamic>)",
+                preamble_lines=(),
+                set_opener_template="",
+                supports_heterogeneity=True,
+                supports_trailing_comma=True,
+            )
+        )
+
+        def __call__(self, default_type: str) -> SetFormatConfig:
+            """Create a set format config for the given type."""
+            return self.value(default_type)
+
+    class CommentFormats(enum.Enum):
+        """Comment style options."""
+
+        DOUBLE_SLASH = CommentConfig(
+            prefix="//",
+            suffix="",
+        )
+        BLOCK = CommentConfig(
+            prefix="/*",
+            suffix=" */",
+        )
+
+    class DeclarationStyles(enum.Enum):
+        """Declaration style options."""
+
+        FINAL = DeclarationStyleConfig(
+            formatter=variable_declaration_formatter(
+                template="final {name} = {value};"
+            ),
+            supports_redefinition=False,
+        )
+        VAR = DeclarationStyleConfig(
+            formatter=variable_declaration_formatter(
+                template="var {name} = {value};"
+            ),
+            supports_redefinition=False,
+        )
+
+    class DictEntryStyles(enum.Enum):
+        """Dict entry style options."""
+
+        DEFAULT = enum.auto()
+
+    class DictFormats(enum.Enum):
+        """Dict/map format options."""
+
+        DEFAULT = enum.auto()
+
+    class EmptyDictKey(enum.Enum):
+        """Empty dict key options."""
+
+        ALLOW = enum.auto()
+
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="Math.POSITIVE_INFINITY",
+        negative_infinity="Math.NEGATIVE_INFINITY",
+        nan="Math.NaN",
+    ):
+        """Float format options."""
+
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
+
+    class IntegerFormats(enum.Enum):
+        """Integer format options."""
+
+        DECIMAL = enum.member(value=str)
+        HEX = enum.member(value=format_integer_hex)
+
+        def __call__(self, value: int, /) -> str:
+            """Format an integer."""
+            formatter: Callable[[int], str] = self.value
+            return formatter(value)
+
+    class NumericLiteralSuffixes(enum.Enum):
+        """Numeric literal suffix options."""
+
+        NONE = enum.auto()
+
+    class NumericSeparators(enum.Enum):
+        """Numeric separator options."""
+
+        NONE = enum.auto()
+
+    class NumericStyles(enum.Enum):
+        """Numeric literal style options."""
+
+        OVERLOADED = enum.auto()
+
+    class StringFormats(enum.Enum):
+        """String format options.
+
+        Only double-quoted strings are emitted: Haxe performs string
+        interpolation in single-quoted strings, so double quotes give a
+        literal ``$`` with no escaping.
+        """
+
+        DOUBLE = enum.member(value=format_string_backslash)
+
+        def __call__(self, value: str, /) -> str:
+            """Format a string."""
+            return self.value(value=value)
+
+    class TrailingCommas(enum.Enum):
+        """Trailing comma options."""
+
+        YES = TrailingCommaConfig(multiline_trailing_comma=True)
+        NO = TrailingCommaConfig(multiline_trailing_comma=False)
+
+    date_formats = DateFormats
+    datetime_formats = DatetimeFormats
+    bytes_formats = BytesFormats
+    sequence_formats = SequenceFormats
+    set_formats = SetFormats
+    comment_formats = CommentFormats
+
+    class VariableTypeHints(enum.Enum):
+        """Variable type hint options."""
+
+        NEVER = enum.auto()
+        ALWAYS = enum.auto()
+        SAFE = enum.auto()
+
+        def formatter(
+            self,
+            *,
+            auto_formatter: Callable[
+                [str, str, Value, frozenset[enum.Enum]], str
+            ],
+            keyword: str,
+            date_hint: str,
+            datetime_hint: str,
+        ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+            """Return the variable declaration formatter.
+
+            Collection literals already carry an explicit type cast, so
+            ``NEVER`` and ``SAFE`` need no annotation; ``ALWAYS`` adds a
+            redundant-but-valid annotation.
+            """
+            if self.name in {"NEVER", "SAFE"}:
+                return auto_formatter
+
+            def _typed_formatter(
+                name: str,
+                value: str,
+                data: Value,
+                modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Adapt :func:`_format_haxe_typed_declaration` to the
+                positional formatter interface.
+                """
+                return _format_haxe_typed_declaration(
+                    name=name,
+                    value=value,
+                    data=data,
+                    _modifiers=modifiers,
+                    keyword=keyword,
+                    date_hint=date_hint,
+                    datetime_hint=datetime_hint,
+                )
+
+            return _typed_formatter
+
+    variable_type_hints_formats = VariableTypeHints
+    declaration_styles = DeclarationStyles
+    dict_entry_styles = DictEntryStyles
+    dict_formats = DictFormats
+    empty_dict_keys = EmptyDictKey
+    float_formats = FloatFormats
+    integer_formats = IntegerFormats
+    numeric_literal_suffixes = NumericLiteralSuffixes
+    numeric_separators = NumericSeparators
+    numeric_styles = NumericStyles
+    string_formats = StringFormats
+    trailing_commas = TrailingCommas
+
+    class StatementTerminatorStyles(enum.Enum):
+        """Statement terminator options."""
+
+        SEMICOLON = enum.auto()
+
+    statement_terminator_styles = StatementTerminatorStyles
+
+    class CallStyles(enum.Enum):
+        """Haxe call style options."""
+
+        POSITIONAL = PositionalCallStyle()
+
+    call_styles = CallStyles
+
+    class Modifiers(enum.Enum):
+        """C++/Java/C#-style declaration modifiers: this language has none."""
+
+    modifiers = Modifiers
+
+    class HeterogeneousStrategies(enum.Enum):
+        """Heterogeneous-scalar strategy options — this language only
+        supports raising.
+        """
+
+        ERROR = NO_HETEROGENEOUS_BEHAVIOR
+
+    heterogeneous_strategies = HeterogeneousStrategies
+
+    class VersionFormats(enum.Enum):
+        """Version options for Haxe."""
+
+        V4 = enum.auto()
+
+    version_formats = VersionFormats
+
+    modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
+    identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
+        IdentifierCase.CAMEL,
+        IdentifierCase.PASCAL,
+        IdentifierCase.UPPER_SNAKE,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
+    )
+    module_name_case: ClassVar[IdentifierCase] = IdentifierCase.PASCAL
+
+    def wrap_in_file(
+        self,
+        content: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap code in a valid Haxe file.
+
+        Everything (reference declarations, call stubs and the value
+        itself) goes inside ``static function main()`` of a single
+        class.  Haxe permits local functions and anonymous-structure
+        closures inside a function body, so call stubs are emitted as
+        local declarations rather than file-scope types.
+        """
+        del variable_name
+        inner = prepend_body_preamble(
+            content=content,
+            body_preamble=body_preamble,
+        )
+        body_indent = self.indent + self.indent
+        indented = "\n".join(
+            f"{body_indent}{line}" if line.strip() else line
+            for line in inner.split(sep="\n")
+        )
+        return "\n".join(
+            [
+                f"class {self.module_name} {{",
+                f"{self.indent}public static function main() {{",
+                indented,
+                f"{self.indent}}}",
+                "}",
+            ]
+        )
+
+    @staticmethod
+    def wrap_combined_in_file(
+        declaration: str,
+        assignment: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Unsupported: literalize() rejects BothVariableForms
+        upstream.
+        """
+        del declaration, assignment, variable_name, body_preamble
+        raise WrapCombinedInFileNotSupportedError
+
+    date_format: DateFormats = DateFormats.ISO
+    datetime_format: DatetimeFormats = DatetimeFormats.ISO
+    bytes_format: BytesFormats = BytesFormats.HEX
+    sequence_format: SequenceFormats = SequenceFormats.ARRAY
+    set_format: SetFormats = SetFormats.SET
+    default_set_element_type: str = "Dynamic"
+    default_dict_key_type: str = "String"
+    default_dict_value_type: str = "Dynamic"
+    variable_type_hints: VariableTypeHints = VariableTypeHints.NEVER
+    comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
+    declaration_style: DeclarationStyles = DeclarationStyles.FINAL
+    dict_entry_style: DictEntryStyles = DictEntryStyles.DEFAULT
+    dict_format: DictFormats = DictFormats.DEFAULT
+    float_format: FloatFormats = FloatFormats.REPR
+    integer_format: IntegerFormats = IntegerFormats.DECIMAL
+    numeric_literal_suffix: NumericLiteralSuffixes = (
+        NumericLiteralSuffixes.NONE
+    )
+    numeric_separator: NumericSeparators = NumericSeparators.NONE
+    numeric_style: NumericStyles = NumericStyles.OVERLOADED
+    string_format: StringFormats = StringFormats.DOUBLE
+    trailing_comma: TrailingCommas = TrailingCommas.YES
+    statement_terminator_style: StatementTerminatorStyles = (
+        StatementTerminatorStyles.SEMICOLON
+    )
+    call_style: CallStyles = CallStyles.POSITIONAL
+    heterogeneous_strategy: HeterogeneousStrategies = (
+        HeterogeneousStrategies.ERROR
+    )
+    # `4` matches the major version of `Haxe.language_version` (`V4`);
+    # keep in sync with the `haxe` install pinned in
+    # `.github/workflows/lint.yml`.
+    language_version: VersionFormats = VersionFormats.V4
+    module_name: str = "Main"
+    indent: str = "    "
+
+    null_literal: ClassVar[str] = "null"
+    true_literal: ClassVar[str] = "true"
+    false_literal: ClassVar[str] = "false"
+    indent_closing_delimiter: ClassVar[bool] = False
+    element_separator: ClassVar[str] = ", "
+    skip_null_dict_values: ClassVar[bool] = False
+    supports_collection_comments: ClassVar[bool] = True
+    supports_scalar_before_comments: ClassVar[bool] = True
+    supports_scalar_inline_comments: ClassVar[bool] = False
+    statement_terminator: ClassVar[str] = ";"
+    static_preamble: ClassVar[Sequence[str]] = ()
+    static_body_preamble: ClassVar[Sequence[str]] = ()
+    special_float_preamble: ClassVar[tuple[str, ...]] = ()
+
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
+    @cached_property
+    def format_sequence_entry(self) -> Callable[[Value, str], str]:
+        """Format a sequence entry."""
+        return passthrough_sequence_entry
+
+    @cached_property
+    def format_set_entry(self) -> Callable[[Value, str], str]:
+        """Format a set entry."""
+        return passthrough_set_entry
+
+    @cached_property
+    def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
+        """Format an assignment to an existing variable."""
+        return variable_formatter(template="{name} = {value};")
+
+    @cached_property
+    def format_ordered_map_entry(self) -> Callable[[str, Value, str], str]:
+        """Format one ordered-map entry."""
+        return dict_entry_with_separator(
+            separator=" => ", format_value=passthrough_sequence_entry
+        )
+
+    @cached_property
+    def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines."""
+        return no_data_preamble
+
+    @cached_property
+    def heterogeneous_behavior(self) -> HeterogeneousBehavior:
+        """Return the heterogeneous-behavior config."""
+        return self.heterogeneous_strategy.value
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
+
+    @cached_property
+    def type_hint_collection_preamble_lines(
+        self,
+    ) -> Callable[[frozenset[type]], tuple[str, ...]]:
+        """Return preamble lines for empty-collection type hints."""
+        return no_type_hint_preamble
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        config: CallStyle = self.call_style.value
+        return config
+
+    @cached_property
+    def format_call_stub(
+        self,
+    ) -> Callable[
+        [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
+        tuple[str, ...],
+    ]:
+        """Return stub declarations for a call expression."""
+        return _haxe_call_stub
+
+    @cached_property
+    def format_call_preamble_stub(
+        self,
+    ) -> Callable[
+        [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
+        tuple[str, ...],
+    ]:
+        """Return file-scope stubs for a call expression."""
+        return no_call_stub
+
+    @cached_property
+    def format_call_target(self) -> Callable[[Sequence[str]], str]:
+        """Rewrite a dotted call target into the language's call
+        syntax.
+        """
+        return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(
+        self,
+    ) -> Callable[[str, Value | None], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
+
+    @cached_property
+    def format_call_arg_ref_identifier(
+        self,
+    ) -> Callable[[str, Value | None], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
+    def format_call_arg_ref_identifier_consumable(
+        self,
+    ) -> Callable[[str, Value | None], str]:
+        """Format a ``$ref`` the caller authorized as consumable."""
+        return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+        """
+        return never_inhibits_consuming_form
+
+    @cached_property
+    def sequence_format_config(self) -> SequenceFormatConfig:
+        """Configuration for the chosen sequence format."""
+        return self.sequence_format.value
+
+    @cached_property
+    def set_format_config(self) -> SetFormatConfig:
+        """Configuration for the chosen set format."""
+        return self.set_format(
+            default_type=self.default_set_element_type,
+        )
+
+    @cached_property
+    def sequence_open(self) -> Callable[[list[Value]], str]:
+        """Callable that returns the opening delimiter for a sequence."""
+        return self.sequence_format.value.sequence_open
+
+    @cached_property
+    def dict_format_config(self) -> DictFormatConfig:
+        """Configuration for dict formatting."""
+        return DictFormatConfig(
+            dict_open=fixed_open(open_str="(["),
+            close="] : Map<String, Dynamic>)",
+            format_entry=dict_entry_with_separator(
+                separator=" => ",
+                format_value=passthrough_sequence_entry,
+            ),
+            empty_dict=None,
+            preamble_lines=(),
+            narrowed_open=None,
+            supports_trailing_comma=True,
+        )
+
+    @cached_property
+    def trailing_comma_config(self) -> TrailingCommaConfig:
+        """Configuration for trailing-comma behavior."""
+        return self.trailing_comma.value
+
+    @cached_property
+    def format_bytes(self) -> Callable[[bytes], str]:
+        """Callable that formats a bytes value as a string literal."""
+        return self.bytes_format
+
+    @cached_property
+    def format_date(self) -> Callable[[datetime.date], str]:
+        """Callable that formats a date as a string literal."""
+        return self.date_format
+
+    @cached_property
+    def format_datetime(self) -> Callable[[datetime.datetime], str]:
+        """Callable that formats a datetime as a string literal."""
+        return self.datetime_format
+
+    @cached_property
+    def format_time(self) -> Callable[[datetime.time], str]:
+        """Callable that formats a time as a string literal."""
+        return format_time_iso
+
+    @cached_property
+    def format_string(self) -> Callable[[str], str]:
+        """Callable that formats a string value as a quoted literal."""
+        return self.string_format
+
+    @cached_property
+    def format_float(self) -> Callable[[float], str]:
+        """Callable that formats a float value as a literal."""
+        return self.float_format
+
+    @cached_property
+    def format_integer(self) -> Callable[[int], str]:
+        """Callable that formats an int value as a literal."""
+        return self.integer_format
+
+    @cached_property
+    def comment_config(self) -> CommentConfig:
+        """Configuration for the language's comment syntax."""
+        return self.comment_format.value
+
+    @cached_property
+    def ordered_map_format_config(self) -> OrderedMapFormatConfig:
+        """Configuration for ordered-map formatting."""
+        return OrderedMapFormatConfig(
+            ordered_map_open=fixed_open(open_str="(["),
+            close="] : Map<String, Dynamic>)",
+            preamble_lines=(),
+        )
+
+    @cached_property
+    def format_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a new variable declaration."""
+        return self.variable_type_hints.formatter(
+            auto_formatter=self.declaration_style.value.formatter,
+            keyword=f"{self.declaration_style.name.lower()} ",
+            date_hint=(
+                "String"
+                if self.date_format.value.type_produced is str
+                else "Date"
+            ),
+            datetime_hint=(
+                "Int"
+                if self.datetime_format.value.type_produced is int
+                else (
+                    "String"
+                    if self.datetime_format.value.type_produced is str
+                    else "Date"
+                )
+            ),
+        )
+
+    @cached_property
+    def scalar_preamble(self) -> dict[type, tuple[str, ...]]:
+        """Per-instance scalar preamble (Haxe needs none)."""
+        return {}
+
+    @cached_property
+    def scalar_body_preamble(self) -> dict[type, tuple[str, ...]]:
+        """Per-instance scalar body preamble (Haxe needs none)."""
+        return {}
+
+    @cached_property
+    def compute_body_preamble(
+        self,
+    ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
+        """Compute body-preamble lines from the scalar map."""
+        return body_preamble_from_scalars(
+            scalar_body_preamble=self.scalar_body_preamble,
+            format_lines=tuple,
+        )

--- a/src/literalizer/languages/haxe.py
+++ b/src/literalizer/languages/haxe.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 from collections.abc import Callable, Sequence
 from functools import cached_property
-from typing import ClassVar, assert_never
+from typing import ClassVar
 
 from beartype import beartype
 
@@ -75,60 +75,18 @@ from literalizer._language import (
     no_validate_spec_for_data,
     prepend_body_preamble,
 )
-from literalizer._types import Scalar, Value
+from literalizer._types import Value
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 
-# The Haxe ``Int`` is a 32-bit signed integer on static targets; only
-# values inside this range are guaranteed to round-trip as an ``Int``.
-# Wider values are annotated as ``Float`` (an ``Int`` literal converts
-# implicitly to ``Float``, so the annotation is always safe).
-_I32_MIN = -(2**31)
-_I32_MAX = 2**31 - 1
-
 
 @beartype
-def _haxe_scalar_hint(
-    *,
-    data: Scalar,
-    date_hint: str,
-    datetime_hint: str,
-) -> str:
-    """Derive the Haxe annotation for a scalar value."""
-    match data:
-        case bool():
-            hint = "Bool"
-        case int():
-            hint = "Int" if _I32_MIN <= data <= _I32_MAX else "Float"
-        case float():
-            hint = "Float"
-        case str() | bytes():
-            hint = "String"
-        case datetime.datetime():
-            hint = datetime_hint
-        case datetime.date():
-            hint = date_hint
-        case datetime.time():
-            hint = "String"
-        case None:
-            hint = "Dynamic"
-        case _ as unreachable:
-            assert_never(unreachable)
-    return hint
-
-
-@beartype
-def _haxe_type_hint(
-    *,
-    data: Value,
-    date_hint: str,
-    datetime_hint: str,
-) -> str:
-    """Derive a Haxe type annotation from *data*.
+def _haxe_type_hint(data: Value, /) -> str:
+    """Derive the coarse Haxe annotation for *data*.
 
     Every collection literal is rendered with an explicit
-    ``(... : Array<Dynamic>)`` / ``(... : Map<String, Dynamic>)`` cast,
-    so the matching variable annotation is the same coarse type
-    regardless of element types.
+    ``(... : Array<Dynamic>)`` / ``(... : Map<String, Dynamic>)`` cast
+    and every scalar is assignable to ``Dynamic``, so the variable
+    annotation is the same coarse type regardless of element types.
     """
     match data:
         case dict():
@@ -136,11 +94,7 @@ def _haxe_type_hint(
         case list() | set():
             return "Array<Dynamic>"
         case _:
-            return _haxe_scalar_hint(
-                data=data,
-                date_hint=date_hint,
-                datetime_hint=datetime_hint,
-            )
+            return "Dynamic"
 
 
 @beartype
@@ -151,16 +105,9 @@ def _format_haxe_typed_declaration(
     data: Value,
     _modifiers: frozenset[enum.Enum],
     keyword: str,
-    date_hint: str,
-    datetime_hint: str,
 ) -> str:
     """Format a Haxe variable declaration with an explicit type."""
-    hint = _haxe_type_hint(
-        data=data,
-        date_hint=date_hint,
-        datetime_hint=datetime_hint,
-    )
-    return f"{keyword}{name}:{hint} = {value};"
+    return f"{keyword}{name}:{_haxe_type_hint(data)} = {value};"
 
 
 @beartype
@@ -512,8 +459,6 @@ class Haxe(metaclass=LanguageCls):
                 [str, str, Value, frozenset[enum.Enum]], str
             ],
             keyword: str,
-            date_hint: str,
-            datetime_hint: str,
         ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
             """Return the variable declaration formatter.
 
@@ -539,8 +484,6 @@ class Haxe(metaclass=LanguageCls):
                     data=data,
                     _modifiers=modifiers,
                     keyword=keyword,
-                    date_hint=date_hint,
-                    datetime_hint=datetime_hint,
                 )
 
             return _typed_formatter
@@ -921,20 +864,6 @@ class Haxe(metaclass=LanguageCls):
         return self.variable_type_hints.formatter(
             auto_formatter=self.declaration_style.value.formatter,
             keyword=f"{self.declaration_style.name.lower()} ",
-            date_hint=(
-                "String"
-                if self.date_format.value.type_produced is str
-                else "Date"
-            ),
-            datetime_hint=(
-                "Int"
-                if self.datetime_format.value.type_produced is int
-                else (
-                    "String"
-                    if self.datetime_format.value.type_produced is str
-                    else "Date"
-                )
-            ),
         )
 
     @cached_property

--- a/tests/integration/cases/binary/Haxe@v4.hx
+++ b/tests/integration/cases/binary/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_binary_Haxe {
+    public static function main() {
+        final my_data = ([
+            "48656c6c6f",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/binary/Haxe_bytes_format_base64@v4.hx
+++ b/tests/integration/cases/binary/Haxe_bytes_format_base64@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_binary_Haxe_bytes_format_base64 {
+    public static function main() {
+        final my_data = ([
+            "SGVsbG8=",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/binary/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/binary/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_binary_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([
+            "48656c6c6f",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/binary/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/binary/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_binary_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            "48656c6c6f",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/binary/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/binary/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_binary_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            "48656c6c6f",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/binary_list/Haxe@v4.hx
+++ b/tests/integration/cases/binary_list/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_binary_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            "48656c6c6f",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/binary_with_empty_sibling/Haxe@v4.hx
+++ b/tests/integration/cases/binary_with_empty_sibling/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_binary_with_empty_sibling_Haxe {
+    public static function main() {
+        final my_data = ([
+            "48656c6c6f",
+            ([] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/bool_list/Haxe@v4.hx
+++ b/tests/integration/cases/bool_list/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_bool_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            true,
+            false,
+            true,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/bool_list/Haxe_indent_three_space@v4.hx
+++ b/tests/integration/cases/bool_list/Haxe_indent_three_space@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_bool_list_Haxe_indent_three_space {
+   public static function main() {
+      final my_data = ([
+         true,
+         false,
+         true,
+      ] : Array<Dynamic>);
+   }
+}

--- a/tests/integration/cases/bool_list/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/bool_list/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_bool_list_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            true,
+            false,
+            true,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/bool_list/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/bool_list/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_bool_list_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([
+            true,
+            false,
+            true,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/call_27_parameters/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_27_parameters/Haxe_call@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_call_27_parameters_Haxe_call {
+    public static function main() {
+        function process(p0:Dynamic, p1:Dynamic, p2:Dynamic, p3:Dynamic, p4:Dynamic, p5:Dynamic, p6:Dynamic, p7:Dynamic, p8:Dynamic, p9:Dynamic, p10:Dynamic, p11:Dynamic, p12:Dynamic, p13:Dynamic, p14:Dynamic, p15:Dynamic, p16:Dynamic, p17:Dynamic, p18:Dynamic, p19:Dynamic, p20:Dynamic, p21:Dynamic, p22:Dynamic, p23:Dynamic, p24:Dynamic, p25:Dynamic, p26:Dynamic):Dynamic return null;
+        process(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
+    }
+}

--- a/tests/integration/cases/call_comments/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_comments/Haxe_call@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_call_comments_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        // Test cases
+        process("hello");  // single word
+        process("hello world");  // two words
+        // trailing comment
+    }
+}

--- a/tests/integration/cases/call_comments_dict_args/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_comments_dict_args/Haxe_call@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_call_comments_dict_args_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        // Test cases
+        process((["type" => "create", "pr_id" => "pr_1"] : Map<String, Dynamic>));  // first case
+        process((["type" => "update", "pr_id" => "pr_2"] : Map<String, Dynamic>));  // second case
+        // third case
+        process((["type" => "delete", "pr_id" => "pr_3"] : Map<String, Dynamic>));
+    }
+}

--- a/tests/integration/cases/call_deep_dotted_method/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_deep_dotted_method/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_deep_dotted_method_Haxe_call {
+    public static function main() {
+        var obj = { api: { client: { post: function(data:Dynamic):Dynamic return null } } };
+        obj.api.client.post("hello");
+        obj.api.client.post(42);
+        obj.api.client.post(true);
+    }
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_deep_dotted_transformed/Haxe_call@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_call_deep_dotted_transformed_Haxe_call {
+    public static function main() {
+        var app = { client: { fetch: function(payload:Dynamic):Dynamic return null } };
+        function emit(_arg:Dynamic):Dynamic return null;
+        emit(app.client.fetch("hello"));
+        emit(app.client.fetch(42));
+        emit(app.client.fetch(true));
+    }
+}

--- a/tests/integration/cases/call_dotted_method/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_dotted_method/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_dotted_method_Haxe_call {
+    public static function main() {
+        var app = { client: { fetch: function(payload:Dynamic):Dynamic return null } };
+        app.client.fetch("hello");
+        app.client.fetch(42);
+        app.client.fetch(true);
+    }
+}

--- a/tests/integration/cases/call_dotted_transform_stub/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_dotted_transform_stub/Haxe_call@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_call_dotted_transform_stub_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        var tracer = { emit: function(_arg:Dynamic):Dynamic return null };
+        tracer.emit(process("hello"));
+        tracer.emit(process(42));
+        tracer.emit(process(true));
+    }
+}

--- a/tests/integration/cases/call_existing_ref_arg/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_existing_ref_arg/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_existing_ref_arg_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        final existing = 42;
+        process(existing);
+    }
+}

--- a/tests/integration/cases/call_homogeneous_dotted_method/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_homogeneous_dotted_method/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_homogeneous_dotted_method_Haxe_call {
+    public static function main() {
+        var app = { client: { fetch: function(value:Dynamic):Dynamic return null } };
+        app.client.fetch("hello");
+        app.client.fetch("world");
+    }
+}

--- a/tests/integration/cases/call_homogeneous_value_dict_arg/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_homogeneous_value_dict_arg/Haxe_call@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_call_homogeneous_value_dict_arg_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        process((["a" => 1, "b" => 2] : Map<String, Dynamic>));
+    }
+}

--- a/tests/integration/cases/call_keyword_args/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_keyword_args/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_keyword_args_Haxe_call {
+    public static function main() {
+        var throttler = { check: function(user_id:Dynamic, ts:Dynamic):Dynamic return null };
+        function emit(_arg:Dynamic):Dynamic return null;
+        emit(throttler.check("user_1", 1000.0));
+        emit(throttler.check("user_2", 2000.5));
+    }
+}

--- a/tests/integration/cases/call_line_comments/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_line_comments/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_line_comments_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        process("Dune");  // first edition
+        process("Solaris");
+        process("Neuromancer");  // cyberpunk
+    }
+}

--- a/tests/integration/cases/call_mixed_type_dicts/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_mixed_type_dicts/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_mixed_type_dicts_Haxe_call {
+    public static function main() {
+        var app = { mgr: { run: function(operation:Dynamic):Dynamic return null } };
+        app.mgr.run((["type" => "create", "pr_id" => "pr_1", "draft" => true] : Map<String, Dynamic>));
+        app.mgr.run((["type" => "create", "pr_id" => "pr_2"] : Map<String, Dynamic>));
+    }
+}

--- a/tests/integration/cases/call_multi_args/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_multi_args/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_multi_args_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic, count:Dynamic):Dynamic return null;
+        process(1, 42);
+        process(2, 100);
+    }
+}

--- a/tests/integration/cases/call_negative_int/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_negative_int/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_negative_int_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        process(-1);
+        process(-2);
+        process(-3);
+    }
+}

--- a/tests/integration/cases/call_no_params/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_no_params/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_no_params_Haxe_call {
+    public static function main() {
+        function process():Dynamic return null;
+        process();
+        process();
+    }
+}

--- a/tests/integration/cases/call_no_params_dotted/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_no_params_dotted/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_no_params_dotted_Haxe_call {
+    public static function main() {
+        var throttler = { check: function():Dynamic return null };
+        throttler.check();
+        throttler.check();
+    }
+}

--- a/tests/integration/cases/call_no_params_transform/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_no_params_transform/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_no_params_transform_Haxe_call {
+    public static function main() {
+        function process():Dynamic return null;
+        function emit(_arg:Dynamic):Dynamic return null;
+        emit(process());
+        emit(process());
+    }
+}

--- a/tests/integration/cases/call_per_element_false/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_per_element_false/Haxe_call@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_call_per_element_false_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic):Dynamic return null;
+        process(1);
+    }
+}

--- a/tests/integration/cases/call_per_element_false_dict_arg/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_per_element_false_dict_arg/Haxe_call@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_call_per_element_false_dict_arg_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        process((["a" => 1, "b" => "x"] : Map<String, Dynamic>));
+    }
+}

--- a/tests/integration/cases/call_quad_args/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_quad_args/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_quad_args_Haxe_call {
+    public static function main() {
+        function process(a:Dynamic, b:Dynamic, c:Dynamic, d:Dynamic):Dynamic return null;
+        process(1, 2, 3, 4);
+        process(5, 6, 7, 8);
+    }
+}

--- a/tests/integration/cases/call_ref_args/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args/Haxe_call@v4.hx
@@ -1,0 +1,17 @@
+class Fixture_call_ref_args_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic, count:Dynamic):Dynamic return null;
+        final my_var = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+        final my_other = ([
+            4,
+            5,
+            6,
+        ] : Array<Dynamic>);
+        process(my_var, 42);
+        process(my_other, 7);
+    }
+}

--- a/tests/integration/cases/call_ref_args_converted/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args_converted/Haxe_call@v4.hx
@@ -1,0 +1,17 @@
+class Fixture_call_ref_args_converted_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic, count:Dynamic):Dynamic return null;
+        final myVar = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+        final myOther = ([
+            4,
+            5,
+            6,
+        ] : Array<Dynamic>);
+        process(myVar, 42);
+        process(myOther, 7);
+    }
+}

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Haxe_call@v4.hx
@@ -1,0 +1,17 @@
+class Fixture_call_ref_args_converted_nonsnake_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic, count:Dynamic):Dynamic return null;
+        final myVar = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+        final myOther = ([
+            4,
+            5,
+            6,
+        ] : Array<Dynamic>);
+        process(myVar, 42);
+        process(myOther, 7);
+    }
+}

--- a/tests/integration/cases/call_ref_args_converted_whole/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args_converted_whole/Haxe_call@v4.hx
@@ -1,0 +1,11 @@
+class Fixture_call_ref_args_converted_whole_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic):Dynamic return null;
+        final myVar = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+        process(myVar);
+    }
+}

--- a/tests/integration/cases/call_ref_args_escaped_quote/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_ref_args_escaped_quote_Haxe_call {
+    public static function main() {
+        function process(v:Dynamic):Dynamic return null;
+        final my_str = "a\"b";
+        process(my_str);
+    }
+}

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Haxe_call@v4.hx
@@ -1,0 +1,18 @@
+class Fixture_call_ref_args_heterogeneous_list_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic, count:Dynamic):Dynamic return null;
+        final my_ints = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+        final my_strings = ([
+            "a",
+            "b",
+        ] : Array<Dynamic>);
+        final my_empty = ([] : Array<Dynamic>);
+        process(my_ints, 42);
+        process(my_strings, 7);
+        process(my_empty, 99);
+    }
+}

--- a/tests/integration/cases/call_ref_args_reused/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args_reused/Haxe_call@v4.hx
@@ -1,0 +1,14 @@
+class Fixture_call_ref_args_reused_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic, count:Dynamic):Dynamic return null;
+        final single_var = ([
+            4,
+            5,
+            6,
+        ] : Array<Dynamic>);
+        final repeated_var = 1;
+        process(repeated_var, 1);
+        process(single_var, 0);
+        process(repeated_var, 8);
+    }
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_args_trivial_register/Haxe_call@v4.hx
@@ -1,0 +1,17 @@
+class Fixture_call_ref_args_trivial_register_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic, count:Dynamic):Dynamic return null;
+        final my_int = 1;
+        final my_bool = true;
+        final my_float = 3.14;
+        final my_list = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+        process(my_int, 42);
+        process(my_bool, 7);
+        process(my_float, 9);
+        process(my_list, 1);
+    }
+}

--- a/tests/integration/cases/call_ref_nested_converted/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_nested_converted/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_ref_nested_converted_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic):Dynamic return null;
+        final myVar = 42;
+        process(([myVar, 42, "static"] : Array<Dynamic>));
+    }
+}

--- a/tests/integration/cases/call_ref_nested_in_dict/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_nested_in_dict/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_ref_nested_in_dict_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic):Dynamic return null;
+        final my_var = 42;
+        process((["key" => my_var, "count" => 42] : Map<String, Dynamic>));
+    }
+}

--- a/tests/integration/cases/call_ref_nested_in_list/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_ref_nested_in_list/Haxe_call@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_call_ref_nested_in_list_Haxe_call {
+    public static function main() {
+        function process(data:Dynamic):Dynamic return null;
+        final my_var = 42;
+        final my_other = 7;
+        process(([my_var, 42, "static"] : Array<Dynamic>));
+        process(([my_other, 7, "label"] : Array<Dynamic>));
+    }
+}

--- a/tests/integration/cases/call_reserved_target/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_reserved_target/Haxe_call@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_call_reserved_target_Haxe_call {
+    public static function main() {
+        function op(value:Dynamic):Dynamic return null;
+        op("hello");
+    }
+}

--- a/tests/integration/cases/call_scalar_args/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_scalar_args/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_scalar_args_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        process("hello");
+        process(42);
+        process(true);
+    }
+}

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_scalar_args_uniform_second_slot_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic, label:Dynamic):Dynamic return null;
+        process("hello", "a");
+        process(42, "b");
+        process(true, "c");
+    }
+}

--- a/tests/integration/cases/call_scalar_args_with_null/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_scalar_args_with_null/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_scalar_args_with_null_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        process(null);
+        process("hello");
+    }
+}

--- a/tests/integration/cases/call_snake_dotted_method/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_snake_dotted_method/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_snake_dotted_method_Haxe_call {
+    public static function main() {
+        var my_app = { http_client: { fetch: function(payload:Dynamic):Dynamic return null } };
+        my_app.http_client.fetch("hello");
+        my_app.http_client.fetch(42);
+        my_app.http_client.fetch(true);
+    }
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_transform_no_wrapper/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_transform_no_wrapper_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        process("hello");
+        process(42);
+        process(true);
+    }
+}

--- a/tests/integration/cases/call_variable_form_new/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_variable_form_new/Haxe_call@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_call_variable_form_new_Haxe_call {
+    public static function main() {
+        function make_widget(count:Dynamic):Dynamic return null;
+        final my_data = make_widget(42);
+    }
+}

--- a/tests/integration/cases/call_wrap_in_file/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_wrap_in_file/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_wrap_in_file_Haxe_call {
+    public static function main() {
+        function process(a:Dynamic, b:Dynamic):Dynamic return null;
+        process(1, 2);
+        process(3, 4);
+    }
+}

--- a/tests/integration/cases/call_wrap_in_file_escaped_quote/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_wrap_in_file_escaped_quote/Haxe_call@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_call_wrap_in_file_escaped_quote_Haxe_call {
+    public static function main() {
+        function process(v:Dynamic):Dynamic return null;
+        process("a\"b");
+    }
+}

--- a/tests/integration/cases/call_zip_source_whole/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_zip_source_whole/Haxe_call@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_call_zip_source_whole_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        function emit(_call:Dynamic, _zip:Dynamic):Dynamic return null;
+        emit(process(42), true);
+    }
+}

--- a/tests/integration/cases/call_zip_values/Haxe_call@v4.hx
+++ b/tests/integration/cases/call_zip_values/Haxe_call@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_call_zip_values_Haxe_call {
+    public static function main() {
+        function process(value:Dynamic):Dynamic return null;
+        function emit(_call:Dynamic, _zip:Dynamic):Dynamic return null;
+        emit(process("hello"), true);
+        emit(process(42), false);
+    }
+}

--- a/tests/integration/cases/comment_block_scalar_not_comment/Haxe@v4.hx
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_comment_block_scalar_not_comment_Haxe {
+    public static function main() {
+        final my_data = ([
+            "description" => "# not a comment\n",
+            "name" => "foo",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comment_scalar/Haxe@v4.hx
+++ b/tests/integration/cases/comment_scalar/Haxe@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_comment_scalar_Haxe {
+    public static function main() {
+        final my_data = // note
+        42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_before_and_inline/Haxe@v4.hx
+++ b/tests/integration/cases/comment_scalar_before_and_inline/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_comment_scalar_before_and_inline_Haxe {
+    public static function main() {
+        // inline
+        final my_data = // before
+        "plain";
+    }
+}

--- a/tests/integration/cases/comment_scalar_document_markers/Haxe@v4.hx
+++ b/tests/integration/cases/comment_scalar_document_markers/Haxe@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_comment_scalar_document_markers_Haxe {
+    public static function main() {
+        final my_data = // note
+        42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_inline/Haxe@v4.hx
+++ b/tests/integration/cases/comment_scalar_inline/Haxe@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_comment_scalar_inline_Haxe {
+    public static function main() {
+        // note
+        final my_data = 42;
+    }
+}

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Haxe@v4.hx
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Haxe@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_comment_scalar_quoted_with_hash_Haxe {
+    public static function main() {
+        // note
+        final my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/comments/Haxe@v4.hx
+++ b/tests/integration/cases/comments/Haxe@v4.hx
@@ -1,0 +1,11 @@
+class Fixture_comments_Haxe {
+    public static function main() {
+        final my_data = ([
+            // Server configuration
+            "host" => "localhost",  // default host
+            "port" => 8080,
+            // Enable debug mode
+            "debug" => true,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments/Haxe_comment_block@v4.hx
+++ b/tests/integration/cases/comments/Haxe_comment_block@v4.hx
@@ -1,0 +1,11 @@
+class Fixture_comments_Haxe_comment_block {
+    public static function main() {
+        final my_data = ([
+            /* Server configuration */
+            "host" => "localhost",  /* default host */
+            "port" => 8080,
+            /* Enable debug mode */
+            "debug" => true,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_bang_in_double_quote/Haxe@v4.hx
+++ b/tests/integration/cases/comments_bang_in_double_quote/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_comments_bang_in_double_quote_Haxe {
+    public static function main() {
+        final my_data = ([
+            "key" => "\"bang!\"",  // real
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_double_hash/Haxe@v4.hx
+++ b/tests/integration/cases/comments_double_hash/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_comments_double_hash_Haxe {
+    public static function main() {
+        final my_data = ([
+            // # section
+            "a",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_empty_line/Haxe@v4.hx
+++ b/tests/integration/cases/comments_empty_line/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_comments_empty_line_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a",
+            //
+            "b",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_escaped_quote/Haxe@v4.hx
+++ b/tests/integration/cases/comments_escaped_quote/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_comments_escaped_quote_Haxe {
+    public static function main() {
+        final my_data = ([
+            "key" => "value \" # not a comment",  // real
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote/Haxe@v4.hx
+++ b/tests/integration/cases/comments_escaped_single_quote/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_comments_escaped_single_quote_Haxe {
+    public static function main() {
+        final my_data = ([
+            "key" => "it's here",  // a comment
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Haxe@v4.hx
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_comments_escaped_single_quote_multiple_Haxe {
+    public static function main() {
+        final my_data = ([
+            "host" => "it's here",  // a comment
+            "port" => 80,  // another
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_multi_line/Haxe@v4.hx
+++ b/tests/integration/cases/comments_multi_line/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_comments_multi_line_Haxe {
+    public static function main() {
+        final my_data = ([
+            // line 1
+            // line 2
+            "a",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_nested_mapping/Haxe@v4.hx
+++ b/tests/integration/cases/comments_nested_mapping/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_comments_nested_mapping_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => (["x" => 1] : Map<String, Dynamic>),
+            "b" => 2,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_nested_sequence_scalar/Haxe@v4.hx
+++ b/tests/integration/cases/comments_nested_sequence_scalar/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_comments_nested_sequence_scalar_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["ADD", "alice", "hello"] : Array<Dynamic>),
+            (["DEL", "bob", "5"] : Array<Dynamic>),  // removes "world"
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_sequence_before/Haxe@v4.hx
+++ b/tests/integration/cases/comments_sequence_before/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_comments_sequence_before_Haxe {
+    public static function main() {
+        final my_data = ([
+            // first
+            "a",
+            // second
+            "b",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_sequence_inline/Haxe@v4.hx
+++ b/tests/integration/cases/comments_sequence_inline/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_comments_sequence_inline_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a",  // note a
+            "b",  // note b
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_trailing/Haxe@v4.hx
+++ b/tests/integration/cases/comments_trailing/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_comments_trailing_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a",
+            // trailing
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/comments_vb_before_dim/Haxe@v4.hx
+++ b/tests/integration/cases/comments_vb_before_dim/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_comments_vb_before_dim_Haxe {
+    public static function main() {
+        final my_data = ([
+            // Configuration
+            "name" => "app",
+            // Port setting
+            "port" => 3000,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/date_list/Haxe@v4.hx
+++ b/tests/integration/cases/date_list/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_date_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            "2024-01-15",
+            "2024-02-20",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/date_set/Haxe@v4.hx
+++ b/tests/integration/cases/date_set/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_date_set_Haxe {
+    public static function main() {
+        final my_data = ([
+            "2024-01-15",
+            "2024-06-01",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/dates/Haxe@v4.hx
+++ b/tests/integration/cases/dates/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dates_Haxe {
+    public static function main() {
+        final my_data = ([
+            "date" => "2024-01-15",
+            "datetime" => "2024-01-15T12:30:00+00:00",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/datetime_list/Haxe@v4.hx
+++ b/tests/integration/cases/datetime_list/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_datetime_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            "2024-01-15T12:30:00.123456+00:00",
+            "2024-06-01T08:00:00+00:00",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/datetime_list/Haxe_datetime_epoch@v4.hx
+++ b/tests/integration/cases/datetime_list/Haxe_datetime_epoch@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_datetime_list_Haxe_datetime_epoch {
+    public static function main() {
+        final my_data = ([
+            1705321800,
+            1717228800,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/deep_nesting/Haxe@v4.hx
+++ b/tests/integration/cases/deep_nesting/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_deep_nesting_Haxe {
+    public static function main() {
+        final my_data = ([
+            "level1" => (["level2" => (["level3" => (["level4" => (["value" => "deep", "items" => (["a", "b"] : Array<Dynamic>)] : Map<String, Dynamic>)] : Map<String, Dynamic>), "sibling" => 42] : Map<String, Dynamic>), "tags" => ([(["name" => "tag1", "meta" => (["priority" => 1, "labels" => (["x", "y"] : Array<Dynamic>)] : Map<String, Dynamic>)] : Map<String, Dynamic>)] : Array<Dynamic>)] : Map<String, Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_all_null_trailing_comment/Haxe@v4.hx
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_dict_all_null_trailing_comment_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => null,
+            "b" => null,
+            // trailing
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_all_scalar_types/Haxe@v4.hx
+++ b/tests/integration/cases/dict_all_scalar_types/Haxe@v4.hx
@@ -1,0 +1,14 @@
+class Fixture_dict_all_scalar_types_Haxe {
+    public static function main() {
+        final my_data = ([
+            "s" => "string",
+            "i" => 1,
+            "f" => 1.5,
+            "b" => true,
+            "n" => null,
+            "d" => "2024-01-15",
+            "dt" => "2024-01-15T12:00:00",
+            "by" => "48656c6c6f",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_escaped_quote_key/Haxe@v4.hx
+++ b/tests/integration/cases/dict_escaped_quote_key/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_dict_escaped_quote_key_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a\"b" => 1,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_in_sequence_with_empty_sibling/Haxe@v4.hx
+++ b/tests/integration/cases/dict_in_sequence_with_empty_sibling/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_in_sequence_with_empty_sibling_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["a" => 1] : Map<String, Dynamic>),
+            ([] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Haxe@v4.hx
+++ b/tests/integration/cases/dict_mixed_int_widths/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_dict_mixed_int_widths_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => 1,
+            "b" => 3000000000,
+            "c" => "x",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_mixed_scalars/Haxe@v4.hx
+++ b/tests/integration/cases/dict_mixed_scalars/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_mixed_scalars_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => 1,
+            "b" => "x",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_null_leading_comment/Haxe@v4.hx
+++ b/tests/integration/cases/dict_null_leading_comment/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_dict_null_leading_comment_Haxe {
+    public static function main() {
+        final my_data = ([
+            // comment
+            "name" => "Alice",
+            "score" => null,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_null_middle_inline_comment/Haxe@v4.hx
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_dict_null_middle_inline_comment_Haxe {
+    public static function main() {
+        final my_data = ([
+            "host" => "localhost",
+            "port" => null,  // not configured yet
+            "debug" => true,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Haxe@v4.hx
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_null_trailing_inline_comment_Haxe {
+    public static function main() {
+        final my_data = ([
+            "host" => "localhost",
+            "port" => null,  // not configured yet
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_control_char_keys/Haxe@v4.hx
+++ b/tests/integration/cases/dict_with_control_char_keys/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_dict_with_control_char_keys_Haxe {
+    public static function main() {
+        final my_data = ([
+            "key\nwith\nnewlines" => "value1",
+            "key\twith\ttabs" => "value2",
+            "" => "value3",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_homogeneous_annotated_values/Haxe@v4.hx
+++ b/tests/integration/cases/dict_with_homogeneous_annotated_values/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_with_homogeneous_annotated_values_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => ([] : Array<Dynamic>),
+            "b" => ([] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_hyphen_keys/Haxe@v4.hx
+++ b/tests/integration/cases/dict_with_hyphen_keys/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_dict_with_hyphen_keys_Haxe {
+    public static function main() {
+        final my_data = ([
+            "my-key" => "value1",
+            "another-key" => "value2",
+            "normal_key" => "value3",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Haxe@v4.hx
+++ b/tests/integration/cases/dict_with_list_value/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_with_list_value_Haxe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "scores" => ([10, 20, 30] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Haxe_collection_layout_compact@v4.hx
+++ b/tests/integration/cases/dict_with_list_value/Haxe_collection_layout_compact@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_with_list_value_Haxe_collection_layout_compact {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "scores" => ([10, 20, 30] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Haxe_collection_layout_multiline@v4.hx
+++ b/tests/integration/cases/dict_with_list_value/Haxe_collection_layout_multiline@v4.hx
@@ -1,0 +1,12 @@
+class Fixture_dict_with_list_value_Haxe_collection_layout_multiline {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "scores" => ([
+                10,
+                20,
+                30,
+            ] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/dict_with_list_value/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_with_list_value_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Map<String, Dynamic> = ([
+            "name" => "Alice",
+            "scores" => ([10, 20, 30] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/dict_with_list_value/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_with_list_value_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "scores" => ([10, 20, 30] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_nulls/Haxe@v4.hx
+++ b/tests/integration/cases/dict_with_nulls/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_dict_with_nulls_Haxe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "score" => null,
+            "age" => 30,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/dict_with_quoted_digit_keys/Haxe@v4.hx
+++ b/tests/integration/cases/dict_with_quoted_digit_keys/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_dict_with_quoted_digit_keys_Haxe {
+    public static function main() {
+        final my_data = ([
+            "0a" => "first",
+            "1b" => "second",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Haxe@v4.hx
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_doubly_nested_list_with_empty_sibling_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([([1, 2] : Array<Dynamic>)] : Array<Dynamic>),
+            ([] : Array<Dynamic>),
+            ([([3, 4] : Array<Dynamic>)] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_dict/Haxe@v4.hx
+++ b/tests/integration/cases/empty_dict/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_dict_Haxe {
+    public static function main() {
+        final my_data = ([] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_dict/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/empty_dict/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_dict_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/empty_dicts_in_sequence/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_empty_dicts_in_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([] : Map<String, Dynamic>),
+            ([] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/empty_dicts_in_sequence/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_empty_dicts_in_sequence_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            ([] : Map<String, Dynamic>),
+            ([] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/empty_dicts_in_sequence/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_empty_dicts_in_sequence_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            ([] : Map<String, Dynamic>),
+            ([] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_list/Haxe@v4.hx
+++ b/tests/integration/cases/empty_list/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_list_Haxe {
+    public static function main() {
+        final my_data = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_list/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/empty_list/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_list_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_list/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/empty_list/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_list_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_list/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/empty_list/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_list_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_list/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/empty_list/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_list_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_list/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/empty_list/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_list_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_ordered_map/Haxe@v4.hx
+++ b/tests/integration/cases/empty_ordered_map/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_ordered_map_Haxe {
+    public static function main() {
+        final my_data = ([] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_value_in_dict/Haxe@v4.hx
+++ b/tests/integration/cases/empty_orderedmap_value_in_dict/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_empty_orderedmap_value_in_dict_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => ([] : Map<String, Dynamic>),
+            "b" => 1,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_orderedmap_with_sibling/Haxe@v4.hx
+++ b/tests/integration/cases/empty_orderedmap_with_sibling/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_empty_orderedmap_with_sibling_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([] : Map<String, Dynamic>),
+            ([] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/empty_sequence/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_empty_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([] : Array<Dynamic>),
+            ([] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_set/Haxe@v4.hx
+++ b/tests/integration/cases/empty_set/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_set_Haxe {
+    public static function main() {
+        final my_data = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_set/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/empty_set/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_set_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/empty_set/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/empty_set/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_empty_set_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_list/Haxe@v4.hx
+++ b/tests/integration/cases/float_list/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            1.1,
+            -2.2,
+            3.3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_list/Haxe_float_format_fixed@v4.hx
+++ b/tests/integration/cases/float_list/Haxe_float_format_fixed@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_list_Haxe_float_format_fixed {
+    public static function main() {
+        final my_data = ([
+            1.100000,
+            -2.200000,
+            3.300000,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_list/Haxe_float_format_scientific@v4.hx
+++ b/tests/integration/cases/float_list/Haxe_float_format_scientific@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_list_Haxe_float_format_scientific {
+    public static function main() {
+        final my_data = ([
+            1.1,
+            -2.2,
+            3.3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_list/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/float_list/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_list_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1.1,
+            -2.2,
+            3.3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_list/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/float_list/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_list_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1.1,
+            -2.2,
+            3.3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_list/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/float_list/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_list_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            1.1,
+            -2.2,
+            3.3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_list/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/float_list/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_list_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([
+            1.1,
+            -2.2,
+            3.3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_negative_zero/Haxe@v4.hx
+++ b/tests/integration/cases/float_negative_zero/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_float_negative_zero_Haxe {
+    public static function main() {
+        final my_data = ([
+            -0.0,
+            1.5,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_scientific_notation/Haxe@v4.hx
+++ b/tests/integration/cases/float_scientific_notation/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_float_scientific_notation_Haxe {
+    public static function main() {
+        final my_data = ([
+            0.0,
+            1.0,
+            1500.0,
+            0.001,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_scientific_notation/Haxe_float_format_fixed_s@v4.hx
+++ b/tests/integration/cases/float_scientific_notation/Haxe_float_format_fixed_s@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_float_scientific_notation_Haxe_float_format_fixed_s {
+    public static function main() {
+        final my_data = ([
+            0.000000,
+            1.000000,
+            1500.000000,
+            0.001000,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_scientific_notation/Haxe_float_format_scientific_s@v4.hx
+++ b/tests/integration/cases/float_scientific_notation/Haxe_float_format_scientific_s@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_float_scientific_notation_Haxe_float_format_scientific_s {
+    public static function main() {
+        final my_data = ([
+            0.0,
+            1.0,
+            1.5e3,
+            1.0e-3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_special_values/Haxe@v4.hx
+++ b/tests/integration/cases/float_special_values/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_special_values_Haxe {
+    public static function main() {
+        final my_data = ([
+            Math.POSITIVE_INFINITY,
+            Math.NEGATIVE_INFINITY,
+            Math.NaN,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_special_values/Haxe_float_format_fixed_v@v4.hx
+++ b/tests/integration/cases/float_special_values/Haxe_float_format_fixed_v@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_special_values_Haxe_float_format_fixed_v {
+    public static function main() {
+        final my_data = ([
+            Math.POSITIVE_INFINITY,
+            Math.NEGATIVE_INFINITY,
+            Math.NaN,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/float_special_values/Haxe_float_format_scientific_v@v4.hx
+++ b/tests/integration/cases/float_special_values/Haxe_float_format_scientific_v@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_float_special_values_Haxe_float_format_scientific_v {
+    public static function main() {
+        final my_data = ([
+            Math.POSITIVE_INFINITY,
+            Math.NEGATIVE_INFINITY,
+            Math.NaN,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Haxe@v4.hx
+++ b/tests/integration/cases/heterogeneous_list_with_string/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_heterogeneous_list_with_string_Haxe {
+    public static function main() {
+        final my_data = ([
+            "hello",
+            42,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Haxe@v4.hx
@@ -1,0 +1,12 @@
+class Fixture_heterogeneous_scalars_in_annotated_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            true,
+            1.5,
+            null,
+            "2020-01-01",
+            "2020-01-01T00:00:00+00:00",
+            ([] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list/Haxe@v4.hx
+++ b/tests/integration/cases/int_list/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/int_list/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list/Haxe_integer_format_hex@v4.hx
+++ b/tests/integration/cases/int_list/Haxe_integer_format_hex@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_Haxe_integer_format_hex {
+    public static function main() {
+        final my_data = ([
+            0x1,
+            0x2,
+            0x3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/int_list/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/int_list/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/int_list/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/int_list/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list_large/Haxe@v4.hx
+++ b/tests/integration/cases/int_list_large/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_int_list_large_Haxe {
+    public static function main() {
+        final my_data = ([
+            1000000,
+            -1234,
+            255,
+            -10,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list_large/Haxe_integer_format_hex_large@v4.hx
+++ b/tests/integration/cases/int_list_large/Haxe_integer_format_hex_large@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_int_list_large_Haxe_integer_format_hex_large {
+    public static function main() {
+        final my_data = ([
+            0xf4240,
+            -0x4d2,
+            0xff,
+            -0xa,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list_large/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/int_list_large/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_int_list_large_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1000000,
+            -1234,
+            255,
+            -10,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list_large/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/int_list_large/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_int_list_large_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([
+            1000000,
+            -1234,
+            255,
+            -10,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list_single/Haxe@v4.hx
+++ b/tests/integration/cases/int_list_single/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_int_list_single_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list_with_zero/Haxe@v4.hx
+++ b/tests/integration/cases/int_list_with_zero/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_with_zero_Haxe {
+    public static function main() {
+        final my_data = ([
+            0,
+            1,
+            -1,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_list_with_zero/Haxe_integer_format_hex_zero@v4.hx
+++ b/tests/integration/cases/int_list_with_zero/Haxe_integer_format_hex_zero@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_list_with_zero_Haxe_integer_format_hex_zero {
+    public static function main() {
+        final my_data = ([
+            0x0,
+            0x1,
+            -0x1,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_set/Haxe@v4.hx
+++ b/tests/integration/cases/int_set/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_set_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_set/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/int_set/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_set_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_set/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/int_set/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_set_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_set/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/int_set/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_set_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/int_set/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/int_set/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_int_set_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([
+            1,
+            2,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_camel_name/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_camel_name/Haxe_ref@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_literalize_ref_camel_name_Haxe_ref {
+    public static function main() {
+        final myVar = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = myVar;
+    }
+}

--- a/tests/integration/cases/literalize_ref_deep_nesting/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_deep_nesting/Haxe_ref@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_literalize_ref_deep_nesting_Haxe_ref {
+    public static function main() {
+        final deep = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = ([
+            "a" => (["b" => (["c" => deep] : Map<String, Dynamic>)] : Map<String, Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_default_nested/Haxe_ref_default@v4.hx
+++ b/tests/integration/cases/literalize_ref_default_nested/Haxe_ref_default@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_literalize_ref_default_nested_Haxe_ref_default {
+    public static function main() {
+        final item_var = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = ([
+            "items" => ([item_var, (["fallback" => "value"] : Map<String, Dynamic>)] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_default_whole/Haxe_ref_default@v4.hx
+++ b/tests/integration/cases/literalize_ref_default_whole/Haxe_ref_default@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_literalize_ref_default_whole_Haxe_ref_default {
+    public static function main() {
+        final my_var = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = my_var;
+    }
+}

--- a/tests/integration/cases/literalize_ref_heterogeneous/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_heterogeneous/Haxe_ref@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_literalize_ref_heterogeneous_Haxe_ref {
+    public static function main() {
+        final my_data = ([
+            "a" => 1,
+            "b" => "hello",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_in_dict/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_in_dict/Haxe_ref@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_literalize_ref_in_dict_Haxe_ref {
+    public static function main() {
+        final myVar = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = ([
+            "key" => myVar,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_in_list/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_in_list/Haxe_ref@v4.hx
@@ -1,0 +1,14 @@
+class Fixture_literalize_ref_in_list_Haxe_ref {
+    public static function main() {
+        final valX = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final valY = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = ([
+            valX,
+            valY,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_in_mixed_list/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_in_mixed_list/Haxe_ref@v4.hx
@@ -1,0 +1,12 @@
+class Fixture_literalize_ref_in_mixed_list_Haxe_ref {
+    public static function main() {
+        final refX = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = ([
+            refX,
+            1,
+            2,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_json5_unquoted_key/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_json5_unquoted_key/Haxe_ref@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_literalize_ref_json5_unquoted_key_Haxe_ref {
+    public static function main() {
+        final myVar = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = myVar;
+    }
+}

--- a/tests/integration/cases/literalize_ref_json_escaped_key/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_json_escaped_key/Haxe_ref@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_literalize_ref_json_escaped_key_Haxe_ref {
+    public static function main() {
+        final myVar = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = myVar;
+    }
+}

--- a/tests/integration/cases/literalize_ref_scalar/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_scalar/Haxe_ref@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_literalize_ref_scalar_Haxe_ref {
+    public static function main() {
+        final myInt = 42;
+        final my_data = myInt;
+    }
+}

--- a/tests/integration/cases/literalize_ref_toml_table/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_toml_table/Haxe_ref@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_literalize_ref_toml_table_Haxe_ref {
+    public static function main() {
+        final myVar = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = ([
+            "key" => myVar,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/literalize_ref_whole/Haxe_ref@v4.hx
+++ b/tests/integration/cases/literalize_ref_whole/Haxe_ref@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_literalize_ref_whole_Haxe_ref {
+    public static function main() {
+        final myVar = ([
+            "_" => "_",
+        ] : Map<String, Dynamic>);
+        final my_data = myVar;
+    }
+}

--- a/tests/integration/cases/mixed_number_dict/Haxe@v4.hx
+++ b/tests/integration/cases/mixed_number_dict/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_mixed_number_dict_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => 1,
+            "b" => 2.5,
+            "c" => 3,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_number_list/Haxe@v4.hx
+++ b/tests/integration/cases/mixed_number_list/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_mixed_number_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            2.5,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_number_list/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/mixed_number_list/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_mixed_number_list_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1,
+            2.5,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_number_list/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/mixed_number_list/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_mixed_number_list_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            1,
+            2.5,
+            3,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_set/Haxe@v4.hx
+++ b/tests/integration/cases/mixed_set/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_mixed_set_Haxe {
+    public static function main() {
+        final my_data = ([
+            true,
+            42,
+            "apple",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_set/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/mixed_set/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_mixed_set_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            true,
+            42,
+            "apple",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_set/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/mixed_set/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_mixed_set_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            true,
+            42,
+            "apple",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_mixed_type_dicts_in_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["type" => "create", "pr_id" => "pr_1", "draft" => true] : Map<String, Dynamic>),
+            (["type" => "create", "pr_id" => "pr_2"] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_mixed_type_dicts_in_sequence_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            (["type" => "create", "pr_id" => "pr_1", "draft" => true] : Map<String, Dynamic>),
+            (["type" => "create", "pr_id" => "pr_2"] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_mixed_type_dicts_in_sequence_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            (["type" => "create", "pr_id" => "pr_1", "draft" => true] : Map<String, Dynamic>),
+            (["type" => "create", "pr_id" => "pr_2"] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Haxe@v4.hx
+++ b/tests/integration/cases/multiline_sibling_list_widening/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_multiline_sibling_list_widening_Haxe {
+    public static function main() {
+        final my_data = ([
+            "omap_value" => (["first" => 1] : Map<String, Dynamic>),
+            "sibling_lists" => (["numbers" => ([1, 2] : Array<Dynamic>), "strings" => (["x", "y"] : Array<Dynamic>)] : Map<String, Dynamic>),
+            "ref_marker_present" => (["$keep", "z"] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Haxe_collection_layout_compact@v4.hx
+++ b/tests/integration/cases/multiline_sibling_list_widening/Haxe_collection_layout_compact@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_multiline_sibling_list_widening_Haxe_collection_layout_compact {
+    public static function main() {
+        final my_data = ([
+            "omap_value" => (["first" => 1] : Map<String, Dynamic>),
+            "sibling_lists" => (["numbers" => ([1, 2] : Array<Dynamic>), "strings" => (["x", "y"] : Array<Dynamic>)] : Map<String, Dynamic>),
+            "ref_marker_present" => (["$keep", "z"] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Haxe_collection_layout_multiline@v4.hx
+++ b/tests/integration/cases/multiline_sibling_list_widening/Haxe_collection_layout_multiline@v4.hx
@@ -1,0 +1,23 @@
+class Fixture_multiline_sibling_list_widening_Haxe_collection_layout_multiline {
+    public static function main() {
+        final my_data = ([
+            "omap_value" => ([
+                "first" => 1,
+            ] : Map<String, Dynamic>),
+            "sibling_lists" => ([
+                "numbers" => ([
+                    1,
+                    2,
+                ] : Array<Dynamic>),
+                "strings" => ([
+                    "x",
+                    "y",
+                ] : Array<Dynamic>),
+            ] : Map<String, Dynamic>),
+            "ref_marker_present" => ([
+                "$keep",
+                "z",
+            ] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested/Haxe@v4.hx
+++ b/tests/integration/cases/nested/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_nested_Haxe {
+    public static function main() {
+        final my_data = ([
+            "users" => ([(["name" => "Bob", "tags" => (["admin", "user"] : Array<Dynamic>)] : Map<String, Dynamic>), (["name" => "Carol", "tags" => (["guest"] : Array<Dynamic>)] : Map<String, Dynamic>)] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested/Haxe_collection_layout_compact@v4.hx
+++ b/tests/integration/cases/nested/Haxe_collection_layout_compact@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_nested_Haxe_collection_layout_compact {
+    public static function main() {
+        final my_data = ([
+            "users" => ([(["name" => "Bob", "tags" => (["admin", "user"] : Array<Dynamic>)] : Map<String, Dynamic>), (["name" => "Carol", "tags" => (["guest"] : Array<Dynamic>)] : Map<String, Dynamic>)] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested/Haxe_collection_layout_multiline@v4.hx
+++ b/tests/integration/cases/nested/Haxe_collection_layout_multiline@v4.hx
@@ -1,0 +1,21 @@
+class Fixture_nested_Haxe_collection_layout_multiline {
+    public static function main() {
+        final my_data = ([
+            "users" => ([
+                ([
+                    "name" => "Bob",
+                    "tags" => ([
+                        "admin",
+                        "user",
+                    ] : Array<Dynamic>),
+                ] : Map<String, Dynamic>),
+                ([
+                    "name" => "Carol",
+                    "tags" => ([
+                        "guest",
+                    ] : Array<Dynamic>),
+                ] : Map<String, Dynamic>),
+            ] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_bool_list/Haxe@v4.hx
+++ b/tests/integration/cases/nested_bool_list/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_bool_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([true, false] : Array<Dynamic>),
+            ([true, true] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_collection_multi_space_string/Haxe@v4.hx
+++ b/tests/integration/cases/nested_collection_multi_space_string/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_nested_collection_multi_space_string_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["key" => "hello   world", "value" => 1] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_deep_empty/Haxe@v4.hx
+++ b/tests/integration/cases/nested_deep_empty/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_nested_deep_empty_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([([] : Array<Dynamic>), ([] : Array<Dynamic>)] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_deep_mixed/Haxe@v4.hx
+++ b/tests/integration/cases/nested_deep_mixed/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_nested_deep_mixed_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([([1, 2] : Array<Dynamic>), (["a", "b"] : Array<Dynamic>)] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_empty_inner/Haxe@v4.hx
+++ b/tests/integration/cases/nested_empty_inner/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_empty_inner_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([] : Array<Dynamic>),
+            ([] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_float_list/Haxe@v4.hx
+++ b/tests/integration/cases/nested_float_list/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_float_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([1.5, 2.5] : Array<Dynamic>),
+            ([3.5, 4.5] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_float_list/Haxe_float_format_fixed_n@v4.hx
+++ b/tests/integration/cases/nested_float_list/Haxe_float_format_fixed_n@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_float_list_Haxe_float_format_fixed_n {
+    public static function main() {
+        final my_data = ([
+            ([1.500000, 2.500000] : Array<Dynamic>),
+            ([3.500000, 4.500000] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_float_list/Haxe_float_format_scientific_n@v4.hx
+++ b/tests/integration/cases/nested_float_list/Haxe_float_format_scientific_n@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_float_list_Haxe_float_format_scientific_n {
+    public static function main() {
+        final my_data = ([
+            ([1.5, 2.5] : Array<Dynamic>),
+            ([3.5, 4.5] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Haxe@v4.hx
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_nested_list_mixed_sibling_types_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([1, 2] : Array<Dynamic>),
+            ([] : Array<Dynamic>),
+            (["a", "b"] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_list_of_dicts/Haxe@v4.hx
+++ b/tests/integration/cases/nested_list_of_dicts/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_list_of_dicts_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([(["name" => "Alice"] : Map<String, Dynamic>), (["name" => "Bob"] : Map<String, Dynamic>)] : Array<Dynamic>),
+            ([(["name" => "Charlie"] : Map<String, Dynamic>), (["name" => "Dave"] : Map<String, Dynamic>)] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_list_with_empty_sibling/Haxe@v4.hx
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_nested_list_with_empty_sibling_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([1, 2] : Array<Dynamic>),
+            ([] : Array<Dynamic>),
+            ([3, 4] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_mixed_dict/Haxe@v4.hx
+++ b/tests/integration/cases/nested_mixed_dict/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_nested_mixed_dict_Haxe {
+    public static function main() {
+        final my_data = ([
+            "outer" => (["a" => 1, "b" => "x", "c" => null] : Map<String, Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_mixed_inner/Haxe@v4.hx
+++ b/tests/integration/cases/nested_mixed_inner/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_mixed_inner_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([1, "a"] : Array<Dynamic>),
+            ([2, "b"] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_mixed_set/Haxe@v4.hx
+++ b/tests/integration/cases/nested_mixed_set/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_mixed_set_Haxe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "tags" => ([true, 42, "apple"] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_mixed_set/Haxe_collection_layout_compact@v4.hx
+++ b/tests/integration/cases/nested_mixed_set/Haxe_collection_layout_compact@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_mixed_set_Haxe_collection_layout_compact {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "tags" => ([true, 42, "apple"] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_mixed_set/Haxe_collection_layout_multiline@v4.hx
+++ b/tests/integration/cases/nested_mixed_set/Haxe_collection_layout_multiline@v4.hx
@@ -1,0 +1,12 @@
+class Fixture_nested_mixed_set_Haxe_collection_layout_multiline {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "tags" => ([
+                true,
+                42,
+                "apple",
+            ] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_mixed_types/Haxe@v4.hx
+++ b/tests/integration/cases/nested_mixed_types/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_mixed_types_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([1, 2] : Array<Dynamic>),
+            (["a", "b"] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/nested_sequence/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_nested_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            true,
+            "hi",
+            ([1, 2] : Array<Dynamic>),
+            null,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_sequence/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/nested_sequence/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_nested_sequence_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            true,
+            "hi",
+            ([1, 2] : Array<Dynamic>),
+            null,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_sequence/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/nested_sequence/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_nested_sequence_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            true,
+            "hi",
+            ([1, 2] : Array<Dynamic>),
+            null,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/nested_sequences/Haxe@v4.hx
+++ b/tests/integration/cases/nested_sequences/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_nested_sequences_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([([1, 2] : Array<Dynamic>), ([3, 4] : Array<Dynamic>)] : Array<Dynamic>),
+            ([([5] : Array<Dynamic>)] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/no_comment/Haxe@v4.hx
+++ b/tests/integration/cases/no_comment/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_no_comment_Haxe {
+    public static function main() {
+        final my_data = ([
+            "message" => "no comment here",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/null_list/Haxe@v4.hx
+++ b/tests/integration/cases/null_list/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_null_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            null,
+            null,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/ordered_map/Haxe@v4.hx
+++ b/tests/integration/cases/ordered_map/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_ordered_map_Haxe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/ordered_map_in_sequence/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_ordered_map_in_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["a" => 1] : Map<String, Dynamic>),
+            "hello",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/ordered_map_in_sequence/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_ordered_map_in_sequence_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            (["a" => 1] : Map<String, Dynamic>),
+            "hello",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/ordered_map_in_sequence/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_ordered_map_in_sequence_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            (["a" => 1] : Map<String, Dynamic>),
+            "hello",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/ordered_map_string_values/Haxe@v4.hx
+++ b/tests/integration/cases/ordered_map_string_values/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_ordered_map_string_values_Haxe {
+    public static function main() {
+        final my_data = ([
+            "first" => "one",
+            "second" => "two",
+            "third" => "three",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/orderedmap_with_annotated_value/Haxe@v4.hx
+++ b/tests/integration/cases/orderedmap_with_annotated_value/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_orderedmap_with_annotated_value_Haxe {
+    public static function main() {
+        final my_data = ([
+            "a" => ([] : Array<Dynamic>),
+            "b" => 1,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/orderedmap_with_empty_sibling/Haxe@v4.hx
+++ b/tests/integration/cases/orderedmap_with_empty_sibling/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_orderedmap_with_empty_sibling_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["a" => 1] : Map<String, Dynamic>),
+            ([] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/pair_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/pair_sequence/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_pair_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            "hello",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/pair_sequence/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/pair_sequence/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_pair_sequence_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1,
+            "hello",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/pair_sequence/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/pair_sequence/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_pair_sequence_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([
+            1,
+            "hello",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_basic/Haxe@v4.hx
+++ b/tests/integration/cases/record_basic/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_record_basic_Haxe {
+    public static function main() {
+        final my_data = ([
+            "id" => 1,
+            "description" => "She said \"hello\", then waved",
+            "is_done" => false,
+            "blocks" => ([1, 2, 3] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_epoch_datetime_i32_overflow/Haxe@v4.hx
+++ b/tests/integration/cases/record_epoch_datetime_i32_overflow/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_record_epoch_datetime_i32_overflow_Haxe {
+    public static function main() {
+        final my_data = ([
+            "within_i32" => "2024-01-15T12:00:00",
+            "beyond_i32" => "2099-06-15T08:30:00",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_named_nested_record/Haxe@v4.hx
+++ b/tests/integration/cases/record_named_nested_record/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_record_named_nested_record_Haxe {
+    public static function main() {
+        final my_data = ([
+            "project" => "alpha",
+            "lead_task" => (["id" => 100, "description" => "first task", "is_done" => false, "blocks" => ([102, 103] : Array<Dynamic>)] : Map<String, Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_named_shape/Haxe@v4.hx
+++ b/tests/integration/cases/record_named_shape/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_record_named_shape_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["id" => 100, "description" => "first task", "is_done" => false, "blocks" => ([102, 103] : Array<Dynamic>)] : Map<String, Dynamic>),
+            (["id" => 101, "description" => "second task", "is_done" => true, "blocks" => ([100] : Array<Dynamic>)] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_nested_container/Haxe@v4.hx
+++ b/tests/integration/cases/record_nested_container/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_record_nested_container_Haxe {
+    public static function main() {
+        final my_data = ([
+            "title" => "report",
+            "tags" => (["draft", "urgent", "review"] : Array<Dynamic>),
+            "priority" => 2,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_nested_record/Haxe@v4.hx
+++ b/tests/integration/cases/record_nested_record/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_record_nested_record_Haxe {
+    public static function main() {
+        final my_data = ([
+            "id" => 1,
+            "owner" => (["name" => "Alice", "age" => 30] : Map<String, Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_optional_unify/Haxe@v4.hx
+++ b/tests/integration/cases/record_optional_unify/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_record_optional_unify_Haxe {
+    public static function main() {
+        final my_data = ([
+            "items" => ([(["id" => 1] : Map<String, Dynamic>), (["id" => 2, "count" => 10] : Map<String, Dynamic>), (["id" => 3, "count" => 20] : Map<String, Dynamic>)] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_pure_scalars/Haxe@v4.hx
+++ b/tests/integration/cases/record_pure_scalars/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_record_pure_scalars_Haxe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => 4.5,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/record_sequence/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_record_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["id" => 1, "label" => "first", "tags" => ([] : Array<Dynamic>)] : Map<String, Dynamic>),
+            (["id" => 2, "label" => "second", "tags" => ([] : Array<Dynamic>)] : Map<String, Dynamic>),
+            (["id" => 3, "label" => "third", "tags" => ([] : Array<Dynamic>)] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/record_two_shapes/Haxe@v4.hx
+++ b/tests/integration/cases/record_two_shapes/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_record_two_shapes_Haxe {
+    public static function main() {
+        final my_data = ([
+            "metrics" => (["count" => 100, "rate" => 50] : Map<String, Dynamic>),
+            "flags" => (["retries" => 3, "timeout" => 30] : Map<String, Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/scalar_bool/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_bool/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_bool_Haxe {
+    public static function main() {
+        final my_data = true;
+    }
+}

--- a/tests/integration/cases/scalar_bool/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_bool/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_bool_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = true;
+    }
+}

--- a/tests/integration/cases/scalar_date/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_date_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15";
+    }
+}

--- a/tests/integration/cases/scalar_date/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_date_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = "2024-01-15";
+    }
+}

--- a/tests/integration/cases/scalar_date/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe_type_hints_always@v4.hx
@@ -1,5 +1,5 @@
 class Fixture_scalar_date_Haxe_type_hints_always {
     public static function main() {
-        final my_data:String = "2024-01-15";
+        final my_data:Dynamic = "2024-01-15";
     }
 }

--- a/tests/integration/cases/scalar_date/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_date_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:String = "2024-01-15";
+    }
+}

--- a/tests/integration/cases/scalar_date/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_date_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:String = "2024-01-15";
+    }
+}

--- a/tests/integration/cases/scalar_date/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,5 +1,5 @@
 class Fixture_scalar_date_Haxe_type_hints_always_dt_epoch {
     public static function main() {
-        final my_data:String = "2024-01-15";
+        final my_data:Dynamic = "2024-01-15";
     }
 }

--- a/tests/integration/cases/scalar_date/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_date_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = "2024-01-15";
+    }
+}

--- a/tests/integration/cases/scalar_date/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/scalar_date/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_date_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = "2024-01-15";
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15T12:30:00+00:00";
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Haxe_datetime_epoch@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_datetime_epoch@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_Haxe_datetime_epoch {
+    public static function main() {
+        final my_data = 1705321800;
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = "2024-01-15T12:30:00+00:00";
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_type_hints_always@v4.hx
@@ -1,5 +1,5 @@
 class Fixture_scalar_datetime_Haxe_type_hints_always {
     public static function main() {
-        final my_data:String = "2024-01-15T12:30:00+00:00";
+        final my_data:Dynamic = "2024-01-15T12:30:00+00:00";
     }
 }

--- a/tests/integration/cases/scalar_datetime/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:String = "2024-01-15T12:30:00+00:00";
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Int = 1705321800;
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,5 +1,5 @@
 class Fixture_scalar_datetime_Haxe_type_hints_always_dt_epoch {
     public static function main() {
-        final my_data:Int = 1705321800;
+        final my_data:Dynamic = 1705321800;
     }
 }

--- a/tests/integration/cases/scalar_datetime/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = "2024-01-15T12:30:00+00:00";
+    }
+}

--- a/tests/integration/cases/scalar_datetime/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/scalar_datetime/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = 1705321800;
+    }
+}

--- a/tests/integration/cases/scalar_datetime_microsecond/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_datetime_microsecond/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_microsecond_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15T12:30:00.123456+00:00";
+    }
+}

--- a/tests/integration/cases/scalar_datetime_midnight/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_datetime_midnight/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_midnight_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15T00:00:00";
+    }
+}

--- a/tests/integration/cases/scalar_datetime_naive/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_datetime_naive/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_naive_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15T12:30:00";
+    }
+}

--- a/tests/integration/cases/scalar_datetime_naive/Haxe_datetime_epoch_naive@v4.hx
+++ b/tests/integration/cases/scalar_datetime_naive/Haxe_datetime_epoch_naive@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_naive_Haxe_datetime_epoch_naive {
+    public static function main() {
+        final my_data = 1705321800;
+    }
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_datetime_non_utc/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_non_utc_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15T18:00:00+05:30";
+    }
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Haxe_datetime_epoch_non_utc@v4.hx
+++ b/tests/integration/cases/scalar_datetime_non_utc/Haxe_datetime_epoch_non_utc@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_non_utc_Haxe_datetime_epoch_non_utc {
+    public static function main() {
+        final my_data = 1705321800;
+    }
+}

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_seconds_microsecond_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15T12:30:45.123456";
+    }
+}

--- a/tests/integration/cases/scalar_datetime_whole_hour_offset/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_datetime_whole_hour_offset/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_datetime_whole_hour_offset_Haxe {
+    public static function main() {
+        final my_data = "2024-01-15T18:00:00+05:00";
+    }
+}

--- a/tests/integration/cases/scalar_float/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_float/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_float_Haxe {
+    public static function main() {
+        final my_data = 3.14;
+    }
+}

--- a/tests/integration/cases/scalar_float/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_float/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_float_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = 3.14;
+    }
+}

--- a/tests/integration/cases/scalar_float/Haxe_float_format_fixed@v4.hx
+++ b/tests/integration/cases/scalar_float/Haxe_float_format_fixed@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_float_Haxe_float_format_fixed {
+    public static function main() {
+        final my_data = 3.140000;
+    }
+}

--- a/tests/integration/cases/scalar_float/Haxe_float_format_scientific@v4.hx
+++ b/tests/integration/cases/scalar_float/Haxe_float_format_scientific@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_float_Haxe_float_format_scientific {
+    public static function main() {
+        final my_data = 3.14;
+    }
+}

--- a/tests/integration/cases/scalar_int/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_int/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_Haxe {
+    public static function main() {
+        final my_data = 42;
+    }
+}

--- a/tests/integration/cases/scalar_int/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_int/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = 42;
+    }
+}

--- a/tests/integration/cases/scalar_int/Haxe_integer_format_hex@v4.hx
+++ b/tests/integration/cases/scalar_int/Haxe_integer_format_hex@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_Haxe_integer_format_hex {
+    public static function main() {
+        final my_data = 0x2a;
+    }
+}

--- a/tests/integration/cases/scalar_int_large/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_int_large/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_large_Haxe {
+    public static function main() {
+        final my_data = 2147483648;
+    }
+}

--- a/tests/integration/cases/scalar_int_large/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_int_large/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_large_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = 2147483648;
+    }
+}

--- a/tests/integration/cases/scalar_int_large/Haxe_integer_format_hex@v4.hx
+++ b/tests/integration/cases/scalar_int_large/Haxe_integer_format_hex@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_large_Haxe_integer_format_hex {
+    public static function main() {
+        final my_data = 0x80000000;
+    }
+}

--- a/tests/integration/cases/scalar_int_negative_large/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_int_negative_large/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_negative_large_Haxe {
+    public static function main() {
+        final my_data = -2147483649;
+    }
+}

--- a/tests/integration/cases/scalar_int_very_large/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_int_very_large/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_very_large_Haxe {
+    public static function main() {
+        final my_data = 9223372036854775808;
+    }
+}

--- a/tests/integration/cases/scalar_int_very_negative_large/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_int_very_negative_large/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_int_very_negative_large_Haxe {
+    public static function main() {
+        final my_data = -9223372036854775809;
+    }
+}

--- a/tests/integration/cases/scalar_null/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_null/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_null_Haxe {
+    public static function main() {
+        final my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_null/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_null/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_null_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_null_with_comment/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_null_with_comment/Haxe@v4.hx
@@ -1,0 +1,6 @@
+class Fixture_scalar_null_with_comment_Haxe {
+    public static function main() {
+        // note
+        final my_data = null;
+    }
+}

--- a/tests/integration/cases/scalar_quoted_with_hash_no_comment/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_quoted_with_hash_no_comment/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_quoted_with_hash_no_comment_Haxe {
+    public static function main() {
+        final my_data = "hello # world";
+    }
+}

--- a/tests/integration/cases/scalar_string/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_string/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_string_Haxe {
+    public static function main() {
+        final my_data = "hello";
+    }
+}

--- a/tests/integration/cases/scalar_string/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/scalar_string/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_scalar_string_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = "hello";
+    }
+}

--- a/tests/integration/cases/scalar_time/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_time/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_scalar_time_Haxe {
+    public static function main() {
+        final my_data = ([
+            "starts_at" => "09:30:00",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/scalar_time/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/scalar_time/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_scalar_time_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Map<String, Dynamic> = ([
+            "starts_at" => "09:30:00",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/scalar_time/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/scalar_time/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_scalar_time_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            "starts_at" => "09:30:00",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/scalar_time_microsecond/Haxe@v4.hx
+++ b/tests/integration/cases/scalar_time_microsecond/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_scalar_time_microsecond_Haxe {
+    public static function main() {
+        final my_data = ([
+            "exact_millisecond" => "09:30:15.123000",
+            "sub_millisecond" => "09:30:15.123456",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/scalars/Haxe@v4.hx
+++ b/tests/integration/cases/scalars/Haxe@v4.hx
@@ -1,0 +1,11 @@
+class Fixture_scalars_Haxe {
+    public static function main() {
+        final my_data = ([
+            42,
+            3.14,
+            true,
+            false,
+            "hello \"world\"",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/sequence_of_dicts/Haxe@v4.hx
+++ b/tests/integration/cases/sequence_of_dicts/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_sequence_of_dicts_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["name" => "Alice", "age" => 30] : Map<String, Dynamic>),
+            (["name" => "Bob", "age" => 25] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set/Haxe@v4.hx
+++ b/tests/integration/cases/set/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_set_Haxe {
+    public static function main() {
+        final my_data = ([
+            "apple",
+            "banana",
+            "cherry",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set/Haxe_trailing_comma_no_set@v4.hx
+++ b/tests/integration/cases/set/Haxe_trailing_comma_no_set@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_set_Haxe_trailing_comma_no_set {
+    public static function main() {
+        final my_data = ([
+            "apple",
+            "banana",
+            "cherry"
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_comments/Haxe@v4.hx
+++ b/tests/integration/cases/set_comments/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_set_comments_Haxe {
+    public static function main() {
+        final my_data = ([
+            "apple",  // inline comment
+            // before banana
+            "banana",
+            // trailing
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_comments_unsorted_order/Haxe@v4.hx
+++ b/tests/integration/cases/set_comments_unsorted_order/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_set_comments_unsorted_order_Haxe {
+    public static function main() {
+        final my_data = ([
+            // before apple
+            "apple",
+            "banana",  // banana inline
+            // trailing
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_in_annotated_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/set_in_annotated_sequence/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_set_in_annotated_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            ([] : Array<Dynamic>),
+            ([1, 2] : Array<Dynamic>),
+            ([] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_in_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/set_in_sequence/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_set_in_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["a", "b"] : Array<Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_mixed_int_widths/Haxe@v4.hx
+++ b/tests/integration/cases/set_mixed_int_widths/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_set_mixed_int_widths_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            1099511627776,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_mixed_int_widths/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/set_mixed_int_widths/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_set_mixed_int_widths_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([
+            1,
+            1099511627776,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_mixed_int_widths/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/set_mixed_int_widths/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_set_mixed_int_widths_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Array<Dynamic> = ([
+            1,
+            1099511627776,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/set_mixed_int_widths/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/set_mixed_int_widths/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_set_mixed_int_widths_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            1,
+            1099511627776,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_nested/Haxe@v4.hx
+++ b/tests/integration/cases/sibling_list_values_nested/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_sibling_list_values_nested_Haxe {
+    public static function main() {
+        final my_data = ([
+            "lint" => ([2, ([] : Array<Dynamic>)] : Array<Dynamic>),
+            "test" => ([5, (["compile"] : Array<Dynamic>)] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Haxe@v4.hx
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_sibling_list_values_uniform_inner_Haxe {
+    public static function main() {
+        final my_data = ([
+            "lint" => ([2, ([1] : Array<Dynamic>)] : Array<Dynamic>),
+            "test" => ([5, ([7] : Array<Dynamic>)] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_dict/Haxe@v4.hx
+++ b/tests/integration/cases/simple_dict/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_dict_Haxe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_dict/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/simple_dict/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_dict_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_dict/Haxe_trailing_comma_no_dict@v4.hx
+++ b/tests/integration/cases/simple_dict/Haxe_trailing_comma_no_dict@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_dict_Haxe_trailing_comma_no_dict {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_dict/Haxe_type_hints_always_dt_epoch@v4.hx
+++ b/tests/integration/cases/simple_dict/Haxe_type_hints_always_dt_epoch@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_dict_Haxe_type_hints_always_dt_epoch {
+    public static function main() {
+        final my_data:Map<String, Dynamic> = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_dict/Haxe_type_hints_safe_dt_epoch@v4.hx
+++ b/tests/integration/cases/simple_dict/Haxe_type_hints_safe_dt_epoch@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_dict_Haxe_type_hints_safe_dt_epoch {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null,
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/simple_sequence/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            "hello",
+            true,
+            null,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_sequence/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/simple_sequence/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_sequence_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([
+            1,
+            "hello",
+            true,
+            null,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/simple_sequence/Haxe_trailing_comma_no@v4.hx
+++ b/tests/integration/cases/simple_sequence/Haxe_trailing_comma_no@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_simple_sequence_Haxe_trailing_comma_no {
+    public static function main() {
+        final my_data = ([
+            1,
+            "hello",
+            true,
+            null
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/string_control_chars/Haxe@v4.hx
+++ b/tests/integration/cases/string_control_chars/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_string_control_chars_Haxe {
+    public static function main() {
+        final my_data = ([
+            "line1\r\nline2",
+            "line1\rline2",
+            "",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Haxe@v4.hx
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Haxe@v4.hx
@@ -1,0 +1,5 @@
+class Fixture_string_escaped_quotes_and_dashes_Haxe {
+    public static function main() {
+        final my_data = "hello \"world\" -- not a comment";
+    }
+}

--- a/tests/integration/cases/string_list/Haxe@v4.hx
+++ b/tests/integration/cases/string_list/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_string_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            "foo",
+            "bar",
+            "baz",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/string_with_backslash/Haxe@v4.hx
+++ b/tests/integration/cases/string_with_backslash/Haxe@v4.hx
@@ -1,0 +1,13 @@
+class Fixture_string_with_backslash_Haxe {
+    public static function main() {
+        final my_data = ([
+            "C:\\path\\to\\file",
+            "back\\\\slash",
+            "hello \\\"world\\\"",
+            "path\\to \"# file",
+            "trailing\\",
+            "both \"quotes''' here",
+            "line1\\nline2\nwith newline",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/string_with_dollar/Haxe@v4.hx
+++ b/tests/integration/cases/string_with_dollar/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_string_with_dollar_Haxe {
+    public static function main() {
+        final my_data = ([
+            "price $10",
+            "$HOME",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/string_with_dollar_brace/Haxe@v4.hx
+++ b/tests/integration/cases/string_with_dollar_brace/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_string_with_dollar_brace_Haxe {
+    public static function main() {
+        final my_data = ([
+            "prefix ${HOME} suffix",
+            "${interpolated}",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/string_with_hash/Haxe@v4.hx
+++ b/tests/integration/cases/string_with_hash/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_string_with_hash_Haxe {
+    public static function main() {
+        final my_data = ([
+            "issue #{42}",
+            "color #red",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/string_with_percent/Haxe@v4.hx
+++ b/tests/integration/cases/string_with_percent/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_string_with_percent_Haxe {
+    public static function main() {
+        final my_data = ([
+            "100% done",
+            "%(name) is here",
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/time_dict/Haxe@v4.hx
+++ b/tests/integration/cases/time_dict/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_time_dict_Haxe {
+    public static function main() {
+        final my_data = ([
+            "morning" => "09:30:00",
+            "afternoon" => "14:15:00",
+            "evening" => "23:59:59",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/time_dict/Haxe_declaration_style_var@v4.hx
+++ b/tests/integration/cases/time_dict/Haxe_declaration_style_var@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_time_dict_Haxe_declaration_style_var {
+    public static function main() {
+        var my_data = ([
+            "morning" => "09:30:00",
+            "afternoon" => "14:15:00",
+            "evening" => "23:59:59",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/time_list/Haxe@v4.hx
+++ b/tests/integration/cases/time_list/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_time_list_Haxe {
+    public static function main() {
+        final my_data = ([
+            "times" => (["09:30:00", "17:45:00", "23:59:59"] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/times_heterogeneous_with_dates/Haxe@v4.hx
+++ b/tests/integration/cases/times_heterogeneous_with_dates/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_times_heterogeneous_with_dates_Haxe {
+    public static function main() {
+        final my_data = ([
+            "vals" => (["2024-01-15", "09:30:00"] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/toml_comments/Haxe@v4.hx
+++ b/tests/integration/cases/toml_comments/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_toml_comments_Haxe {
+    public static function main() {
+        final my_data = ([
+            // before
+            "answer" => 42,  // inline
+            "plain" => "ok",
+            // trailing
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/toml_table/Haxe@v4.hx
+++ b/tests/integration/cases/toml_table/Haxe@v4.hx
@@ -1,0 +1,7 @@
+class Fixture_toml_table_Haxe {
+    public static function main() {
+        final my_data = ([
+            "section" => (["value" => 1] : Map<String, Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/triple_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/triple_sequence/Haxe@v4.hx
@@ -1,0 +1,9 @@
+class Fixture_triple_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            "hello",
+            true,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/tuple_record_field/Haxe@v4.hx
+++ b/tests/integration/cases/tuple_record_field/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_tuple_record_field_Haxe {
+    public static function main() {
+        final my_data = ([
+            "call" => "send",
+            "args" => ([1, "email", "a@gmail.com", 100] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/tuple_record_seq_sibling/Haxe@v4.hx
+++ b/tests/integration/cases/tuple_record_seq_sibling/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_tuple_record_seq_sibling_Haxe {
+    public static function main() {
+        final my_data = ([
+            "scores" => ([10, 20, 30] : Array<Dynamic>),
+            "args" => ([1, "email", "a@gmail.com", 100] : Array<Dynamic>),
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/tuple_record_sequence/Haxe@v4.hx
+++ b/tests/integration/cases/tuple_record_sequence/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_tuple_record_sequence_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["call" => "send", "args" => ([1, "email", "a@gmail.com", 100] : Array<Dynamic>)] : Map<String, Dynamic>),
+            (["call" => "recv", "args" => ([2, "sms", "b@example.com", 200] : Array<Dynamic>)] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/tuple_top_level/Haxe@v4.hx
+++ b/tests/integration/cases/tuple_top_level/Haxe@v4.hx
@@ -1,0 +1,10 @@
+class Fixture_tuple_top_level_Haxe {
+    public static function main() {
+        final my_data = ([
+            1,
+            "email",
+            "a@gmail.com",
+            100,
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/type_hints/Haxe@v4.hx
+++ b/tests/integration/cases/type_hints/Haxe@v4.hx
@@ -1,0 +1,13 @@
+class Fixture_type_hints_Haxe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null,
+            "joined" => "2024-01-15",
+            "last_login" => "2024-01-15T12:30:00+00:00",
+            "avatar" => "48656c6c6f",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/type_hints/Haxe_type_hints_always@v4.hx
+++ b/tests/integration/cases/type_hints/Haxe_type_hints_always@v4.hx
@@ -1,0 +1,13 @@
+class Fixture_type_hints_Haxe_type_hints_always {
+    public static function main() {
+        final my_data:Map<String, Dynamic> = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null,
+            "joined" => "2024-01-15",
+            "last_login" => "2024-01-15T12:30:00+00:00",
+            "avatar" => "48656c6c6f",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/type_hints/Haxe_type_hints_safe@v4.hx
+++ b/tests/integration/cases/type_hints/Haxe_type_hints_safe@v4.hx
@@ -1,0 +1,13 @@
+class Fixture_type_hints_Haxe_type_hints_safe {
+    public static function main() {
+        final my_data = ([
+            "name" => "Alice",
+            "age" => 30,
+            "active" => true,
+            "score" => null,
+            "joined" => "2024-01-15",
+            "last_login" => "2024-01-15T12:30:00+00:00",
+            "avatar" => "48656c6c6f",
+        ] : Map<String, Dynamic>);
+    }
+}

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Haxe@v4.hx
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_uniform_mixed_num_dicts_in_seq_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["x" => 1, "y" => 2.5] : Map<String, Dynamic>),
+            (["x" => 3, "y" => 4.0] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Haxe@v4.hx
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Haxe@v4.hx
@@ -1,0 +1,8 @@
+class Fixture_uniform_string_dicts_in_seq_Haxe {
+    public static function main() {
+        final my_data = ([
+            (["first" => "Alice", "last" => "Smith"] : Map<String, Dynamic>),
+            (["first" => "Bob", "last" => "Jones"] : Map<String, Dynamic>),
+        ] : Array<Dynamic>);
+    }
+}

--- a/tests/integration/language_specs.py
+++ b/tests/integration/language_specs.py
@@ -20,6 +20,7 @@ from literalizer.languages import (
     Erlang,
     Gleam,
     Haskell,
+    Haxe,
     Scala,
 )
 
@@ -91,6 +92,20 @@ def haskell_module_name(*, golden_path: Path) -> str:
 
 
 @beartype
+def haxe_module_name(*, golden_path: Path) -> str:
+    """Return the Haxe class name for *golden_path*.
+
+    Produces a deterministic, per-fixture name so every compiled
+    ``.hx`` file in CI has a unique class declaration (and so the file
+    can be renamed to match the class for ``haxe --main``) without
+    needing ``sed`` rewriting.
+    """
+    dir_name = golden_path.parent.name
+    stem = _logical_stem(path=golden_path)
+    return f"Fixture_{dir_name}_{stem}"
+
+
+@beartype
 def with_per_fixture_module_name(
     *,
     spec: literalizer.Language,
@@ -99,8 +114,8 @@ def with_per_fixture_module_name(
     """Return *spec* with a per-fixture ``module_name`` if applicable.
 
     Languages whose CI lint requires unique module names (Crystal, Erlang,
-    Haskell, Scala) get a deterministic name derived from *golden_path*; all
-    other languages are returned unchanged.
+    Haskell, Haxe, Scala) get a deterministic name derived from
+    *golden_path*; all other languages are returned unchanged.
     """
     if isinstance(spec, Crystal):
         return dataclasses.replace(
@@ -116,6 +131,11 @@ def with_per_fixture_module_name(
         return dataclasses.replace(
             spec,
             module_name=haskell_module_name(golden_path=golden_path),
+        )
+    if isinstance(spec, Haxe):
+        return dataclasses.replace(
+            spec,
+            module_name=haxe_module_name(golden_path=golden_path),
         )
     if isinstance(spec, Scala):
         return dataclasses.replace(


### PR DESCRIPTION
Adds Haxe (roadmap issue #307) as a new output language: a new `Haxe` spec in `src/literalizer/languages/haxe.py`, registered in `languages/__init__.py`, plus 318 regenerated golden fixtures and a `haxe_module_name` helper in the test harness. Every collection literal is rendered with an explicit `(... : Array<Dynamic>)` / `(... : Map<String, Dynamic>)` cast so heterogeneous and empty collections type-check in any context with no per-variable annotation machinery; maps use Haxe's `["key" => value]` syntax, strings are double-quoted (no interpolation), and calls use positional syntax with local-function/anonymous-closure stubs inside `static function main()`. A new `lint-haxe` CI job compiles and runs every `.hx` fixture in a single `haxe --interp` invocation, mirroring the per-fixture class-name pattern used by Scala/Haskell/Crystal/Erlang, and is wired into the `completion-lint` gate. README, CHANGELOG, and the spelling dictionary are updated accordingly. All 318 fixtures compile and run under Haxe 4.3 locally, the full test suite passes (4822 passed), and mypy/pyright/ty/pyrefly/ruff/pylint/zizmor are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a brand-new language backend plus a new CI lint job that compiles/runs generated fixtures, so regressions are mostly limited to Haxe rendering and pipeline time/flake risk.
> 
> **Overview**
> Adds **Haxe** as a new output language, registering a new `Haxe` spec and implementing Haxe literal rendering (notably explicit `Array<Dynamic>`/`Map<String, Dynamic>` casts, map literal syntax, string quoting, and call-stub generation inside `static function main()`).
> 
> Extends integration coverage by adding a large set of `.hx` golden fixtures and updating the test harness to generate per-fixture Haxe class names.
> 
> Updates CI to include a `lint-haxe` job that installs Haxe and compiles/runs all `.hx` fixtures in one `haxe --interp` pass, and refreshes docs/metadata (`README.rst`, `CHANGELOG.rst`, spelling dictionary) to list Haxe support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e88525e3f89fa05766ccb9e36285382480f327d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->