### PR TITLE
[codex] Add Ruby round-trip check

### DIFF
--- a/.github/scripts/run_ruby_roundtrip.py
+++ b/.github/scripts/run_ruby_roundtrip.py
@@ -1,0 +1,76 @@
+"""Ruby JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Ruby
+``myData = ...`` assignment, wrap it in a tiny script that prints
+``JSON.generate(myData)``, run it with Ruby, and hand the emitted JSON
+to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Ruby roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where the Ruby toolchain is installed.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Ruby
+
+_VAR_NAME = "myData"
+_LABEL = "Ruby"
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Ruby program literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Ruby(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "# frozen_string_literal: true\n"
+        "\n"
+        "require 'json'\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"STDOUT.write(JSON.generate({_VAR_NAME}))\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Ruby backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    ruby = shutil.which(cmd="ruby") or "ruby"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        script_path = Path(tmpdir_name) / "main.rb"
+        script_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[ruby, str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: ruby runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.exit(1)
+    roundtrip_common.verify(label=_LABEL, produced_json=run_result.stdout)
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -226,6 +226,14 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 ruby -c < /tmp/files-ruby
           xargs -0 -P "$(nproc)" -n1 ruby < /tmp/files-ruby
 
+      # Basic JSON -> Ruby -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Ruby toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_ruby_roundtrip.py`.
+      - name: Ruby roundtrip
+        run: uv run python .github/scripts/run_ruby_roundtrip.py
+
       - name: Lint JavaScript
         run: |-
           find tests/integration/cases -name '*.js' -print0 > /tmp/files-js && test -s /tmp/files-js

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,0 +1,1 @@
+Add a Ruby JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
Adds a Ruby JSON round-trip helper that literalizes the shared fixture, runs it through Ruby, and verifies the emitted JSON with the existing round-trip common code. Wires that helper into the lint workflow immediately after the Ruby fixture lint step so CI now checks Ruby for issue #1867. Adds a towncrier fragment for the CI coverage change. Validated with the direct Ruby round-trip, ruff, actionlint, metadata tests, and the repo commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an extra CI verification step and a small helper script, without changing runtime/library behavior.
> 
> **Overview**
> Adds a new `.github/scripts/run_ruby_roundtrip.py` helper that literalizes the shared `roundtrip_input.json` into Ruby, executes Ruby to re-emit JSON, and verifies the result via `roundtrip_common.verify`.
> 
> Wires this into `.github/workflows/lint.yml` as a new `Ruby roundtrip` step (run via `uv run`) immediately after the Ruby fixture lint, and documents the CI coverage change via `newsfragments/1867.change`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e48c5622db72f05075e116d7d6a2851e1ad34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->