### PR TITLE
[codex] Ignore nested doccmd paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,9 @@ MESSAGES-CONTROL.disable = [
 MESSAGES-CONTROL.per-file-ignores = [
     "docs/source/conf.py:invalid-name",
     "docs/source/doccmd_*.py:invalid-name",
+    "docs/source/doccmd_*/*.py:invalid-name",
     "doccmd_README_rst_*.py:invalid-name",
+    "doccmd_*/*.py:invalid-name",
 ]
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.


### PR DESCRIPTION
Adds Pylint per-file ignores for nested `doccmd` generated snippet directories. This fixes the `doccmd==2026.5.16` behavior that writes snippets under `doccmd_<hash>/...py`, which caused docs Pylint to report `invalid-name` on example globals. Validated with `pylint-docs` against PR #2544's head and with the local `pyproject-fmt` hook; commit and push hooks also passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change: expands Pylint `per-file-ignores` to cover additional generated docs snippet locations, reducing false-positive `invalid-name` warnings without affecting runtime code.
> 
> **Overview**
> Updates Pylint configuration in `pyproject.toml` to also ignore `invalid-name` for Python files generated by `doccmd` in *nested* snippet directories (e.g. `docs/source/doccmd_*/*.py` and `doccmd_*/*.py`). This aligns linting with newer `doccmd` output paths and prevents docs lint failures caused by example globals/module names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e24bd5b4cbaddf15834a1a6bb3fbc09588b4d983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->