### PR TITLE
Ban dynamic builtin attribute helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,9 +171,6 @@ lint.per-file-ignores."tests/integration/test_*.py" = [
 # We comment out code during development, and with VSCode auto-save, this code
 # is sometimes annoyingly removed.
 lint.unfixable = [ "ERA001" ]
-lint.flake8-tidy-imports.banned-api."builtins.getattr".msg = "getattr is banned: declare a typed protocol and use isinstance narrowing, or access the attribute directly."
-lint.flake8-tidy-imports.banned-api."builtins.hasattr".msg = "hasattr is banned: declare a typed protocol and use isinstance narrowing instead."
-lint.flake8-tidy-imports.banned-api."builtins.setattr".msg = "setattr is banned: assign through a typed attribute or constructor instead."
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
@@ -217,6 +214,17 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
+]
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where


### PR DESCRIPTION
## Summary

Ban bare `getattr`, `hasattr`, and `setattr` calls through Pylint's `bad-builtin` checker while preserving Pylint's default `map` and `filter` bans.

Remove the ineffective Ruff `builtins.*` banned-api entries, since Ruff does not currently flag bare builtin calls for these APIs.

Link the Pylint fallback to the relevant Ruff issues so it can be removed when Ruff supports this directly.

## Checks

- `uv run --extra=dev -m ruff check pyproject.toml`
- pre-commit hooks during commit
- pre-push hooks during `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-only linting changes; the main impact is potentially new lint failures in code that calls these builtins directly.
> 
> **Overview**
> **Lint policy change:** removes Ruff `flake8-tidy-imports` `builtins.*` `banned-api` entries for `getattr`/`hasattr`/`setattr` (since Ruff doesn’t flag bare builtin calls).
> 
> **Enforcement moved to Pylint:** adds `DEPRECATED_BUILTINS.bad-functions` to ban `getattr`/`hasattr`/`setattr` via `pylint.extensions.bad_builtin`, explicitly retaining the existing `map`/`filter` bans and documenting the Ruff issues that would allow removing this workaround later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c9112cea062d2ccbfa9a643bbb11bcc4ea320a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->