### PR TITLE
[codex] Address constructor target review comments

### DIFF
--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -67,8 +67,8 @@ from literalizer._language import (
     identity_call_ref_identifier,
     identity_call_statement,
     identity_call_target,
-    identity_constructor_target,
     never_inhibits_consuming_form,
+    new_constructor_target,
     no_call_binding_body_preamble,
     no_call_binding_file_pragmas,
     no_call_stub,
@@ -150,7 +150,7 @@ class Groovy(metaclass=LanguageCls):
 
     format_integer_widened = no_format_integer_widened
     format_constructor_target: ClassVar["staticmethod[[str], str]"] = (
-        staticmethod(identity_constructor_target)
+        staticmethod(new_constructor_target)
     )
     format_call_variable_declaration = default_format_call_variable_declaration
     format_call_variable_assignment = default_format_call_variable_assignment

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -267,7 +267,7 @@ def _format_constructor_target(class_name: str, /) -> str:
     return f"New {class_name}"
 
 
-format_constructor_target: Callable[[str], str] = _format_constructor_target
+_constructor_target: Callable[[str], str] = _format_constructor_target
 
 
 @beartype
@@ -286,7 +286,7 @@ class VisualBasic(metaclass=LanguageCls):
     format_call_variable_declaration = default_format_call_variable_declaration
     format_call_variable_assignment = default_format_call_variable_assignment
     format_constructor_target: ClassVar["staticmethod[[str], str]"] = (
-        staticmethod(format_constructor_target)
+        staticmethod(_constructor_target)
     )
     sequence_binding_declarations = default_sequence_binding_declarations
     format_call_binding_body_preamble = no_call_binding_body_preamble

--- a/tests/integration/constructor_targets/Groovy_constructor_call@v4.txt
+++ b/tests/integration/constructor_targets/Groovy_constructor_call@v4.txt
@@ -1,1 +1,1 @@
-def p = Playlist()
+def p = new Playlist()

--- a/tests/integration/constructor_targets/Groovy_constructor_call_positional@v4.txt
+++ b/tests/integration/constructor_targets/Groovy_constructor_call_positional@v4.txt
@@ -1,1 +1,1 @@
-def p = Playlist()
+def p = new Playlist()

--- a/tests/integration/constructor_targets/Groovy_constructor_target@v4.txt
+++ b/tests/integration/constructor_targets/Groovy_constructor_target@v4.txt
@@ -1,1 +1,1 @@
-Playlist
+new Playlist


### PR DESCRIPTION
Fixes the constructor target review comments from PR #2572.

Groovy now uses the shared `new_constructor_target` helper so generated constructor calls emit `new Playlist()` rather than `Playlist()`. The VB.NET constructor target alias is now private, matching the custom helper pattern used by other language modules. Updated the affected Groovy golden fixtures and validated with the constructor-target integration tests plus Ruff on the touched language files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only constructor-call rendering for Groovy and a naming/visibility tweak in VB.NET, with updated golden fixtures to catch regressions.
> 
> **Overview**
> Groovy constructor call generation now uses the shared `new_constructor_target`, so emitted constructor targets include `new` (e.g. `new Playlist()`), and Groovy constructor-target integration fixtures are updated accordingly.
> 
> VB.NET keeps the same constructor target formatting behavior but renames the exported alias to a private `_constructor_target` to match the helper pattern used by other language modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8914977b347d09d522477b70e9de9504d6a34daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->