### PR TITLE
[codex] Remove seealso from changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,6 @@
 Changelog
 =========
 
-.. seealso::
-
-   :doc:`heterogeneous-strategies` documents the strategies for
-   rendering mixed-type collections (``ERROR``, ``TAGGED_ENUM``,
-   ``RECORD``, ``TUPLE``, and per-language equivalents) and the
-   per-language support matrix.  New strategy additions are recorded
-   there as well as in the entries below.
-
 .. towncrier release notes start
 
 2026.05.20


### PR DESCRIPTION
Removes the `.. seealso::` block from the top of `CHANGELOG.rst` so the changelog starts directly with the Towncrier release marker. This keeps the generated changelog focused on release entries while leaving other documentation untouched. Validated by checking that `CHANGELOG.rst` and `docs/source/changelog.rst` no longer contain `.. seealso::`; the repository pre-commit hooks also passed during commit and push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes a top-of-file directive without affecting runtime behavior.
> 
> **Overview**
> Removes the `.. seealso::` block from the top of `CHANGELOG.rst`, so the file now begins directly at the `.. towncrier release notes start` marker and the release entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9079f8df18f3ac4957052e5d0da775850f407b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->