### PR TITLE
Add PHP JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_php_roundtrip.py
+++ b/.github/scripts/run_php_roundtrip.py
@@ -1,0 +1,83 @@
+"""PHP JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a PHP
+``$myData = ...`` assignment, wrap it in a tiny script that prints
+``json_encode($myData)``, run it with PHP, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Php roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where the PHP toolchain is installed.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+Two fields are excluded from the comparison because PHP's JSON encoder
+cannot represent them losslessly:
+
+* ``biginteger`` -- the 26-digit literal overflows PHP's signed 64-bit
+  integer and is widened to ``float``, so ``json_encode`` re-emits it
+  as ``1.0e+26``.
+* ``empty_object`` -- PHP has a single sequence/map array type, so an
+  empty associative array is indistinguishable from an empty list and
+  ``json_encode`` emits it as ``[]`` rather than ``{}``.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Php
+
+_VAR_NAME = "myData"
+_LABEL = "PHP"
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable PHP program literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Php(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n{result.code}\necho json_encode(${_VAR_NAME});\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the PHP backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    php = shutil.which(cmd="php") or "php"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        script_path = Path(tmpdir_name) / "main.php"
+        script_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[php, str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: php runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=("biginteger", "empty_object"),
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -289,6 +289,13 @@ jobs:
           xargs -0 php -l < /tmp/files-php
           xargs -0 -P "$(nproc)" -n1 php < /tmp/files-php
 
+      # Basic JSON -> PHP -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the PHP toolchain; `uv run` (project
+      # mode, not `--no-project`) is required so `import literalizer`
+      # resolves. See `.github/scripts/run_php_roundtrip.py`.
+      - name: Php roundtrip
+        run: uv run python .github/scripts/run_php_roundtrip.py
+
       # Parse every fixture inside a single pwsh invocation so the .NET
       # and PowerShell startup cost is paid once instead of per fixture.
       # The run step reuses the same trick: one pwsh process iterates

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, and Perl JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, and PHP JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- New `.github/scripts/run_php_roundtrip.py` literalizes the shared `roundtrip_input.json` to a PHP `$myData = ...` assignment, runs it under `php`, and feeds `json_encode` output to `roundtrip_common.verify`.
- Wired into the `Php roundtrip` step in the `lint-fast` job of `.github/workflows/lint.yml`, alongside the existing Ruby/Java steps.
- Excludes `biginteger` (overflows PHP int64 to float) and `empty_object` (PHP's unified sequence/map array makes `[]` indistinguishable from `{}` for `json_encode`).
- Updated `newsfragments/1867.change` to mention PHP.

## Test plan
- [x] `uv run python .github/scripts/run_php_roundtrip.py` locally → `PHP round-trip OK`
- [ ] CI `lint-fast` `Php roundtrip` step passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI verification step and helper script without changing runtime/library behavior; failures would mainly surface as CI breakage due to PHP encoding differences.
> 
> **Overview**
> Adds a new CI guard that round-trips the shared `roundtrip_input.json` through PHP by literalizing it into a small PHP program, running `php`, and comparing `json_encode` output via `roundtrip_common.verify`.
> 
> Wires this into the `lint-fast` workflow as a `Php roundtrip` step, excluding `biginteger` and `empty_object` from comparison due to PHP JSON encoding limitations, and updates the `1867` newsfragment to mention PHP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b38ea03840729edd278f6ebe0e4d244d87d4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->