### PR TITLE
[codex] Speed up benchmark CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: uv run --extra=dev pytest tests/benchmarks --codspeed -n0
+          run: uv run --extra=benchmark pytest tests/benchmarks --codspeed -o addopts=
 
   completion-ci:
     needs: [build, benchmarks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
     # ``typing`` module only from Python 3.13.
     "typing-extensions>=4.10",
 ]
+optional-dependencies.benchmark = [
+    "pytest==9.0.3",
+    "pytest-codspeed==5.0.2",
+]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
@@ -320,6 +324,7 @@ ignore = [
 
 [tool.deptry]
 optional_dependencies_dev_groups = [
+    "benchmark",
     "dev",
     "release",
 ]

--- a/tests/benchmarks/test_bench_literalize.py
+++ b/tests/benchmarks/test_bench_literalize.py
@@ -89,7 +89,7 @@ def _build_json_flat_records_source(*, n_records: int) -> str:
 _YAML_FAST = _build_yaml_source(n_records=100, with_comments=False)
 _YAML_WITH_COMMENTS = _build_yaml_source(n_records=100, with_comments=True)
 _JSON_NESTED = _build_json_source(depth=4, fanout=4)
-_JSON_LARGE_FLAT_RECORDS = _build_json_flat_records_source(n_records=5_000)
+_JSON_LARGE_FLAT_RECORDS = _build_json_flat_records_source(n_records=1_000)
 _JSON_HETEROGENEOUS = json.dumps(
     obj={
         "rows": [


### PR DESCRIPTION
## Summary

This reduces the benchmark CI job by running CodSpeed with a new benchmark-only optional dependency group instead of the full dev toolchain. It also shrinks the large flat JSON benchmark from 5,000 to 1,000 records, which keeps the high-volume rendering signal while avoiding most of the simulation-mode runtime. The deptry config now treats the benchmark extra as a tooling group so the pre-commit dependency check accepts the pytest-only benchmark dependencies.

## Validation

- `uv run --isolated --extra=benchmark pytest tests/benchmarks --codspeed -o addopts=`
- `uv run --isolated --extra=benchmark pytest tests/benchmarks --codspeed --codspeed-mode simulation -o addopts=`
- commit and push hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI benchmarking configuration and benchmark fixture sizing, with no production/runtime logic affected.
> 
> **Overview**
> **Benchmark CI now installs a minimal benchmark toolchain** by switching the CodSpeed step to `uv run --extra=benchmark ...` (and overriding pytest `addopts`), instead of relying on the full `dev` extras.
> 
> Adds a dedicated `optional-dependencies.benchmark` group in `pyproject.toml` (pytest + `pytest-codspeed`) and marks it as a tooling group for `deptry`. Separately reduces the `test_json_large_flat_records` benchmark input from 5,000 to 1,000 records to cut simulation-mode runtime while keeping the workload representative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b19c48c1c4319a62263f497db82b9c6652929a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->