### PR TITLE
Add basic JSON round-trip check for the Java backend (#1867)

### DIFF
--- a/.github/scripts/JavaRoundtripSerializer.java
+++ b/.github/scripts/JavaRoundtripSerializer.java
@@ -1,0 +1,89 @@
+import java.lang.reflect.Array;
+import java.math.BigInteger;
+import java.util.Map;
+
+// Serialize a value back to JSON for the Java round-trip check driven by
+// `.github/scripts/run_java_roundtrip.py` (invoked from the `Java
+// roundtrip` step of the `lint-fast` job in
+// `.github/workflows/lint.yml`, which is where the JDK toolchain is set
+// up). The runner literalizes the shared `roundtrip_input.json`
+// document to a Java `var myData = ...;` declaration, generates a tiny
+// `Main` that calls
+// `JavaRoundtripSerializer.toJson(myData)`, and compiles this file
+// alongside it (the same standalone-`.java`-helper pattern as
+// `CheckJavaSyntax.java`, kept out of the pytest suite and out of a
+// Python string so it stays real, highlightable, compilable Java).
+//
+// `toJson` covers exactly the types the default `Java()` config in
+// `src/literalizer/languages/java.py` emits for null-free JSON:
+// `java.util.Map` (from `Map.ofEntries`), primitive/Object arrays (via
+// `java.lang.reflect.Array`, so `int[]`/`double[]`/`boolean[]`/`Object[]`
+// share one path because `Array.get` auto-boxes), `String`, `Boolean`,
+// `Integer`, `Long`, `BigInteger` and `Double`. `Double.toString` emits
+// the shortest round-tripping form, which Python `json.loads` reparses to
+// the equal float. `Map.ofEntries` iteration order is unspecified, but
+// Python `dict` equality is order-independent; arrays preserve order.
+// JSON `null` is intentionally unsupported (see the runner docstring).
+final class JavaRoundtripSerializer {
+    private JavaRoundtripSerializer() {
+    }
+
+    static String toJson(final Object o) {
+        if (o == null) {
+            return "null";
+        }
+        if (o instanceof Boolean || o instanceof Integer
+                || o instanceof Long || o instanceof BigInteger) {
+            return o.toString();
+        }
+        if (o instanceof Double) {
+            return Double.toString((Double) o);
+        }
+        if (o instanceof String) {
+            final String s = (String) o;
+            final StringBuilder b = new StringBuilder();
+            b.append('"');
+            for (int i = 0; i < s.length(); i++) {
+                final char c = s.charAt(i);
+                if (c == '\\' || c == '"') {
+                    b.append('\\');
+                    b.append(c);
+                } else if (c < 0x20) {
+                    b.append(String.format("\\u%04x", (int) c));
+                } else {
+                    b.append(c);
+                }
+            }
+            b.append('"');
+            return b.toString();
+        }
+        if (o instanceof Map) {
+            final StringBuilder b = new StringBuilder("{");
+            boolean first = true;
+            for (final Map.Entry<?, ?> e : ((Map<?, ?>) o).entrySet()) {
+                if (!first) {
+                    b.append(",");
+                }
+                first = false;
+                b.append(toJson(e.getKey().toString()));
+                b.append(":");
+                b.append(toJson(e.getValue()));
+            }
+            b.append("}");
+            return b.toString();
+        }
+        if (o.getClass().isArray()) {
+            final StringBuilder b = new StringBuilder("[");
+            final int n = Array.getLength(o);
+            for (int i = 0; i < n; i++) {
+                if (i > 0) {
+                    b.append(",");
+                }
+                b.append(toJson(Array.get(o, i)));
+            }
+            b.append("]");
+            return b.toString();
+        }
+        throw new IllegalArgumentException("unhandled " + o.getClass());
+    }
+}

--- a/.github/scripts/roundtrip_common.py
+++ b/.github/scripts/roundtrip_common.py
@@ -1,0 +1,54 @@
+"""Shared pieces for the per-language JSON round-trip checks (#1867).
+
+Every ``run_<lang>_roundtrip.py`` helper literalizes the SAME single
+``roundtrip_input.json`` document to its language, compiles and runs the
+result so it re-emits JSON on stdout, then calls :func:`verify` here to
+assert the emitted JSON parses back to the original value.  Keeping the
+input and the comparison in one module means a new language only has to
+add the language-specific literalize + toolchain glue.
+
+The shared document is deliberately ``null``-free: several backends drop
+null map values or cannot infer the type of a bare ``null``.  Per-value
+type coverage (wide ints, large-exponent / negative-zero floats, unicode
+and escaped strings, empty/nested arrays and objects, heterogeneous
+arrays) lives in that one file rather than in many small cases.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+INPUT_PATH = Path(__file__).resolve().parent / "roundtrip_input.json"
+
+
+def read_input() -> str:
+    """Return the shared round-trip JSON document as text."""
+    return INPUT_PATH.read_text(encoding="utf-8")
+
+
+def expected() -> object:
+    """Return the parsed value the round-trip must reproduce."""
+    return json.loads(s=read_input())
+
+
+def verify(label: str, produced_json: str) -> None:
+    """Compare *produced_json* to :func:`expected`, exiting 1 on mismatch.
+
+    *label* names the language for the diagnostic.  JSON object key order
+    is irrelevant because the comparison is on parsed Python values.
+    """
+    want = expected()
+    try:
+        got = json.loads(s=produced_json)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(
+            f"{label}: produced invalid JSON ({exc})\n{produced_json!r}\n",
+        )
+        sys.exit(1)
+    if got != want:
+        sys.stderr.write(
+            f"{label}: round-trip mismatch\n"
+            f"  expected: {want!r}\n"
+            f"  got:      {got!r}\n",
+        )
+        sys.exit(1)

--- a/.github/scripts/roundtrip_input.json
+++ b/.github/scripts/roundtrip_input.json
@@ -1,0 +1,23 @@
+{
+  "int": 42,
+  "negative_int": -7,
+  "biginteger": 99999999999999999999999999,
+  "long": 2147483648,
+  "float": 3.14,
+  "float_large_exponent": 1.7976931348623157e308,
+  "negative_zero": -0.0,
+  "bool_true": true,
+  "bool_false": false,
+  "string": "hello",
+  "string_unicode": "unicode é 中",
+  "string_escapes": "quote \" backslash \\",
+  "empty_array": [],
+  "int_array": [1, 2, 3],
+  "double_array": [1.0, 2.5],
+  "bool_array": [true, false],
+  "mixed_array": [1, 2.5, "x", true],
+  "nested_array": [[1], [2, 3], []],
+  "empty_object": {},
+  "flat_object": {"a": 1, "b": "x", "c": true},
+  "nested_object": {"a": 1, "b": [1, 2.5, "x"], "c": {"d": true}}
+}

--- a/.github/scripts/run_java_roundtrip.py
+++ b/.github/scripts/run_java_roundtrip.py
@@ -1,0 +1,106 @@
+"""Java JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Java
+``var myData = ...;`` declaration, wrap it in a tiny ``Main`` whose
+``main`` prints ``JavaRoundtripSerializer.toJson(myData)``, compile that
+together with ``JavaRoundtripSerializer.java`` (copied from this
+directory, the same ``run_ada.py`` + ``a_stub.*`` pattern), run it, and
+hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Java roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where the JDK toolchain is installed; it is deliberately not a pytest
+test under ``tests/``.  It is the template for further per-language
+``run_<lang>_roundtrip.py`` helpers sharing one input document.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Java
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_SERIALIZER_SRC = _SCRIPT_DIR / "JavaRoundtripSerializer.java"
+_VAR_NAME = "myData"
+_LABEL = "Java"
+
+
+def _build_main(json_text: str) -> str:
+    """Return a runnable ``Main`` program literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Java(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    imports = "\n".join(result.preamble)
+    body_preamble = "\n".join(result.body_preamble)
+    indented_decl = result.code.replace("\n", "\n        ")
+    return (
+        f"{imports}\n"
+        f"{body_preamble}\n"
+        "public class Main {\n"
+        "    public static void main(String[] args) throws Exception {\n"
+        f"        {indented_decl}\n"
+        "        java.io.PrintStream out = new java.io.PrintStream(\n"
+        '            System.out, true, "UTF-8");\n'
+        "        out.print(JavaRoundtripSerializer.toJson(\n"
+        f"            {_VAR_NAME}));\n"
+        "        out.flush();\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Java backend."""
+    program = _build_main(json_text=roundtrip_common.read_input())
+    javac = shutil.which(cmd="javac") or "javac"
+    java = shutil.which(cmd="java") or "java"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        (tmpdir / "Main.java").write_text(data=program, encoding="utf-8")
+        shutil.copy(src=_SERIALIZER_SRC, dst=tmpdir / _SERIALIZER_SRC.name)
+        compile_result = subprocess.run(
+            args=[javac, "Main.java", _SERIALIZER_SRC.name],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            encoding="utf-8",
+        )
+        if compile_result.returncode != 0:
+            sys.stderr.write(
+                f"{_LABEL}: javac error\n{compile_result.stdout}"
+                f"{compile_result.stderr}",
+            )
+            sys.exit(1)
+        run_result = subprocess.run(
+            args=[java, "Main"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: java runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.exit(1)
+    roundtrip_common.verify(label=_LABEL, produced_json=run_result.stdout)
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -247,6 +247,13 @@ jobs:
           find tests/integration/cases -name '*@jdk_16.java' -print0 > /tmp/files-java-16 && test -s /tmp/files-java-16
           xargs -0 java CheckJavaSyntax.java 16 < /tmp/files-java-16
 
+      # Basic JSON -> Java -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the JDK toolchain; `uv run` (project
+      # mode, not `--no-project`) is required so `import literalizer`
+      # resolves. See `.github/scripts/run_java_roundtrip.py`.
+      - name: Java roundtrip
+        run: uv run python .github/scripts/run_java_roundtrip.py
+
       - name: Lint Php
         run: |-
           find tests/integration/cases -name '*.php' -print0 > /tmp/files-php && test -s /tmp/files-php


### PR DESCRIPTION
Adds a basic JSON -> Java -> JSON round-trip check for issue #1867: one shared `roundtrip_input.json` document is literalized to Java, compiled and run so it re-emits JSON, and asserted to parse back to the original value. It lives in `.github/scripts/` driven by a new `Java roundtrip` step in the `lint-fast` job (where the JDK toolchain is already set up), deliberately not as a pytest test, so it carries no coverage/spelling gate coupling and follows the existing `run_*.py` helper convention. The input document and the comparison logic (`roundtrip_common.py`) are shared and language-agnostic, and the Java runner plus `JavaRoundtripSerializer.java` form the copy-me template so further per-language round-trip checks reuse them. JSON `null` is intentionally excluded (the default Java config drops null map values and a bare `null` is uninferable); broadening to more languages and null support is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new CI validation scripts and a workflow step without changing runtime/library behavior, though it may introduce new CI failures if serialization edge cases are wrong.
> 
> **Overview**
> Adds a **Java JSON round-trip gate** to CI: a shared `roundtrip_input.json` fixture is literalized via the Java backend, compiled/executed, and the emitted JSON is compared to the original parsed value.
> 
> Introduces shared round-trip utilities (`roundtrip_common.py` + `roundtrip_input.json`), a Java runner (`run_java_roundtrip.py`), and a small Java-side JSON serializer (`JavaRoundtripSerializer.java`), and wires the check into `lint-fast` in `lint.yml` via a new `Java roundtrip` step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5957cf08457fbcff006379ffa1c6226121f6da8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->