### PR TITLE
Add Carbon as an output language

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -457,12 +457,21 @@ jobs:
             -o /tmp/carbon.tar.gz
           mkdir -p /tmp/carbon
           tar -xzf /tmp/carbon.tar.gz -C /tmp/carbon
-          carbon_bin=$(find /tmp/carbon -type f -name carbon -perm -u+x | head -n1)
-          if [ -z "$carbon_bin" ]; then
+          # ``bin/carbon`` is a symlink to ``lib/carbon/carbon-busybox``
+          # (so ``find -type f`` never matches it), and the busybox
+          # resolves its prelude relative to its own real path -- so it
+          # must be invoked through the in-tree symlink rather than
+          # copied out with ``install``/``cp`` (which would dereference
+          # it and break prelude lookup). Symlink it onto PATH instead.
+          carbon_root=$(find /tmp/carbon -maxdepth 1 -type d -name 'carbon_toolchain-*' | head -n1)
+          carbon_bin="$carbon_root/bin/carbon"
+          if [ ! -e "$carbon_bin" ]; then
             echo "carbon binary not found in toolchain tarball" >&2
+            find /tmp/carbon -maxdepth 3 >&2
             exit 1
           fi
-          sudo install "$carbon_bin" /usr/local/bin/carbon
+          sudo ln -s "$carbon_bin" /usr/local/bin/carbon
+          carbon compile --help >/dev/null
       - name: Lint Carbon
         run: |-
           find tests/integration/cases -name '*.carbon' -print0 > /tmp/files-carbon && test -s /tmp/files-carbon

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -435,6 +435,39 @@ jobs:
             run_odin "$src" || run_odin "$src" || exit 1
           done
 
+  lint-carbon:
+    runs-on: ubuntu-latest
+    # Carbon has no stable release; the toolchain ships only as dated
+    # ``carbon_toolchain-0.0.0-0.nightly.YYYY.MM.DD.tar.gz`` nightly
+    # assets (old nightlies are retained, so a dated URL is stable).
+    # This ``2026.05.17`` nightly is documented against the ``V0``
+    # default of ``Carbon.language_version`` in
+    # ``src/literalizer/languages/carbon.py``; keep them in sync.
+    # Carbon has no ``--langversion``-style flag, so the pinned nightly
+    # is the only mechanism for pinning the language version.
+    env:
+      CARBON_NIGHTLY: 0.0.0-0.nightly.2026.05.17
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Carbon
+        run: |-
+          curl -fsSL "https://github.com/carbon-language/carbon-lang/releases/download/v${CARBON_NIGHTLY}/carbon_toolchain-${CARBON_NIGHTLY}.tar.gz" \
+            -o /tmp/carbon.tar.gz
+          mkdir -p /tmp/carbon
+          tar -xzf /tmp/carbon.tar.gz -C /tmp/carbon
+          carbon_bin=$(find /tmp/carbon -type f -name carbon -perm -u+x | head -n1)
+          if [ -z "$carbon_bin" ]; then
+            echo "carbon binary not found in toolchain tarball" >&2
+            exit 1
+          fi
+          sudo install "$carbon_bin" /usr/local/bin/carbon
+      - name: Lint Carbon
+        run: |-
+          find tests/integration/cases -name '*.carbon' -print0 > /tmp/files-carbon && test -s /tmp/files-carbon
+          xargs -0 -P "$(nproc)" -n1 carbon compile --phase=check < /tmp/files-carbon
+
   lint-roc:
     runs-on: ubuntu-latest
     # Roc has no stable release, and the upstream ``nightly`` GitHub
@@ -2104,6 +2137,7 @@ jobs:
       - lint-haskell-family
       - lint-c-tidy
       - lint-cpp-tidy
+      - lint-carbon
       - lint-cobol
       - lint-cpp
       - lint-kotlin

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ Changelog
 Next
 ----
 
+- Added :class:`~literalizer.Carbon`, an output language for the
+  experimental Carbon successor-to-C++ language.  Heterogeneous
+  JSON/YAML data is represented through a single ``choice CVal``
+  tagged union (the Carbon analog of the Zig ``ZVal`` model), with
+  ``//`` whole-line comments, semicolon-terminated statements, and
+  ``{.field = value}`` struct literals.  Fixtures are compiled in CI
+  by the ``lint-carbon`` job against a pinned ``carbon`` nightly.
+
 - :class:`~literalizer.CSharp` array sequence-format no longer emits
   ``using System;`` or ``using System.Collections.Generic;``.  A C#
   array literal (``new T[] {...}``) is a built-in language feature and

--- a/src/literalizer/languages/__init__.py
+++ b/src/literalizer/languages/__init__.py
@@ -5,6 +5,7 @@ from literalizer._language import LanguageCls
 from .ada import Ada
 from .bash import Bash
 from .c import C
+from .carbon import Carbon
 from .clojure import Clojure
 from .cobol import Cobol
 from .common_lisp import CommonLisp
@@ -71,6 +72,7 @@ ALL_LANGUAGES: frozenset[LanguageCls] = frozenset(
         Ada,
         Bash,
         C,
+        Carbon,
         Clojure,
         Cobol,
         CommonLisp,
@@ -140,6 +142,7 @@ __all__ = [
     "Bash",
     "C",
     "CSharp",
+    "Carbon",
     "Clojure",
     "Cobol",
     "CommonLisp",

--- a/src/literalizer/languages/carbon.py
+++ b/src/literalizer/languages/carbon.py
@@ -1,0 +1,1092 @@
+"""Carbon language specification.
+
+Carbon is the experimental successor-to-C++ language from the
+``carbon-language`` project.  It is statically typed with explicit
+type annotations on declarations (``var x: i32 = 1;`` / ``let x: i32 =
+1;``), uses ``//`` whole-line comments, semicolon-terminated
+statements, and struct value literals of the form ``{.field = value}``
+-- structurally the closest existing analog is :class:`~literalizer.
+languages.Zig`.
+
+Because Carbon is strongly typed and has no ``null``, arbitrary
+heterogeneous JSON/YAML data is represented through a single
+``choice CVal`` tagged union (the Carbon equivalent of the Zig
+``ZVal`` union): every scalar, sequence, set, and map entry is
+wrapped in the matching ``CVal`` alternative so collections remain
+homogeneously typed.
+
+Generated fixtures are compiled in CI by the ``lint-carbon`` job
+against a pinned ``carbon`` nightly (see
+``.github/workflows/lint.yml``).
+"""
+
+import dataclasses
+import datetime
+import enum
+import textwrap
+from collections.abc import Callable, Sequence
+from functools import cached_property
+from types import MappingProxyType
+from typing import ClassVar
+
+from beartype import beartype
+
+from literalizer._formatters.collection_openers import (
+    fixed_open,
+)
+from literalizer._formatters.format_dates import (
+    format_date_iso,
+    format_datetime_epoch,
+    format_datetime_iso,
+    format_time_iso,
+)
+from literalizer._formatters.format_entries import (
+    dict_entry_with_template,
+    format_bytes_base64,
+    format_bytes_hex,
+    passthrough_sequence_entry,
+)
+from literalizer._formatters.format_floats import (
+    format_float_fixed,
+    format_float_repr,
+    format_float_scientific,
+)
+from literalizer._formatters.format_integers import (
+    I64_MAX,
+    I64_MIN,
+    format_integer_binary,
+    format_integer_hex,
+    format_integer_underscore,
+)
+from literalizer._formatters.format_strings import (
+    format_string_backslash_control,
+)
+from literalizer._language import (
+    NO_CALL_PARAMETER_LIMIT,
+    NO_HETEROGENEOUS_BEHAVIOR,
+    NON_KEBAB_REF_CASES,
+    CallStyle,
+    CommentConfig,
+    DateFormatConfig,
+    DatetimeFormatConfig,
+    DictFormatConfig,
+    FloatSpecialsMixin,
+    HeterogeneousBehavior,
+    IdentifierCase,
+    LanguageCls,
+    ModifierCombination,
+    OrderedMapFormatConfig,
+    PositionalCallStyle,
+    SequenceFormatConfig,
+    SetFormatConfig,
+    StubReturn,
+    TrailingCommaConfig,
+    body_preamble_from_scalars,
+    default_sequence_binding_declarations,
+    default_wrap_calls_with_declarations,
+    identity_call_ref_identifier,
+    identity_call_statement,
+    identity_call_target,
+    never_inhibits_consuming_form,
+    no_call_binding_body_preamble,
+    no_call_binding_file_pragmas,
+    no_call_stub,
+    no_data_preamble,
+    no_format_integer_widened,
+    no_leading_preamble,
+    no_type_hint_preamble,
+    no_validate_call_arg,
+    no_validate_spec_for_data,
+    prepend_body_preamble,
+)
+from literalizer._types import Value
+from literalizer.exceptions import UnrepresentableIntegerError
+
+
+@beartype
+def _format_date_carbon(value: datetime.date) -> str:
+    """Format a date as epoch seconds (midnight UTC)."""
+    dt = datetime.datetime(
+        year=value.year,
+        month=value.month,
+        day=value.day,
+        tzinfo=datetime.UTC,
+    )
+    return str(object=int(dt.timestamp()))
+
+
+@beartype
+def _format_datetime_carbon(value: datetime.datetime) -> str:
+    """Format a datetime as epoch seconds (UTC)."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.UTC)
+    return str(object=int(value.timestamp()))
+
+
+@dataclasses.dataclass(frozen=True)
+class _CarbonDeclarationStyleConfig:
+    """Configuration for a Carbon declaration style.
+
+    Unlike :class:`DeclarationStyleConfig`, this carries no
+    ``formatter`` slot: Carbon builds its declaration formatter
+    per-instance in :attr:`Carbon.format_variable_declaration`.
+    """
+
+    keyword: str
+    supports_redefinition: bool
+
+
+@beartype
+def _format_carbon_entry(
+    *,
+    original: Value,
+    formatted: str,
+    date_type: type,
+    datetime_type: type,
+) -> str:
+    """Wrap a formatted entry in the appropriate ``CVal`` alternative.
+
+    The ``str`` vs ``int`` choice for dates/datetimes is driven by the
+    parsed :class:`Value` together with the chosen date/datetime
+    format's ``type_produced``, rather than by sniffing *formatted*.
+    """
+    match original:
+        case bool():
+            return formatted
+        case int():
+            if original < I64_MIN:
+                msg = (
+                    f"Carbon cannot represent negative integer "
+                    f"{original} below the signed 64-bit range using "
+                    "the CVal union's unsigned alternative."
+                )
+                raise UnrepresentableIntegerError(msg)
+            tag = "UInt" if original > I64_MAX else "Int"
+        case float():
+            tag = "Float"
+        case str() | bytes():
+            tag = "Str"
+        case datetime.datetime():
+            tag = "Str" if datetime_type is str else "Int"
+        case datetime.time():
+            tag = "Str"
+        case datetime.date():
+            tag = "Str" if date_type is str else "Int"
+        case _:
+            return formatted
+    return f"CVal.{tag}({formatted})"
+
+
+@beartype
+def _make_carbon_call_preamble_stub() -> Callable[
+    [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
+    tuple[str, ...],
+]:
+    """Build the file-scope Carbon call-stub formatter.
+
+    Carbon disallows nested function declarations, so call stubs are
+    emitted at file scope.  Stubs return nothing so a bare
+    ``stub(...);`` statement is valid whether or not a
+    ``call_transform`` consumed the value.  Every parameter is typed
+    ``CVal`` so the union literals emitted at the call site
+    (``CVal.Int(1)``) match the parameter shape.  Dotted targets are
+    realized as a nested ``class`` chain rooted at a file-level
+    constant, so an expression like ``app.client.fetch(...)`` resolves
+    to a real method call on a real value.
+    """
+
+    @beartype
+    def _carbon_call_preamble_stub(
+        parts: Sequence[str],
+        params: Sequence[str],
+        _stub_return: StubReturn,
+        _args: Sequence[Value],
+        /,
+    ) -> tuple[str, ...]:
+        """Return file-scope Carbon stub declarations for a call name."""
+        method = parts[-1]
+        if len(parts) == 1:
+            param_list = ", ".join(f"{p}: CVal" for p in params)
+            return (f"fn {method}({param_list}) {{}}",)
+        chain = parts[:-1]
+        holder = chain[-1]
+        holder_type = f"{holder.title()}Type_"
+        # A Carbon method takes its receiver as a ``[self: Self]``
+        # deduced parameter before the ordinary parameter list.
+        method_params = ", ".join(f"{p}: CVal" for p in params)
+        lines: list[str] = [
+            f"class {holder_type} {{ "
+            f"fn {method}[self: Self]({method_params}) {{}} }}",
+        ]
+        prev_type = holder_type
+        for i in range(len(chain) - 2, 0, -1):
+            curr_type = f"{chain[i].title()}Type_"
+            lines.append(
+                f"class {curr_type} {{ var {chain[i + 1]}: {prev_type}; }}",
+            )
+            prev_type = curr_type
+        root = chain[0]
+        intermediates = chain[1:]
+        if intermediates:
+            root_type = f"{root.title()}Type_"
+            lines.append(
+                f"class {root_type} {{ var {intermediates[0]}: "
+                f"{prev_type}; }}",
+            )
+        else:
+            root_type = prev_type
+        lines.append(f"var {root}: {root_type};")
+        return tuple(lines)
+
+    return _carbon_call_preamble_stub
+
+
+@beartype
+def _format_carbon_call_assignment(
+    name: str,
+    value: str,
+    _data: Value,
+) -> str:
+    """Format a Carbon reassignment binding a call result.
+
+    The call-expression counterpart of
+    :attr:`Carbon.format_call_variable_declaration`; the variable
+    already exists, so the call result is assigned directly with none
+    of the ``CVal`` union wrapping a literal-binding assignment applies
+    (a call result is not a ``CVal`` union literal).
+    """
+    return f"{name} = {value};"
+
+
+@beartype
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Carbon(metaclass=LanguageCls):
+    """Carbon language specification."""
+
+    format_integer_widened = no_format_integer_widened
+    sequence_binding_declarations = default_sequence_binding_declarations
+    format_call_binding_body_preamble = no_call_binding_body_preamble
+    format_call_binding_file_pragmas = no_call_binding_file_pragmas
+
+    leading_preamble = no_leading_preamble
+    extension = ".carbon"
+    pygments_name = None
+    supports_special_floats = False
+    supports_variable_names = True
+    supports_no_variable_wrap_in_file = False
+    dict_supports_heterogeneous_values = True
+    supports_dotted_calls = True
+    has_free_function_calls = True
+    reserved_identifiers: ClassVar[frozenset[str]] = frozenset(
+        {
+            "abstract",
+            "addr",
+            "alias",
+            "and",
+            "api",
+            "as",
+            "auto",
+            "base",
+            "break",
+            "case",
+            "choice",
+            "class",
+            "constraint",
+            "continue",
+            "default",
+            "else",
+            "extend",
+            "final",
+            "fn",
+            "for",
+            "forall",
+            "friend",
+            "if",
+            "impl",
+            "import",
+            "in",
+            "interface",
+            "let",
+            "library",
+            "match",
+            "namespace",
+            "not",
+            "observe",
+            "or",
+            "override",
+            "package",
+            "partial",
+            "private",
+            "protected",
+            "require",
+            "return",
+            "returned",
+            "self",
+            "then",
+            "type",
+            "var",
+            "virtual",
+            "where",
+            "while",
+        },
+    )
+    allows_empty_call_parens = True
+    supports_dotted_call_stub = True
+    call_returns_expression = True
+    supports_zero_parameter_calls = True
+    max_call_parameters = NO_CALL_PARAMETER_LIMIT
+    supports_inline_multiline_dict_args = True
+    supports_standalone_comments_in_wrapped_calls = True
+    supports_module_name = False
+    supports_empty_dict_key = False
+    supports_call_style = True
+    supports_default_dict_key_type = False
+    supports_default_dict_value_type = False
+    supports_default_sequence_element_type = False
+    supports_default_set_element_type = False
+    supports_default_ordered_map_value_type = False
+    supports_record_struct_name_prefix = False
+    supports_record_shape_names = False
+    supports_non_string_dict_keys = False
+
+    class DateFormats(enum.Enum):
+        """Date format options for Carbon."""
+
+        CARBON = DateFormatConfig(
+            formatter=_format_date_carbon,
+            type_produced=int,
+        )
+        ISO = DateFormatConfig(formatter=format_date_iso, type_produced=str)
+
+        def __call__(self, date_value: datetime.date, /) -> str:
+            """Format a date."""
+            return self.value.formatter(date_value)
+
+    class DatetimeFormats(enum.Enum):
+        """Datetime format options for Carbon."""
+
+        CARBON = DatetimeFormatConfig(
+            formatter=_format_datetime_carbon,
+            type_produced=int,
+        )
+        ISO = DatetimeFormatConfig(
+            formatter=format_datetime_iso,
+            type_produced=str,
+        )
+
+        EPOCH = DatetimeFormatConfig(
+            formatter=format_datetime_epoch,
+            type_produced=int,
+        )
+
+        def __call__(self, dt_value: datetime.datetime, /) -> str:
+            """Format a datetime."""
+            return self.value.formatter(dt_value)
+
+    class BytesFormats(enum.Enum):
+        """Bytes formatting options."""
+
+        HEX = enum.member(value=format_bytes_hex)
+        BASE64 = enum.member(value=format_bytes_base64)
+
+        def __call__(self, data: bytes, /) -> str:
+            """Format bytes."""
+            return self.value(value=data)
+
+    class SequenceFormats(enum.Enum):
+        """Sequence type options for Carbon."""
+
+        ARRAY = SequenceFormatConfig(
+            sequence_open=fixed_open(open_str="CVal.Arr(("),
+            close="))",
+            supports_heterogeneity=True,
+            single_element_trailing_comma=False,
+            supports_trailing_comma=True,
+            empty_sequence=None,
+            preamble_lines=(),
+            format_entry=passthrough_sequence_entry,
+            typed_opener_fallback=None,
+            uses_typed_literal_for_scalars=False,
+            requires_uniform_record_shapes=False,
+            declared_type=None,
+            narrowed_empty_form=None,
+        )
+
+    class SetFormats(enum.Enum):
+        """Set type options for Carbon."""
+
+        SET = SetFormatConfig(
+            set_open=fixed_open(open_str="CVal.Set(("),
+            close="))",
+            empty_set=None,
+            preamble_lines=(),
+            set_opener_template="",
+            supports_heterogeneity=True,
+            supports_trailing_comma=True,
+        )
+
+    class CommentFormats(enum.Enum):
+        """Comment style options."""
+
+        DOUBLE_SLASH = CommentConfig(
+            prefix="//",
+            suffix="",
+        )
+
+    class DeclarationStyles(enum.Enum):
+        """Declaration style options."""
+
+        LET = _CarbonDeclarationStyleConfig(
+            keyword="let",
+            supports_redefinition=False,
+        )
+        VAR = _CarbonDeclarationStyleConfig(
+            keyword="var",
+            supports_redefinition=True,
+        )
+
+    class DictEntryStyles(enum.Enum):
+        """Dict entry style options."""
+
+        DEFAULT = enum.auto()
+
+    class DictFormats(enum.Enum):
+        """Dict/map format options."""
+
+        DEFAULT = enum.auto()
+
+    class EmptyDictKey(enum.Enum):
+        """Empty dict key options."""
+
+        ALLOW = enum.auto()
+
+    class FloatFormats(
+        FloatSpecialsMixin,
+        enum.Enum,
+        positive_infinity="",
+        negative_infinity="",
+        nan="",
+    ):
+        """Float format options.
+
+        Carbon has no portable infinity/NaN literal, so
+        :attr:`supports_special_floats` is ``False`` and the
+        :class:`FloatSpecialsMixin` special strings are never emitted.
+        """
+
+        REPR = enum.member(value=format_float_repr)
+        SCIENTIFIC = enum.member(value=format_float_scientific)
+        FIXED = enum.member(value=format_float_fixed)
+
+    class IntegerFormats(enum.Enum):
+        """Integer format options.
+
+        Carbon has no octal literal syntax, so only decimal, hex, and
+        binary are offered.
+        """
+
+        DECIMAL = MappingProxyType(
+            mapping={
+                "NONE": str,
+                "UNDERSCORE": format_integer_underscore,
+            }
+        )
+        HEX = MappingProxyType(
+            mapping={
+                "NONE": format_integer_hex,
+                "UNDERSCORE": format_integer_hex,
+            }
+        )
+        BINARY = MappingProxyType(
+            mapping={
+                "NONE": format_integer_binary,
+                "UNDERSCORE": format_integer_binary,
+            }
+        )
+
+        def get_formatter(
+            self,
+            numeric_separator: enum.Enum,
+        ) -> Callable[[int], str]:
+            """Return the integer formatter for the given separator."""
+            formatter: Callable[[int], str] = self.value[
+                numeric_separator.name
+            ]
+            return formatter
+
+    class NumericLiteralSuffixes(enum.Enum):
+        """Numeric literal suffix options."""
+
+        NONE = enum.auto()
+
+    class NumericSeparators(enum.Enum):
+        """Numeric separator options."""
+
+        NONE = enum.auto()
+        UNDERSCORE = enum.auto()
+
+    class NumericStyles(enum.Enum):
+        """Numeric literal style options."""
+
+        OVERLOADED = enum.auto()
+
+    class StringFormats(enum.Enum):
+        """String format options."""
+
+        DOUBLE = enum.auto()
+
+    class TrailingCommas(enum.Enum):
+        """Trailing comma options."""
+
+        YES = TrailingCommaConfig(multiline_trailing_comma=True)
+        NO = TrailingCommaConfig(multiline_trailing_comma=False)
+
+    date_formats = DateFormats
+    datetime_formats = DatetimeFormats
+    bytes_formats = BytesFormats
+    sequence_formats = SequenceFormats
+    set_formats = SetFormats
+    comment_formats = CommentFormats
+
+    class VariableTypeHints(enum.Enum):
+        """Variable type hint options."""
+
+        NEVER = enum.auto()
+        SAFE = enum.auto()
+
+    variable_type_hints_formats = VariableTypeHints
+    declaration_styles = DeclarationStyles
+    dict_entry_styles = DictEntryStyles
+    dict_formats = DictFormats
+    empty_dict_keys = EmptyDictKey
+    float_formats = FloatFormats
+    integer_formats = IntegerFormats
+    numeric_literal_suffixes = NumericLiteralSuffixes
+    numeric_separators = NumericSeparators
+    numeric_styles = NumericStyles
+    string_formats = StringFormats
+    trailing_commas = TrailingCommas
+
+    class StatementTerminatorStyles(enum.Enum):
+        """Statement terminator options."""
+
+        SEMICOLON = enum.auto()
+
+    statement_terminator_styles = StatementTerminatorStyles
+
+    class CallStyles(enum.Enum):
+        """Carbon call style options."""
+
+        POSITIONAL = PositionalCallStyle()
+
+    call_styles = CallStyles
+
+    class Modifiers(enum.Enum):
+        """C++/Java/C#-style declaration modifiers: this language has none."""
+
+    modifiers = Modifiers
+
+    class HeterogeneousStrategies(enum.Enum):
+        """Heterogeneous-scalar strategy options.
+
+        ``ERROR`` keeps the default ``CVal`` union model: a
+        record-shaped dict that mixes scalars with a container is
+        rendered as a homogeneous-typed ``CVal.Map((...))``.
+        """
+
+        ERROR = enum.auto()
+
+    heterogeneous_strategies = HeterogeneousStrategies
+
+    class VersionFormats(enum.Enum):
+        """Version options for Carbon."""
+
+        V0 = enum.auto()
+
+    version_formats = VersionFormats
+
+    modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
+    identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
+        IdentifierCase.SNAKE,
+        IdentifierCase.PASCAL,
+        IdentifierCase.CAMEL,
+    )
+    supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
+        NON_KEBAB_REF_CASES
+    )
+
+    validate_spec_for_data = no_validate_spec_for_data
+
+    @cached_property
+    def validate_call_arg(self) -> Callable[[Value], None]:
+        """Return call-argument validation for this language."""
+        return no_validate_call_arg
+
+    @cached_property
+    def format_call_statement(self) -> Callable[[str], str]:
+        """Return call-statement formatting for this language."""
+        return identity_call_statement
+
+    wrap_calls_with_declarations = default_wrap_calls_with_declarations
+
+    def wrap_in_file(
+        self,
+        content: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap a Carbon declaration in a ``Run`` function."""
+        content = prepend_body_preamble(
+            content=content,
+            body_preamble=body_preamble,
+        )
+        indented = textwrap.indent(text=content, prefix=self.indent)
+        if not variable_name:
+            return f"fn Run() {{\n{indented}\n}}"
+        use = f"{self.indent}let _: CVal = {variable_name};"
+        return f"fn Run() {{\n{indented}\n{use}\n}}"
+
+    def wrap_combined_in_file(
+        self,
+        declaration: str,
+        assignment: str,
+        variable_name: str,
+        body_preamble: tuple[str, ...],
+    ) -> str:
+        """Wrap Carbon declaration + assignment in a ``Run`` function."""
+        return self.wrap_in_file(
+            content=declaration + "\n" + assignment,
+            variable_name=variable_name,
+            body_preamble=body_preamble,
+        )
+
+    date_format: DateFormats = DateFormats.CARBON
+    datetime_format: DatetimeFormats = DatetimeFormats.CARBON
+    bytes_format: BytesFormats = BytesFormats.HEX
+    sequence_format: SequenceFormats = SequenceFormats.ARRAY
+    set_format: SetFormats = SetFormats.SET
+    variable_type_hints: VariableTypeHints = VariableTypeHints.NEVER
+    comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
+    declaration_style: DeclarationStyles = DeclarationStyles.LET
+    dict_entry_style: DictEntryStyles = DictEntryStyles.DEFAULT
+    dict_format: DictFormats = DictFormats.DEFAULT
+    float_format: FloatFormats = FloatFormats.REPR
+    integer_format: IntegerFormats = IntegerFormats.DECIMAL
+    numeric_literal_suffix: NumericLiteralSuffixes = (
+        NumericLiteralSuffixes.NONE
+    )
+    numeric_separator: NumericSeparators = NumericSeparators.NONE
+    numeric_style: NumericStyles = NumericStyles.OVERLOADED
+    string_format: StringFormats = StringFormats.DOUBLE
+    trailing_comma: TrailingCommas = TrailingCommas.YES
+    statement_terminator_style: StatementTerminatorStyles = (
+        StatementTerminatorStyles.SEMICOLON
+    )
+    heterogeneous_strategy: HeterogeneousStrategies = (
+        HeterogeneousStrategies.ERROR
+    )
+    language_version: VersionFormats = VersionFormats.V0
+    indent: str = "  "
+
+    indent_closing_delimiter: ClassVar[bool] = False
+    element_separator: ClassVar[str] = ", "
+    skip_null_dict_values: ClassVar[bool] = False
+    supports_collection_comments: ClassVar[bool] = True
+    supports_scalar_before_comments: ClassVar[bool] = True
+    supports_scalar_inline_comments: ClassVar[bool] = False
+    statement_terminator: ClassVar[str] = ";"
+    static_body_preamble: ClassVar[Sequence[str]] = ()
+    special_float_preamble: ClassVar[tuple[str, ...]] = ()
+    call_style: CallStyles = CallStyles.POSITIONAL
+
+    @cached_property
+    def call_style_config(self) -> CallStyle:
+        """Configuration for the chosen call style."""
+        return self.call_style.value
+
+    @cached_property
+    def _format_entry(self) -> Callable[[Value, str], str]:
+        """Shared entry formatter closing over date/datetime
+        ``type_produced``.
+        """
+        date_type = self.date_format.value.type_produced
+        datetime_type = self.datetime_format.value.type_produced
+
+        @beartype
+        def _formatter(original: Value, formatted: str) -> str:
+            """Adapt :func:`_format_carbon_entry` to the positional
+            entry-formatter interface.
+            """
+            return _format_carbon_entry(
+                original=original,
+                formatted=formatted,
+                date_type=date_type,
+                datetime_type=datetime_type,
+            )
+
+        return _formatter
+
+    @cached_property
+    def format_sequence_entry(self) -> Callable[[Value, str], str]:
+        """Format a sequence entry."""
+        return self._format_entry
+
+    @cached_property
+    def format_set_entry(self) -> Callable[[Value, str], str]:
+        """Format a set entry."""
+        return self._format_entry
+
+    @cached_property
+    def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
+        """Format an assignment to an existing variable."""
+        format_entry = self._format_entry
+
+        @beartype
+        def _format_assign(name: str, value: str, data: Value) -> str:
+            """Format a Carbon assignment to an existing ``CVal``
+            variable.
+            """
+            wrapped = format_entry(data, value)
+            return f"{name} = {wrapped};"
+
+        return _format_assign
+
+    @cached_property
+    def null_literal(self) -> str:
+        """The literal representing null (the ``CVal.Nil``
+        alternative).
+        """
+        return "CVal.Nil"
+
+    @cached_property
+    def true_literal(self) -> str:
+        """The literal representing true."""
+        return "CVal.Bool(true)"
+
+    @cached_property
+    def false_literal(self) -> str:
+        """The literal representing false."""
+        return "CVal.Bool(false)"
+
+    @cached_property
+    def static_preamble(self) -> Sequence[str]:
+        """File-scope preamble: the ``CVal`` tagged-union declaration.
+
+        ``Core.String`` is the prelude string type and the array
+        alternatives carry a homogeneous ``CVal`` element type so a
+        sequence/set/map can hold mixed JSON values.
+        """
+        return (
+            "choice CVal {",
+            "  Nil,",
+            "  Bool(bool),",
+            "  Int(i64),",
+            "  UInt(u64),",
+            "  Float(f64),",
+            "  Str(Core.String),",
+            "  Arr(Core.Array(CVal)),",
+            "  Map(Core.Array({.key: Core.String, .val: CVal})),",
+            "  Set(Core.Array(CVal)),",
+            "}",
+        )
+
+    @cached_property
+    def data_dependent_preamble(self) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines (Carbon needs none)."""
+        return no_data_preamble
+
+    @cached_property
+    def heterogeneous_behavior(self) -> HeterogeneousBehavior:
+        """Return the heterogeneous-behavior config.
+
+        The ``CVal`` union model represents every mixed collection
+        natively, so no special heterogeneous behavior is required.
+        """
+        return NO_HETEROGENEOUS_BEHAVIOR
+
+    @cached_property
+    def call_data_dependent_preamble(
+        self,
+    ) -> Callable[[Value], tuple[str, ...]]:
+        """Return data-dependent preamble lines for call rendering."""
+        return self.data_dependent_preamble
+
+    @cached_property
+    def type_hint_collection_preamble_lines(
+        self,
+    ) -> Callable[[frozenset[type]], tuple[str, ...]]:
+        """Return preamble lines for empty-collection type hints."""
+        return no_type_hint_preamble
+
+    @cached_property
+    def format_call_stub(
+        self,
+    ) -> Callable[
+        [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
+        tuple[str, ...],
+    ]:
+        """Return stub declarations for a call expression.
+
+        Carbon disallows nested function declarations, so every stub is
+        emitted at file scope via :attr:`format_call_preamble_stub`
+        instead.
+        """
+        return no_call_stub
+
+    @cached_property
+    def format_call_preamble_stub(
+        self,
+    ) -> Callable[
+        [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
+        tuple[str, ...],
+    ]:
+        """Return file-scope stubs for a call expression."""
+        return _make_carbon_call_preamble_stub()
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Wrap each call argument in the ``CVal`` union so call sites
+        match the parameter shape emitted by
+        :func:`_carbon_call_preamble_stub`.
+        """
+        return self._format_entry
+
+    @cached_property
+    def format_call_target(self) -> Callable[[Sequence[str]], str]:
+        """Rewrite a dotted call target into the language's call
+        syntax.
+        """
+        return identity_call_target
+
+    @cached_property
+    def format_call_ref_identifier(
+        self,
+    ) -> Callable[[str, Value | None], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier into the
+        language's call expression syntax.
+        """
+        return identity_call_ref_identifier
+
+    @cached_property
+    def format_call_arg_ref_identifier(
+        self,
+    ) -> Callable[[str, Value | None], str]:
+        """Rewrite a ``{"$ref": "name"}`` identifier in a call-argument
+        context.
+        """
+        return self.format_call_ref_identifier
+
+    @cached_property
+    def format_call_arg_ref_identifier_consumable(
+        self,
+    ) -> Callable[[str, Value | None], str]:
+        """Format a ``$ref`` the caller authorized as consumable."""
+        return self.format_call_arg_ref_identifier
+
+    @cached_property
+    def consumable_ref_value_inhibits_consuming_form(
+        self,
+    ) -> Callable[[Value], bool]:
+        """Predicate deciding whether a ref's underlying value type
+        inhibits the consume form.
+        """
+        return never_inhibits_consuming_form
+
+    @cached_property
+    def sequence_format_config(self) -> SequenceFormatConfig:
+        """Configuration for the chosen sequence format."""
+        return self.sequence_format.value
+
+    @cached_property
+    def set_format_config(self) -> SetFormatConfig:
+        """Configuration for the chosen set format."""
+        return self.set_format.value
+
+    @cached_property
+    def sequence_open(self) -> Callable[[list[Value]], str]:
+        """Callable that returns the opening delimiter for a sequence."""
+        return self.sequence_format.value.sequence_open
+
+    @cached_property
+    def dict_format_config(self) -> DictFormatConfig:
+        """Configuration for dict formatting.
+
+        Every dict is rendered as the ``CVal.Map`` alternative whose
+        entries are ``{.key = ..., .val = ...}`` struct literals.
+        """
+        return DictFormatConfig(
+            dict_open=fixed_open(open_str="CVal.Map(("),
+            close="))",
+            format_entry=dict_entry_with_template(
+                template="{{.key = {key}, .val = {value}}}",
+                format_value=self._format_entry,
+            ),
+            empty_dict=None,
+            preamble_lines=(),
+            narrowed_open=None,
+            supports_trailing_comma=True,
+        )
+
+    @cached_property
+    def trailing_comma_config(self) -> TrailingCommaConfig:
+        """Configuration for trailing-comma behavior."""
+        return self.trailing_comma.value
+
+    @cached_property
+    def format_bytes(self) -> Callable[[bytes], str]:
+        """Callable that formats a bytes value as a string literal."""
+        return self.bytes_format
+
+    @cached_property
+    def format_date(self) -> Callable[[datetime.date], str]:
+        """Callable that formats a date as a string literal."""
+        return self.date_format
+
+    @cached_property
+    def format_datetime(self) -> Callable[[datetime.datetime], str]:
+        """Callable that formats a datetime as a string literal."""
+        return self.datetime_format
+
+    @cached_property
+    def format_time(self) -> Callable[[datetime.time], str]:
+        """Callable that formats a time as a string literal."""
+        return format_time_iso
+
+    @cached_property
+    def format_string(self) -> Callable[[str], str]:
+        """Callable that formats a string value as a quoted literal."""
+
+        def _format(value: str) -> str:
+            """Format a string as a Carbon quoted literal."""
+            return format_string_backslash_control(
+                value=value,
+                control_char_fmt="\\x{:02X}",
+            )
+
+        return _format
+
+    @cached_property
+    def format_float(self) -> Callable[[float], str]:
+        """Callable that formats a float value as a literal."""
+        return self.float_format
+
+    @cached_property
+    def format_integer(self) -> Callable[[int], str]:
+        """Callable that formats an int value as a literal."""
+        return self.integer_format.get_formatter(
+            numeric_separator=self.numeric_separator,
+        )
+
+    @cached_property
+    def comment_config(self) -> CommentConfig:
+        """Configuration for the language's comment syntax."""
+        return self.comment_format.value
+
+    @cached_property
+    def ordered_map_format_config(self) -> OrderedMapFormatConfig:
+        """Configuration for ordered-map formatting.
+
+        An ordered map is rendered with the same ``CVal.Map``
+        alternative as a plain dict.
+        """
+        return OrderedMapFormatConfig(
+            ordered_map_open=fixed_open(open_str="CVal.Map(("),
+            close="))",
+            preamble_lines=(),
+        )
+
+    @cached_property
+    def format_ordered_map_entry(self) -> Callable[[str, Value, str], str]:
+        """Callable that formats one ordered-map entry."""
+        return dict_entry_with_template(
+            template="{{.key = {key}, .val = {value}}}",
+            format_value=self._format_entry,
+        )
+
+    @cached_property
+    def format_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a new variable declaration.
+
+        Closes over the chosen date/datetime ``type_produced`` so the
+        ``CVal`` alternative selection is driven by the parsed
+        :class:`Value` rather than the rendered text.
+        """
+        keyword = self.declaration_style.value.keyword
+        format_entry = self._format_entry
+
+        @beartype
+        def _format_decl(
+            name: str,
+            value: str,
+            data: Value,
+            _modifiers: frozenset[enum.Enum],
+        ) -> str:
+            """Format a Carbon declaration with an explicit ``: CVal``
+            type.
+            """
+            wrapped = format_entry(data, value)
+            return f"{keyword} {name}: CVal = {wrapped};"
+
+        return _format_decl
+
+    @cached_property
+    def format_call_variable_declaration(
+        self,
+    ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+        """Callable that formats a declaration binding a call result.
+
+        A ``CVal`` literal binding declares an explicit ``: CVal``
+        type.  A call's return type is opaque to the renderer, so the
+        call result is bound with an inferred ``: auto`` declaration
+        (``let my_data: auto = make_widget(...);`` /
+        ``var my_data: auto = make_widget(...);``): no caller-supplied
+        return-type hint is needed and the value-wrapping is dropped.
+        """
+        keyword = self.declaration_style.value.keyword
+
+        @beartype
+        def _format_call_decl(
+            name: str,
+            value: str,
+            _data: Value,
+            _modifiers: frozenset[enum.Enum],
+        ) -> str:
+            """Format an inferred Carbon declaration binding a call."""
+            return f"{keyword} {name}: auto = {value};"
+
+        return _format_call_decl
+
+    @cached_property
+    def format_call_variable_assignment(
+        self,
+    ) -> Callable[[str, str, Value], str]:
+        """Callable that formats an assignment binding a call result.
+
+        The call-expression counterpart of
+        :attr:`format_call_variable_declaration`; the ``CVal`` wrapping
+        a literal-binding assignment applies is dropped since a call
+        result is not a ``CVal`` union literal.
+        """
+        return _format_carbon_call_assignment
+
+    @cached_property
+    def scalar_preamble(self) -> dict[type, tuple[str, ...]]:
+        """Per-instance scalar preamble (Carbon needs none)."""
+        return {}
+
+    @cached_property
+    def scalar_body_preamble(self) -> dict[type, tuple[str, ...]]:
+        """Per-instance scalar body preamble (Carbon needs none)."""
+        return {}
+
+    @cached_property
+    def compute_body_preamble(
+        self,
+    ) -> Callable[[frozenset[type], Value], tuple[str, ...]]:
+        """Compute body-preamble lines from the scalar map."""
+        return body_preamble_from_scalars(
+            scalar_body_preamble=self.scalar_body_preamble,
+            format_lines=tuple,
+        )

--- a/tests/integration/cases/binary/Carbon@v0.carbon
+++ b/tests/integration/cases/binary/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary/Carbon_bytes_format_base64@v0.carbon
+++ b/tests/integration/cases/binary/Carbon_bytes_format_base64@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("SGVsbG8="),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/binary/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/binary/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/binary/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary_list/Carbon@v0.carbon
+++ b/tests/integration/cases/binary_list/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/binary_list/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary_with_empty_sibling/Carbon@v0.carbon
+++ b/tests/integration/cases/binary_with_empty_sibling/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/binary_with_empty_sibling/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/binary_with_empty_sibling/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+    CVal.Arr(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("48656c6c6f"),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/bool_list/Carbon@v0.carbon
+++ b/tests/integration/cases/bool_list/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Bool(true),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/bool_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/bool_list/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Bool(true),
+  ));
+  my_data = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Bool(true),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/bool_list/Carbon_indent_three_space@v0.carbon
+++ b/tests/integration/cases/bool_list/Carbon_indent_three_space@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+   let my_data: CVal = CVal.Arr((
+      CVal.Bool(true),
+      CVal.Bool(false),
+      CVal.Bool(true),
+   ));
+   let _: CVal = my_data;
+}

--- a/tests/integration/cases/bool_list/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/bool_list/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Bool(true),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/bool_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/bool_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Bool(true),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/bool_list/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/bool_list/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Bool(true),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/call_27_parameters/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_27_parameters/Carbon_call@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(p0: CVal, p1: CVal, p2: CVal, p3: CVal, p4: CVal, p5: CVal, p6: CVal, p7: CVal, p8: CVal, p9: CVal, p10: CVal, p11: CVal, p12: CVal, p13: CVal, p14: CVal, p15: CVal, p16: CVal, p17: CVal, p18: CVal, p19: CVal, p20: CVal, p21: CVal, p22: CVal, p23: CVal, p24: CVal, p25: CVal, p26: CVal) {}
+fn Run() {
+  process(CVal.Int(0), CVal.Int(1), CVal.Int(2), CVal.Int(3), CVal.Int(4), CVal.Int(5), CVal.Int(6), CVal.Int(7), CVal.Int(8), CVal.Int(9), CVal.Int(10), CVal.Int(11), CVal.Int(12), CVal.Int(13), CVal.Int(14), CVal.Int(15), CVal.Int(16), CVal.Int(17), CVal.Int(18), CVal.Int(19), CVal.Int(20), CVal.Int(21), CVal.Int(22), CVal.Int(23), CVal.Int(24), CVal.Int(25), CVal.Int(26));
+}

--- a/tests/integration/cases/call_comments/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_comments/Carbon_call@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  // Test cases
+  process(CVal.Str("hello"));  // single word
+  process(CVal.Str("hello world"));  // two words
+  // trailing comment
+}

--- a/tests/integration/cases/call_comments_dict_args/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_comments_dict_args/Carbon_call@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  // Test cases
+  process(CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_1")})));  // first case
+  process(CVal.Map(({.key = "type", .val = CVal.Str("update")}, {.key = "pr_id", .val = CVal.Str("pr_2")})));  // second case
+  // third case
+  process(CVal.Map(({.key = "type", .val = CVal.Str("delete")}, {.key = "pr_id", .val = CVal.Str("pr_3")})));
+}

--- a/tests/integration/cases/call_deep_dotted_method/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_deep_dotted_method/Carbon_call@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class ClientType_ { fn post[self: Self](data: CVal) {} }
+class ApiType_ { var client: ClientType_; }
+class ObjType_ { var api: ApiType_; }
+var obj: ObjType_;
+fn Run() {
+  obj.api.client.post(CVal.Str("hello"));
+  obj.api.client.post(CVal.Int(42));
+  obj.api.client.post(CVal.Bool(true));
+}

--- a/tests/integration/cases/call_deep_dotted_transformed/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_deep_dotted_transformed/Carbon_call@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class ClientType_ { fn fetch[self: Self](payload: CVal) {} }
+class AppType_ { var client: ClientType_; }
+var app: AppType_;
+fn emit(_arg: CVal) {}
+fn Run() {
+  emit(app.client.fetch(CVal.Str("hello")));
+  emit(app.client.fetch(CVal.Int(42)));
+  emit(app.client.fetch(CVal.Bool(true)));
+}

--- a/tests/integration/cases/call_dotted_method/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_dotted_method/Carbon_call@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class ClientType_ { fn fetch[self: Self](payload: CVal) {} }
+class AppType_ { var client: ClientType_; }
+var app: AppType_;
+fn Run() {
+  app.client.fetch(CVal.Str("hello"));
+  app.client.fetch(CVal.Int(42));
+  app.client.fetch(CVal.Bool(true));
+}

--- a/tests/integration/cases/call_dotted_transform_stub/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_dotted_transform_stub/Carbon_call@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+class TracerType_ { fn emit[self: Self](_arg: CVal) {} }
+var tracer: TracerType_;
+fn Run() {
+  tracer.emit(process(CVal.Str("hello")));
+  tracer.emit(process(CVal.Int(42)));
+  tracer.emit(process(CVal.Bool(true)));
+}

--- a/tests/integration/cases/call_existing_ref_arg/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_existing_ref_arg/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  let existing: CVal = CVal.Int(42);
+  process(existing);
+}

--- a/tests/integration/cases/call_homogeneous_dotted_method/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_homogeneous_dotted_method/Carbon_call@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class ClientType_ { fn fetch[self: Self](value: CVal) {} }
+class AppType_ { var client: ClientType_; }
+var app: AppType_;
+fn Run() {
+  app.client.fetch(CVal.Str("hello"));
+  app.client.fetch(CVal.Str("world"));
+}

--- a/tests/integration/cases/call_homogeneous_value_dict_arg/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_homogeneous_value_dict_arg/Carbon_call@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  process(CVal.Map(({.key = "a", .val = CVal.Int(1)}, {.key = "b", .val = CVal.Int(2)})));
+}

--- a/tests/integration/cases/call_keyword_args/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_keyword_args/Carbon_call@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class ThrottlerType_ { fn check[self: Self](user_id: CVal, ts: CVal) {} }
+var throttler: ThrottlerType_;
+fn emit(_arg: CVal) {}
+fn Run() {
+  emit(throttler.check(CVal.Str("user_1"), CVal.Float(1000.0)));
+  emit(throttler.check(CVal.Str("user_2"), CVal.Float(2000.5)));
+}

--- a/tests/integration/cases/call_line_comments/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_line_comments/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  process(CVal.Str("Dune"));  // first edition
+  process(CVal.Str("Solaris"));
+  process(CVal.Str("Neuromancer"));  // cyberpunk
+}

--- a/tests/integration/cases/call_mixed_type_dicts/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_mixed_type_dicts/Carbon_call@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class MgrType_ { fn run[self: Self](operation: CVal) {} }
+class AppType_ { var mgr: MgrType_; }
+var app: AppType_;
+fn Run() {
+  app.mgr.run(CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_1")}, {.key = "draft", .val = CVal.Bool(true)})));
+  app.mgr.run(CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_2")})));
+}

--- a/tests/integration/cases/call_multi_args/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_multi_args/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal, count: CVal) {}
+fn Run() {
+  process(CVal.Int(1), CVal.Int(42));
+  process(CVal.Int(2), CVal.Int(100));
+}

--- a/tests/integration/cases/call_negative_int/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_negative_int/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  process(CVal.Int(-1));
+  process(CVal.Int(-2));
+  process(CVal.Int(-3));
+}

--- a/tests/integration/cases/call_no_params/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_no_params/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process() {}
+fn Run() {
+  process();
+  process();
+}

--- a/tests/integration/cases/call_no_params_dotted/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_no_params_dotted/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class ThrottlerType_ { fn check[self: Self]() {} }
+var throttler: ThrottlerType_;
+fn Run() {
+  throttler.check();
+  throttler.check();
+}

--- a/tests/integration/cases/call_no_params_transform/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_no_params_transform/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process() {}
+fn emit(_arg: CVal) {}
+fn Run() {
+  emit(process());
+  emit(process());
+}

--- a/tests/integration/cases/call_per_element_false/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_per_element_false/Carbon_call@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal) {}
+fn Run() {
+  process(CVal.Int(1));
+}

--- a/tests/integration/cases/call_per_element_false_dict_arg/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_per_element_false_dict_arg/Carbon_call@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  process(CVal.Map(({.key = "a", .val = CVal.Int(1)}, {.key = "b", .val = CVal.Str("x")})));
+}

--- a/tests/integration/cases/call_quad_args/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_quad_args/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(a: CVal, b: CVal, c: CVal, d: CVal) {}
+fn Run() {
+  process(CVal.Int(1), CVal.Int(2), CVal.Int(3), CVal.Int(4));
+  process(CVal.Int(5), CVal.Int(6), CVal.Int(7), CVal.Int(8));
+}

--- a/tests/integration/cases/call_ref_args/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args/Carbon_call@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal, count: CVal) {}
+fn Run() {
+  let my_var: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let my_other: CVal = CVal.Arr((
+    CVal.Int(4),
+    CVal.Int(5),
+    CVal.Int(6),
+  ));
+  process(my_var, CVal.Int(42));
+  process(my_other, CVal.Int(7));
+}

--- a/tests/integration/cases/call_ref_args_converted/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args_converted/Carbon_call@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal, count: CVal) {}
+fn Run() {
+  let my_var: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let my_other: CVal = CVal.Arr((
+    CVal.Int(4),
+    CVal.Int(5),
+    CVal.Int(6),
+  ));
+  process(my_var, CVal.Int(42));
+  process(my_other, CVal.Int(7));
+}

--- a/tests/integration/cases/call_ref_args_converted_nonsnake/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args_converted_nonsnake/Carbon_call@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal, count: CVal) {}
+fn Run() {
+  let my_var: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let my_other: CVal = CVal.Arr((
+    CVal.Int(4),
+    CVal.Int(5),
+    CVal.Int(6),
+  ));
+  process(my_var, CVal.Int(42));
+  process(my_other, CVal.Int(7));
+}

--- a/tests/integration/cases/call_ref_args_converted_whole/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args_converted_whole/Carbon_call@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal) {}
+fn Run() {
+  let my_var: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  process(my_var);
+}

--- a/tests/integration/cases/call_ref_args_escaped_quote/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args_escaped_quote/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(v: CVal) {}
+fn Run() {
+  let my_str: CVal = CVal.Str("a\"b");
+  process(my_str);
+}

--- a/tests/integration/cases/call_ref_args_heterogeneous_list/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args_heterogeneous_list/Carbon_call@v0.carbon
@@ -1,0 +1,27 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal, count: CVal) {}
+fn Run() {
+  let my_ints: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let my_strings: CVal = CVal.Arr((
+    CVal.Str("a"),
+    CVal.Str("b"),
+  ));
+  let my_empty: CVal = CVal.Arr(());
+  process(my_ints, CVal.Int(42));
+  process(my_strings, CVal.Int(7));
+  process(my_empty, CVal.Int(99));
+}

--- a/tests/integration/cases/call_ref_args_reused/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args_reused/Carbon_call@v0.carbon
@@ -1,0 +1,23 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal, count: CVal) {}
+fn Run() {
+  let single_var: CVal = CVal.Arr((
+    CVal.Int(4),
+    CVal.Int(5),
+    CVal.Int(6),
+  ));
+  let repeated_var: CVal = CVal.Int(1);
+  process(repeated_var, CVal.Int(1));
+  process(single_var, CVal.Int(0));
+  process(repeated_var, CVal.Int(8));
+}

--- a/tests/integration/cases/call_ref_args_trivial_register/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_args_trivial_register/Carbon_call@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal, count: CVal) {}
+fn Run() {
+  let my_int: CVal = CVal.Int(1);
+  let my_bool: CVal = CVal.Bool(true);
+  let my_float: CVal = CVal.Float(3.14);
+  let my_list: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  process(my_int, CVal.Int(42));
+  process(my_bool, CVal.Int(7));
+  process(my_float, CVal.Int(9));
+  process(my_list, CVal.Int(1));
+}

--- a/tests/integration/cases/call_ref_nested_converted/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_nested_converted/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal) {}
+fn Run() {
+  let my_var: CVal = CVal.Int(42);
+  process(CVal.Arr((my_var, CVal.Int(42), CVal.Str("static"))));
+}

--- a/tests/integration/cases/call_ref_nested_in_dict/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_nested_in_dict/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal) {}
+fn Run() {
+  let my_var: CVal = CVal.Int(42);
+  process(CVal.Map(({.key = "key", .val = my_var}, {.key = "count", .val = CVal.Int(42)})));
+}

--- a/tests/integration/cases/call_ref_nested_in_list/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_ref_nested_in_list/Carbon_call@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(data: CVal) {}
+fn Run() {
+  let my_var: CVal = CVal.Int(42);
+  let my_other: CVal = CVal.Int(7);
+  process(CVal.Arr((my_var, CVal.Int(42), CVal.Str("static"))));
+  process(CVal.Arr((my_other, CVal.Int(7), CVal.Str("label"))));
+}

--- a/tests/integration/cases/call_reserved_target/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_reserved_target/Carbon_call@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn op(value: CVal) {}
+fn Run() {
+  op(CVal.Str("hello"));
+}

--- a/tests/integration/cases/call_scalar_args/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_scalar_args/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  process(CVal.Str("hello"));
+  process(CVal.Int(42));
+  process(CVal.Bool(true));
+}

--- a/tests/integration/cases/call_scalar_args_uniform_second_slot/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_scalar_args_uniform_second_slot/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal, label: CVal) {}
+fn Run() {
+  process(CVal.Str("hello"), CVal.Str("a"));
+  process(CVal.Int(42), CVal.Str("b"));
+  process(CVal.Bool(true), CVal.Str("c"));
+}

--- a/tests/integration/cases/call_scalar_args_with_null/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_scalar_args_with_null/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  process(CVal.Nil);
+  process(CVal.Str("hello"));
+}

--- a/tests/integration/cases/call_snake_dotted_method/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_snake_dotted_method/Carbon_call@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+class Http_ClientType_ { fn fetch[self: Self](payload: CVal) {} }
+class My_AppType_ { var http_client: Http_ClientType_; }
+var my_app: My_AppType_;
+fn Run() {
+  my_app.http_client.fetch(CVal.Str("hello"));
+  my_app.http_client.fetch(CVal.Int(42));
+  my_app.http_client.fetch(CVal.Bool(true));
+}

--- a/tests/integration/cases/call_transform_no_wrapper/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_transform_no_wrapper/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn Run() {
+  process(CVal.Str("hello"));
+  process(CVal.Int(42));
+  process(CVal.Bool(true));
+}

--- a/tests/integration/cases/call_variable_form_new/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_variable_form_new/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn make_widget(count: CVal) {}
+fn Run() {
+  let my_data: auto = make_widget(CVal.Int(42));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/call_wrap_in_file/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_wrap_in_file/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(a: CVal, b: CVal) {}
+fn Run() {
+  process(CVal.Int(1), CVal.Int(2));
+  process(CVal.Int(3), CVal.Int(4));
+}

--- a/tests/integration/cases/call_wrap_in_file_escaped_quote/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_wrap_in_file_escaped_quote/Carbon_call@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(v: CVal) {}
+fn Run() {
+  process(CVal.Str("a\"b"));
+}

--- a/tests/integration/cases/call_zip_source_whole/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_zip_source_whole/Carbon_call@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn emit(_call: CVal, _zip: CVal) {}
+fn Run() {
+  emit(process(CVal.Int(42)), CVal.Bool(true));
+}

--- a/tests/integration/cases/call_zip_values/Carbon_call@v0.carbon
+++ b/tests/integration/cases/call_zip_values/Carbon_call@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn process(value: CVal) {}
+fn emit(_call: CVal, _zip: CVal) {}
+fn Run() {
+  emit(process(CVal.Str("hello")), CVal.Bool(true));
+  emit(process(CVal.Int(42)), CVal.Bool(false));
+}

--- a/tests/integration/cases/comment_block_scalar_not_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "description", .val = CVal.Str("# not a comment\n")},
+    {.key = "name", .val = CVal.Str("foo")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_block_scalar_not_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comment_block_scalar_not_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "description", .val = CVal.Str("# not a comment\n")},
+    {.key = "name", .val = CVal.Str("foo")},
+  ));
+  my_data = CVal.Map((
+    {.key = "description", .val = CVal.Str("# not a comment\n")},
+    {.key = "name", .val = CVal.Str("foo")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar/Carbon@v0.carbon
+++ b/tests/integration/cases/comment_scalar/Carbon@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(// note
+  42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comment_scalar/Carbon_combined@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(// note
+  42);
+  my_data = CVal.Int(// note
+  42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_before_and_inline/Carbon@v0.carbon
+++ b/tests/integration/cases/comment_scalar_before_and_inline/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // inline
+  let my_data: CVal = CVal.Str(// before
+  "plain");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_before_and_inline/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comment_scalar_before_and_inline/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // inline
+  var my_data: CVal = CVal.Str(// before
+  "plain");
+  // inline
+  my_data = CVal.Str(// before
+  "plain");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_document_markers/Carbon@v0.carbon
+++ b/tests/integration/cases/comment_scalar_document_markers/Carbon@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(// note
+  42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_document_markers/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comment_scalar_document_markers/Carbon_combined@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(// note
+  42);
+  my_data = CVal.Int(// note
+  42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_inline/Carbon@v0.carbon
+++ b/tests/integration/cases/comment_scalar_inline/Carbon@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // note
+  let my_data: CVal = CVal.Int(42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_inline/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comment_scalar_inline/Carbon_combined@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // note
+  var my_data: CVal = CVal.Int(42);
+  // note
+  my_data = CVal.Int(42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Carbon@v0.carbon
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Carbon@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // note
+  let my_data: CVal = CVal.Str("hello # world");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comment_scalar_quoted_with_hash/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comment_scalar_quoted_with_hash/Carbon_combined@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // note
+  var my_data: CVal = CVal.Str("hello # world");
+  // note
+  my_data = CVal.Str("hello # world");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments/Carbon@v0.carbon
+++ b/tests/integration/cases/comments/Carbon@v0.carbon
@@ -1,0 +1,21 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    // Server configuration
+    {.key = "host", .val = CVal.Str("localhost")},  // default host
+    {.key = "port", .val = CVal.Int(8080)},
+    // Enable debug mode
+    {.key = "debug", .val = CVal.Bool(true)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments/Carbon_combined@v0.carbon
@@ -1,0 +1,28 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    // Server configuration
+    {.key = "host", .val = CVal.Str("localhost")},  // default host
+    {.key = "port", .val = CVal.Int(8080)},
+    // Enable debug mode
+    {.key = "debug", .val = CVal.Bool(true)},
+  ));
+  my_data = CVal.Map((
+    // Server configuration
+    {.key = "host", .val = CVal.Str("localhost")},  // default host
+    {.key = "port", .val = CVal.Int(8080)},
+    // Enable debug mode
+    {.key = "debug", .val = CVal.Bool(true)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_bang_in_double_quote/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_bang_in_double_quote/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "key", .val = CVal.Str("\"bang!\"")},  // real
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_bang_in_double_quote/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_bang_in_double_quote/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "key", .val = CVal.Str("\"bang!\"")},  // real
+  ));
+  my_data = CVal.Map((
+    {.key = "key", .val = CVal.Str("\"bang!\"")},  // real
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_double_hash/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_double_hash/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    // # section
+    CVal.Str("a"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_double_hash/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_double_hash/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    // # section
+    CVal.Str("a"),
+  ));
+  my_data = CVal.Arr((
+    // # section
+    CVal.Str("a"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_empty_line/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_empty_line/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("a"),
+    //
+    CVal.Str("b"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_empty_line/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_empty_line/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("a"),
+    //
+    CVal.Str("b"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("a"),
+    //
+    CVal.Str("b"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_escaped_quote/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_escaped_quote/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "key", .val = CVal.Str("value \" # not a comment")},  // real
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_escaped_quote/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_escaped_quote/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "key", .val = CVal.Str("value \" # not a comment")},  // real
+  ));
+  my_data = CVal.Map((
+    {.key = "key", .val = CVal.Str("value \" # not a comment")},  // real
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_escaped_single_quote/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_escaped_single_quote/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "key", .val = CVal.Str("it's here")},  // a comment
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_escaped_single_quote/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_escaped_single_quote/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "key", .val = CVal.Str("it's here")},  // a comment
+  ));
+  my_data = CVal.Map((
+    {.key = "key", .val = CVal.Str("it's here")},  // a comment
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "host", .val = CVal.Str("it's here")},  // a comment
+    {.key = "port", .val = CVal.Int(80)},  // another
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_escaped_single_quote_multiple/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_escaped_single_quote_multiple/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "host", .val = CVal.Str("it's here")},  // a comment
+    {.key = "port", .val = CVal.Int(80)},  // another
+  ));
+  my_data = CVal.Map((
+    {.key = "host", .val = CVal.Str("it's here")},  // a comment
+    {.key = "port", .val = CVal.Int(80)},  // another
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_multi_line/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_multi_line/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    // line 1
+    // line 2
+    CVal.Str("a"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_multi_line/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_multi_line/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    // line 1
+    // line 2
+    CVal.Str("a"),
+  ));
+  my_data = CVal.Arr((
+    // line 1
+    // line 2
+    CVal.Str("a"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_nested_mapping/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_nested_mapping/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Map(({.key = "x", .val = CVal.Int(1)}))},
+    {.key = "b", .val = CVal.Int(2)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_nested_mapping/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_nested_mapping/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Map(({.key = "x", .val = CVal.Int(1)}))},
+    {.key = "b", .val = CVal.Int(2)},
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Map(({.key = "x", .val = CVal.Int(1)}))},
+    {.key = "b", .val = CVal.Int(2)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_nested_sequence_scalar/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_nested_sequence_scalar/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Str("ADD"), CVal.Str("alice"), CVal.Str("hello"))),
+    CVal.Arr((CVal.Str("DEL"), CVal.Str("bob"), CVal.Str("5"))),  // removes "world"
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_nested_sequence_scalar/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_nested_sequence_scalar/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Str("ADD"), CVal.Str("alice"), CVal.Str("hello"))),
+    CVal.Arr((CVal.Str("DEL"), CVal.Str("bob"), CVal.Str("5"))),  // removes "world"
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Str("ADD"), CVal.Str("alice"), CVal.Str("hello"))),
+    CVal.Arr((CVal.Str("DEL"), CVal.Str("bob"), CVal.Str("5"))),  // removes "world"
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_sequence_before/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_sequence_before/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    // first
+    CVal.Str("a"),
+    // second
+    CVal.Str("b"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_sequence_before/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_sequence_before/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    // first
+    CVal.Str("a"),
+    // second
+    CVal.Str("b"),
+  ));
+  my_data = CVal.Arr((
+    // first
+    CVal.Str("a"),
+    // second
+    CVal.Str("b"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_sequence_inline/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_sequence_inline/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("a"),  // note a
+    CVal.Str("b"),  // note b
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_sequence_inline/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_sequence_inline/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("a"),  // note a
+    CVal.Str("b"),  // note b
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("a"),  // note a
+    CVal.Str("b"),  // note b
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_trailing/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_trailing/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("a"),
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_trailing/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_trailing/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("a"),
+    // trailing
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("a"),
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_vb_before_dim/Carbon@v0.carbon
+++ b/tests/integration/cases/comments_vb_before_dim/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    // Configuration
+    {.key = "name", .val = CVal.Str("app")},
+    // Port setting
+    {.key = "port", .val = CVal.Int(3000)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/comments_vb_before_dim/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/comments_vb_before_dim/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    // Configuration
+    {.key = "name", .val = CVal.Str("app")},
+    // Port setting
+    {.key = "port", .val = CVal.Int(3000)},
+  ));
+  my_data = CVal.Map((
+    // Configuration
+    {.key = "name", .val = CVal.Str("app")},
+    // Port setting
+    {.key = "port", .val = CVal.Int(3000)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/date_list/Carbon@v0.carbon
+++ b/tests/integration/cases/date_list/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1705276800),
+    CVal.Int(1708387200),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/date_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/date_list/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1705276800),
+    CVal.Int(1708387200),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1705276800),
+    CVal.Int(1708387200),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/date_list/Carbon_date_iso@v0.carbon
+++ b/tests/integration/cases/date_list/Carbon_date_iso@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("2024-01-15"),
+    CVal.Str("2024-02-20"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/date_set/Carbon@v0.carbon
+++ b/tests/integration/cases/date_set/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1705276800),
+    CVal.Int(1717200000),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/date_set/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/date_set/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    CVal.Int(1705276800),
+    CVal.Int(1717200000),
+  ));
+  my_data = CVal.Set((
+    CVal.Int(1705276800),
+    CVal.Int(1717200000),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/date_set/Carbon_date_iso@v0.carbon
+++ b/tests/integration/cases/date_set/Carbon_date_iso@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Str("2024-01-15"),
+    CVal.Str("2024-06-01"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dates/Carbon@v0.carbon
+++ b/tests/integration/cases/dates/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "date", .val = CVal.Int(1705276800)},
+    {.key = "datetime", .val = CVal.Int(1705321800)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dates/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dates/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "date", .val = CVal.Int(1705276800)},
+    {.key = "datetime", .val = CVal.Int(1705321800)},
+  ));
+  my_data = CVal.Map((
+    {.key = "date", .val = CVal.Int(1705276800)},
+    {.key = "datetime", .val = CVal.Int(1705321800)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/datetime_list/Carbon@v0.carbon
+++ b/tests/integration/cases/datetime_list/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1705321800),
+    CVal.Int(1717228800),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/datetime_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/datetime_list/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1705321800),
+    CVal.Int(1717228800),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1705321800),
+    CVal.Int(1717228800),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/datetime_list/Carbon_datetime_epoch@v0.carbon
+++ b/tests/integration/cases/datetime_list/Carbon_datetime_epoch@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1705321800),
+    CVal.Int(1717228800),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/datetime_list/Carbon_datetime_iso@v0.carbon
+++ b/tests/integration/cases/datetime_list/Carbon_datetime_iso@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("2024-01-15T12:30:00.123456+00:00"),
+    CVal.Str("2024-06-01T08:00:00+00:00"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/deep_nesting/Carbon@v0.carbon
+++ b/tests/integration/cases/deep_nesting/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "level1", .val = CVal.Map(({.key = "level2", .val = CVal.Map(({.key = "level3", .val = CVal.Map(({.key = "level4", .val = CVal.Map(({.key = "value", .val = CVal.Str("deep")}, {.key = "items", .val = CVal.Arr((CVal.Str("a"), CVal.Str("b")))}))}))}, {.key = "sibling", .val = CVal.Int(42)}))}, {.key = "tags", .val = CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("tag1")}, {.key = "meta", .val = CVal.Map(({.key = "priority", .val = CVal.Int(1)}, {.key = "labels", .val = CVal.Arr((CVal.Str("x"), CVal.Str("y")))}))}))))}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/deep_nesting/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/deep_nesting/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "level1", .val = CVal.Map(({.key = "level2", .val = CVal.Map(({.key = "level3", .val = CVal.Map(({.key = "level4", .val = CVal.Map(({.key = "value", .val = CVal.Str("deep")}, {.key = "items", .val = CVal.Arr((CVal.Str("a"), CVal.Str("b")))}))}))}, {.key = "sibling", .val = CVal.Int(42)}))}, {.key = "tags", .val = CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("tag1")}, {.key = "meta", .val = CVal.Map(({.key = "priority", .val = CVal.Int(1)}, {.key = "labels", .val = CVal.Arr((CVal.Str("x"), CVal.Str("y")))}))}))))}))},
+  ));
+  my_data = CVal.Map((
+    {.key = "level1", .val = CVal.Map(({.key = "level2", .val = CVal.Map(({.key = "level3", .val = CVal.Map(({.key = "level4", .val = CVal.Map(({.key = "value", .val = CVal.Str("deep")}, {.key = "items", .val = CVal.Arr((CVal.Str("a"), CVal.Str("b")))}))}))}, {.key = "sibling", .val = CVal.Int(42)}))}, {.key = "tags", .val = CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("tag1")}, {.key = "meta", .val = CVal.Map(({.key = "priority", .val = CVal.Int(1)}, {.key = "labels", .val = CVal.Arr((CVal.Str("x"), CVal.Str("y")))}))}))))}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_all_null_trailing_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Nil},
+    {.key = "b", .val = CVal.Nil},
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_all_null_trailing_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_all_null_trailing_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Nil},
+    {.key = "b", .val = CVal.Nil},
+    // trailing
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Nil},
+    {.key = "b", .val = CVal.Nil},
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_all_scalar_types/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_all_scalar_types/Carbon@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "s", .val = CVal.Str("string")},
+    {.key = "i", .val = CVal.Int(1)},
+    {.key = "f", .val = CVal.Float(1.5)},
+    {.key = "b", .val = CVal.Bool(true)},
+    {.key = "n", .val = CVal.Nil},
+    {.key = "d", .val = CVal.Int(1705276800)},
+    {.key = "dt", .val = CVal.Int(1705320000)},
+    {.key = "by", .val = CVal.Str("48656c6c6f")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_all_scalar_types/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_all_scalar_types/Carbon_combined@v0.carbon
@@ -1,0 +1,34 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "s", .val = CVal.Str("string")},
+    {.key = "i", .val = CVal.Int(1)},
+    {.key = "f", .val = CVal.Float(1.5)},
+    {.key = "b", .val = CVal.Bool(true)},
+    {.key = "n", .val = CVal.Nil},
+    {.key = "d", .val = CVal.Int(1705276800)},
+    {.key = "dt", .val = CVal.Int(1705320000)},
+    {.key = "by", .val = CVal.Str("48656c6c6f")},
+  ));
+  my_data = CVal.Map((
+    {.key = "s", .val = CVal.Str("string")},
+    {.key = "i", .val = CVal.Int(1)},
+    {.key = "f", .val = CVal.Float(1.5)},
+    {.key = "b", .val = CVal.Bool(true)},
+    {.key = "n", .val = CVal.Nil},
+    {.key = "d", .val = CVal.Int(1705276800)},
+    {.key = "dt", .val = CVal.Int(1705320000)},
+    {.key = "by", .val = CVal.Str("48656c6c6f")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_escaped_quote_key/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_escaped_quote_key/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a\"b", .val = CVal.Int(1)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_escaped_quote_key/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_escaped_quote_key/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a\"b", .val = CVal.Int(1)},
+  ));
+  my_data = CVal.Map((
+    {.key = "a\"b", .val = CVal.Int(1)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_in_sequence_with_empty_sibling/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_in_sequence_with_empty_sibling/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_in_sequence_with_empty_sibling/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_in_sequence_with_empty_sibling/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Arr(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_mixed_int_widths/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Int(3000000000)},
+    {.key = "c", .val = CVal.Str("x")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_mixed_int_widths/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_mixed_int_widths/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Int(3000000000)},
+    {.key = "c", .val = CVal.Str("x")},
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Int(3000000000)},
+    {.key = "c", .val = CVal.Str("x")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_mixed_scalars/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_mixed_scalars/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Str("x")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_mixed_scalars/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_mixed_scalars/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Str("x")},
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Str("x")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_null_leading_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_null_leading_comment/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    // comment
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_null_leading_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_null_leading_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    // comment
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  my_data = CVal.Map((
+    // comment
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_null_middle_inline_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "host", .val = CVal.Str("localhost")},
+    {.key = "port", .val = CVal.Nil},  // not configured yet
+    {.key = "debug", .val = CVal.Bool(true)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_null_middle_inline_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_null_middle_inline_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "host", .val = CVal.Str("localhost")},
+    {.key = "port", .val = CVal.Nil},  // not configured yet
+    {.key = "debug", .val = CVal.Bool(true)},
+  ));
+  my_data = CVal.Map((
+    {.key = "host", .val = CVal.Str("localhost")},
+    {.key = "port", .val = CVal.Nil},  // not configured yet
+    {.key = "debug", .val = CVal.Bool(true)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "host", .val = CVal.Str("localhost")},
+    {.key = "port", .val = CVal.Nil},  // not configured yet
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_null_trailing_inline_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_null_trailing_inline_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "host", .val = CVal.Str("localhost")},
+    {.key = "port", .val = CVal.Nil},  // not configured yet
+  ));
+  my_data = CVal.Map((
+    {.key = "host", .val = CVal.Str("localhost")},
+    {.key = "port", .val = CVal.Nil},  // not configured yet
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_control_char_keys/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_with_control_char_keys/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "key\nwith\nnewlines", .val = CVal.Str("value1")},
+    {.key = "key\twith\ttabs", .val = CVal.Str("value2")},
+    {.key = "", .val = CVal.Str("value3")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_control_char_keys/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_with_control_char_keys/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "key\nwith\nnewlines", .val = CVal.Str("value1")},
+    {.key = "key\twith\ttabs", .val = CVal.Str("value2")},
+    {.key = "", .val = CVal.Str("value3")},
+  ));
+  my_data = CVal.Map((
+    {.key = "key\nwith\nnewlines", .val = CVal.Str("value1")},
+    {.key = "key\twith\ttabs", .val = CVal.Str("value2")},
+    {.key = "", .val = CVal.Str("value3")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_homogeneous_annotated_values/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_with_homogeneous_annotated_values/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Arr(())},
+    {.key = "b", .val = CVal.Arr(())},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_homogeneous_annotated_values/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_with_homogeneous_annotated_values/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Arr(())},
+    {.key = "b", .val = CVal.Arr(())},
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Arr(())},
+    {.key = "b", .val = CVal.Arr(())},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_hyphen_keys/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_with_hyphen_keys/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "my-key", .val = CVal.Str("value1")},
+    {.key = "another-key", .val = CVal.Str("value2")},
+    {.key = "normal_key", .val = CVal.Str("value3")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_hyphen_keys/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_with_hyphen_keys/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "my-key", .val = CVal.Str("value1")},
+    {.key = "another-key", .val = CVal.Str("value2")},
+    {.key = "normal_key", .val = CVal.Str("value3")},
+  ));
+  my_data = CVal.Map((
+    {.key = "my-key", .val = CVal.Str("value1")},
+    {.key = "another-key", .val = CVal.Str("value2")},
+    {.key = "normal_key", .val = CVal.Str("value3")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_with_list_value/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Carbon_collection_layout_compact@v0.carbon
+++ b/tests/integration/cases/dict_with_list_value/Carbon_collection_layout_compact@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Carbon_collection_layout_multiline@v0.carbon
+++ b/tests/integration/cases/dict_with_list_value/Carbon_collection_layout_multiline@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "scores", .val = CVal.Arr((
+      CVal.Int(10),
+      CVal.Int(20),
+      CVal.Int(30),
+    ))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_with_list_value/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+  ));
+  my_data = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/dict_with_list_value/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_nulls/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_with_nulls/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "score", .val = CVal.Nil},
+    {.key = "age", .val = CVal.Int(30)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_nulls/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_with_nulls/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "score", .val = CVal.Nil},
+    {.key = "age", .val = CVal.Int(30)},
+  ));
+  my_data = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "score", .val = CVal.Nil},
+    {.key = "age", .val = CVal.Int(30)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_quoted_digit_keys/Carbon@v0.carbon
+++ b/tests/integration/cases/dict_with_quoted_digit_keys/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "0a", .val = CVal.Str("first")},
+    {.key = "1b", .val = CVal.Str("second")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/dict_with_quoted_digit_keys/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/dict_with_quoted_digit_keys/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "0a", .val = CVal.Str("first")},
+    {.key = "1b", .val = CVal.Str("second")},
+  ));
+  my_data = CVal.Map((
+    {.key = "0a", .val = CVal.Str("first")},
+    {.key = "1b", .val = CVal.Str("second")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Carbon@v0.carbon
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Arr((CVal.Int(3), CVal.Int(4))))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/doubly_nested_list_with_empty_sibling/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/doubly_nested_list_with_empty_sibling/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Arr((CVal.Int(3), CVal.Int(4))))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Arr((CVal.Int(3), CVal.Int(4))))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_dict/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_dict/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_dict/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_dict/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map(());
+  my_data = CVal.Map(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_dict/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/empty_dict/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_dicts_in_sequence/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(()),
+    CVal.Map(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_dicts_in_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(()),
+    CVal.Map(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(()),
+    CVal.Map(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_dicts_in_sequence/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/empty_dicts_in_sequence/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(()),
+    CVal.Map(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_list/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_list/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_list/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr(());
+  my_data = CVal.Arr(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_list/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/empty_list/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_list/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/empty_list/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_list/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/empty_list/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/empty_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_list/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/empty_list/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_ordered_map/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_ordered_map/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_ordered_map/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_ordered_map/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map(());
+  my_data = CVal.Map(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_orderedmap_value_in_dict/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_orderedmap_value_in_dict/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Map(())},
+    {.key = "b", .val = CVal.Int(1)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_orderedmap_value_in_dict/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_orderedmap_value_in_dict/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Map(())},
+    {.key = "b", .val = CVal.Int(1)},
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Map(())},
+    {.key = "b", .val = CVal.Int(1)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_orderedmap_with_sibling/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_orderedmap_with_sibling/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(()),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_orderedmap_with_sibling/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_orderedmap_with_sibling/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(()),
+    CVal.Arr(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(()),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_sequence/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr(()),
+    CVal.Map(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr(()),
+    CVal.Map(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr(()),
+    CVal.Map(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_set/Carbon@v0.carbon
+++ b/tests/integration/cases/empty_set/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_set/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/empty_set/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set(());
+  my_data = CVal.Set(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/empty_set/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/empty_set/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set(());
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  my_data = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_float_format_fixed@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_float_format_fixed@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.100000),
+    CVal.Float(-2.200000),
+    CVal.Float(3.300000),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_float_format_scientific@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_float_format_scientific@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_numeric_separator_underscore_float@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_numeric_separator_underscore_float@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_list/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/float_list/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(1.1),
+    CVal.Float(-2.2),
+    CVal.Float(3.3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_negative_zero/Carbon@v0.carbon
+++ b/tests/integration/cases/float_negative_zero/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(-0.0),
+    CVal.Float(1.5),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_negative_zero/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/float_negative_zero/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Float(-0.0),
+    CVal.Float(1.5),
+  ));
+  my_data = CVal.Arr((
+    CVal.Float(-0.0),
+    CVal.Float(1.5),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_scientific_notation/Carbon@v0.carbon
+++ b/tests/integration/cases/float_scientific_notation/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(0.0),
+    CVal.Float(1.0),
+    CVal.Float(1500.0),
+    CVal.Float(0.001),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_scientific_notation/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/float_scientific_notation/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Float(0.0),
+    CVal.Float(1.0),
+    CVal.Float(1500.0),
+    CVal.Float(0.001),
+  ));
+  my_data = CVal.Arr((
+    CVal.Float(0.0),
+    CVal.Float(1.0),
+    CVal.Float(1500.0),
+    CVal.Float(0.001),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_scientific_notation/Carbon_float_format_fixed_s@v0.carbon
+++ b/tests/integration/cases/float_scientific_notation/Carbon_float_format_fixed_s@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(0.000000),
+    CVal.Float(1.000000),
+    CVal.Float(1500.000000),
+    CVal.Float(0.001000),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_scientific_notation/Carbon_float_format_scientific_s@v0.carbon
+++ b/tests/integration/cases/float_scientific_notation/Carbon_float_format_scientific_s@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(0.0),
+    CVal.Float(1.0),
+    CVal.Float(1.5e3),
+    CVal.Float(1.0e-3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/float_scientific_notation/Carbon_numeric_separator_underscore_float_s@v0.carbon
+++ b/tests/integration/cases/float_scientific_notation/Carbon_numeric_separator_underscore_float_s@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Float(0.0),
+    CVal.Float(1.0),
+    CVal.Float(1500.0),
+    CVal.Float(0.001),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Carbon@v0.carbon
+++ b/tests/integration/cases/heterogeneous_list_with_string/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("hello"),
+    CVal.Int(42),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/heterogeneous_list_with_string/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/heterogeneous_list_with_string/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("hello"),
+    CVal.Int(42),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("hello"),
+    CVal.Int(42),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Carbon@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Float(1.5),
+    CVal.Nil,
+    CVal.Int(1577836800),
+    CVal.Int(1577836800),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/heterogeneous_scalars_in_annotated_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,30 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Float(1.5),
+    CVal.Nil,
+    CVal.Int(1577836800),
+    CVal.Int(1577836800),
+    CVal.Arr(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Float(1.5),
+    CVal.Nil,
+    CVal.Int(1577836800),
+    CVal.Int(1577836800),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_integer_format_binary@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_integer_format_binary@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0b1),
+    CVal.Int(0b10),
+    CVal.Int(0b11),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_integer_format_hex@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_integer_format_hex@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0x1),
+    CVal.Int(0x2),
+    CVal.Int(0x3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_numeric_separator_underscore@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_numeric_separator_underscore@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/int_list/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1000000),
+    CVal.Int(-1234),
+    CVal.Int(255),
+    CVal.Int(-10),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1000000),
+    CVal.Int(-1234),
+    CVal.Int(255),
+    CVal.Int(-10),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1000000),
+    CVal.Int(-1234),
+    CVal.Int(255),
+    CVal.Int(-10),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon_integer_format_binary_large@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon_integer_format_binary_large@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0b11110100001001000000),
+    CVal.Int(-0b10011010010),
+    CVal.Int(0b11111111),
+    CVal.Int(-0b1010),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon_integer_format_hex_large@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon_integer_format_hex_large@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0xf4240),
+    CVal.Int(-0x4d2),
+    CVal.Int(0xff),
+    CVal.Int(-0xa),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon_numeric_separator_underscore_large@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon_numeric_separator_underscore_large@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1_000_000),
+    CVal.Int(-1_234),
+    CVal.Int(255),
+    CVal.Int(-10),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1000000),
+    CVal.Int(-1234),
+    CVal.Int(255),
+    CVal.Int(-10),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1000000),
+    CVal.Int(-1234),
+    CVal.Int(255),
+    CVal.Int(-10),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_large/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/int_list_large/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1000000),
+    CVal.Int(-1234),
+    CVal.Int(255),
+    CVal.Int(-10),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_single/Carbon@v0.carbon
+++ b/tests/integration/cases/int_list_single/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_single/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/int_list_single/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_with_zero/Carbon@v0.carbon
+++ b/tests/integration/cases/int_list_with_zero/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0),
+    CVal.Int(1),
+    CVal.Int(-1),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_with_zero/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/int_list_with_zero/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(0),
+    CVal.Int(1),
+    CVal.Int(-1),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(0),
+    CVal.Int(1),
+    CVal.Int(-1),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_with_zero/Carbon_integer_format_binary_zero@v0.carbon
+++ b/tests/integration/cases/int_list_with_zero/Carbon_integer_format_binary_zero@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0b0),
+    CVal.Int(0b1),
+    CVal.Int(-0b1),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_with_zero/Carbon_integer_format_hex_zero@v0.carbon
+++ b/tests/integration/cases/int_list_with_zero/Carbon_integer_format_hex_zero@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0x0),
+    CVal.Int(0x1),
+    CVal.Int(-0x1),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_list_with_zero/Carbon_numeric_separator_underscore_zero@v0.carbon
+++ b/tests/integration/cases/int_list_with_zero/Carbon_numeric_separator_underscore_zero@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(0),
+    CVal.Int(1),
+    CVal.Int(-1),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_set/Carbon@v0.carbon
+++ b/tests/integration/cases/int_set/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_set/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/int_set/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  my_data = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_set/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/int_set/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_set/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/int_set/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_set/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/int_set/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/int_set/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/int_set/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(2),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_camel_name/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_camel_name/Carbon_ref@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = my_var;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_deep_nesting/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_deep_nesting/Carbon_ref@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let deep: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Map(({.key = "b", .val = CVal.Map(({.key = "c", .val = deep}))}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_default_nested/Carbon_ref_default@v0.carbon
+++ b/tests/integration/cases/literalize_ref_default_nested/Carbon_ref_default@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let item_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = CVal.Map((
+    {.key = "items", .val = CVal.Arr((item_var, CVal.Map(({.key = "fallback", .val = CVal.Str("value")}))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_default_whole/Carbon_ref_default@v0.carbon
+++ b/tests/integration/cases/literalize_ref_default_whole/Carbon_ref_default@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = my_var;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_heterogeneous/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_heterogeneous/Carbon_ref@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Str("hello")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_in_dict/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_in_dict/Carbon_ref@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = CVal.Map((
+    {.key = "key", .val = my_var},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_in_list/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_in_list/Carbon_ref@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let val_x: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let val_y: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = CVal.Arr((
+    val_x,
+    val_y,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_in_mixed_list/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_in_mixed_list/Carbon_ref@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let ref_x: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = CVal.Arr((
+    ref_x,
+    CVal.Int(1),
+    CVal.Int(2),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_json5_unquoted_key/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_json5_unquoted_key/Carbon_ref@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = my_var;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_json_escaped_key/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_json_escaped_key/Carbon_ref@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = my_var;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_scalar/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_scalar/Carbon_ref@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_int: CVal = CVal.Int(42);
+  let my_data: CVal = my_int;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_toml_table/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_toml_table/Carbon_ref@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = CVal.Map((
+    {.key = "key", .val = my_var},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/literalize_ref_whole/Carbon_ref@v0.carbon
+++ b/tests/integration/cases/literalize_ref_whole/Carbon_ref@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_var: CVal = CVal.Map((
+    {.key = "_", .val = CVal.Str("_")},
+  ));
+  let my_data: CVal = my_var;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_number_dict/Carbon@v0.carbon
+++ b/tests/integration/cases/mixed_number_dict/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Float(2.5)},
+    {.key = "c", .val = CVal.Int(3)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_number_dict/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/mixed_number_dict/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Float(2.5)},
+    {.key = "c", .val = CVal.Int(3)},
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Int(1)},
+    {.key = "b", .val = CVal.Float(2.5)},
+    {.key = "c", .val = CVal.Int(3)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_number_list/Carbon@v0.carbon
+++ b/tests/integration/cases/mixed_number_list/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Float(2.5),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_number_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/mixed_number_list/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Float(2.5),
+    CVal.Int(3),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1),
+    CVal.Float(2.5),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_number_list/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/mixed_number_list/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Float(2.5),
+    CVal.Int(3),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_set/Carbon@v0.carbon
+++ b/tests/integration/cases/mixed_set/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Bool(true),
+    CVal.Int(42),
+    CVal.Str("apple"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_set/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/mixed_set/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    CVal.Bool(true),
+    CVal.Int(42),
+    CVal.Str("apple"),
+  ));
+  my_data = CVal.Set((
+    CVal.Bool(true),
+    CVal.Int(42),
+    CVal.Str("apple"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_set/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/mixed_set/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Bool(true),
+    CVal.Int(42),
+    CVal.Str("apple"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_1")}, {.key = "draft", .val = CVal.Bool(true)})),
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_2")})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_1")}, {.key = "draft", .val = CVal.Bool(true)})),
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_2")})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_1")}, {.key = "draft", .val = CVal.Bool(true)})),
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_2")})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/mixed_type_dicts_in_sequence/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/mixed_type_dicts_in_sequence/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_1")}, {.key = "draft", .val = CVal.Bool(true)})),
+    CVal.Map(({.key = "type", .val = CVal.Str("create")}, {.key = "pr_id", .val = CVal.Str("pr_2")})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Carbon@v0.carbon
+++ b/tests/integration/cases/multiline_sibling_list_widening/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "omap_value", .val = CVal.Map(({.key = "first", .val = CVal.Int(1)}))},
+    {.key = "sibling_lists", .val = CVal.Map(({.key = "numbers", .val = CVal.Arr((CVal.Int(1), CVal.Int(2)))}, {.key = "strings", .val = CVal.Arr((CVal.Str("x"), CVal.Str("y")))}))},
+    {.key = "ref_marker_present", .val = CVal.Arr((CVal.Str("$keep"), CVal.Str("z")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Carbon_collection_layout_compact@v0.carbon
+++ b/tests/integration/cases/multiline_sibling_list_widening/Carbon_collection_layout_compact@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "omap_value", .val = CVal.Map(({.key = "first", .val = CVal.Int(1)}))},
+    {.key = "sibling_lists", .val = CVal.Map(({.key = "numbers", .val = CVal.Arr((CVal.Int(1), CVal.Int(2)))}, {.key = "strings", .val = CVal.Arr((CVal.Str("x"), CVal.Str("y")))}))},
+    {.key = "ref_marker_present", .val = CVal.Arr((CVal.Str("$keep"), CVal.Str("z")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Carbon_collection_layout_multiline@v0.carbon
+++ b/tests/integration/cases/multiline_sibling_list_widening/Carbon_collection_layout_multiline@v0.carbon
@@ -1,0 +1,33 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "omap_value", .val = CVal.Map((
+      {.key = "first", .val = CVal.Int(1)},
+    ))},
+    {.key = "sibling_lists", .val = CVal.Map((
+      {.key = "numbers", .val = CVal.Arr((
+        CVal.Int(1),
+        CVal.Int(2),
+      ))},
+      {.key = "strings", .val = CVal.Arr((
+        CVal.Str("x"),
+        CVal.Str("y"),
+      ))},
+    ))},
+    {.key = "ref_marker_present", .val = CVal.Arr((
+      CVal.Str("$keep"),
+      CVal.Str("z"),
+    ))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/multiline_sibling_list_widening/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/multiline_sibling_list_widening/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "omap_value", .val = CVal.Map(({.key = "first", .val = CVal.Int(1)}))},
+    {.key = "sibling_lists", .val = CVal.Map(({.key = "numbers", .val = CVal.Arr((CVal.Int(1), CVal.Int(2)))}, {.key = "strings", .val = CVal.Arr((CVal.Str("x"), CVal.Str("y")))}))},
+    {.key = "ref_marker_present", .val = CVal.Arr((CVal.Str("$keep"), CVal.Str("z")))},
+  ));
+  my_data = CVal.Map((
+    {.key = "omap_value", .val = CVal.Map(({.key = "first", .val = CVal.Int(1)}))},
+    {.key = "sibling_lists", .val = CVal.Map(({.key = "numbers", .val = CVal.Arr((CVal.Int(1), CVal.Int(2)))}, {.key = "strings", .val = CVal.Arr((CVal.Str("x"), CVal.Str("y")))}))},
+    {.key = "ref_marker_present", .val = CVal.Arr((CVal.Str("$keep"), CVal.Str("z")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested/Carbon@v0.carbon
+++ b/tests/integration/cases/nested/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "users", .val = CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Bob")}, {.key = "tags", .val = CVal.Arr((CVal.Str("admin"), CVal.Str("user")))})), CVal.Map(({.key = "name", .val = CVal.Str("Carol")}, {.key = "tags", .val = CVal.Arr((CVal.Str("guest")))}))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested/Carbon_collection_layout_compact@v0.carbon
+++ b/tests/integration/cases/nested/Carbon_collection_layout_compact@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "users", .val = CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Bob")}, {.key = "tags", .val = CVal.Arr((CVal.Str("admin"), CVal.Str("user")))})), CVal.Map(({.key = "name", .val = CVal.Str("Carol")}, {.key = "tags", .val = CVal.Arr((CVal.Str("guest")))}))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested/Carbon_collection_layout_multiline@v0.carbon
+++ b/tests/integration/cases/nested/Carbon_collection_layout_multiline@v0.carbon
@@ -1,0 +1,31 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "users", .val = CVal.Arr((
+      CVal.Map((
+        {.key = "name", .val = CVal.Str("Bob")},
+        {.key = "tags", .val = CVal.Arr((
+          CVal.Str("admin"),
+          CVal.Str("user"),
+        ))},
+      )),
+      CVal.Map((
+        {.key = "name", .val = CVal.Str("Carol")},
+        {.key = "tags", .val = CVal.Arr((
+          CVal.Str("guest"),
+        ))},
+      )),
+    ))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "users", .val = CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Bob")}, {.key = "tags", .val = CVal.Arr((CVal.Str("admin"), CVal.Str("user")))})), CVal.Map(({.key = "name", .val = CVal.Str("Carol")}, {.key = "tags", .val = CVal.Arr((CVal.Str("guest")))}))))},
+  ));
+  my_data = CVal.Map((
+    {.key = "users", .val = CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Bob")}, {.key = "tags", .val = CVal.Arr((CVal.Str("admin"), CVal.Str("user")))})), CVal.Map(({.key = "name", .val = CVal.Str("Carol")}, {.key = "tags", .val = CVal.Arr((CVal.Str("guest")))}))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_bool_list/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_bool_list/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Bool(true), CVal.Bool(false))),
+    CVal.Arr((CVal.Bool(true), CVal.Bool(true))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_bool_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_bool_list/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Bool(true), CVal.Bool(false))),
+    CVal.Arr((CVal.Bool(true), CVal.Bool(true))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Bool(true), CVal.Bool(false))),
+    CVal.Arr((CVal.Bool(true), CVal.Bool(true))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_collection_multi_space_string/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_collection_multi_space_string/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "key", .val = CVal.Str("hello   world")}, {.key = "value", .val = CVal.Int(1)})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_collection_multi_space_string/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_collection_multi_space_string/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "key", .val = CVal.Str("hello   world")}, {.key = "value", .val = CVal.Int(1)})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "key", .val = CVal.Str("hello   world")}, {.key = "value", .val = CVal.Int(1)})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_deep_empty/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_deep_empty/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr(()), CVal.Arr(()))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_deep_empty/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_deep_empty/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr(()), CVal.Arr(()))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Arr(()), CVal.Arr(()))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_deep_mixed/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_deep_mixed/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))), CVal.Arr((CVal.Str("a"), CVal.Str("b"))))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_deep_mixed/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_deep_mixed/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))), CVal.Arr((CVal.Str("a"), CVal.Str("b"))))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))), CVal.Arr((CVal.Str("a"), CVal.Str("b"))))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_empty_inner/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_empty_inner/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr(()),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_empty_inner/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_empty_inner/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr(()),
+    CVal.Arr(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr(()),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_float_list/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_float_list/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Float(1.5), CVal.Float(2.5))),
+    CVal.Arr((CVal.Float(3.5), CVal.Float(4.5))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_float_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_float_list/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Float(1.5), CVal.Float(2.5))),
+    CVal.Arr((CVal.Float(3.5), CVal.Float(4.5))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Float(1.5), CVal.Float(2.5))),
+    CVal.Arr((CVal.Float(3.5), CVal.Float(4.5))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_float_list/Carbon_float_format_fixed_n@v0.carbon
+++ b/tests/integration/cases/nested_float_list/Carbon_float_format_fixed_n@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Float(1.500000), CVal.Float(2.500000))),
+    CVal.Arr((CVal.Float(3.500000), CVal.Float(4.500000))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_float_list/Carbon_float_format_scientific_n@v0.carbon
+++ b/tests/integration/cases/nested_float_list/Carbon_float_format_scientific_n@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Float(1.5), CVal.Float(2.5))),
+    CVal.Arr((CVal.Float(3.5), CVal.Float(4.5))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_float_list/Carbon_numeric_separator_underscore_float_n@v0.carbon
+++ b/tests/integration/cases/nested_float_list/Carbon_numeric_separator_underscore_float_n@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Float(1.5), CVal.Float(2.5))),
+    CVal.Arr((CVal.Float(3.5), CVal.Float(4.5))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_list_mixed_sibling_types/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_list_mixed_sibling_types/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_list_of_dicts/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_list_of_dicts/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Alice")})), CVal.Map(({.key = "name", .val = CVal.Str("Bob")})))),
+    CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Charlie")})), CVal.Map(({.key = "name", .val = CVal.Str("Dave")})))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_list_of_dicts/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_list_of_dicts/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Alice")})), CVal.Map(({.key = "name", .val = CVal.Str("Bob")})))),
+    CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Charlie")})), CVal.Map(({.key = "name", .val = CVal.Str("Dave")})))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Alice")})), CVal.Map(({.key = "name", .val = CVal.Str("Bob")})))),
+    CVal.Arr((CVal.Map(({.key = "name", .val = CVal.Str("Charlie")})), CVal.Map(({.key = "name", .val = CVal.Str("Dave")})))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_list_with_empty_sibling/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Int(3), CVal.Int(4))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_list_with_empty_sibling/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_list_with_empty_sibling/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Int(3), CVal.Int(4))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+    CVal.Arr((CVal.Int(3), CVal.Int(4))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_dict/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_mixed_dict/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "outer", .val = CVal.Map(({.key = "a", .val = CVal.Int(1)}, {.key = "b", .val = CVal.Str("x")}, {.key = "c", .val = CVal.Nil}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_dict/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_mixed_dict/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "outer", .val = CVal.Map(({.key = "a", .val = CVal.Int(1)}, {.key = "b", .val = CVal.Str("x")}, {.key = "c", .val = CVal.Nil}))},
+  ));
+  my_data = CVal.Map((
+    {.key = "outer", .val = CVal.Map(({.key = "a", .val = CVal.Int(1)}, {.key = "b", .val = CVal.Str("x")}, {.key = "c", .val = CVal.Nil}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_inner/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_mixed_inner/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Str("a"))),
+    CVal.Arr((CVal.Int(2), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_inner/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_mixed_inner/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Str("a"))),
+    CVal.Arr((CVal.Int(2), CVal.Str("b"))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Str("a"))),
+    CVal.Arr((CVal.Int(2), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_set/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_mixed_set/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "tags", .val = CVal.Set((CVal.Bool(true), CVal.Int(42), CVal.Str("apple")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_set/Carbon_collection_layout_compact@v0.carbon
+++ b/tests/integration/cases/nested_mixed_set/Carbon_collection_layout_compact@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "tags", .val = CVal.Set((CVal.Bool(true), CVal.Int(42), CVal.Str("apple")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_set/Carbon_collection_layout_multiline@v0.carbon
+++ b/tests/integration/cases/nested_mixed_set/Carbon_collection_layout_multiline@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "tags", .val = CVal.Set((
+      CVal.Bool(true),
+      CVal.Int(42),
+      CVal.Str("apple"),
+    ))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_set/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_mixed_set/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "tags", .val = CVal.Set((CVal.Bool(true), CVal.Int(42), CVal.Str("apple")))},
+  ));
+  my_data = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "tags", .val = CVal.Set((CVal.Bool(true), CVal.Int(42), CVal.Str("apple")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_types/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_mixed_types/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_mixed_types/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_mixed_types/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_sequence/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Str("hi"),
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Str("hi"),
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Nil,
+  ));
+  my_data = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Str("hi"),
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_sequence/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/nested_sequence/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Bool(true),
+    CVal.Str("hi"),
+    CVal.Arr((CVal.Int(1), CVal.Int(2))),
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_sequences/Carbon@v0.carbon
+++ b/tests/integration/cases/nested_sequences/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))), CVal.Arr((CVal.Int(3), CVal.Int(4))))),
+    CVal.Arr((CVal.Arr((CVal.Int(5))))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/nested_sequences/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/nested_sequences/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))), CVal.Arr((CVal.Int(3), CVal.Int(4))))),
+    CVal.Arr((CVal.Arr((CVal.Int(5))))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Arr((CVal.Arr((CVal.Int(1), CVal.Int(2))), CVal.Arr((CVal.Int(3), CVal.Int(4))))),
+    CVal.Arr((CVal.Arr((CVal.Int(5))))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/no_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/no_comment/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "message", .val = CVal.Str("no comment here")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/no_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/no_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "message", .val = CVal.Str("no comment here")},
+  ));
+  my_data = CVal.Map((
+    {.key = "message", .val = CVal.Str("no comment here")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/null_list/Carbon@v0.carbon
+++ b/tests/integration/cases/null_list/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Nil,
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/null_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/null_list/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Nil,
+    CVal.Nil,
+  ));
+  my_data = CVal.Arr((
+    CVal.Nil,
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/ordered_map/Carbon@v0.carbon
+++ b/tests/integration/cases/ordered_map/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/ordered_map/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/ordered_map/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+  ));
+  my_data = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/ordered_map_in_sequence/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/ordered_map_in_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Str("hello"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/ordered_map_in_sequence/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/ordered_map_in_sequence/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/ordered_map_string_values/Carbon@v0.carbon
+++ b/tests/integration/cases/ordered_map_string_values/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "first", .val = CVal.Str("one")},
+    {.key = "second", .val = CVal.Str("two")},
+    {.key = "third", .val = CVal.Str("three")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/ordered_map_string_values/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/ordered_map_string_values/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "first", .val = CVal.Str("one")},
+    {.key = "second", .val = CVal.Str("two")},
+    {.key = "third", .val = CVal.Str("three")},
+  ));
+  my_data = CVal.Map((
+    {.key = "first", .val = CVal.Str("one")},
+    {.key = "second", .val = CVal.Str("two")},
+    {.key = "third", .val = CVal.Str("three")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/orderedmap_with_annotated_value/Carbon@v0.carbon
+++ b/tests/integration/cases/orderedmap_with_annotated_value/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Arr(())},
+    {.key = "b", .val = CVal.Int(1)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/orderedmap_with_annotated_value/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/orderedmap_with_annotated_value/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "a", .val = CVal.Arr(())},
+    {.key = "b", .val = CVal.Int(1)},
+  ));
+  my_data = CVal.Map((
+    {.key = "a", .val = CVal.Arr(())},
+    {.key = "b", .val = CVal.Int(1)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/orderedmap_with_empty_sibling/Carbon@v0.carbon
+++ b/tests/integration/cases/orderedmap_with_empty_sibling/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/orderedmap_with_empty_sibling/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/orderedmap_with_empty_sibling/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Arr(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "a", .val = CVal.Int(1)})),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/pair_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/pair_sequence/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/pair_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/pair_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/pair_sequence/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/pair_sequence/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/pair_sequence/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/pair_sequence/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/pair_sequence/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/pair_sequence/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_basic/Carbon@v0.carbon
+++ b/tests/integration/cases/record_basic/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "id", .val = CVal.Int(1)},
+    {.key = "description", .val = CVal.Str("She said \"hello\", then waved")},
+    {.key = "is_done", .val = CVal.Bool(false)},
+    {.key = "blocks", .val = CVal.Arr((CVal.Int(1), CVal.Int(2), CVal.Int(3)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_basic/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_basic/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "id", .val = CVal.Int(1)},
+    {.key = "description", .val = CVal.Str("She said \"hello\", then waved")},
+    {.key = "is_done", .val = CVal.Bool(false)},
+    {.key = "blocks", .val = CVal.Arr((CVal.Int(1), CVal.Int(2), CVal.Int(3)))},
+  ));
+  my_data = CVal.Map((
+    {.key = "id", .val = CVal.Int(1)},
+    {.key = "description", .val = CVal.Str("She said \"hello\", then waved")},
+    {.key = "is_done", .val = CVal.Bool(false)},
+    {.key = "blocks", .val = CVal.Arr((CVal.Int(1), CVal.Int(2), CVal.Int(3)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_epoch_datetime_i32_overflow/Carbon@v0.carbon
+++ b/tests/integration/cases/record_epoch_datetime_i32_overflow/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "within_i32", .val = CVal.Int(1705320000)},
+    {.key = "beyond_i32", .val = CVal.Int(4085195400)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_epoch_datetime_i32_overflow/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_epoch_datetime_i32_overflow/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "within_i32", .val = CVal.Int(1705320000)},
+    {.key = "beyond_i32", .val = CVal.Int(4085195400)},
+  ));
+  my_data = CVal.Map((
+    {.key = "within_i32", .val = CVal.Int(1705320000)},
+    {.key = "beyond_i32", .val = CVal.Int(4085195400)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_named_nested_record/Carbon@v0.carbon
+++ b/tests/integration/cases/record_named_nested_record/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "project", .val = CVal.Str("alpha")},
+    {.key = "lead_task", .val = CVal.Map(({.key = "id", .val = CVal.Int(100)}, {.key = "description", .val = CVal.Str("first task")}, {.key = "is_done", .val = CVal.Bool(false)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(102), CVal.Int(103)))}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_named_nested_record/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_named_nested_record/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "project", .val = CVal.Str("alpha")},
+    {.key = "lead_task", .val = CVal.Map(({.key = "id", .val = CVal.Int(100)}, {.key = "description", .val = CVal.Str("first task")}, {.key = "is_done", .val = CVal.Bool(false)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(102), CVal.Int(103)))}))},
+  ));
+  my_data = CVal.Map((
+    {.key = "project", .val = CVal.Str("alpha")},
+    {.key = "lead_task", .val = CVal.Map(({.key = "id", .val = CVal.Int(100)}, {.key = "description", .val = CVal.Str("first task")}, {.key = "is_done", .val = CVal.Bool(false)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(102), CVal.Int(103)))}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_named_shape/Carbon@v0.carbon
+++ b/tests/integration/cases/record_named_shape/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "id", .val = CVal.Int(100)}, {.key = "description", .val = CVal.Str("first task")}, {.key = "is_done", .val = CVal.Bool(false)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(102), CVal.Int(103)))})),
+    CVal.Map(({.key = "id", .val = CVal.Int(101)}, {.key = "description", .val = CVal.Str("second task")}, {.key = "is_done", .val = CVal.Bool(true)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(100)))})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_named_shape/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_named_shape/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "id", .val = CVal.Int(100)}, {.key = "description", .val = CVal.Str("first task")}, {.key = "is_done", .val = CVal.Bool(false)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(102), CVal.Int(103)))})),
+    CVal.Map(({.key = "id", .val = CVal.Int(101)}, {.key = "description", .val = CVal.Str("second task")}, {.key = "is_done", .val = CVal.Bool(true)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(100)))})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "id", .val = CVal.Int(100)}, {.key = "description", .val = CVal.Str("first task")}, {.key = "is_done", .val = CVal.Bool(false)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(102), CVal.Int(103)))})),
+    CVal.Map(({.key = "id", .val = CVal.Int(101)}, {.key = "description", .val = CVal.Str("second task")}, {.key = "is_done", .val = CVal.Bool(true)}, {.key = "blocks", .val = CVal.Arr((CVal.Int(100)))})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_nested_container/Carbon@v0.carbon
+++ b/tests/integration/cases/record_nested_container/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "title", .val = CVal.Str("report")},
+    {.key = "tags", .val = CVal.Arr((CVal.Str("draft"), CVal.Str("urgent"), CVal.Str("review")))},
+    {.key = "priority", .val = CVal.Int(2)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_nested_container/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_nested_container/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "title", .val = CVal.Str("report")},
+    {.key = "tags", .val = CVal.Arr((CVal.Str("draft"), CVal.Str("urgent"), CVal.Str("review")))},
+    {.key = "priority", .val = CVal.Int(2)},
+  ));
+  my_data = CVal.Map((
+    {.key = "title", .val = CVal.Str("report")},
+    {.key = "tags", .val = CVal.Arr((CVal.Str("draft"), CVal.Str("urgent"), CVal.Str("review")))},
+    {.key = "priority", .val = CVal.Int(2)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_nested_record/Carbon@v0.carbon
+++ b/tests/integration/cases/record_nested_record/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "id", .val = CVal.Int(1)},
+    {.key = "owner", .val = CVal.Map(({.key = "name", .val = CVal.Str("Alice")}, {.key = "age", .val = CVal.Int(30)}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_nested_record/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_nested_record/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "id", .val = CVal.Int(1)},
+    {.key = "owner", .val = CVal.Map(({.key = "name", .val = CVal.Str("Alice")}, {.key = "age", .val = CVal.Int(30)}))},
+  ));
+  my_data = CVal.Map((
+    {.key = "id", .val = CVal.Int(1)},
+    {.key = "owner", .val = CVal.Map(({.key = "name", .val = CVal.Str("Alice")}, {.key = "age", .val = CVal.Int(30)}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_optional_unify/Carbon@v0.carbon
+++ b/tests/integration/cases/record_optional_unify/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "items", .val = CVal.Arr((CVal.Map(({.key = "id", .val = CVal.Int(1)})), CVal.Map(({.key = "id", .val = CVal.Int(2)}, {.key = "count", .val = CVal.Int(10)})), CVal.Map(({.key = "id", .val = CVal.Int(3)}, {.key = "count", .val = CVal.Int(20)}))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_optional_unify/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_optional_unify/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "items", .val = CVal.Arr((CVal.Map(({.key = "id", .val = CVal.Int(1)})), CVal.Map(({.key = "id", .val = CVal.Int(2)}, {.key = "count", .val = CVal.Int(10)})), CVal.Map(({.key = "id", .val = CVal.Int(3)}, {.key = "count", .val = CVal.Int(20)}))))},
+  ));
+  my_data = CVal.Map((
+    {.key = "items", .val = CVal.Arr((CVal.Map(({.key = "id", .val = CVal.Int(1)})), CVal.Map(({.key = "id", .val = CVal.Int(2)}, {.key = "count", .val = CVal.Int(10)})), CVal.Map(({.key = "id", .val = CVal.Int(3)}, {.key = "count", .val = CVal.Int(20)}))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_pure_scalars/Carbon@v0.carbon
+++ b/tests/integration/cases/record_pure_scalars/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Float(4.5)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_pure_scalars/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_pure_scalars/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Float(4.5)},
+  ));
+  my_data = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Float(4.5)},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/record_sequence/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "id", .val = CVal.Int(1)}, {.key = "label", .val = CVal.Str("first")}, {.key = "tags", .val = CVal.Arr(())})),
+    CVal.Map(({.key = "id", .val = CVal.Int(2)}, {.key = "label", .val = CVal.Str("second")}, {.key = "tags", .val = CVal.Arr(())})),
+    CVal.Map(({.key = "id", .val = CVal.Int(3)}, {.key = "label", .val = CVal.Str("third")}, {.key = "tags", .val = CVal.Arr(())})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "id", .val = CVal.Int(1)}, {.key = "label", .val = CVal.Str("first")}, {.key = "tags", .val = CVal.Arr(())})),
+    CVal.Map(({.key = "id", .val = CVal.Int(2)}, {.key = "label", .val = CVal.Str("second")}, {.key = "tags", .val = CVal.Arr(())})),
+    CVal.Map(({.key = "id", .val = CVal.Int(3)}, {.key = "label", .val = CVal.Str("third")}, {.key = "tags", .val = CVal.Arr(())})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "id", .val = CVal.Int(1)}, {.key = "label", .val = CVal.Str("first")}, {.key = "tags", .val = CVal.Arr(())})),
+    CVal.Map(({.key = "id", .val = CVal.Int(2)}, {.key = "label", .val = CVal.Str("second")}, {.key = "tags", .val = CVal.Arr(())})),
+    CVal.Map(({.key = "id", .val = CVal.Int(3)}, {.key = "label", .val = CVal.Str("third")}, {.key = "tags", .val = CVal.Arr(())})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_two_shapes/Carbon@v0.carbon
+++ b/tests/integration/cases/record_two_shapes/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "metrics", .val = CVal.Map(({.key = "count", .val = CVal.Int(100)}, {.key = "rate", .val = CVal.Int(50)}))},
+    {.key = "flags", .val = CVal.Map(({.key = "retries", .val = CVal.Int(3)}, {.key = "timeout", .val = CVal.Int(30)}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/record_two_shapes/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/record_two_shapes/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "metrics", .val = CVal.Map(({.key = "count", .val = CVal.Int(100)}, {.key = "rate", .val = CVal.Int(50)}))},
+    {.key = "flags", .val = CVal.Map(({.key = "retries", .val = CVal.Int(3)}, {.key = "timeout", .val = CVal.Int(30)}))},
+  ));
+  my_data = CVal.Map((
+    {.key = "metrics", .val = CVal.Map(({.key = "count", .val = CVal.Int(100)}, {.key = "rate", .val = CVal.Int(50)}))},
+    {.key = "flags", .val = CVal.Map(({.key = "retries", .val = CVal.Int(3)}, {.key = "timeout", .val = CVal.Int(30)}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_bool/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_bool/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Bool(true);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_bool/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_bool/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Bool(true);
+  my_data = CVal.Bool(true);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_bool/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_bool/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Bool(true);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705276800);
+  my_data = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon_date_iso@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon_date_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("2024-01-15");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("2024-01-15");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_date/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/scalar_date/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705321800);
+  my_data = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_datetime_epoch@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_datetime_epoch@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_datetime_iso@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_datetime_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("2024-01-15T12:30:00+00:00");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/scalar_datetime/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("2024-01-15T12:30:00+00:00");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_microsecond/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_microsecond/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_microsecond/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_microsecond/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705321800);
+  my_data = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_midnight/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_midnight/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_midnight/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_midnight/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705276800);
+  my_data = CVal.Int(1705276800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_naive/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_naive/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_naive/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_naive/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705321800);
+  my_data = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_naive/Carbon_datetime_epoch_naive@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_naive/Carbon_datetime_epoch_naive@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_naive/Carbon_datetime_iso_naive@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_naive/Carbon_datetime_iso_naive@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("2024-01-15T12:30:00");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_non_utc/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_non_utc/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705321800);
+  my_data = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Carbon_datetime_epoch_non_utc@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_non_utc/Carbon_datetime_epoch_non_utc@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321800);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_non_utc/Carbon_datetime_iso_non_utc@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_non_utc/Carbon_datetime_iso_non_utc@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("2024-01-15T18:00:00+05:30");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705321845);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_seconds_microsecond/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_seconds_microsecond/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705321845);
+  my_data = CVal.Int(1705321845);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_whole_hour_offset/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_whole_hour_offset/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(1705323600);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_datetime_whole_hour_offset/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_datetime_whole_hour_offset/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(1705323600);
+  my_data = CVal.Int(1705323600);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_float/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_float/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Float(3.14);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_float/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_float/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Float(3.14);
+  my_data = CVal.Float(3.14);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_float/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_float/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Float(3.14);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_float/Carbon_float_format_fixed@v0.carbon
+++ b/tests/integration/cases/scalar_float/Carbon_float_format_fixed@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Float(3.140000);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_float/Carbon_float_format_scientific@v0.carbon
+++ b/tests/integration/cases/scalar_float/Carbon_float_format_scientific@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Float(3.14);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_float/Carbon_numeric_separator_underscore_float_scalar@v0.carbon
+++ b/tests/integration/cases/scalar_float/Carbon_numeric_separator_underscore_float_scalar@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Float(3.14);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_int/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_int/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(42);
+  my_data = CVal.Int(42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_int/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int/Carbon_integer_format_binary@v0.carbon
+++ b/tests/integration/cases/scalar_int/Carbon_integer_format_binary@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(0b101010);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int/Carbon_integer_format_hex@v0.carbon
+++ b/tests/integration/cases/scalar_int/Carbon_integer_format_hex@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(0x2a);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int/Carbon_numeric_separator_underscore@v0.carbon
+++ b/tests/integration/cases/scalar_int/Carbon_numeric_separator_underscore@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(42);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_large/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_int_large/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(2147483648);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_large/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_int_large/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(2147483648);
+  my_data = CVal.Int(2147483648);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_large/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_int_large/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(2147483648);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_large/Carbon_integer_format_binary@v0.carbon
+++ b/tests/integration/cases/scalar_int_large/Carbon_integer_format_binary@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(0b10000000000000000000000000000000);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_large/Carbon_integer_format_hex@v0.carbon
+++ b/tests/integration/cases/scalar_int_large/Carbon_integer_format_hex@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(0x80000000);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_large/Carbon_numeric_separator_underscore@v0.carbon
+++ b/tests/integration/cases/scalar_int_large/Carbon_numeric_separator_underscore@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(2_147_483_648);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_negative_large/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_int_negative_large/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Int(-2147483649);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_negative_large/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_int_negative_large/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Int(-2147483649);
+  my_data = CVal.Int(-2147483649);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_very_large/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_int_very_large/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.UInt(9223372036854775808);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_int_very_large/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_int_very_large/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.UInt(9223372036854775808);
+  my_data = CVal.UInt(9223372036854775808);
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_null/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_null/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Nil;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_null/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_null/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Nil;
+  my_data = CVal.Nil;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_null/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_null/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Nil;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_null_with_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_null_with_comment/Carbon@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // note
+  let my_data: CVal = CVal.Nil;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_null_with_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_null_with_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  // note
+  var my_data: CVal = CVal.Nil;
+  // note
+  my_data = CVal.Nil;
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_quoted_with_hash_no_comment/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_quoted_with_hash_no_comment/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("hello # world");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_quoted_with_hash_no_comment/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_quoted_with_hash_no_comment/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Str("hello # world");
+  my_data = CVal.Str("hello # world");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_string/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_string/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("hello");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_string/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_string/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Str("hello");
+  my_data = CVal.Str("hello");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_string/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/scalar_string/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Str("hello");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_time/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_time/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "starts_at", .val = CVal.Str("09:30:00")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_time/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_time/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "starts_at", .val = CVal.Str("09:30:00")},
+  ));
+  my_data = CVal.Map((
+    {.key = "starts_at", .val = CVal.Str("09:30:00")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_time/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/scalar_time/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "starts_at", .val = CVal.Str("09:30:00")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_time_microsecond/Carbon@v0.carbon
+++ b/tests/integration/cases/scalar_time_microsecond/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "exact_millisecond", .val = CVal.Str("09:30:15.123000")},
+    {.key = "sub_millisecond", .val = CVal.Str("09:30:15.123456")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalar_time_microsecond/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalar_time_microsecond/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "exact_millisecond", .val = CVal.Str("09:30:15.123000")},
+    {.key = "sub_millisecond", .val = CVal.Str("09:30:15.123456")},
+  ));
+  my_data = CVal.Map((
+    {.key = "exact_millisecond", .val = CVal.Str("09:30:15.123000")},
+    {.key = "sub_millisecond", .val = CVal.Str("09:30:15.123456")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalars/Carbon@v0.carbon
+++ b/tests/integration/cases/scalars/Carbon@v0.carbon
@@ -1,0 +1,21 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(42),
+    CVal.Float(3.14),
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Str("hello \"world\""),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/scalars/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/scalars/Carbon_combined@v0.carbon
@@ -1,0 +1,28 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(42),
+    CVal.Float(3.14),
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Str("hello \"world\""),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(42),
+    CVal.Float(3.14),
+    CVal.Bool(true),
+    CVal.Bool(false),
+    CVal.Str("hello \"world\""),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/sequence_of_dicts/Carbon@v0.carbon
+++ b/tests/integration/cases/sequence_of_dicts/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "name", .val = CVal.Str("Alice")}, {.key = "age", .val = CVal.Int(30)})),
+    CVal.Map(({.key = "name", .val = CVal.Str("Bob")}, {.key = "age", .val = CVal.Int(25)})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/sequence_of_dicts/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/sequence_of_dicts/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "name", .val = CVal.Str("Alice")}, {.key = "age", .val = CVal.Int(30)})),
+    CVal.Map(({.key = "name", .val = CVal.Str("Bob")}, {.key = "age", .val = CVal.Int(25)})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "name", .val = CVal.Str("Alice")}, {.key = "age", .val = CVal.Int(30)})),
+    CVal.Map(({.key = "name", .val = CVal.Str("Bob")}, {.key = "age", .val = CVal.Int(25)})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set/Carbon@v0.carbon
+++ b/tests/integration/cases/set/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Str("apple"),
+    CVal.Str("banana"),
+    CVal.Str("cherry"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/set/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    CVal.Str("apple"),
+    CVal.Str("banana"),
+    CVal.Str("cherry"),
+  ));
+  my_data = CVal.Set((
+    CVal.Str("apple"),
+    CVal.Str("banana"),
+    CVal.Str("cherry"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set/Carbon_trailing_comma_no_set@v0.carbon
+++ b/tests/integration/cases/set/Carbon_trailing_comma_no_set@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Str("apple"),
+    CVal.Str("banana"),
+    CVal.Str("cherry")
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_comments/Carbon@v0.carbon
+++ b/tests/integration/cases/set_comments/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Str("apple"),  // inline comment
+    // before banana
+    CVal.Str("banana"),
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_comments/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/set_comments/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    CVal.Str("apple"),  // inline comment
+    // before banana
+    CVal.Str("banana"),
+    // trailing
+  ));
+  my_data = CVal.Set((
+    CVal.Str("apple"),  // inline comment
+    // before banana
+    CVal.Str("banana"),
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/Carbon@v0.carbon
+++ b/tests/integration/cases/set_comments_unsorted_order/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    // before apple
+    CVal.Str("apple"),
+    CVal.Str("banana"),  // banana inline
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_comments_unsorted_order/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/set_comments_unsorted_order/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    // before apple
+    CVal.Str("apple"),
+    CVal.Str("banana"),  // banana inline
+    // trailing
+  ));
+  my_data = CVal.Set((
+    // before apple
+    CVal.Str("apple"),
+    CVal.Str("banana"),  // banana inline
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_in_annotated_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/set_in_annotated_sequence/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Set(()),
+    CVal.Set((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_in_annotated_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/set_in_annotated_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Set(()),
+    CVal.Set((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+  ));
+  my_data = CVal.Arr((
+    CVal.Set(()),
+    CVal.Set((CVal.Int(1), CVal.Int(2))),
+    CVal.Arr(()),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_in_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/set_in_sequence/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Set((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_in_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/set_in_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Set((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  my_data = CVal.Arr((
+    CVal.Set((CVal.Str("a"), CVal.Str("b"))),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_mixed_int_widths/Carbon@v0.carbon
+++ b/tests/integration/cases/set_mixed_int_widths/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(1099511627776),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_mixed_int_widths/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/set_mixed_int_widths/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(1099511627776),
+  ));
+  my_data = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(1099511627776),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_mixed_int_widths/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/set_mixed_int_widths/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(1099511627776),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/set_mixed_int_widths/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/set_mixed_int_widths/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Set((
+    CVal.Int(1),
+    CVal.Int(1099511627776),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/sibling_list_values_nested/Carbon@v0.carbon
+++ b/tests/integration/cases/sibling_list_values_nested/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "lint", .val = CVal.Arr((CVal.Int(2), CVal.Arr(())))},
+    {.key = "test", .val = CVal.Arr((CVal.Int(5), CVal.Arr((CVal.Str("compile")))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/sibling_list_values_nested/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/sibling_list_values_nested/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "lint", .val = CVal.Arr((CVal.Int(2), CVal.Arr(())))},
+    {.key = "test", .val = CVal.Arr((CVal.Int(5), CVal.Arr((CVal.Str("compile")))))},
+  ));
+  my_data = CVal.Map((
+    {.key = "lint", .val = CVal.Arr((CVal.Int(2), CVal.Arr(())))},
+    {.key = "test", .val = CVal.Arr((CVal.Int(5), CVal.Arr((CVal.Str("compile")))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Carbon@v0.carbon
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "lint", .val = CVal.Arr((CVal.Int(2), CVal.Arr((CVal.Int(1)))))},
+    {.key = "test", .val = CVal.Arr((CVal.Int(5), CVal.Arr((CVal.Int(7)))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/sibling_list_values_uniform_inner/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/sibling_list_values_uniform_inner/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "lint", .val = CVal.Arr((CVal.Int(2), CVal.Arr((CVal.Int(1)))))},
+    {.key = "test", .val = CVal.Arr((CVal.Int(5), CVal.Arr((CVal.Int(7)))))},
+  ));
+  my_data = CVal.Map((
+    {.key = "lint", .val = CVal.Arr((CVal.Int(2), CVal.Arr((CVal.Int(1)))))},
+    {.key = "test", .val = CVal.Arr((CVal.Int(5), CVal.Arr((CVal.Int(7)))))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_dict/Carbon@v0.carbon
+++ b/tests/integration/cases/simple_dict/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_dict/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/simple_dict/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  my_data = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_dict/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/simple_dict/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_dict/Carbon_trailing_comma_no_dict@v0.carbon
+++ b/tests/integration/cases/simple_dict/Carbon_trailing_comma_no_dict@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil}
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_dict/Carbon_type_hints_safe_date_iso@v0.carbon
+++ b/tests/integration/cases/simple_dict/Carbon_type_hints_safe_date_iso@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_dict/Carbon_type_hints_safe_dt_epoch@v0.carbon
+++ b/tests/integration/cases/simple_dict/Carbon_type_hints_safe_dt_epoch@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_dict/Carbon_type_hints_safe_dt_iso@v0.carbon
+++ b/tests/integration/cases/simple_dict/Carbon_type_hints_safe_dt_iso@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/simple_sequence/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/simple_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+    CVal.Nil,
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_sequence/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/simple_sequence/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+    CVal.Nil,
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/simple_sequence/Carbon_trailing_comma_no@v0.carbon
+++ b/tests/integration/cases/simple_sequence/Carbon_trailing_comma_no@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+    CVal.Nil
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_control_chars/Carbon@v0.carbon
+++ b/tests/integration/cases/string_control_chars/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("line1\r\nline2"),
+    CVal.Str("line1\rline2"),
+    CVal.Str("\x01"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_control_chars/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_control_chars/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("line1\r\nline2"),
+    CVal.Str("line1\rline2"),
+    CVal.Str("\x01"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("line1\r\nline2"),
+    CVal.Str("line1\rline2"),
+    CVal.Str("\x01"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Carbon@v0.carbon
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Carbon@v0.carbon
@@ -1,0 +1,15 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Str("hello \"world\" -- not a comment");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_escaped_quotes_and_dashes/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_escaped_quotes_and_dashes/Carbon_combined@v0.carbon
@@ -1,0 +1,16 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Str("hello \"world\" -- not a comment");
+  my_data = CVal.Str("hello \"world\" -- not a comment");
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_list/Carbon@v0.carbon
+++ b/tests/integration/cases/string_list/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("foo"),
+    CVal.Str("bar"),
+    CVal.Str("baz"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_list/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("foo"),
+    CVal.Str("bar"),
+    CVal.Str("baz"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("foo"),
+    CVal.Str("bar"),
+    CVal.Str("baz"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_backslash/Carbon@v0.carbon
+++ b/tests/integration/cases/string_with_backslash/Carbon@v0.carbon
@@ -1,0 +1,23 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("C:\\path\\to\\file"),
+    CVal.Str("back\\\\slash"),
+    CVal.Str("hello \\\"world\\\""),
+    CVal.Str("path\\to \"# file"),
+    CVal.Str("trailing\\"),
+    CVal.Str("both \"quotes''' here"),
+    CVal.Str("line1\\nline2\nwith newline"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_backslash/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_with_backslash/Carbon_combined@v0.carbon
@@ -1,0 +1,32 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("C:\\path\\to\\file"),
+    CVal.Str("back\\\\slash"),
+    CVal.Str("hello \\\"world\\\""),
+    CVal.Str("path\\to \"# file"),
+    CVal.Str("trailing\\"),
+    CVal.Str("both \"quotes''' here"),
+    CVal.Str("line1\\nline2\nwith newline"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("C:\\path\\to\\file"),
+    CVal.Str("back\\\\slash"),
+    CVal.Str("hello \\\"world\\\""),
+    CVal.Str("path\\to \"# file"),
+    CVal.Str("trailing\\"),
+    CVal.Str("both \"quotes''' here"),
+    CVal.Str("line1\\nline2\nwith newline"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_dollar/Carbon@v0.carbon
+++ b/tests/integration/cases/string_with_dollar/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("price $10"),
+    CVal.Str("$HOME"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_dollar/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_with_dollar/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("price $10"),
+    CVal.Str("$HOME"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("price $10"),
+    CVal.Str("$HOME"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_dollar_brace/Carbon@v0.carbon
+++ b/tests/integration/cases/string_with_dollar_brace/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("prefix ${HOME} suffix"),
+    CVal.Str("${interpolated}"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_dollar_brace/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_with_dollar_brace/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("prefix ${HOME} suffix"),
+    CVal.Str("${interpolated}"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("prefix ${HOME} suffix"),
+    CVal.Str("${interpolated}"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_hash/Carbon@v0.carbon
+++ b/tests/integration/cases/string_with_hash/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("issue #{42}"),
+    CVal.Str("color #red"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_hash/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_with_hash/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("issue #{42}"),
+    CVal.Str("color #red"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("issue #{42}"),
+    CVal.Str("color #red"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_percent/Carbon@v0.carbon
+++ b/tests/integration/cases/string_with_percent/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Str("100% done"),
+    CVal.Str("%(name) is here"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/string_with_percent/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/string_with_percent/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Str("100% done"),
+    CVal.Str("%(name) is here"),
+  ));
+  my_data = CVal.Arr((
+    CVal.Str("100% done"),
+    CVal.Str("%(name) is here"),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/time_dict/Carbon@v0.carbon
+++ b/tests/integration/cases/time_dict/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "morning", .val = CVal.Str("09:30:00")},
+    {.key = "afternoon", .val = CVal.Str("14:15:00")},
+    {.key = "evening", .val = CVal.Str("23:59:59")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/time_dict/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/time_dict/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "morning", .val = CVal.Str("09:30:00")},
+    {.key = "afternoon", .val = CVal.Str("14:15:00")},
+    {.key = "evening", .val = CVal.Str("23:59:59")},
+  ));
+  my_data = CVal.Map((
+    {.key = "morning", .val = CVal.Str("09:30:00")},
+    {.key = "afternoon", .val = CVal.Str("14:15:00")},
+    {.key = "evening", .val = CVal.Str("23:59:59")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/time_dict/Carbon_declaration_style_var@v0.carbon
+++ b/tests/integration/cases/time_dict/Carbon_declaration_style_var@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "morning", .val = CVal.Str("09:30:00")},
+    {.key = "afternoon", .val = CVal.Str("14:15:00")},
+    {.key = "evening", .val = CVal.Str("23:59:59")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/time_list/Carbon@v0.carbon
+++ b/tests/integration/cases/time_list/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "times", .val = CVal.Arr((CVal.Str("09:30:00"), CVal.Str("17:45:00"), CVal.Str("23:59:59")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/time_list/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/time_list/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "times", .val = CVal.Arr((CVal.Str("09:30:00"), CVal.Str("17:45:00"), CVal.Str("23:59:59")))},
+  ));
+  my_data = CVal.Map((
+    {.key = "times", .val = CVal.Arr((CVal.Str("09:30:00"), CVal.Str("17:45:00"), CVal.Str("23:59:59")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/times_heterogeneous_with_dates/Carbon@v0.carbon
+++ b/tests/integration/cases/times_heterogeneous_with_dates/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "vals", .val = CVal.Arr((CVal.Int(1705276800), CVal.Str("09:30:00")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/times_heterogeneous_with_dates/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/times_heterogeneous_with_dates/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "vals", .val = CVal.Arr((CVal.Int(1705276800), CVal.Str("09:30:00")))},
+  ));
+  my_data = CVal.Map((
+    {.key = "vals", .val = CVal.Arr((CVal.Int(1705276800), CVal.Str("09:30:00")))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/toml_comments/Carbon@v0.carbon
+++ b/tests/integration/cases/toml_comments/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    // before
+    {.key = "answer", .val = CVal.Int(42)},  // inline
+    {.key = "plain", .val = CVal.Str("ok")},
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/toml_comments/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/toml_comments/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    // before
+    {.key = "answer", .val = CVal.Int(42)},  // inline
+    {.key = "plain", .val = CVal.Str("ok")},
+    // trailing
+  ));
+  my_data = CVal.Map((
+    // before
+    {.key = "answer", .val = CVal.Int(42)},  // inline
+    {.key = "plain", .val = CVal.Str("ok")},
+    // trailing
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/toml_table/Carbon@v0.carbon
+++ b/tests/integration/cases/toml_table/Carbon@v0.carbon
@@ -1,0 +1,17 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "section", .val = CVal.Map(({.key = "value", .val = CVal.Int(1)}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/toml_table/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/toml_table/Carbon_combined@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "section", .val = CVal.Map(({.key = "value", .val = CVal.Int(1)}))},
+  ));
+  my_data = CVal.Map((
+    {.key = "section", .val = CVal.Map(({.key = "value", .val = CVal.Int(1)}))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/triple_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/triple_sequence/Carbon@v0.carbon
@@ -1,0 +1,19 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/triple_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/triple_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,24 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("hello"),
+    CVal.Bool(true),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_record_field/Carbon@v0.carbon
+++ b/tests/integration/cases/tuple_record_field/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "call", .val = CVal.Str("send")},
+    {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_record_field/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/tuple_record_field/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "call", .val = CVal.Str("send")},
+    {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))},
+  ));
+  my_data = CVal.Map((
+    {.key = "call", .val = CVal.Str("send")},
+    {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_record_seq_sibling/Carbon@v0.carbon
+++ b/tests/integration/cases/tuple_record_seq_sibling/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+    {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_record_seq_sibling/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/tuple_record_seq_sibling/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+    {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))},
+  ));
+  my_data = CVal.Map((
+    {.key = "scores", .val = CVal.Arr((CVal.Int(10), CVal.Int(20), CVal.Int(30)))},
+    {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_record_sequence/Carbon@v0.carbon
+++ b/tests/integration/cases/tuple_record_sequence/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "call", .val = CVal.Str("send")}, {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))})),
+    CVal.Map(({.key = "call", .val = CVal.Str("recv")}, {.key = "args", .val = CVal.Arr((CVal.Int(2), CVal.Str("sms"), CVal.Str("b@example.com"), CVal.Int(200)))})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_record_sequence/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/tuple_record_sequence/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "call", .val = CVal.Str("send")}, {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))})),
+    CVal.Map(({.key = "call", .val = CVal.Str("recv")}, {.key = "args", .val = CVal.Arr((CVal.Int(2), CVal.Str("sms"), CVal.Str("b@example.com"), CVal.Int(200)))})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "call", .val = CVal.Str("send")}, {.key = "args", .val = CVal.Arr((CVal.Int(1), CVal.Str("email"), CVal.Str("a@gmail.com"), CVal.Int(100)))})),
+    CVal.Map(({.key = "call", .val = CVal.Str("recv")}, {.key = "args", .val = CVal.Arr((CVal.Int(2), CVal.Str("sms"), CVal.Str("b@example.com"), CVal.Int(200)))})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_top_level/Carbon@v0.carbon
+++ b/tests/integration/cases/tuple_top_level/Carbon@v0.carbon
@@ -1,0 +1,20 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("email"),
+    CVal.Str("a@gmail.com"),
+    CVal.Int(100),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/tuple_top_level/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/tuple_top_level/Carbon_combined@v0.carbon
@@ -1,0 +1,26 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("email"),
+    CVal.Str("a@gmail.com"),
+    CVal.Int(100),
+  ));
+  my_data = CVal.Arr((
+    CVal.Int(1),
+    CVal.Str("email"),
+    CVal.Str("a@gmail.com"),
+    CVal.Int(100),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/type_hints/Carbon@v0.carbon
+++ b/tests/integration/cases/type_hints/Carbon@v0.carbon
@@ -1,0 +1,23 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+    {.key = "joined", .val = CVal.Int(1705276800)},
+    {.key = "last_login", .val = CVal.Int(1705321800)},
+    {.key = "avatar", .val = CVal.Str("48656c6c6f")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/type_hints/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/type_hints/Carbon_combined@v0.carbon
@@ -1,0 +1,32 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+    {.key = "joined", .val = CVal.Int(1705276800)},
+    {.key = "last_login", .val = CVal.Int(1705321800)},
+    {.key = "avatar", .val = CVal.Str("48656c6c6f")},
+  ));
+  my_data = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+    {.key = "joined", .val = CVal.Int(1705276800)},
+    {.key = "last_login", .val = CVal.Int(1705321800)},
+    {.key = "avatar", .val = CVal.Str("48656c6c6f")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/type_hints/Carbon_type_hints_safe@v0.carbon
+++ b/tests/integration/cases/type_hints/Carbon_type_hints_safe@v0.carbon
@@ -1,0 +1,23 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Map((
+    {.key = "name", .val = CVal.Str("Alice")},
+    {.key = "age", .val = CVal.Int(30)},
+    {.key = "active", .val = CVal.Bool(true)},
+    {.key = "score", .val = CVal.Nil},
+    {.key = "joined", .val = CVal.Int(1705276800)},
+    {.key = "last_login", .val = CVal.Int(1705321800)},
+    {.key = "avatar", .val = CVal.Str("48656c6c6f")},
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Carbon@v0.carbon
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "x", .val = CVal.Int(1)}, {.key = "y", .val = CVal.Float(2.5)})),
+    CVal.Map(({.key = "x", .val = CVal.Int(3)}, {.key = "y", .val = CVal.Float(4.0)})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/uniform_mixed_num_dicts_in_seq/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "x", .val = CVal.Int(1)}, {.key = "y", .val = CVal.Float(2.5)})),
+    CVal.Map(({.key = "x", .val = CVal.Int(3)}, {.key = "y", .val = CVal.Float(4.0)})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "x", .val = CVal.Int(1)}, {.key = "y", .val = CVal.Float(2.5)})),
+    CVal.Map(({.key = "x", .val = CVal.Int(3)}, {.key = "y", .val = CVal.Float(4.0)})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Carbon@v0.carbon
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Carbon@v0.carbon
@@ -1,0 +1,18 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  let my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "first", .val = CVal.Str("Alice")}, {.key = "last", .val = CVal.Str("Smith")})),
+    CVal.Map(({.key = "first", .val = CVal.Str("Bob")}, {.key = "last", .val = CVal.Str("Jones")})),
+  ));
+  let _: CVal = my_data;
+}

--- a/tests/integration/cases/uniform_string_dicts_in_seq/Carbon_combined@v0.carbon
+++ b/tests/integration/cases/uniform_string_dicts_in_seq/Carbon_combined@v0.carbon
@@ -1,0 +1,22 @@
+choice CVal {
+  Nil,
+  Bool(bool),
+  Int(i64),
+  UInt(u64),
+  Float(f64),
+  Str(Core.String),
+  Arr(Core.Array(CVal)),
+  Map(Core.Array({.key: Core.String, .val: CVal})),
+  Set(Core.Array(CVal)),
+}
+fn Run() {
+  var my_data: CVal = CVal.Arr((
+    CVal.Map(({.key = "first", .val = CVal.Str("Alice")}, {.key = "last", .val = CVal.Str("Smith")})),
+    CVal.Map(({.key = "first", .val = CVal.Str("Bob")}, {.key = "last", .val = CVal.Str("Jones")})),
+  ));
+  my_data = CVal.Arr((
+    CVal.Map(({.key = "first", .val = CVal.Str("Alice")}, {.key = "last", .val = CVal.Str("Smith")})),
+    CVal.Map(({.key = "first", .val = CVal.Str("Bob")}, {.key = "last", .val = CVal.Str("Jones")})),
+  ));
+  let _: CVal = my_data;
+}


### PR DESCRIPTION
Adds `literalizer.languages.Carbon`, an output language for the experimental Carbon successor-to-C++ language modelled on Zig: heterogeneous JSON/YAML is rendered through a single `choice CVal` tagged union with `//` whole-line comments, semicolons, and `{.field = value}` struct literals. The new `src/literalizer/languages/carbon.py` is registered in the languages package, with 481 generated golden fixtures, a `CHANGELOG.rst` entry, and an enforcing `lint-carbon` CI job (pinned `carbon` nightly, wired into the `completion-lint` gate). The full Python test suite (4821 passed) and all pre-commit/pre-push/docs hooks are green.

Known limitation, verified by compiling fixtures in a pinned-nightly Docker container: the current pre-1.0 Carbon toolchain does not implement parameterized `choice` alternatives, so the `CVal` model does not compile today and the enforcing `lint-carbon` job will fail until either the language module is reworked to a structural (struct/tuple/array) model or upstream implements the missing features. Docker testing also surfaced hard toolchain gaps (no negative-float literal syntax, no working `Optional`/null) that constrain any future rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new language backend plus a new required CI `lint-carbon` job that installs a pinned Carbon nightly and compiles all `*.carbon` fixtures; this can break the main lint gate if the toolchain or generated output is incompatible.
> 
> **Overview**
> Adds `literalizer.languages.Carbon`, a new output language that renders data using a `choice CVal` tagged-union model (with Carbon syntax like `//` comments, semicolon-terminated statements, and `{.field = value}` struct literals).
> 
> Registers `Carbon` in `languages/__init__.py`, adds extensive generated `.carbon` golden fixtures, and introduces a `lint-carbon` GitHub Actions job that downloads a pinned Carbon nightly toolchain and runs `carbon compile --phase=check` over all Carbon fixtures (wired into the `completion-lint` gate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c0230e2724ad515452ec189e91ca581572e590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->