### PR TITLE
Add Rust MUT modifier for mutable `let mut` variable bindings (#2537)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Changelog
 Next
 ----
 
+- :class:`~literalizer.languages.rust.Rust` now exposes a non-empty
+  ``Modifiers`` enum with a single ``MUT`` member.  Passing
+  ``NewVariable(name=..., modifiers={Rust.Modifiers.MUT})`` (or the same
+  via :func:`~literalizer.literalize_call`) renders a mutable binding
+  (``let mut name = ...;``) instead of the immutable default
+  (``let name = ...;``), so a value constructed and bound through the
+  variable form can then be mutated through that binding.  The modifier
+  applies to the default ``LET`` declaration style; other declaration
+  styles ignore it.
+
 - Added two metadata properties to the :class:`~literalizer.Language`
   protocol: ``supports_multi_param_call_wrapper_stub`` (whether the
   language can declare and positionally invoke a wrapper stub that

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -112,6 +112,25 @@ from literalizer.exceptions import (
     UnrepresentableInputError,
 )
 
+
+class _RustModifiers(enum.Enum):
+    """Declaration modifiers supported by Rust.
+
+    Rust has no C++/Java/C#-style storage or qualifier keywords, but a
+    ``let`` binding is immutable by default and a mutate-after-bind
+    sequence needs ``let mut``.  ``MUT`` requests that mutable binding
+    (issue #2537); the member's value is the ``mut`` keyword it renders
+    to.  It applies to the default ``LET`` declaration style only.
+
+    Exposed as :attr:`Rust.Modifiers` / :attr:`Rust.modifiers`.
+    """
+
+    MUT = "mut"
+    """Mutability: the binding may be mutated through its name, so a
+    subsequent ``&mut self`` method call on the bound value compiles.
+    """
+
+
 _PASCAL_CASE_IDENTIFIER = re.compile(pattern=r"^[A-Z][A-Za-z0-9_]*$")
 
 # Rust keywords (strict, reserved, weak) that are syntactically valid
@@ -430,6 +449,25 @@ def _lazy_static_placeholder_formatter(
         "placeholder and must not be called directly."
     )
     raise NotImplementedError(msg)
+
+
+@beartype
+def _format_let_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a Rust ``let`` binding for the ``LET`` declaration style.
+
+    ``LET`` is immutable by default.  When the caller requests
+    :attr:`Rust.Modifiers.MUT` via ``NewVariable(modifiers=…)`` the
+    rendered binding gains a ``mut`` keyword after ``let`` so the bound
+    value can be mutated through the name (issue #2537).  Modifier
+    members of other languages' enums are silently ignored.
+    """
+    keyword = "let mut" if _RustModifiers.MUT in modifiers else "let"
+    return f"{keyword} {name} = {value};"
 
 
 @beartype
@@ -1477,9 +1515,7 @@ class Rust(metaclass=LanguageCls):
         """Declaration style options."""
 
         LET = DeclarationStyleConfig(
-            formatter=variable_declaration_formatter(
-                template="let {name} = {value};"
-            ),
+            formatter=_format_let_declaration,
             supports_redefinition=False,
         )
         LET_MUT = DeclarationStyleConfig(
@@ -1790,10 +1826,9 @@ class Rust(metaclass=LanguageCls):
 
     call_styles = CallStyles
 
-    class Modifiers(enum.Enum):
-        """C++/Java/C#-style declaration modifiers: this language has none."""
+    Modifiers = _RustModifiers
 
-    modifiers = Modifiers
+    modifiers = _RustModifiers
 
     class HeterogeneousStrategies(enum.Enum):
         """Strategy for representing dicts or lists whose scalar values

--- a/tests/integration/cases/empty_set/Rust_modifiers_mut@edition_2021.rs
+++ b/tests/integration/cases/empty_set/Rust_modifiers_mut@edition_2021.rs
@@ -1,0 +1,5 @@
+use std::collections::HashSet;
+fn main() {
+    let mut my_data = HashSet::<String>::new();
+    let _ = my_data;
+}

--- a/tests/integration/cases/scalar_date/Rust_modifiers_mut@edition_2021.rs
+++ b/tests/integration/cases/scalar_date/Rust_modifiers_mut@edition_2021.rs
@@ -1,0 +1,5 @@
+use chrono::NaiveDate;
+fn main() {
+    let mut my_data = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let _ = my_data;
+}

--- a/tests/integration/cases/scalar_datetime/Rust_modifiers_mut@edition_2021.rs
+++ b/tests/integration/cases/scalar_datetime/Rust_modifiers_mut@edition_2021.rs
@@ -1,0 +1,7 @@
+use chrono::NaiveDate;
+use chrono::NaiveDateTime;
+use chrono::NaiveTime;
+fn main() {
+    let mut my_data = NaiveDateTime::new(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(), NaiveTime::from_hms_opt(12, 30, 0).unwrap());
+    let _ = my_data;
+}

--- a/tests/integration/cases/scalar_int/Rust_modifiers_mut@edition_2021.rs
+++ b/tests/integration/cases/scalar_int/Rust_modifiers_mut@edition_2021.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let mut my_data = 42;
+    let _ = my_data;
+}

--- a/tests/integration/cases/scalar_time/Rust_modifiers_mut@edition_2021.rs
+++ b/tests/integration/cases/scalar_time/Rust_modifiers_mut@edition_2021.rs
@@ -1,0 +1,7 @@
+use std::collections::HashMap;
+fn main() {
+    let mut my_data = HashMap::from([
+        ("starts_at", "09:30:00"),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/set/Rust_modifiers_mut@edition_2021.rs
+++ b/tests/integration/cases/set/Rust_modifiers_mut@edition_2021.rs
@@ -1,0 +1,9 @@
+use std::collections::HashSet;
+fn main() {
+    let mut my_data = HashSet::from([
+        "apple",
+        "banana",
+        "cherry",
+    ]);
+    let _ = my_data;
+}


### PR DESCRIPTION
Closes #2537. `Rust.Modifiers` was empty, so no `variable_form` could emit a mutable Rust binding, leaving mutate-after-bind sequences non-compiling. This adds a non-empty `_RustModifiers` enum with a sole `MUT` member (exposed as `Rust.Modifiers`/`Rust.modifiers`) and makes the default `LET` declaration style honor it, rendering `let mut name = ...;` (immutable `let` remains the default); this flows through `literalize_call` too since its declaration formatter defaults to the literal one. The established modifier-variant golden harness automatically discovers the non-empty enum, regenerating six new `Rust_modifiers_mut` golden fixtures (the heterogeneous `simple_dict` input is auto-skipped under Rust's default ERROR strategy). A `CHANGELOG.rst` "Next" entry was added, and the full ruff/mypy/pyright/ty/pylint/spelling/golden suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Rust-only output formatting change gated behind an explicit modifier, plus golden fixture updates to lock in behavior.
> 
> **Overview**
> **Rust variable bindings can now be made mutable via modifiers.** Rust gains a non-empty `Modifiers` enum (`MUT`) and the default `DeclarationStyles.LET` formatter now renders `let mut name = ...;` when `Rust.Modifiers.MUT` is present (otherwise it stays `let name = ...;`).
> 
> Adds a changelog entry and new `Rust_modifiers_mut@edition_2021.rs` integration fixtures covering several value shapes to validate the new rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a62247fdbd77784be393b80af150e3e67d508f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->