### PR TITLE
Add TypeScript JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/roundtrip_common.py
+++ b/.github/scripts/roundtrip_common.py
@@ -26,25 +26,44 @@ def read_input() -> str:
     return INPUT_PATH.read_text(encoding="utf-8")
 
 
-def expected() -> object:
-    """Return the parsed value the round-trip must reproduce."""
-    return json.loads(s=read_input())
+def expected() -> dict[str, object]:
+    """Return the parsed value the round-trip must reproduce.
+
+    The shared ``roundtrip_input.json`` document is a top-level JSON
+    object, so the parsed value is always a ``dict``.
+    """
+    parsed: dict[str, object] = json.loads(s=read_input())
+    return parsed
 
 
-def verify(label: str, produced_json: str) -> None:
+def verify(
+    label: str,
+    produced_json: str,
+    exclude_keys: tuple[str, ...],
+) -> None:
     """Compare *produced_json* to :func:`expected`, exiting 1 on mismatch.
 
     *label* names the language for the diagnostic.  JSON object key order
     is irrelevant because the comparison is on parsed Python values.
+
+    *exclude_keys* drops the named top-level object keys from both sides
+    before comparing.  This is for languages whose JSON number type
+    cannot represent a value in the shared input losslessly (e.g. the
+    wide ``biginteger`` field in TypeScript, where the literalized
+    program collapses the 26-digit literal to a JS ``number`` before
+    serialization).  Pass ``()`` when no field needs to be skipped.
     """
     want = expected()
     try:
-        got = json.loads(s=produced_json)
+        got: dict[str, object] = json.loads(s=produced_json)
     except json.JSONDecodeError as exc:
         sys.stderr.write(
             f"{label}: produced invalid JSON ({exc})\n{produced_json!r}\n",
         )
         sys.exit(1)
+    for key in exclude_keys:
+        want.pop(key, None)
+        got.pop(key, None)
     if got != want:
         sys.stderr.write(
             f"{label}: round-trip mismatch\n"

--- a/.github/scripts/run_java_roundtrip.py
+++ b/.github/scripts/run_java_roundtrip.py
@@ -98,7 +98,11 @@ def main() -> None:
             f"{run_result.stderr}",
         )
         sys.exit(1)
-    roundtrip_common.verify(label=_LABEL, produced_json=run_result.stdout)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=(),
+    )
     sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 

--- a/.github/scripts/run_ruby_roundtrip.py
+++ b/.github/scripts/run_ruby_roundtrip.py
@@ -68,7 +68,11 @@ def main() -> None:
             f"{run_result.stderr}",
         )
         sys.exit(1)
-    roundtrip_common.verify(label=_LABEL, produced_json=run_result.stdout)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=(),
+    )
     sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 

--- a/.github/scripts/run_typescript_roundtrip.py
+++ b/.github/scripts/run_typescript_roundtrip.py
@@ -1,0 +1,87 @@
+"""TypeScript JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a TypeScript
+``const myData = ...;`` declaration, wrap it in a tiny script that
+writes ``JSON.stringify(myData)`` to stdout, run it with ``tsx``, and
+hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-typescript-run`` job in
+``.github/workflows/lint.yml``, because that job is where the Node and
+``tsx`` toolchain are installed.  It follows the same template as
+``run_ruby_roundtrip.py``: a single ``.py`` file, no separate serializer
+source, because ``JSON.stringify`` is in the JavaScript standard
+library.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+the literalizer emits a plain numeric literal, which JavaScript stores
+as an IEEE-754 double, so the original 26-digit integer cannot survive
+the round-trip even with a custom serializer.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import TypeScript
+
+_VAR_NAME = "myData"
+_LABEL = "TypeScript"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable TypeScript program literalized from
+    *json_text*.
+    """
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=TypeScript(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"process.stdout.write(JSON.stringify({_VAR_NAME}));\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the TypeScript backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    tsx = shutil.which(cmd="tsx") or "tsx"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        script_path = Path(tmpdir_name) / "main.ts"
+        script_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[tsx, str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: tsx runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -642,11 +642,26 @@ jobs:
         run: |
           npm ci --prefix .github/npm-linters
           echo "$GITHUB_WORKSPACE/.github/npm-linters/node_modules/.bin" >> "$GITHUB_PATH"
+      # `uv` is needed by the `TypeScript roundtrip` step below; it runs
+      # the helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
 
       - name: Run TypeScript files
         run: |-
           find tests/integration/cases -name '*.ts' -print0 > /tmp/files-ts && test -s /tmp/files-ts
           xargs -0 -P "$(nproc)" -n1 tsx < /tmp/files-ts
+
+      # Basic JSON -> TypeScript -> JSON round-trip (issue 1867).  Runs
+      # here because this is the job with the Node + `tsx` toolchain;
+      # `uv run` (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves.  See
+      # `.github/scripts/run_typescript_roundtrip.py`.
+      - name: TypeScript roundtrip
+        run: uv run python .github/scripts/run_typescript_roundtrip.py
 
   # Elm format + syntax check. Split from `lint-elm-run` so the two
   # `elm make`-based passes (compile-only vs. compile + Node execute)


### PR DESCRIPTION
## Summary
- Port the Java/Ruby JSON round-trip helper to TypeScript: literalize the shared `roundtrip_input.json` to `const myData = ...`, run it under `tsx`, and compare `JSON.stringify(myData)` back to the original.
- Wired into the existing `lint-typescript-run` job (already has Node + `tsx`); a new `astral-sh/setup-uv` step lets the helper run in project mode so `import literalizer` resolves.
- Extend `roundtrip_common.verify` with `exclude_keys` so a backend can drop a top-level field it cannot represent losslessly; TypeScript uses this for the wide `biginteger` field, which JS collapses to an IEEE-754 double.

## Test plan
- [x] `uv run python .github/scripts/run_typescript_roundtrip.py` passes locally
- [x] `uv run python .github/scripts/run_ruby_roundtrip.py` still passes (callers updated for the new keyword)
- [x] `ruff`, `mypy`, `basedpyright`, `pyright`, `ty`, `pyrefly`, `actionlint`, `zizmor` clean
- [ ] CI `lint-typescript-run` job is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI helpers/workflow wiring and a small, opt-in enhancement to the round-trip comparison logic.
> 
> **Overview**
> Adds a new `.github/scripts/run_typescript_roundtrip.py` helper that literalizes the shared `roundtrip_input.json` into TypeScript, executes it via `tsx`, and verifies the emitted `JSON.stringify` output (skipping the `biginteger` field).
> 
> Extends `roundtrip_common.verify` to accept an `exclude_keys` list (and tightens types to a top-level `dict`), updating the existing Java/Ruby round-trip scripts accordingly. Wires the TypeScript round-trip into `lint-typescript-run` in `lint.yml`, including installing `uv` so the helper can run in project mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71d2344383d7881b49093d59cb47092a38005d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->