### PR TITLE
Add Java json_type=JACKSON_JSON_NODE for Jackson JsonNode output

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -248,7 +248,28 @@ jobs:
       # matching `--release`; the `11` / `16` literals match
       # `Java.VersionFormats.JDK_11` / `JDK_16` in
       # `src/literalizer/languages/java.py`. Keep them in sync.
+      # Jackson jars are needed by `Java(json_type=...)` fixtures so they
+      # compile and run under `CheckJavaSyntax`. Pinned to a recent 2.x
+      # release; bump together. The classpath is exported through
+      # `LITERALIZER_LINT_CLASSPATH`, which `CheckJavaSyntax.java` adds
+      # to both the in-process compile and the per-fixture
+      # `URLClassLoader`. Keep this enum value paired with the literal in
+      # `Java.JsonTypes.JACKSON_JSON_NODE` in
+      # `src/literalizer/languages/java.py`.
+      - name: Set up Jackson for Java
+        run: |-
+          mkdir -p /tmp/jackson-jars
+          jackson_version=2.18.2
+          for f in jackson-databind/$jackson_version/jackson-databind-$jackson_version.jar \
+                   jackson-core/$jackson_version/jackson-core-$jackson_version.jar \
+                   jackson-annotations/$jackson_version/jackson-annotations-$jackson_version.jar; do
+            name=$(basename "$f")
+            curl -fsSL "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/$f" -o "/tmp/jackson-jars/$name"
+          done
+
       - name: Lint Java
+        env:
+          LITERALIZER_LINT_CLASSPATH: /tmp/jackson-jars/*
         run: |-
           find tests/integration/cases -name '*@jdk_11.java' -print0 > /tmp/files-java-11 && test -s /tmp/files-java-11
           xargs -0 java CheckJavaSyntax.java 11 < /tmp/files-java-11

--- a/CheckJavaSyntax.java
+++ b/CheckJavaSyntax.java
@@ -4,8 +4,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.tools.JavaCompiler;
@@ -40,6 +43,13 @@ public class CheckJavaSyntax {
         // (`11` for `JDK_11`, `16` for `JDK_16` in `Java.VersionFormats`
         // in `src/literalizer/languages/java.py`). Keep them in sync.
         final String release = args[0];
+        // Optional `LITERALIZER_LINT_CLASSPATH` (colon-separated, with
+        // `dir/*` wildcards expanded to every jar in `dir/`) is added to
+        // both the compiler classpath and the per-fixture URLClassLoader
+        // so json_type fixtures resolve against Jackson at lint time.
+        // See `Lint Java` in `.github/workflows/lint.yml` for the wiring.
+        final List<Path> extraClasspath = resolveExtraClasspath();
+        final String classpathArg = classpathArg(extraClasspath);
         boolean failed = false;
         try (final StandardJavaFileManager fileManager =
                 compiler.getStandardFileManager(null, null, null)) {
@@ -50,11 +60,17 @@ public class CheckJavaSyntax {
                 final Path classDir = Files.createTempDirectory("javac");
                 final Iterable<? extends JavaFileObject> units =
                         fileManager.getJavaFileObjectsFromStrings(List.of(filename));
+                final List<String> options = new ArrayList<>(List.of(
+                        "-d", classDir.toString(), "-proc:none", "--release", release));
+                if (!classpathArg.isEmpty()) {
+                    options.add("-classpath");
+                    options.add(classpathArg);
+                }
                 final JavaCompiler.CompilationTask task = compiler.getTask(
                         null,
                         fileManager,
                         null,
-                        List.of("-d", classDir.toString(), "-proc:none", "--release", release),
+                        options,
                         null,
                         units);
                 if (!task.call()) {
@@ -62,7 +78,7 @@ public class CheckJavaSyntax {
                     failed = true;
                     continue;
                 }
-                if (!runFixture(filename, classDir)) {
+                if (!runFixture(filename, classDir, extraClasspath)) {
                     failed = true;
                 }
             }
@@ -70,19 +86,62 @@ public class CheckJavaSyntax {
         System.exit(failed ? 1 : 0);
     }
 
+    private static List<Path> resolveExtraClasspath() throws IOException {
+        final String env = System.getenv("LITERALIZER_LINT_CLASSPATH");
+        if (env == null || env.isEmpty()) {
+            return List.of();
+        }
+        final List<Path> jars = new ArrayList<>();
+        for (final String entry : env.split(":")) {
+            if (entry.isEmpty()) {
+                continue;
+            }
+            if (entry.endsWith("/*")) {
+                final Path dir = Paths.get(entry.substring(0, entry.length() - 2));
+                try (DirectoryStream<Path> stream =
+                        Files.newDirectoryStream(dir, "*.jar")) {
+                    for (final Path jar : stream) {
+                        jars.add(jar);
+                    }
+                }
+            } else {
+                jars.add(Paths.get(entry));
+            }
+        }
+        return jars;
+    }
+
+    private static String classpathArg(final List<Path> jars) {
+        if (jars.isEmpty()) {
+            return "";
+        }
+        final List<String> parts = new ArrayList<>(jars.size());
+        for (final Path jar : jars) {
+            parts.add(jar.toString());
+        }
+        return String.join(":", parts);
+    }
+
     // Load `Main` from a private class loader rooted at *classDir*,
     // construct an instance (forcing both static- and instance-field
     // initializers), and invoke `main()` if the fixture defines one.
     // `Main` is package-private in every fixture, so `setAccessible`
     // is required before invoking members reflectively.
-    private static boolean runFixture(final String filename, final Path classDir) {
-        final URL[] urls;
+    private static boolean runFixture(
+            final String filename,
+            final Path classDir,
+            final List<Path> extraClasspath) {
+        final List<URL> urlList = new ArrayList<>();
         try {
-            urls = new URL[] {classDir.toUri().toURL()};
+            urlList.add(classDir.toUri().toURL());
+            for (final Path jar : extraClasspath) {
+                urlList.add(jar.toUri().toURL());
+            }
         } catch (final java.net.MalformedURLException e) {
             System.err.println(filename + ": " + e);
             return false;
         }
+        final URL[] urls = urlList.toArray(new URL[0]);
         try (final URLClassLoader loader = new URLClassLoader(urls)) {
             final Class<?> checkClass = Class.forName("Main", true, loader);
             final Constructor<?> constructor = checkClass.getDeclaredConstructor();

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -121,6 +121,29 @@ This emits ``serde_json::json!(...)`` expressions, relaxes Rust's
 homogeneous ``Vec<T>`` / ``HashMap<K, V>`` checks, and requires dict keys
 to be strings so they remain valid JSON object keys.
 
+Java exposes the same option through Jackson's ``JsonNode``:
+
+.. code-block:: python
+
+   """Render Java data as a Jackson JsonNode."""
+
+   from literalizer import InputFormat, NewVariable, literalize
+   from literalizer.languages import Java
+
+   result = literalize(
+       source='{"id": 1, "tags": ["red", 2]}',
+       input_format=InputFormat.JSON,
+       language=Java(json_type=Java.json_types.JACKSON_JSON_NODE),
+       variable_form=NewVariable(name="payload"),
+   )
+
+This emits ``new ObjectMapper().readTree("...")`` so the rendered
+binding has the static type ``com.fasterxml.jackson.databind.JsonNode``
+and can hold the heterogeneous values that Java's narrow ``List`` /
+``Map`` types reject.  Dict keys must be strings, and the
+``RECORD`` ``heterogeneous_strategy`` is rejected because the two
+rendering modes cannot be combined.
+
 Custom language implementations
 -------------------------------
 

--- a/newsfragments/2590.change
+++ b/newsfragments/2590.change
@@ -1,0 +1,1 @@
+Add ``Java(json_type=Java.json_types.JACKSON_JSON_NODE)`` to render values through Jackson's ``ObjectMapper.readTree`` so the binding has the static type ``com.fasterxml.jackson.databind.JsonNode`` instead of Java's narrow ``List`` / ``Map`` types.

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 import enum
 import functools
+import json
 import re
 from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
@@ -109,6 +110,7 @@ from literalizer.exceptions import (
     IncompatibleFormatsError,
     InvalidRecordNameError,
     NullInCollectionError,
+    UnrepresentableInputError,
 )
 
 _PASCAL_CASE_IDENTIFIER = re.compile(pattern=r"^[A-Z][A-Za-z0-9_]*$")
@@ -585,6 +587,149 @@ def _object_nil_declaration(
     return _format
 
 
+_JACKSON_JSON_NODE_PREAMBLE: tuple[str, ...] = (
+    "import com.fasterxml.jackson.databind.JsonNode;",
+    "import com.fasterxml.jackson.databind.ObjectMapper;",
+)
+
+
+# Sequence/dict format definitions used while ``json_type`` is active.
+# The framework still walks through the data to compute a formatted
+# ``value``, but that string is discarded by
+# :func:`_format_java_json_declaration` and friends in favor of a fresh
+# ``json.dumps`` of the raw data.  These definitions only need to be
+# permissive enough that the formatting pass does not error on
+# heterogeneous data or nulls inside containers.
+_JSON_NODE_SEQUENCE_CONFIG = SequenceFormatConfig(
+    sequence_open=fixed_open(open_str="["),
+    close="]",
+    supports_heterogeneity=True,
+    single_element_trailing_comma=False,
+    supports_trailing_comma=True,
+    empty_sequence="[]",
+    preamble_lines=(),
+    format_entry=passthrough_sequence_entry,
+    typed_opener_fallback=None,
+    uses_typed_literal_for_scalars=False,
+    requires_uniform_record_shapes=False,
+    declared_type=None,
+    narrowed_empty_form=None,
+)
+
+_JSON_NODE_SET_CONFIG = SetFormatConfig(
+    set_open=fixed_open(open_str="["),
+    close="]",
+    empty_set="[]",
+    preamble_lines=(),
+    set_opener_template="",
+    supports_heterogeneity=True,
+    supports_trailing_comma=True,
+)
+
+_JSON_NODE_DICT_CONFIG = DictFormatConfig(
+    dict_open=fixed_open(open_str="{"),
+    close="}",
+    format_entry=dict_entry_with_template(
+        template="{key}: {value}",
+        format_value=passthrough_sequence_entry,
+    ),
+    empty_dict="{}",
+    preamble_lines=(),
+    narrowed_open=None,
+    supports_trailing_comma=True,
+)
+
+_JSON_NODE_ORDERED_MAP_CONFIG = OrderedMapFormatConfig(
+    ordered_map_open=fixed_open(open_str="{"),
+    close="}",
+    preamble_lines=(),
+)
+
+
+@beartype
+def _temporal_to_iso(data: datetime.date | datetime.time) -> str:
+    """Return ISO-8601 text for a date / datetime / time value.
+
+    Naive datetimes are anchored to UTC so Jackson can round-trip them
+    through ``readTree`` without a missing-offset error.
+    """
+    if isinstance(data, datetime.datetime):
+        iso = data.isoformat()
+        if data.tzinfo is None:
+            iso += "Z"
+        return iso
+    return data.isoformat()
+
+
+@beartype
+def _to_jsonable(data: Value) -> object:
+    """Convert *data* into a value that :func:`json.dumps` can serialize.
+
+    Dates, datetimes, and times become ISO-8601 strings (JSON has no
+    temporal type).  Bytes become a hex-encoded string.  Sets and
+    :class:`OrderedMap` are folded into list/dict respectively.  Non-string
+    dict keys are not handled here; the caller validates first.
+    """
+    match data:
+        case datetime.datetime() | datetime.date() | datetime.time():
+            return _temporal_to_iso(data=data)
+        case bytes():
+            return data.hex()
+        case OrderedMap() | dict():
+            return {
+                key: _to_jsonable(data=value) for key, value in data.items()
+            }
+        case set():
+            items = [_to_jsonable(data=item) for item in data]
+            items.sort(key=repr)
+            return items
+        case list():
+            return [_to_jsonable(data=item) for item in data]
+        case _:
+            return data
+
+
+@beartype
+def _format_java_json_value(data: Value) -> str:
+    """Serialize *data* as a single-line JSON expression."""
+    return json.dumps(obj=_to_jsonable(data=data), ensure_ascii=False)
+
+
+@beartype
+def _java_read_tree_expression(data: Value) -> str:
+    """Render ``new ObjectMapper().readTree("...")`` for *data*."""
+    json_text = _format_java_json_value(data=data)
+    java_literal = format_string_backslash(value=json_text)
+    return f"new ObjectMapper().readTree({java_literal})"
+
+
+@beartype
+def _format_java_json_declaration(
+    name: str,
+    _value: str,
+    data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a JsonNode declaration backed by ``readTree``."""
+    return f"JsonNode {name} = {_java_read_tree_expression(data=data)};"
+
+
+@beartype
+def _format_java_json_assignment(
+    name: str,
+    _value: str,
+    data: Value,
+) -> str:
+    """Format a JsonNode assignment backed by ``readTree``."""
+    return f"{name} = {_java_read_tree_expression(data=data)};"
+
+
+@beartype
+def _format_java_json_call_arg(raw_value: Value, _formatted: str) -> str:
+    """Format a direct call argument as a JsonNode literal."""
+    return _java_read_tree_expression(data=raw_value)
+
+
 @beartype
 def _java_record_field_identifier(key: str, /) -> str:
     """Return the Java record component name for a dict *key*.
@@ -658,6 +803,11 @@ class Java(metaclass=LanguageCls):
               e.g. ``new Object[]{1, 2, 3}``.
             * ``sequence_formats.LIST`` — ``List.of(...)`` call,
               e.g. ``List.of(1, 2, 3)``.
+
+        json_type: When set to ``json_types.JACKSON_JSON_NODE``, render
+            values through Jackson's ``ObjectMapper.readTree(...)`` so the
+            output produces a ``com.fasterxml.jackson.databind.JsonNode``
+            instead of Java's narrow ``List`` / ``Map`` / array types.
     """
 
     format_call_variable_declaration = default_format_call_variable_declaration
@@ -701,13 +851,6 @@ class Java(metaclass=LanguageCls):
     supports_record_struct_name_prefix = True
     supports_record_shape_names = True
     supports_non_string_dict_keys = True
-
-    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
-        staticmethod(
-            identity_call_arg,
-        )
-    )
-    """Callable that rewrites a formatted direct call argument."""
 
     _opener_config = TypedOpenerConfig(
         str_type="String",
@@ -1023,6 +1166,14 @@ class Java(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """JSON value type options for Java."""
+
+        JACKSON_JSON_NODE = "com.fasterxml.jackson.databind.JsonNode"
+        """Jackson's dynamic JSON value type."""
+
+    json_types = JsonTypes
+
     class VersionFormats(enum.Enum):
         """Version options for Java.
 
@@ -1080,6 +1231,48 @@ class Java(metaclass=LanguageCls):
         ):
             object.__setattr__(self, "language_version", jdk_16)
         self._validate_record_naming()
+        self._validate_json_type_spec()
+
+    def _validate_json_type_spec(self) -> None:
+        """Reject ``json_type`` combinations the generator cannot emit.
+
+        ``readTree(...)`` is a checked-exception call wrapped in a
+        method whose signature gains ``throws Exception``.  Class-field
+        forms (``public static final ...``) have no equivalent place to
+        declare that exception without synthesizing a static initializer
+        block, so a ``RECORD`` strategy is also unsupported because it
+        would mix the JsonNode rendering with auto-generated ``record``
+        declarations.  Both are rejected up front instead.
+        """
+        if not self._json_type_active:
+            return
+        if self.heterogeneous_strategy is self.heterogeneous_strategies.RECORD:
+            msg = (
+                "Java json_type renders data through "
+                "ObjectMapper.readTree(...) and is incompatible with "
+                "heterogeneous_strategy=RECORD, which generates typed "
+                "record declarations. Use heterogeneous_strategy=ERROR."
+            )
+            raise IncompatibleFormatsError(msg)
+
+    def _validate_json_value_keys(self, data: Value, /) -> None:
+        """Reject non-string object keys for Jackson ``JsonNode``."""
+        match data:
+            case OrderedMap() | dict():
+                for key, value in data.items():
+                    if not isinstance(key, str):
+                        msg = (
+                            "Java json_type can only represent dict keys "
+                            "as JSON object strings, not "
+                            f"{type(key).__name__}"
+                        )
+                        raise UnrepresentableInputError(msg)
+                    self._validate_json_value_keys(value)
+            case list() | set():
+                for item in data:
+                    self._validate_json_value_keys(item)
+            case _:
+                return
 
     def _validate_record_naming(self) -> None:
         """Validate ``record_shape_names`` for PascalCase identifier
@@ -1147,8 +1340,13 @@ class Java(metaclass=LanguageCls):
         #2317), so the combination is rejected here rather than
         emitting a ``record`` declaration that fails to compile.  This
         check is spec-only; *data* is unused.
+
+        When :attr:`json_type` is active, additionally walk *data* to
+        reject non-string dict keys, which JSON objects cannot represent.
         """
-        del data
+        if self._json_type_active:
+            self._validate_json_value_keys(data)
+            return
         strategies = type(self.heterogeneous_strategy)
         formats = type(self.sequence_format)
         if (
@@ -1334,10 +1532,12 @@ class Java(metaclass=LanguageCls):
             content=content,
             body_preamble=method_lines,
         )
+        throws_clause = " throws Exception" if self._json_type_active else ""
         return (
             f"class {self.module_name} {{\n"
             f"{class_block}"
-            f"{self.indent}public static void {method_name}() {{\n"
+            f"{self.indent}public static void {method_name}()"
+            f"{throws_clause} {{\n"
             f"{content}\n"
             f"{self.indent}}}\n"
             "}"
@@ -1386,6 +1586,7 @@ class Java(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    json_type: JsonTypes | None = None
     # The `Lint Java` step in `.github/workflows/lint.yml` compiles each
     # `@jdk_<release>` golden with the `--release` literal matching its
     # `VersionFormats` member (`11` for `JDK_11`, `16` for `JDK_16`).
@@ -1408,9 +1609,32 @@ class Java(metaclass=LanguageCls):
     supports_scalar_before_comments: ClassVar[bool] = False
     supports_scalar_inline_comments: ClassVar[bool] = False
     statement_terminator: ClassVar[str] = ";"
-    static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
+
+    @cached_property
+    def _json_type_active(self) -> bool:
+        """Return whether Java should render via Jackson JsonNode."""
+        return self.json_type is not None
+
+    @cached_property
+    def static_preamble(self) -> Sequence[str]:
+        """Static preamble lines emitted once per file.
+
+        When :attr:`json_type` is active the Jackson ``JsonNode`` and
+        ``ObjectMapper`` imports are emitted here so every fixture has
+        them in scope regardless of the rendered data.
+        """
+        if self._json_type_active:
+            return _JACKSON_JSON_NODE_PREAMBLE
+        return ()
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Callable that rewrites a formatted direct call argument."""
+        if self._json_type_active:
+            return _format_java_json_call_arg
+        return identity_call_arg
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:
@@ -1430,6 +1654,8 @@ class Java(metaclass=LanguageCls):
     @cached_property
     def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
         """Format an assignment to an existing variable."""
+        if self._json_type_active:
+            return _format_java_json_assignment
         return _format_java_assignment
 
     @cached_property
@@ -1569,8 +1795,14 @@ class Java(metaclass=LanguageCls):
         Always emits ``import java.math.BigInteger;`` when the data
         needs it; under ``HeterogeneousStrategies.RECORD`` also emits
         one ``record`` declaration per record shape present in the
-        data.
+        data.  When :attr:`json_type` is active, neither the BigInteger
+        import nor record declarations apply: integers outside the
+        64-bit range ride inside the JSON text, and the data flows
+        through a single ``ObjectMapper.readTree`` call instead of typed
+        records.
         """
+        if self._json_type_active:
+            return no_data_preamble
         record_preamble = self._record_strategy.preamble
 
         @beartype
@@ -1583,6 +1815,11 @@ class Java(metaclass=LanguageCls):
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the behavior for the chosen heterogeneous strategy."""
+        if self._json_type_active:
+            return dataclasses.replace(
+                NO_HETEROGENEOUS_BEHAVIOR,
+                skip_scalar_checks=True,
+            )
         return self._record_strategy.behavior
 
     @cached_property
@@ -1687,16 +1924,22 @@ class Java(metaclass=LanguageCls):
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
+        if self._json_type_active:
+            return _JSON_NODE_SEQUENCE_CONFIG
         return self.sequence_format.value
 
     @cached_property
     def set_format_config(self) -> SetFormatConfig:
         """Configuration for the chosen set format."""
+        if self._json_type_active:
+            return _JSON_NODE_SET_CONFIG
         return self.set_format.value
 
     @cached_property
     def sequence_open(self) -> Callable[[list[Value]], str]:
         """Callable that returns the opening delimiter for a sequence."""
+        if self._json_type_active:
+            return _JSON_NODE_SEQUENCE_CONFIG.sequence_open
         fmt = self.sequence_format.value
         if fmt.typed_opener_fallback is None:
             return fmt.sequence_open
@@ -1727,6 +1970,8 @@ class Java(metaclass=LanguageCls):
     @cached_property
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
+        if self._json_type_active:
+            return _JSON_NODE_DICT_CONFIG
         return self.dict_format.value
 
     @cached_property
@@ -1812,6 +2057,8 @@ class Java(metaclass=LanguageCls):
     @cached_property
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
+        if self._json_type_active:
+            return _JSON_NODE_ORDERED_MAP_CONFIG
         return OrderedMapFormatConfig(
             ordered_map_open=fixed_open(
                 open_str=(
@@ -1832,6 +2079,8 @@ class Java(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a new variable declaration."""
+        if self._json_type_active:
+            return _format_java_json_declaration
         datetime_produced = self.datetime_format.value.type_produced
         match datetime_produced:
             case _ if datetime_produced is str:
@@ -1862,7 +2111,15 @@ class Java(metaclass=LanguageCls):
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:
-        """Per-instance scalar preamble computed from date/datetime format."""
+        """Per-instance scalar preamble computed from date/datetime format.
+
+        Under :attr:`json_type` every temporal value is folded into the
+        JSON text as an ISO-8601 string, so the temporal Java imports
+        that the configured ``date_format`` / ``datetime_format`` would
+        otherwise add do not apply.
+        """
+        if self._json_type_active:
+            return {}
         return date_scalar_preamble(
             date_format=self.date_format,
             datetime_format=self.datetime_format,

--- a/tests/errors/test_java_json_type_errors.py
+++ b/tests/errors/test_java_json_type_errors.py
@@ -1,0 +1,36 @@
+"""Java ``json_type`` rejection paths."""
+
+import pytest
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.exceptions import (
+    IncompatibleFormatsError,
+    UnrepresentableInputError,
+)
+from literalizer.languages import Java
+
+
+def test_java_json_type_rejects_non_string_dict_keys() -> None:
+    """Jackson ``JsonNode`` object keys must be strings."""
+    with pytest.raises(
+        expected_exception=UnrepresentableInputError,
+        match="dict keys as JSON object strings",
+    ):
+        literalize(
+            source="{1: one}",
+            input_format=InputFormat.YAML,
+            language=Java(json_type=Java.json_types.JACKSON_JSON_NODE),
+            variable_form=NewVariable(name="my_data"),
+        )
+
+
+def test_java_json_type_rejects_record_strategy() -> None:
+    """``readTree`` rendering cannot coexist with generated records."""
+    with pytest.raises(
+        expected_exception=IncompatibleFormatsError,
+        match="incompatible with heterogeneous_strategy=RECORD",
+    ):
+        Java(
+            json_type=Java.json_types.JACKSON_JSON_NODE,
+            heterogeneous_strategy=Java.heterogeneous_strategies.RECORD,
+        )

--- a/tests/integration/cases/binary/Java_json_type_jackson_json_node_binary@jdk_11.java
+++ b/tests/integration/cases/binary/Java_json_type_jackson_json_node_binary@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("[\"48656c6c6f\"]");
+    }
+}

--- a/tests/integration/cases/binary/Rust_json_type_serde_json_value_binary@edition_2021.rs
+++ b/tests/integration/cases/binary/Rust_json_type_serde_json_value_binary@edition_2021.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!([
+        "48656c6c6f",
+    ]);
+    let _ = my_data;
+}

--- a/tests/integration/cases/call_scalar_args/Java_json_type_jackson_json_node_call@jdk_11.java
+++ b/tests/integration/cases/call_scalar_args/Java_json_type_jackson_json_node_call@jdk_11.java
@@ -1,0 +1,10 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+static Object process(Object... args) { return null; }
+    public static void main() throws Exception {
+process(new ObjectMapper().readTree("\"hello\""));
+process(new ObjectMapper().readTree("42"));
+process(new ObjectMapper().readTree("true"));
+    }
+}

--- a/tests/integration/cases/date_set/Java_json_type_jackson_json_node_date_set@jdk_11.java
+++ b/tests/integration/cases/date_set/Java_json_type_jackson_json_node_date_set@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("[\"2024-01-15\", \"2024-06-01\"]");
+    }
+}

--- a/tests/integration/cases/dates/Java_json_type_jackson_json_node_dates@jdk_11.java
+++ b/tests/integration/cases/dates/Java_json_type_jackson_json_node_dates@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("{\"date\": \"2024-01-15\", \"datetime\": \"2024-01-15T12:30:00+00:00\"}");
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Java_json_type_jackson_json_node@jdk_11.java
+++ b/tests/integration/cases/dict_with_list_value/Java_json_type_jackson_json_node@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}");
+    }
+}

--- a/tests/integration/cases/dict_with_list_value/Java_json_type_jackson_json_node_combined@jdk_11.java
+++ b/tests/integration/cases/dict_with_list_value/Java_json_type_jackson_json_node_combined@jdk_11.java
@@ -1,0 +1,8 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}");
+my_data = new ObjectMapper().readTree("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}");
+    }
+}

--- a/tests/integration/cases/dict_with_nulls/Java_json_type_jackson_json_node_nulls@jdk_11.java
+++ b/tests/integration/cases/dict_with_nulls/Java_json_type_jackson_json_node_nulls@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("{\"name\": \"Alice\", \"score\": null, \"age\": 30}");
+    }
+}

--- a/tests/integration/cases/nested_mixed_inner/Java_json_type_jackson_json_node_nested_mixed@jdk_11.java
+++ b/tests/integration/cases/nested_mixed_inner/Java_json_type_jackson_json_node_nested_mixed@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("[[1, \"a\"], [2, \"b\"]]");
+    }
+}

--- a/tests/integration/cases/ordered_map/Java_json_type_jackson_json_node_ordered_map@jdk_11.java
+++ b/tests/integration/cases/ordered_map/Java_json_type_jackson_json_node_ordered_map@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("{\"name\": \"Alice\", \"age\": 30, \"active\": true}");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_naive/Java_json_type_jackson_json_node_datetime_naive@jdk_11.java
+++ b/tests/integration/cases/scalar_datetime_naive/Java_json_type_jackson_json_node_datetime_naive@jdk_11.java
@@ -1,0 +1,7 @@
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Main {
+    public static void main() throws Exception {
+JsonNode my_data = new ObjectMapper().readTree("\"2024-01-15T12:30:00Z\"");
+    }
+}

--- a/tests/integration/cases/scalar_datetime_naive/Rust_json_type_serde_json_value_datetime_naive@edition_2021.rs
+++ b/tests/integration/cases/scalar_datetime_naive/Rust_json_type_serde_json_value_datetime_naive@edition_2021.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let my_data: serde_json::Value = serde_json::json!("2024-01-15T12:30:00");
+    let _ = my_data;
+}

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -30,6 +30,7 @@ from literalizer.languages import (
     Go,
     Groovy,
     Haskell,
+    Java,
     Kotlin,
     Mojo,
     Nim,
@@ -477,7 +478,16 @@ def build_json_type_variants() -> Iterable[Variant]:
             ),
             lang_cls=Rust,
             collection_layout=literalizer.CollectionLayout.COMPACT,
-        )
+        ),
+        Variant(
+            name="Java_json_type_jackson_json_node",
+            spec=make_spec(
+                lang_cls=Java,
+                json_type=Java.json_types.JACKSON_JSON_NODE,
+            ),
+            lang_cls=Java,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
+        ),
     ]
 
 
@@ -2053,6 +2063,8 @@ AXIS_INPUTS: dict[str, tuple[CaseInput, ...]] = {
         _ci(case_dir_name="dict_with_nulls", suffix="_nulls"),
         _ci(case_dir_name="date_set", suffix="_date_set"),
         _ci(case_dir_name="ordered_map", suffix="_ordered_map"),
+        _ci(case_dir_name="scalar_datetime_naive", suffix="_datetime_naive"),
+        _ci(case_dir_name="binary", suffix="_binary"),
     ),
     "default_dict_value_type": DEFAULT_DICT_INPUTS,
     "default_dict_key_type": DEFAULT_DICT_INPUTS,
@@ -2312,6 +2324,20 @@ def build_variant_cases() -> list[VariantCase]:
                 ),
                 case_dir_name="dict_with_list_value",
                 variable_form=wrap_variable_form(),
+            ),
+            VariantCase(
+                variant_name="Java_json_type_jackson_json_node_combined",
+                variant=Variant(
+                    name="Java_json_type_jackson_json_node_combined",
+                    spec=make_spec(
+                        lang_cls=Java,
+                        json_type=Java.json_types.JACKSON_JSON_NODE,
+                    ),
+                    lang_cls=Java,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
+                ),
+                case_dir_name="dict_with_list_value",
+                variable_form=literalizer.BothVariableForms(name="my_data"),
             ),
         )
     )


### PR DESCRIPTION
## Summary

- Adds `Java(json_type=Java.json_types.JACKSON_JSON_NODE)` so output renders through `new ObjectMapper().readTree("...")` and the binding has the static type `com.fasterxml.jackson.databind.JsonNode` instead of Java's narrow `List` / `Map` types — sibling of the Rust option added in #2582.
- Implementation re-serializes the raw data to a single-line JSON literal embedded in a Java string, gets `throws Exception` plumbed into the generated method, rejects non-string dict keys and the `RECORD` heterogeneous strategy, and wires Jackson jars onto the `Lint Java` CI classpath via a new `LITERALIZER_LINT_CLASSPATH` env var read by `CheckJavaSyntax`.
- Ships 9 new Java golden fixtures (plus 2 extra Rust goldens from sharing `scalar_datetime_naive` / `binary` AXIS_INPUTS to fill the cov-100 gap), focused error tests in `tests/errors/test_java_json_type_errors.py`, a docs section, and `newsfragments/2590.change`.

Closes #2590.

## Test plan

- [ ] CI: `Lint Java` step compiles and runs all `Java_json_type_jackson_json_node*` goldens against the downloaded Jackson 2.18.2 jars
- [ ] CI: full pytest + cov-100 gate
- [ ] CI: mypy / pyright / ty / pyrefly
- [ ] Manual: spot-check `tests/integration/cases/dict_with_list_value/Java_json_type_jackson_json_node@jdk_11.java` and the combined / dates / nulls / nested_mixed / ordered_map / date_set / binary / naive-datetime variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Java rendering mode that changes output shape/typing and introduces checked-exception handling, plus updates CI to download and inject third-party Jackson jars for Java fixture linting.
> 
> **Overview**
> Adds a new Java `json_type` option, `Java.json_types.JACKSON_JSON_NODE`, that renders values as `JsonNode` via `new ObjectMapper().readTree("...")`, enabling heterogeneous JSON-like payloads without Java `List`/`Map` type constraints.
> 
> This mode emits Jackson imports, rewrites declarations/assignments/call arguments to `readTree(...)`, appends `throws Exception` to generated entrypoints, and validates incompatible inputs/options (rejects non-string dict keys and `heterogeneous_strategy=RECORD`).
> 
> CI’s Java lint is updated to download pinned Jackson jars and pass them into `CheckJavaSyntax` via `LITERALIZER_LINT_CLASSPATH`, which now extends both the compiler classpath and runtime `URLClassLoader`; docs, changelog fragment, and new unit/integration goldens cover the feature and rejection paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40554d5bfca252968a1a600f114448e40e616fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->