### PR TITLE
Use Aeson for Haskell JSON round-trip (#1867)

### DIFF
--- a/.github/scripts/run_haskell_roundtrip.py
+++ b/.github/scripts/run_haskell_roundtrip.py
@@ -3,26 +3,25 @@
 Literalize the shared ``roundtrip_input.json`` document to a Haskell
 ``myData = ...`` binding (with the generated tagged ``Val`` algebraic
 type and the helper ``Num``/``Fractional`` instances that go with it),
-wrap it in a tiny module that serializes ``myData`` back to JSON via a
-hand-written ``toJson :: Val -> String``, compile and run it with GHC,
-and hand the emitted JSON to :func:`roundtrip_common.verify`.
+wrap it in a cabal-script ``Main`` that serializes ``myData`` back to
+JSON via Aeson, run it through ``cabal run``, and hand the emitted JSON
+to :func:`roundtrip_common.verify`.
 
 This lives here, driven by the ``Haskell roundtrip`` step of the
 ``lint-haskell-family`` job in ``.github/workflows/lint.yml``, because
-that job is where the GHC toolchain is installed.  It shares the same
-input and comparison logic as the other per-language round-trip
+that job is where the GHC/cabal toolchain is installed.  It shares the
+same input and comparison logic as the other per-language round-trip
 helpers.
 
-The literalized Haskell ``Val`` algebraic type only carries the
+The generated Haskell ``Val`` algebraic type only carries the
 constructors needed for the values that actually appear in the input,
-so ``toJson`` here covers exactly the six variants the shared input
+so ``valToValue`` here covers exactly the six variants the shared input
 exercises (``HBool``, ``HInt``, ``HFloat``, ``HStr``, ``HList``,
-``HMap``).  If a future expansion of ``roundtrip_input.json`` adds a
-new scalar kind, both this serializer and the Haskell backend's ``Val``
-type would grow together.
+``HMap``).  ``-Wall -Werror`` plus exhaustive pattern matching means a
+future expansion of ``roundtrip_input.json`` that adds a new scalar
+kind would fail compilation here until ``valToValue`` is extended.
 """
 
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -37,38 +36,37 @@ _VAR_NAME = "myData"
 _LABEL = "Haskell"
 _MODULE_NAME = "Main"
 
-_TO_JSON = """\
-toJson :: Val -> String
-toJson (HBool True) = "true"
-toJson (HBool False) = "false"
-toJson (HInt n) = show n
-toJson (HFloat d) = show d
-toJson (HStr s) = encodeStr s
-toJson (HList xs) = "[" ++ intercalate "," (map toJson xs) ++ "]"
-toJson (HMap kvs) =
-    "{" ++ intercalate "," (map kv kvs) ++ "}"
-  where
-    kv (k, v) = encodeStr k ++ ":" ++ toJson v
+# ``default-language: GHC2021`` matches ``Haskell.language_version`` in
+# ``src/literalizer/languages/haskell.py``; keep them in sync.
+_CABAL_HEADER = """\
+{- cabal:
+build-depends: base, aeson, bytestring
+default-language: GHC2021
+ghc-options: -Wall -Werror
+-}
+"""
 
-encodeStr :: String -> String
-encodeStr s = "\\"" ++ concatMap escapeChar s ++ "\\""
-
-escapeChar :: Char -> String
-escapeChar '"' = "\\\\\\""
-escapeChar '\\\\' = "\\\\\\\\"
-escapeChar '\\n' = "\\\\n"
-escapeChar '\\r' = "\\\\r"
-escapeChar '\\t' = "\\\\t"
-escapeChar c
-    | ord c < 0x20 =
-        let h = showHex (ord c) ""
-        in "\\\\u" ++ replicate (4 - length h) '0' ++ h
-    | otherwise = [c]
+# Go through Aeson's ``Encoding`` builder (not ``Value``) so HFloat
+# routes through ``E.double``'s shortest-roundtrip formatter. Building
+# ``A.Value`` would funnel HFloat through ``Scientific``, where (a) the
+# encoder renders integer-valued Scientifics as plain digits regardless
+# of magnitude (turning ``1.7976e308`` into a 309-digit integer) and
+# (b) ``Scientific.fromFloatDigits (-0.0)`` collapses the sign.
+_VAL_TO_ENCODING = """\
+valToEncoding :: Val -> E.Encoding
+valToEncoding (HBool b) = E.bool b
+valToEncoding (HInt n) = E.integer n
+valToEncoding (HFloat d) = E.double d
+valToEncoding (HStr s) = E.string s
+valToEncoding (HList xs) = E.list valToEncoding xs
+valToEncoding (HMap kvs) =
+    E.pairs (mconcat [E.pair (K.fromString k) (valToEncoding v)
+                      | (k, v) <- kvs])
 """
 
 
 def _build_program(json_text: str) -> str:
-    """Return a runnable Haskell program literalized from *json_text*."""
+    """Return a runnable Haskell cabal-script program for *json_text*."""
     result = literalize(
         source=json_text,
         input_format=InputFormat.JSON,
@@ -85,55 +83,31 @@ def _build_program(json_text: str) -> str:
     # duplicate the ``Val`` type and break compilation.
     preamble = "\n".join(result.preamble)
     return (
+        f"{_CABAL_HEADER}"
         f"module {_MODULE_NAME} where\n"
-        "import Data.Char (ord)\n"
-        "import Data.List (intercalate)\n"
-        "import Numeric (showHex)\n"
+        "import qualified Data.Aeson.Encoding as E\n"
+        "import qualified Data.Aeson.Key as K\n"
+        "import qualified Data.ByteString.Lazy as BL\n"
         f"{preamble}\n"
         f"{result.code}\n"
-        f"{_TO_JSON}"
+        f"{_VAL_TO_ENCODING}"
         "main :: IO ()\n"
-        f"main = putStr (toJson {_VAR_NAME})\n"
+        "main = BL.putStr (E.encodingToLazyByteString"
+        f" (valToEncoding {_VAR_NAME}))\n"
     )
 
 
 def main() -> None:
     """Round-trip the shared document through the Haskell backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
-    ghc = shutil.which(cmd="ghc") or "ghc"
     with tempfile.TemporaryDirectory() as tmpdir_name:
         tmpdir = Path(tmpdir_name)
         source_path = tmpdir / f"{_MODULE_NAME}.hs"
         source_path.write_text(data=program, encoding="utf-8")
-        binary_path = tmpdir / "run"
-        # ``-XGHC2021`` matches ``Haskell.language_version``; ``-Wall
-        # -Werror`` matches the policy of the ``Lint Haskell`` step.
-        compile_result = subprocess.run(
-            args=[
-                ghc,
-                "-XGHC2021",
-                "-Wall",
-                "-Werror",
-                "-outputdir",
-                str(tmpdir / "build"),
-                "-o",
-                str(binary_path),
-                str(source_path),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: ghc compile error\n{compile_result.stdout}"
-                f"{compile_result.stderr}",
-            )
-            sys.stderr.write(f"\nProgram:\n{program}\n")
-            sys.exit(1)
+        # ``--verbose=0`` keeps cabal's progress chatter off stdout so
+        # only the program's encoded JSON reaches ``run_result.stdout``.
         run_result = subprocess.run(
-            args=[str(binary_path)],
+            args=["cabal", "run", "--verbose=0", str(source_path)],
             capture_output=True,
             text=True,
             check=False,
@@ -141,8 +115,10 @@ def main() -> None:
         )
     if run_result.returncode != 0:
         sys.stderr.write(
-            f"{_LABEL}: runtime error\n{run_result.stdout}{run_result.stderr}",
+            f"{_LABEL}: cabal run error\n"
+            f"{run_result.stdout}{run_result.stderr}",
         )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
         sys.exit(1)
     roundtrip_common.verify(
         label=_LABEL,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1082,8 +1082,25 @@ jobs:
         with:
           persist-credentials: false
       - uses: haskell-actions/setup@v2
+        id: setup-haskell
         with:
           ghc-version: latest
+
+      # Cache the cabal store (compiled aeson and its deps) used by the
+      # `Haskell roundtrip` step's cabal-script. Keyed on the resolved
+      # GHC version and the script file (whose `{- cabal: ... -}` block
+      # holds the build-depends list), so a dependency bump invalidates
+      # automatically. `~/.cabal/packages` holds the Hackage index.
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/store
+            ~/.cabal/packages
+          key: cabal-${{ runner.os }}-ghc${{ steps.setup-haskell.outputs.ghc-version
+            }}-${{ hashFiles('.github/scripts/run_haskell_roundtrip.py') }}
+          restore-keys: |
+            cabal-${{ runner.os }}-ghc${{ steps.setup-haskell.outputs.ghc-version }}-
       # ``purescript: 0.15.15`` is ``>=`` the ``V0_15`` (PureScript
       # 0.15.x) default of ``PureScript.language_version`` in
       # ``src/literalizer/languages/purescript.py``; keep them in sync.


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `toJson` serializer in `.github/scripts/run_haskell_roundtrip.py` with Aeson's `Data.Aeson.Encoding` builder, run via a cabal-script `cabal run` instead of a bare `ghc` compile-then-execute.
- Encoding-path `E.double` uses shortest-roundtrip formatting, so non-finite / extreme-magnitude floats serialize as valid JSON (the old `show d` would have emitted bare `Infinity`/`NaN`).
- Add an `actions/cache` step in `lint-haskell-family` for `~/.cabal/store` and `~/.cabal/packages`, keyed on resolved GHC version + a hash of the script (which holds the cabal-block `build-depends`), with a GHC-version prefix `restore-keys` so aeson + its deps are reused across script edits.

## Test plan

- [x] Run `uv run --extra dev python .github/scripts/run_haskell_roundtrip.py` locally (with cabal installed via Homebrew): "Haskell round-trip OK".
- [ ] CI `lint-haskell-family` job passes; first run populates the cabal cache, subsequent runs restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CI execution path for the Haskell round-trip check (moving from direct `ghc` compile/run to `cabal run` with new dependencies and caching), which could affect CI reliability and output formatting.
> 
> **Overview**
> Switches the Haskell JSON round-trip check from a hand-rolled string serializer compiled with `ghc` to a cabal-script `Main.hs` that encodes via Aeson’s `Data.Aeson.Encoding` (using `E.double` to preserve shortest-roundtrip float formatting and `-0.0`).
> 
> Updates the CI `lint-haskell-family` job to capture the resolved GHC version, adds an `actions/cache` step for `~/.cabal/store` and `~/.cabal/packages` keyed by GHC version + script hash, and runs the round-trip via `cabal run --verbose=0` so only JSON is emitted on stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b8f0c52a1ac60061519539a2cd5d5a0437b064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->