### PR TITLE
[codex] Enforce no class-level None for Language

### DIFF
--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -115,14 +115,18 @@ of the protocol's nested enum classes and attributes.
 
    from literalizer._formatters.collection_openers import fixed_open
    from literalizer._formatters.format_entries import passthrough_sequence_entry
-   from literalizer._language import LanguageCls, SequenceFormatConfig
+   from literalizer._language import (
+       LanguageCls,
+       SequenceFormatConfig,
+       no_pygments_name,
+   )
 
 
    class MyLanguage(metaclass=LanguageCls):
        """Sketch only; a complete language defines many more nested enums."""
 
        extension = ".my"
-       pygments_name = None
+       pygments_name = no_pygments_name
 
        class SequenceFormats(enum.Enum):
            """Available sequence wrappers."""
@@ -152,6 +156,15 @@ of the protocol's nested enum classes and attributes.
    assert list_member.name == "LIST"
    assert MyLanguage.extension == ".my"
    assert MyLanguage.pygments_name is None
+
+When an attribute is part of the :class:`~literalizer.Language` protocol but
+should resolve to ``None``, expose that value through a descriptor or property
+instead of storing literal ``None`` on the class.  CPython treats class-level
+``None`` as "attribute is not implemented" during runtime protocol checks,
+which can prevent ABC cache warming for large ``@runtime_checkable`` protocols;
+see `python/cpython#102433 <https://github.com/python/cpython/issues/102433>`__.
+Built-in languages use shared descriptors such as ``no_pygments_name`` and
+``no_format_integer_widened`` for this pattern.
 
 Look at any built-in language module under ``literalizer/languages/`` for a
 complete working example.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -11,9 +11,11 @@ AStr
 Args
 Bool
 CPP
+CPython
 CSharp
 Changelog
 Cobol
+Cobol's
 Cpp
 Dhall
 Dhall's
@@ -124,6 +126,7 @@ beartype
 bool
 booleans
 chrono
+closers
 commonjs
 config
 const
@@ -150,6 +153,7 @@ gnatmake
 gofmt
 gregorian
 haskell
+inhomogeneous
 init
 initialisation
 initializer
@@ -165,15 +169,18 @@ kotlinc
 kroc
 kts
 kwargs
+lang
 linter
 literalize
 literalized
 literalizer
 literalizer's
+literalizing
 localhost
 luac
 matlab
 misclassifies
+misclassify
 mixin
 multiline
 mypy
@@ -215,6 +222,7 @@ reportUnknownMemberType
 reportUnknownVariableType
 repr
 representable
+reproducibility
 roundtrip
 ruamel
 scala
@@ -235,6 +243,8 @@ typeclass
 unescape
 unhandled
 unicode
+unmapped
+unresolvable
 unterminated
 uv
 val_t

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -6,7 +6,12 @@ import enum
 import math
 import sys
 from collections.abc import Callable, Mapping, Sequence
-from typing import Final, Protocol, assert_never, runtime_checkable
+from typing import (
+    Final,
+    Protocol,
+    assert_never,
+    runtime_checkable,
+)
 
 import humps
 from beartype import beartype
@@ -2126,6 +2131,31 @@ no_leading_preamble: property = property(fget=_no_leading_preamble)
 """Shared ``leading_preamble`` descriptor for languages that emit no
 preamble lines required to come before :attr:`Language.static_preamble`.
 """
+
+
+class _NoPygmentsName(str):
+    """Descriptor for languages with no matching Pygments lexer alias."""
+
+    __slots__ = ()
+
+    @beartype
+    def __get__(
+        self, _instance: object | None, _owner: type[object] | None = None
+    ) -> None:
+        """Return ``None`` for both class and instance access."""
+        del self, _instance, _owner
+
+
+# Shared ``pygments_name`` descriptor for languages unsupported by Pygments.
+#
+# This resolves to ``None`` without storing literal ``None`` in a language
+# class ``__dict__``. The interpreter treats that literal value as the PEP 544
+# "attribute is not implemented" signal during runtime Protocol checks,
+# which prevents ABC cache warming and makes repeated ``isinstance(_,
+# Language)`` calls walk every protocol member.
+# See https://github.com/python/cpython/issues/102433 for related
+# runtime Protocol attribute lookup context.
+no_pygments_name = _NoPygmentsName()
 
 
 @beartype

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -72,6 +72,7 @@ from literalizer._language import (
     no_data_preamble,
     no_format_integer_widened,
     no_leading_preamble,
+    no_pygments_name,
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
@@ -606,7 +607,7 @@ class Dhall(metaclass=LanguageCls):
 
     leading_preamble = no_leading_preamble
     extension = ".dhall"
-    pygments_name = None
+    pygments_name: ClassVar[str | None] = no_pygments_name
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -71,6 +71,7 @@ from literalizer._language import (
     no_data_preamble,
     no_format_integer_widened,
     no_leading_preamble,
+    no_pygments_name,
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
@@ -107,7 +108,7 @@ class Norg(metaclass=LanguageCls):
 
     leading_preamble = no_leading_preamble
     extension = ".norg"
-    pygments_name = None
+    pygments_name: ClassVar[str | None] = no_pygments_name
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = True

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -70,6 +70,7 @@ from literalizer._language import (
     no_data_preamble,
     no_format_integer_widened,
     no_leading_preamble,
+    no_pygments_name,
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
@@ -152,7 +153,7 @@ class Occam(metaclass=LanguageCls):
 
     leading_preamble = no_leading_preamble
     extension = ".occ"
-    pygments_name = None
+    pygments_name: ClassVar[str | None] = no_pygments_name
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -73,6 +73,7 @@ from literalizer._language import (
     no_data_preamble,
     no_format_integer_widened,
     no_leading_preamble,
+    no_pygments_name,
     no_type_hint_preamble,
     no_validate_call_arg,
     no_validate_spec_for_data,
@@ -729,7 +730,7 @@ class PureScript(metaclass=LanguageCls):
 
     leading_preamble = no_leading_preamble
     extension = ".purs"
-    pygments_name = None
+    pygments_name: ClassVar[str | None] = no_pygments_name
     supports_special_floats = True
     supports_variable_names = True
     supports_no_variable_wrap_in_file = False

--- a/tests/metadata/test_language_metadata.py
+++ b/tests/metadata/test_language_metadata.py
@@ -6,9 +6,10 @@ from typing import Protocol, runtime_checkable
 
 import pytest
 from pygments.lexers import find_lexer_class_by_name
+from typing_extensions import get_protocol_members
 
 import literalizer.languages
-from literalizer import LanguageCls
+from literalizer import Language, LanguageCls
 from literalizer.exceptions import WrapCombinedInFileNotSupportedError
 from literalizer.languages import Python, Raku
 
@@ -83,6 +84,30 @@ def test_protocol_properties_accessible(
     assert isinstance(spec.supports_standalone_comments_in_wrapped_calls, bool)
     assert isinstance(spec.supports_multi_param_call_wrapper_stub, bool)
     assert isinstance(spec.supports_dict_literal_as_free_expression, bool)
+
+
+def test_language_protocol_members_are_not_class_level_none() -> None:
+    """Built-in languages never store Protocol members as literal ``None``.
+
+    The runtime Protocol checker treats class-level ``None`` as the
+    PEP 544 "attribute is not implemented" marker.  That prevents ABC cache
+    warming and makes repeated ``isinstance(_, Language)`` checks traverse the
+    whole protocol.  Related upstream context:
+    https://github.com/python/cpython/issues/102433.
+    """
+    missing = object()
+    protocol_members = get_protocol_members(Language)
+    violations: dict[str, tuple[str, ...]] = {}
+
+    for language_cls in _SORTED_LANGUAGES:
+        class_level_none = [
+            member
+            for member in protocol_members
+            if vars(language_cls).get(member, missing) is None
+        ]
+        violations[language_cls.__name__] = tuple(sorted(class_level_none))
+
+    assert not any(violations.values()), violations
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #2576.

This adds a shared no_pygments_name descriptor and switches Dhall, Norg, Occam, and PureScript away from storing literal class-level None for Language protocol members.
It adds a metadata regression test over typing_extensions.get_protocol_members(Language) and documents the descriptor pattern for custom language authors.
The rationale links to CPython runtime Protocol behavior in https://github.com/python/cpython/issues/102433.
Validated with focused metadata tests, ruff, doc8, and the repository pre-push type-check hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is intended to be unchanged (attributes still resolve to `None`), but it touches core `Language` protocol metadata and could affect runtime protocol/type checks if misapplied.
> 
> **Overview**
> Prevents built-in `Language` implementations from storing runtime-Protocol members as literal class attributes set to `None` (which can degrade `@runtime_checkable` protocol `isinstance` performance in CPython).
> 
> Adds a shared `no_pygments_name` descriptor in `_language.py` and switches Dhall, Norg, Occam, and PureScript to use it for `pygments_name`. Adds a regression test that asserts no built-in language class has any `Language` protocol member set to class-level `None`, and updates the custom-language docs to recommend the descriptor/property pattern when a protocol attribute should resolve to `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7a0861b5b21ec5246cb5f164881059f0b67818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->