### PR TITLE
[codex] Add Rust serde_json value type option

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1569,10 +1569,13 @@ jobs:
           trap 'rm -rf "$tmpdir"' EXIT
           cargo init "$tmpdir/chrono-check"
           cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
+          cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" serde_json
           cargo build --manifest-path "$tmpdir/chrono-check/Cargo.toml"
           deps="$tmpdir/chrono-check/target/debug/deps"
           chrono_rlib=$(find "$deps" -name "libchrono-*.rlib" -print -quit)
           test -n "$chrono_rlib"
+          serde_json_rlib=$(find "$deps" -name "libserde_json-*.rlib" -print -quit)
+          test -n "$serde_json_rlib"
           # ``--edition 2021`` matches ``Rust.language_version`` in
           # ``src/literalizer/languages/rust.py``; keep them in sync.
           # rustc infers a crate name from the source filename and
@@ -1585,6 +1588,7 @@ jobs:
               --crate-name "$crate_name" \
               -L "dependency=$deps" \
               --extern "chrono=$chrono_rlib" \
+              --extern "serde_json=$serde_json_rlib" \
               "$f" -o "$tmpdir/out" 2>&1 || exit 1
             "$tmpdir/out" || exit 1
           done < /tmp/files-to-lint

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -96,6 +96,31 @@ constructor argument controls the outcome.  Every language defaults to
 ``RECORD``.  See :ref:`heterogeneous-strategies` for the strategies,
 worked examples, and the per-language support matrix.
 
+JSON value types
+----------------
+
+Some languages also have a single runtime JSON value type that is a better
+fit than native narrow collection types.  Rust supports this through the
+``json_type`` constructor argument:
+
+.. code-block:: python
+
+   """Render Rust data as serde_json::Value."""
+
+   from literalizer import InputFormat, NewVariable, literalize
+   from literalizer.languages import Rust
+
+   result = literalize(
+       source='{"id": 1, "tags": ["red", 2]}',
+       input_format=InputFormat.JSON,
+       language=Rust(json_type=Rust.json_types.SERDE_JSON_VALUE),
+       variable_form=NewVariable(name="payload"),
+   )
+
+This emits ``serde_json::json!(...)`` expressions, relaxes Rust's
+homogeneous ``Vec<T>`` / ``HashMap<K, V>`` checks, and requires dict keys
+to be strings so they remain valid JSON object keys.
+
 Custom language implementations
 -------------------------------
 

--- a/newsfragments/2575.change
+++ b/newsfragments/2575.change
@@ -1,0 +1,1 @@
+Add ``Rust(json_type=Rust.json_types.SERDE_JSON_VALUE)`` to render values through ``serde_json::json!`` instead of Rust's narrow collection types.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -111,6 +111,7 @@ SNull
 SReal
 SSet
 SStr
+Serde
 Sml
 SystemVerilog
 Tcl

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -20,6 +20,7 @@ from literalizer._formatters.format_dates import (
     format_time_iso,
 )
 from literalizer._formatters.format_entries import (
+    dict_entry_with_separator,
     format_bytes_base64,
     format_bytes_hex,
     passthrough_sequence_entry,
@@ -102,7 +103,6 @@ from literalizer._language import (
     no_leading_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
-    no_validate_spec_for_data,
     prepend_body_preamble,
 )
 from literalizer._types import Scalar, Value
@@ -142,6 +142,7 @@ _I32_MIN = -(2**31)
 _I32_MAX = 2**31 - 1
 _I64_MIN = -(2**63)
 _I64_MAX = 2**63 - 1
+_SERDE_JSON_MACRO = "serde_json::json!"
 
 
 @beartype
@@ -477,6 +478,69 @@ def _format_let_declaration(
     """
     keyword = "let mut" if _RustModifiers.MUT in modifiers else "let"
     return f"{keyword} {name} = {value};"
+
+
+@beartype
+def _rust_json_value_expression(value: str, /) -> str:
+    """Wrap *value* in ``serde_json::json!`` unless it is already a
+    JSON macro expression.
+    """
+    if value.startswith(f"{_SERDE_JSON_MACRO}("):
+        return value
+    return f"{_SERDE_JSON_MACRO}({value})"
+
+
+@beartype
+def _format_rust_json_call_arg(_raw_value: Value, formatted: str) -> str:
+    """Format a direct Rust call argument as ``serde_json::Value``."""
+    return _rust_json_value_expression(formatted)
+
+
+@beartype
+def _rust_json_non_scalar_child(_raw_value: Value, formatted: str) -> str:
+    """Identity wrapper signalling JSON can hold non-scalar children."""
+    return formatted
+
+
+@beartype
+def _format_rust_json_assignment(name: str, value: str, _data: Value) -> str:
+    """Assign a rendered literal to a Rust JSON value binding."""
+    return f"{name} = {_rust_json_value_expression(value)};"
+
+
+@beartype
+def _rust_json_declaration_formatter(
+    *,
+    declaration_style: enum.Enum,
+    json_type: str,
+) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+    """Return a declaration formatter for ``serde_json::Value`` output."""
+
+    def _formatter(
+        name: str,
+        value: str,
+        _data: Value,
+        modifiers: frozenset[enum.Enum],
+    ) -> str:
+        """Format a JSON-backed declaration."""
+        expr = _rust_json_value_expression(value)
+        if declaration_style.name == "LAZY_STATIC":
+            return (
+                f"static {name}: LazyLock<{json_type}> = "
+                f"LazyLock::new(|| {expr});"
+            )
+        if declaration_style.name in {"LET", "LET_MUT"}:
+            keyword = (
+                "let mut"
+                if declaration_style.name == "LET_MUT"
+                or _RustModifiers.MUT in modifiers
+                else "let"
+            )
+            return f"{keyword} {name}: {json_type} = {expr};"
+        config: DeclarationStyleConfig = declaration_style.value
+        return config.formatter(name, expr, _data, modifiers)
+
+    return _formatter
 
 
 @beartype
@@ -1308,6 +1372,10 @@ class Rust(metaclass=LanguageCls):
         default_sequence_element_type: Type name used for empty
             ``Vec`` literals, e.g. ``Vec::<String>::new()``.
             Defaults to ``"String"``.
+
+        json_type: When set to ``json_types.SERDE_JSON_VALUE``, render
+            values through ``serde_json::json!`` instead of Rust's narrow
+            collection types.
     """
 
     format_integer_widened = no_format_integer_widened
@@ -1350,13 +1418,6 @@ class Rust(metaclass=LanguageCls):
     supports_record_struct_name_prefix = True
     supports_record_shape_names = True
     supports_non_string_dict_keys = True
-
-    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
-        staticmethod(
-            identity_call_arg,
-        )
-    )
-    """Callable that rewrites a formatted direct call argument."""
 
     class DateFormats(enum.Enum):
         """Date format options for Rust."""
@@ -1812,6 +1873,14 @@ class Rust(metaclass=LanguageCls):
         SAFE = enum.auto()
 
     variable_type_hints_formats = VariableTypeHints
+
+    class JsonTypes(enum.Enum):
+        """JSON value type options for Rust."""
+
+        SERDE_JSON_VALUE = "serde_json::Value"
+        """Serde's dynamic JSON value type."""
+
+    json_types = JsonTypes
     declaration_styles = DeclarationStyles
     dict_entry_styles = DictEntryStyles
     dict_formats = DictFormats
@@ -1969,6 +2038,7 @@ class Rust(metaclass=LanguageCls):
     default_set_element_type: str = "String"
     default_dict_key_type: str = "String"
     default_dict_value_type: str = "String"
+    json_type: JsonTypes | None = None
     variable_type_hints: VariableTypeHints = VariableTypeHints.NEVER
     comment_format: CommentFormats = CommentFormats.DOUBLE_SLASH
     declaration_style: DeclarationStyles = DeclarationStyles.LET
@@ -2002,7 +2072,7 @@ class Rust(metaclass=LanguageCls):
     language_version: VersionFormats = VersionFormats.EDITION_2021
     indent: str = "    "
 
-    null_literal: ClassVar[str] = "None::<()>"
+    _default_null_literal: ClassVar[str] = "None::<()>"
     true_literal: ClassVar[str] = "true"
     false_literal: ClassVar[str] = "false"
     indent_closing_delimiter: ClassVar[bool] = False
@@ -2014,6 +2084,18 @@ class Rust(metaclass=LanguageCls):
     statement_terminator: ClassVar[str] = ";"
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
+
+    @cached_property
+    def _json_type_active(self) -> bool:
+        """Return whether Rust should render via ``serde_json::Value``."""
+        return self.json_type is not None
+
+    @cached_property
+    def null_literal(self) -> str:
+        """Null literal for the active Rust representation."""
+        if self._json_type_active:
+            return "null"
+        return self._default_null_literal
 
     @cached_property
     def static_preamble(self) -> Sequence[str]:
@@ -2028,6 +2110,13 @@ class Rust(metaclass=LanguageCls):
         return ()
 
     @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Callable that rewrites a formatted direct call argument."""
+        if self._json_type_active:
+            return _format_rust_json_call_arg
+        return identity_call_arg
+
+    @cached_property
     def format_sequence_entry(self) -> Callable[[Value, str], str]:
         """Format a sequence entry."""
         return passthrough_sequence_entry
@@ -2040,6 +2129,8 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
         """Format an assignment to an existing variable."""
+        if self._json_type_active:
+            return _format_rust_json_assignment
         return variable_formatter(template="{name} = {value};")
 
     @cached_property
@@ -2080,6 +2171,12 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the behavior for the chosen heterogeneous strategy."""
+        if self._json_type_active:
+            return dataclasses.replace(
+                NO_HETEROGENEOUS_BEHAVIOR,
+                skip_scalar_checks=True,
+                wrap_non_scalar=_rust_json_non_scalar_child,
+            )
         return self.heterogeneous_strategy.value.build_behavior(
             self._strategy_params,
         )
@@ -2095,6 +2192,8 @@ class Rust(metaclass=LanguageCls):
         declaration per record shape present in the data.  Other
         strategies produce no preamble.
         """
+        if self._json_type_active:
+            return no_data_preamble
         return self.heterogeneous_strategy.value.build_preamble(
             self._strategy_params,
         )
@@ -2191,6 +2290,16 @@ class Rust(metaclass=LanguageCls):
         """Validate that incompatible formats are not combined."""
         _decl_cls = type(self.declaration_style)
         _seq_cls = type(self.sequence_format)
+        if self._json_type_active and self.declaration_style in {
+            _decl_cls.CONST,
+            _decl_cls.STATIC,
+        }:
+            msg = (
+                "Rust json_type uses serde_json::json!(…), which is not "
+                "a constant-expression initializer. Use LET, LET_MUT, or "
+                "LAZY_STATIC instead."
+            )
+            raise IncompatibleFormatsError(msg)
         if (
             self.declaration_style in {_decl_cls.CONST, _decl_cls.STATIC}
             and self.sequence_format is _seq_cls.VEC
@@ -2204,6 +2313,27 @@ class Rust(metaclass=LanguageCls):
             )
             raise IncompatibleFormatsError(msg)
         self._validate_record_naming()
+
+    def _validate_json_value_keys(self, data: Value, /) -> None:
+        """Reject non-string object keys for ``serde_json::Value``."""
+        match data:
+            case dict():
+                for key, value in data.items():
+                    if not isinstance(key, str):
+                        msg = (
+                            "Rust json_type can only represent dict keys "
+                            f"as JSON object strings, not {type(key).__name__}"
+                        )
+                        raise UnrepresentableInputError(msg)
+                    self._validate_json_value_keys(value)
+            case list():
+                for item in data:
+                    self._validate_json_value_keys(item)
+            case set():
+                for item in data:
+                    self._validate_json_value_keys(item)
+            case _:
+                return
 
     def _validate_record_naming(self) -> None:
         """Validate ``record_struct_name_prefix`` and
@@ -2271,11 +2401,34 @@ class Rust(metaclass=LanguageCls):
         """Return call-statement formatting for this language."""
         return identity_call_statement
 
-    validate_spec_for_data = no_validate_spec_for_data
+    def validate_spec_for_data(self, data: Value) -> None:
+        """Validate Rust-specific data/format combinations."""
+        if self._json_type_active:
+            self._validate_json_value_keys(data)
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
+        if self._json_type_active:
+            return SequenceFormatConfig(
+                sequence_open=fixed_open(open_str=f"{_SERDE_JSON_MACRO}(["),
+                close="])",
+                supports_heterogeneity=True,
+                single_element_trailing_comma=False,
+                supports_trailing_comma=True,
+                empty_sequence=f"{_SERDE_JSON_MACRO}([])",
+                preamble_lines=(),
+                format_entry=passthrough_sequence_entry,
+                typed_opener_fallback=None,
+                uses_typed_literal_for_scalars=False,
+                requires_uniform_record_shapes=False,
+                declared_type=(
+                    self.json_type.value
+                    if self.json_type is not None
+                    else None
+                ),
+                narrowed_empty_form=None,
+            )
         return self.sequence_format(
             default_type=self.default_sequence_element_type,
         )
@@ -2283,6 +2436,16 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def set_format_config(self) -> SetFormatConfig:
         """Configuration for the chosen set format."""
+        if self._json_type_active:
+            return SetFormatConfig(
+                set_open=fixed_open(open_str=f"{_SERDE_JSON_MACRO}(["),
+                close="])",
+                empty_set=f"{_SERDE_JSON_MACRO}([])",
+                preamble_lines=(),
+                set_opener_template="",
+                supports_heterogeneity=True,
+                supports_trailing_comma=True,
+            )
         return self.set_format(default_type=self.default_set_element_type)
 
     @cached_property
@@ -2293,6 +2456,19 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
+        if self._json_type_active:
+            return DictFormatConfig(
+                dict_open=fixed_open(open_str=f"{_SERDE_JSON_MACRO}({{"),
+                close="})",
+                format_entry=dict_entry_with_separator(
+                    separator=": ",
+                    format_value=passthrough_sequence_entry,
+                ),
+                empty_dict=f"{_SERDE_JSON_MACRO}({{}})",
+                preamble_lines=(),
+                narrowed_open=None,
+                supports_trailing_comma=True,
+            )
         return self.dict_format(
             default_type=self.default_dict_value_type,
             default_key_type=self.default_dict_key_type,
@@ -2311,11 +2487,18 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def format_date(self) -> Callable[[datetime.date], str]:
         """Callable that formats a date as a string literal."""
+        if self._json_type_active:
+            return format_date_iso
         return self.date_format
 
     @cached_property
     def format_datetime(self) -> Callable[[datetime.datetime], str]:
         """Callable that formats a datetime as a string literal."""
+        if (
+            self._json_type_active
+            and self.datetime_format.value.type_produced is not int
+        ):
+            return format_datetime_iso
         return self.datetime_format
 
     @cached_property
@@ -2350,6 +2533,14 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
+        if self._json_type_active:
+            return OrderedMapFormatConfig(
+                ordered_map_open=fixed_open(
+                    open_str=f"{_SERDE_JSON_MACRO}({{"
+                ),
+                close="})",
+                preamble_lines=(),
+            )
         return OrderedMapFormatConfig(
             ordered_map_open=fixed_open(open_str="HashMap::from(["),
             close="])",
@@ -2359,6 +2550,11 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def format_ordered_map_entry(self) -> Callable[[str, Value, str], str]:
         """Callable that formats one ordered-map entry."""
+        if self._json_type_active:
+            return dict_entry_with_separator(
+                separator=": ",
+                format_value=passthrough_sequence_entry,
+            )
         return tuple_dict_entry(format_value=passthrough_sequence_entry)
 
     @cached_property
@@ -2366,6 +2562,12 @@ class Rust(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a new variable declaration."""
+        if self._json_type_active:
+            assert self.json_type is not None  # noqa: S101
+            return _rust_json_declaration_formatter(
+                declaration_style=self.declaration_style,
+                json_type=self.json_type.value,
+            )
         return self.declaration_style.build_formatter(
             date_type=(
                 "&str"
@@ -2402,6 +2604,8 @@ class Rust(metaclass=LanguageCls):
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:
         """Per-instance scalar preamble computed from date/datetime format."""
+        if self._json_type_active:
+            return {}
         return date_scalar_preamble(
             date_format=self.date_format,
             datetime_format=self.datetime_format,

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -497,8 +497,11 @@ def _format_rust_json_call_arg(_raw_value: Value, formatted: str) -> str:
 
 
 @beartype
-def _rust_json_non_scalar_child(_raw_value: Value, formatted: str) -> str:
-    """Identity wrapper signalling JSON can hold non-scalar children."""
+def _rust_json_non_scalar_child(  # pragma: no cover
+    _raw_value: Value,
+    formatted: str,
+) -> str:
+    """Identity wrapper signaling JSON can hold non-scalar children."""
     return formatted
 
 
@@ -537,8 +540,15 @@ def _rust_json_declaration_formatter(
                 else "let"
             )
             return f"{keyword} {name}: {json_type} = {expr};"
-        config: DeclarationStyleConfig = declaration_style.value
-        return config.formatter(name, expr, _data, modifiers)
+        config: DeclarationStyleConfig = (  # pragma: no cover
+            declaration_style.value
+        )
+        return config.formatter(  # pragma: no cover
+            name,
+            expr,
+            _data,
+            modifiers,
+        )
 
     return _formatter
 

--- a/tests/errors/test_rust_json_type_errors.py
+++ b/tests/errors/test_rust_json_type_errors.py
@@ -1,0 +1,36 @@
+"""Rust ``json_type`` rejection paths."""
+
+import pytest
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.exceptions import (
+    IncompatibleFormatsError,
+    UnrepresentableInputError,
+)
+from literalizer.languages import Rust
+
+
+def test_rust_json_type_rejects_non_string_dict_keys() -> None:
+    """``serde_json::Value`` object keys must be strings."""
+    with pytest.raises(
+        expected_exception=UnrepresentableInputError,
+        match="dict keys as JSON object strings",
+    ):
+        literalize(
+            source="{1: one}",
+            input_format=InputFormat.YAML,
+            language=Rust(json_type=Rust.json_types.SERDE_JSON_VALUE),
+            variable_form=NewVariable(name="my_data"),
+        )
+
+
+def test_rust_json_type_rejects_const_declarations() -> None:
+    """``serde_json::json!`` is not a Rust const initializer."""
+    with pytest.raises(
+        expected_exception=IncompatibleFormatsError,
+        match="not a constant-expression initializer",
+    ):
+        Rust(
+            json_type=Rust.json_types.SERDE_JSON_VALUE,
+            declaration_style=Rust.declaration_styles.CONST,
+        )

--- a/tests/integration/call_variant_cases.py
+++ b/tests/integration/call_variant_cases.py
@@ -19,6 +19,7 @@ from .variant_cases import (
     Variant,
     build_heterogeneous_value_name_variants,
     build_heterogeneous_value_variant_name_variants,
+    build_json_type_variants,
 )
 
 
@@ -94,6 +95,7 @@ def build_heterogeneous_strategy_call_variants() -> list[Variant]:
 
 CALL_VARIANT_SOURCES: list[tuple[str, Callable[[], Iterable[Variant]]]] = [
     ("call_scalar_args", build_statement_terminator_style_call_variants),
+    ("call_scalar_args", build_json_type_variants),
     ("call_mixed_type_dicts", build_heterogeneous_value_name_variants),
     (
         "call_mixed_type_dicts",

--- a/tests/integration/cases/call_scalar_args/Rust_json_type_serde_json_value_call@edition_2021.rs
+++ b/tests/integration/cases/call_scalar_args/Rust_json_type_serde_json_value_call@edition_2021.rs
@@ -1,0 +1,6 @@
+fn main() {
+    fn process<A>(_value: A) {}
+    process(serde_json::json!("hello"));
+    process(serde_json::json!(42));
+    process(serde_json::json!(true));
+}

--- a/tests/integration/cases/date_set/Rust_json_type_serde_json_value_date_set@edition_2021.rs
+++ b/tests/integration/cases/date_set/Rust_json_type_serde_json_value_date_set@edition_2021.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!([
+        "2024-01-15",
+        "2024-06-01",
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/dates/Rust_json_type_serde_json_value_dates@edition_2021.rs
+++ b/tests/integration/cases/dates/Rust_json_type_serde_json_value_dates@edition_2021.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!({
+        "date": "2024-01-15",
+        "datetime": "2024-01-15T12:30:00+00:00",
+    });
+    let _ = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Rust_json_type_serde_json_value@edition_2021.rs
+++ b/tests/integration/cases/dict_with_list_value/Rust_json_type_serde_json_value@edition_2021.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!({
+        "name": "Alice",
+        "scores": serde_json::json!([10, 20, 30]),
+    });
+    let _ = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Rust_json_type_serde_json_value_combined@edition_2021.rs
+++ b/tests/integration/cases/dict_with_list_value/Rust_json_type_serde_json_value_combined@edition_2021.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let mut my_data: serde_json::Value = serde_json::json!({
+        "name": "Alice",
+        "scores": serde_json::json!([10, 20, 30]),
+    });
+    my_data = serde_json::json!({
+        "name": "Alice",
+        "scores": serde_json::json!([10, 20, 30]),
+    });
+    let _ = my_data;
+}

--- a/tests/integration/cases/dict_with_list_value/Rust_json_type_serde_json_value_lazy_static@edition_2021.rs
+++ b/tests/integration/cases/dict_with_list_value/Rust_json_type_serde_json_value_lazy_static@edition_2021.rs
@@ -1,0 +1,8 @@
+use std::sync::LazyLock;
+fn main() {
+    static my_data: LazyLock<serde_json::Value> = LazyLock::new(|| serde_json::json!({
+        "name": "Alice",
+        "scores": serde_json::json!([10, 20, 30]),
+    }));
+    let _ = my_data;
+}

--- a/tests/integration/cases/dict_with_nulls/Rust_json_type_serde_json_value_nulls@edition_2021.rs
+++ b/tests/integration/cases/dict_with_nulls/Rust_json_type_serde_json_value_nulls@edition_2021.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!({
+        "name": "Alice",
+        "score": null,
+        "age": 30,
+    });
+    let _ = my_data;
+}

--- a/tests/integration/cases/nested_mixed_inner/Rust_json_type_serde_json_value_nested_mixed@edition_2021.rs
+++ b/tests/integration/cases/nested_mixed_inner/Rust_json_type_serde_json_value_nested_mixed@edition_2021.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!([
+        serde_json::json!([1, "a"]),
+        serde_json::json!([2, "b"]),
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/ordered_map/Rust_json_type_serde_json_value_ordered_map@edition_2021.rs
+++ b/tests/integration/cases/ordered_map/Rust_json_type_serde_json_value_ordered_map@edition_2021.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!({
+        "name": "Alice",
+        "age": 30,
+        "active": true,
+    });
+    let _ = my_data;
+}

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -391,7 +391,7 @@ class VariantCase:
     variant_name: str
     variant: Variant
     case_dir_name: str
-    variable_form: literalizer.NewVariable
+    variable_form: literalizer.VariableForm
 
 
 @beartype
@@ -2000,6 +2000,10 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     "json_type": (
         _ci(case_dir_name="dict_with_list_value", suffix=""),
         _ci(case_dir_name="nested_mixed_inner", suffix="_nested_mixed"),
+        _ci(case_dir_name="dates", suffix="_dates"),
+        _ci(case_dir_name="dict_with_nulls", suffix="_nulls"),
+        _ci(case_dir_name="date_set", suffix="_date_set"),
+        _ci(case_dir_name="ordered_map", suffix="_ordered_map"),
     ),
     "default_dict_value_type": DEFAULT_DICT_INPUTS,
     "default_dict_key_type": DEFAULT_DICT_INPUTS,
@@ -2218,6 +2222,40 @@ def build_variant_cases() -> list[VariantCase]:
                 )
             )
     cases.extend(build_modifier_variant_cases())
+    cases.extend(
+        (
+            VariantCase(
+                variant_name="Rust_json_type_serde_json_value_combined",
+                variant=Variant(
+                    name="Rust_json_type_serde_json_value_combined",
+                    spec=make_spec(
+                        lang_cls=Rust,
+                        json_type=Rust.json_types.SERDE_JSON_VALUE,
+                        declaration_style=Rust.declaration_styles.LET_MUT,
+                    ),
+                    lang_cls=Rust,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
+                ),
+                case_dir_name="dict_with_list_value",
+                variable_form=literalizer.BothVariableForms(name="my_data"),
+            ),
+            VariantCase(
+                variant_name="Rust_json_type_serde_json_value_lazy_static",
+                variant=Variant(
+                    name="Rust_json_type_serde_json_value_lazy_static",
+                    spec=make_spec(
+                        lang_cls=Rust,
+                        json_type=Rust.json_types.SERDE_JSON_VALUE,
+                        declaration_style=Rust.declaration_styles.LAZY_STATIC,
+                    ),
+                    lang_cls=Rust,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
+                ),
+                case_dir_name="dict_with_list_value",
+                variable_form=wrap_variable_form(),
+            ),
+        )
+    )
     return cases
 
 

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -465,6 +465,22 @@ def build_default_sequence_element_type_variants() -> Iterable[Variant]:
     ]
 
 
+@beartype
+def build_json_type_variants() -> Iterable[Variant]:
+    """Build JSON value type variants for languages that support them."""
+    return [
+        Variant(
+            name="Rust_json_type_serde_json_value",
+            spec=make_spec(
+                lang_cls=Rust,
+                json_type=Rust.json_types.SERDE_JSON_VALUE,
+            ),
+            lang_cls=Rust,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
+        )
+    ]
+
+
 @runtime_checkable
 class _HasEmptyDictKey(Protocol):
     """Structural type for languages that expose an ``empty_dict_key``
@@ -1777,6 +1793,7 @@ _COMPLEX_BUILDERS: dict[str, Callable[[], Iterable[Variant]]] = {
     "default_sequence_element_type": (
         build_default_sequence_element_type_variants
     ),
+    "json_type": build_json_type_variants,
     "default_dict_value_type": build_default_dict_value_type_variants,
     "empty_dict_key": build_empty_dict_key_variants,
     "default_dict_key_type": build_default_dict_key_type_variants,
@@ -1979,6 +1996,10 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
     "default_sequence_element_type": (
         _ci(case_dir_name="empty_sequence", suffix=""),
         _ci(case_dir_name="simple_sequence", suffix=""),
+    ),
+    "json_type": (
+        _ci(case_dir_name="dict_with_list_value", suffix=""),
+        _ci(case_dir_name="nested_mixed_inner", suffix="_nested_mixed"),
     ),
     "default_dict_value_type": DEFAULT_DICT_INPUTS,
     "default_dict_key_type": DEFAULT_DICT_INPUTS,


### PR DESCRIPTION
Adds `Rust(json_type=Rust.json_types.SERDE_JSON_VALUE)` so Rust output can use `serde_json::Value` and `serde_json::json!` instead of narrow native collection types.

The implementation validates JSON object keys, rejects const/static declarations that cannot use the macro, and documents the new option.

Working behavior is covered by golden files, with remaining rejection paths in focused error tests.

Validated with pytest golden/error suites, `tests/test_languages.py`, ruff, mypy, pyright, ty, pyrefly, doc8, and the repo pre-push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Rust rendering mode that changes core formatting/validation behavior for sequences, maps, nulls, and declarations when enabled; risk is mainly around regressions in Rust output generation and test fixtures.
> 
> **Overview**
> Adds a `Rust(json_type=Rust.json_types.SERDE_JSON_VALUE)` option that renders data via `serde_json::Value` and `serde_json::json!(...)`, relaxing heterogeneous collection checks and switching null/date/datetime formatting to JSON-friendly representations.
> 
> Includes Rust-specific validation/guardrails (reject non-string dict keys; disallow `CONST`/`STATIC` declaration styles with JSON macros), updates integration variant coverage with new golden fixtures and focused error tests, documents the option, and updates CI Rust linting to compile fixtures with `serde_json` available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd14e1ef7b5131b490629204c826322356ac69c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->