### PR TITLE
Add Perl JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_perl_roundtrip.py
+++ b/.github/scripts/run_perl_roundtrip.py
@@ -1,0 +1,112 @@
+r"""Perl JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Perl
+``my $myData = ...;`` declaration, wrap it in a tiny script that prints
+``JSON::PP->new->utf8->allow_bignum->encode($myData)``, run it with
+Perl, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+Two non-default Perl options are used so the round-trip is faithful for
+the values Perl *can* represent:
+
+* ``bool_format=JSON_PP_REF`` renders booleans as ``\1`` / ``\0``,
+  which ``JSON::PP`` encodes as JSON ``true`` / ``false``.  The default
+  ``INTEGER`` form would collapse booleans to the integers ``1`` / ``0``
+  (see issue #2586).
+* ``integer_width_strategy=MATH_BIG_INT`` renders integers wider than a
+  native scalar via ``Math::BigInt->new("...")``, which the ``JSON::PP``
+  ``allow_bignum`` mode then serializes back as a plain JSON integer.
+  The default ``BARE`` form would silently demote the 26-digit
+  ``biginteger`` field to an NV (see issue #2588).
+
+Some keys are excluded from the comparison because they cannot survive
+the trip through a Perl scalar at all (no separate double-vs-int type,
+no preserved negative zero, NV mantissa narrower than the IEEE 754
+double in the input):
+
+* ``double_array`` -- ``[1.0, 2.5]`` becomes ``[1, 2.5]`` once Perl
+  numifies ``1.0``.
+* ``negative_zero`` -- ``-0.0`` collapses to ``0`` through any Perl
+  arithmetic or serialization path.
+* ``float_large_exponent`` -- Perl's NV precision rounds the IEEE 754
+  ``1.7976931348623157e308`` to ``1.79769313486232e+308``.
+
+This lives here, driven by the ``Perl roundtrip`` step of the
+``lint-perl`` job in ``.github/workflows/lint.yml``, because that job is
+where the pinned Perl toolchain is installed.  It shares the same input
+and comparison logic as the other per-language round-trip helpers.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Perl
+
+_VAR_NAME = "myData"
+_LABEL = "Perl"
+_EXCLUDED_KEYS = ("double_array", "negative_zero", "float_large_exponent")
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Perl program literalized from *json_text*."""
+    language = Perl(
+        bool_format=Perl.bool_formats.JSON_PP_REF,
+        integer_width_strategy=Perl.integer_width_strategies.MATH_BIG_INT,
+    )
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=language,
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "use strict;\n"
+        "use warnings;\n"
+        "use JSON::PP;\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        "my $json = JSON::PP->new->utf8->allow_bignum->canonical;\n"
+        "binmode STDOUT;\n"
+        f"print $json->encode(${_VAR_NAME});\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Perl backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    perl = shutil.which(cmd="perl") or "perl"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        script_path = Path(tmpdir_name) / "main.pl"
+        script_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[perl, str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: perl runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/run_perl_roundtrip.py
+++ b/.github/scripts/run_perl_roundtrip.py
@@ -18,17 +18,19 @@ the values Perl *can* represent:
   The default ``BARE`` form would silently demote the 26-digit
   ``biginteger`` field to an NV (see issue #2588).
 
-Some keys are excluded from the comparison because they cannot survive
-the trip through a Perl scalar at all (no separate double-vs-int type,
-no preserved negative zero, NV mantissa narrower than the IEEE 754
-double in the input):
+One key is excluded from the comparison because the Perl JSON encoder
+emits floats with only 15 significant digits.  The shared input's
+``float_large_exponent`` value is the IEEE 754 ``DBL_MAX``; rounded to
+15 digits it becomes ``1.79769313486232e+308``, which on parse rounds
+*up* past ``DBL_MAX`` and Python decodes as ``inf``:
 
-* ``double_array`` -- ``[1.0, 2.5]`` becomes ``[1, 2.5]`` once Perl
-  numifies ``1.0``.
-* ``negative_zero`` -- ``-0.0`` collapses to ``0`` through any Perl
-  arithmetic or serialization path.
-* ``float_large_exponent`` -- Perl's NV precision rounds the IEEE 754
-  ``1.7976931348623157e308`` to ``1.79769313486232e+308``.
+* ``float_large_exponent`` -- ``1.7976931348623157e308`` -> ``inf``
+  after encode/decode.
+
+``double_array`` (``[1.0, 2.5]`` -> ``[1, 2.5]``) and ``negative_zero``
+(``-0.0`` -> ``0``) survive the comparison because Python treats
+``1.0 == 1`` and ``-0.0 == 0`` as equal, so they do not need to be
+excluded even though Perl scalars discard the distinction.
 
 This lives here, driven by the ``Perl roundtrip`` step of the
 ``lint-perl`` job in ``.github/workflows/lint.yml``, because that job is
@@ -49,7 +51,7 @@ from literalizer.languages import Perl
 
 _VAR_NAME = "myData"
 _LABEL = "Perl"
-_EXCLUDED_KEYS = ("double_array", "negative_zero", "float_large_exponent")
+_EXCLUDED_KEYS = ("float_large_exponent",)
 
 
 def _build_program(json_text: str) -> str:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -542,6 +542,21 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 perl -c < /tmp/files-perl
           xargs -0 -P "$(nproc)" -n1 perl < /tmp/files-perl
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
+      # Basic JSON -> Perl -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the pinned Perl toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. ``JSON::PP`` and ``Math::BigInt``
+      # are core in the pinned 5.36 interpreter so no extra ``cpanm``
+      # step is needed. See `.github/scripts/run_perl_roundtrip.py`.
+      - name: Perl roundtrip
+        run: uv run python .github/scripts/run_perl_roundtrip.py
+
   # Fixture languages linted by small tools fetched via `go install`.
   lint-go-installed:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, and Haskell JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, and Perl JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary

- Adds `.github/scripts/run_perl_roundtrip.py` driving the shared `roundtrip_input.json` through the Perl backend, wired into the `lint-perl` job (plus a `setup-uv` step so `import literalizer` resolves; `JSON::PP` and `Math::BigInt` are core in the pinned 5.36 interpreter).
- Uses `Perl(bool_format=JSON_PP_REF, integer_width_strategy=MATH_BIG_INT)` to opt into the fixes from #2586 / #2588 so booleans and the 26-digit `biginteger` round-trip cleanly.
- Excludes three keys whose loss is inherent to Perl scalars rather than fixable in the backend: `double_array` (`1.0` numifies to `1`), `negative_zero` (`-0.0` collapses to `0`), `float_large_exponent` (NV precision narrows the IEEE 754 double).
- Updates `newsfragments/1867.change` to mention Perl.

## Test plan

- [x] `uv run python .github/scripts/run_perl_roundtrip.py` locally prints `Perl round-trip OK`
- [x] `ruff check` / `ruff format` / pre-commit (default + manual `spelling`, `pylint`) all pass on the touched files
- [ ] CI `lint-perl` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI verification script and workflow step without changing runtime/library behavior, but may introduce CI flakiness or platform-specific Perl/JSON serialization differences.
> 
> **Overview**
> Adds a new CI **Perl JSON round-trip** check that literalizes the shared `roundtrip_input.json` into Perl, re-encodes it via `JSON::PP` (with BigInt/boolean-safe literalization settings), and verifies the emitted JSON matches the shared fixture (excluding `float_large_exponent` for known precision limits).
> 
> Wires this into the `lint-perl` GitHub Actions job by installing `uv` and running `.github/scripts/run_perl_roundtrip.py`, and updates the `newsfragments/1867.change` entry to include Perl.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b75a72639929e55ce09d08c390eaa0d39101130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->