### PR TITLE
Add Kotlin json_type=KOTLINX_JSON_ELEMENT for JsonElement output (#2592)

### DIFF
--- a/.github/scripts/lint-kotlin.main.kts
+++ b/.github/scripts/lint-kotlin.main.kts
@@ -9,6 +9,30 @@ val files = System.`in`.bufferedReader().readText()
     .split('\u0000')
     .filter { it.isNotEmpty() }
 
+// Optional `LITERALIZER_LINT_CLASSPATH` (colon-separated, with `dir/*`
+// wildcards expanded to every jar in `dir/`) is forwarded to the
+// per-script compiler so json_type fixtures resolve against
+// kotlinx-serialization-json at lint time.  See `Lint Kotlin` in
+// `.github/workflows/lint.yml` for the wiring.
+val extraClasspath = (System.getenv("LITERALIZER_LINT_CLASSPATH") ?: "")
+    .split(":")
+    .filter { it.isNotEmpty() }
+    .flatMap { entry ->
+        if (entry.endsWith("/*")) {
+            val dir = java.nio.file.Paths.get(entry.dropLast(2))
+            java.nio.file.Files.newDirectoryStream(dir, "*.jar").use { stream ->
+                stream.map { it.toString() }.sorted()
+            }
+        } else {
+            listOf(entry)
+        }
+    }
+val classpathArgs = if (extraClasspath.isEmpty()) {
+    emptyList()
+} else {
+    listOf("-classpath", extraClasspath.joinToString(separator = ":"))
+}
+
 val compiler = K2JVMCompiler()
 var allOk = true
 
@@ -18,14 +42,15 @@ for (path in files) {
         // `-language-version 1.9` and `-api-version 1.9` match
         // `Kotlin.language_version` in `src/literalizer/languages/kotlin.py`;
         // keep them in sync.
-        val exit = compiler.exec(
-            System.err,
+        val args = mutableListOf(
             "-script",
             "-language-version", "1.9",
             "-api-version", "1.9",
             "-d", out.absolutePath,
-            path,
         )
+        args.addAll(classpathArgs)
+        args.add(path)
+        val exit = compiler.exec(System.err, *args.toTypedArray())
         if (exit != ExitCode.OK) {
             System.err.println("Failed: $path")
             allOk = false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1371,11 +1371,31 @@ jobs:
         uses: fwilhe2/setup-kotlin@v1
         with:
           version: ${{ env.KOTLIN_VERSION }}
+      # kotlinx-serialization-json jars are needed by
+      # `Kotlin(json_type=...)` fixtures so they type-check under the
+      # K2JVMCompiler script host. Pinned to a recent 1.x release;
+      # bump together. The classpath is exported through
+      # `LITERALIZER_LINT_CLASSPATH`, which
+      # `.github/scripts/lint-kotlin.main.kts` forwards via `-classpath`
+      # to every per-fixture compile. Keep this enum value paired with
+      # the literal in `Kotlin.JsonTypes.KOTLINX_JSON_ELEMENT` in
+      # `src/literalizer/languages/kotlin.py`.
+      - name: Set up kotlinx-serialization-json for Kotlin
+        run: |-
+          mkdir -p /tmp/kotlinx-jars
+          serialization_version=1.7.3
+          for f in kotlinx-serialization-json-jvm/$serialization_version/kotlinx-serialization-json-jvm-$serialization_version.jar \
+                   kotlinx-serialization-core-jvm/$serialization_version/kotlinx-serialization-core-jvm-$serialization_version.jar; do
+            name=$(basename "$f")
+            curl -fsSL "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/$f" -o "/tmp/kotlinx-jars/$name"
+          done
       # Invoke K2JVMCompiler from a single `.main.kts` JVM instead of
       # spawning one `kotlinc -script` per fixture. The JVM + compiler
       # classes load once and each fixture is compiled against the warm
       # compiler, cutting ~355 cold JVM starts to one.
       - name: Check Kotlin syntax
+        env:
+          LITERALIZER_LINT_CLASSPATH: /tmp/kotlinx-jars/*
         run: kotlin .github/scripts/lint-kotlin.main.kts < /tmp/files-to-lint
 
   lint-swift:

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -100,9 +100,9 @@ JSON value types
 ----------------
 
 Some languages also have a single runtime JSON value type that is a better
-fit than native narrow collection types.  Rust, Crystal, Java, Scala, C#,
-Nim, Haskell, Zig, and D support this through the ``json_type``
-constructor argument (D's polarity is reversed; see below):
+fit than native narrow collection types.  Rust, Crystal, Java, Kotlin,
+Scala, C#, Nim, Haskell, Zig, and D support this through the
+``json_type`` constructor argument (D's polarity is reversed; see below):
 
 .. code-block:: python
 
@@ -168,6 +168,30 @@ and can hold the heterogeneous values that Java's narrow ``List`` /
 ``Map`` types reject.  Dict keys must be strings, and the
 ``RECORD`` ``heterogeneous_strategy`` is rejected because the two
 rendering modes cannot be combined.
+
+Kotlin exposes the same option through the ``JsonElement`` type from
+``kotlinx.serialization.json``:
+
+.. code-block:: python
+
+   """Render Kotlin data as a JsonElement."""
+
+   from literalizer import InputFormat, NewVariable, literalize
+   from literalizer.languages import Kotlin
+
+   result = literalize(
+       source='{"id": 1, "tags": ["red", 2]}',
+       input_format=InputFormat.JSON,
+       language=Kotlin(json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT),
+       variable_form=NewVariable(name="payload"),
+   )
+
+This emits ``Json.parseToJsonElement("...")`` so the rendered binding
+has the static type ``kotlinx.serialization.json.JsonElement`` and can
+hold the heterogeneous values that Kotlin's narrow ``List`` / ``Map``
+types reject.  Dict keys must be strings, and the ``RECORD`` and
+``TUPLE`` ``heterogeneous_strategy`` options are rejected because the
+two rendering modes cannot be combined.
 
 Scala exposes the same option for Circe's :class:`io.circe.Json`:
 

--- a/newsfragments/2592.change
+++ b/newsfragments/2592.change
@@ -1,0 +1,1 @@
+Add ``Kotlin(json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT)`` to render values through ``Json.parseToJsonElement`` so the binding has the static type ``kotlinx.serialization.json.JsonElement`` instead of Kotlin's narrow ``List`` / ``Map`` types.

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -631,7 +631,7 @@ _KOTLINX_JSON_ELEMENT_PREAMBLE: tuple[str, ...] = (
 # Sequence/dict format definitions used while ``json_type`` is active.
 # The framework still walks the data to compute a formatted ``value``,
 # but that string is discarded by
-# :func:`_format_kotlin_json_declaration` and friends in favor of a
+# :func:`_make_format_kotlin_json_declaration` and friends in favor of a
 # fresh ``json.dumps`` of the raw data.  These definitions only need to
 # be permissive enough that the formatting pass does not error on
 # heterogeneous data or nulls inside containers.
@@ -734,17 +734,29 @@ def _kotlin_parse_to_json_element_expression(data: Value) -> str:
 
 
 @beartype
-def _format_kotlin_json_declaration(
-    name: str,
-    _value: str,
-    data: Value,
-    _modifiers: frozenset[enum.Enum],
-) -> str:
-    """Format a JsonElement declaration backed by
-    ``parseToJsonElement``.
+def _make_format_kotlin_json_declaration(
+    *,
+    keyword: str,
+) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
+    """Build a JsonElement declaration formatter for ``val`` or ``var``.
+
+    The keyword tracks ``declaration_style`` so the combined
+    declaration + assignment form stays compilable (``var`` lets the
+    later assignment retarget the binding).
     """
-    expression = _kotlin_parse_to_json_element_expression(data=data)
-    return f"val {name}: JsonElement = {expression}"
+
+    @beartype
+    def _format(
+        name: str,
+        _value: str,
+        data: Value,
+        _modifiers: frozenset[enum.Enum],
+    ) -> str:
+        """Format the declaration with the bound *keyword*."""
+        expression = _kotlin_parse_to_json_element_expression(data=data)
+        return f"{keyword} {name}: JsonElement = {expression}"
+
+    return _format
 
 
 @beartype
@@ -1977,7 +1989,9 @@ class Kotlin(metaclass=LanguageCls):
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a new variable declaration."""
         if self._json_type_active:
-            return _format_kotlin_json_declaration
+            return _make_format_kotlin_json_declaration(
+                keyword=self.declaration_style.name.lower(),
+            )
         return self.variable_type_hints.formatter(
             auto_formatter=self.declaration_style.value.formatter,
             keyword=self.declaration_style.name.lower(),

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 import enum
 import functools
+import json
 import re
 from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
@@ -30,6 +31,7 @@ from literalizer._formatters.format_dates import (
 )
 from literalizer._formatters.format_entries import (
     dict_entry_with_separator,
+    dict_entry_with_template,
     format_bytes_base64,
     format_bytes_hex,
     passthrough_sequence_entry,
@@ -116,12 +118,15 @@ from literalizer._language import (
     no_leading_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
-    no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
 from literalizer._types import OrderedMap, Scalar, Value
-from literalizer.exceptions import InvalidRecordNameError
+from literalizer.exceptions import (
+    IncompatibleFormatsError,
+    InvalidRecordNameError,
+    UnrepresentableInputError,
+)
 
 _PASCAL_CASE_IDENTIFIER = re.compile(pattern=r"^[A-Z][A-Za-z0-9_]*$")
 
@@ -617,6 +622,149 @@ def _kotlin_tuple_arity_representable(arity: int, /) -> bool:
     return arity in {2, 3}
 
 
+_KOTLINX_JSON_ELEMENT_PREAMBLE: tuple[str, ...] = (
+    "import kotlinx.serialization.json.Json",
+    "import kotlinx.serialization.json.JsonElement",
+)
+
+
+# Sequence/dict format definitions used while ``json_type`` is active.
+# The framework still walks the data to compute a formatted ``value``,
+# but that string is discarded by
+# :func:`_format_kotlin_json_declaration` and friends in favor of a
+# fresh ``json.dumps`` of the raw data.  These definitions only need to
+# be permissive enough that the formatting pass does not error on
+# heterogeneous data or nulls inside containers.
+_JSON_NODE_SEQUENCE_CONFIG = SequenceFormatConfig(
+    sequence_open=fixed_open(open_str="["),
+    close="]",
+    supports_heterogeneity=True,
+    single_element_trailing_comma=False,
+    supports_trailing_comma=True,
+    empty_sequence="[]",
+    preamble_lines=(),
+    format_entry=passthrough_sequence_entry,
+    typed_opener_fallback=None,
+    uses_typed_literal_for_scalars=False,
+    requires_uniform_record_shapes=False,
+    declared_type=None,
+    narrowed_empty_form=None,
+)
+
+_JSON_NODE_SET_CONFIG = SetFormatConfig(
+    set_open=fixed_open(open_str="["),
+    close="]",
+    empty_set="[]",
+    preamble_lines=(),
+    set_opener_template="",
+    supports_heterogeneity=True,
+    supports_trailing_comma=True,
+)
+
+_JSON_NODE_DICT_CONFIG = DictFormatConfig(
+    dict_open=fixed_open(open_str="{"),
+    close="}",
+    format_entry=dict_entry_with_template(
+        template="{key}: {value}",
+        format_value=passthrough_sequence_entry,
+    ),
+    empty_dict="{}",
+    preamble_lines=(),
+    narrowed_open=None,
+    supports_trailing_comma=True,
+)
+
+_JSON_NODE_ORDERED_MAP_CONFIG = OrderedMapFormatConfig(
+    ordered_map_open=fixed_open(open_str="{"),
+    close="}",
+    preamble_lines=(),
+)
+
+
+@beartype
+def _kotlin_temporal_to_iso(data: datetime.date | datetime.time) -> str:
+    """Return ISO-8601 text for a date / datetime / time value."""
+    return data.isoformat()
+
+
+@beartype
+def _kotlin_to_jsonable(data: Value) -> object:
+    """Convert *data* into a value :func:`json.dumps` can serialize.
+
+    Dates, datetimes, and times become ISO-8601 strings (JSON has no
+    temporal type).  Bytes become a hex-encoded string.  Sets and
+    :class:`OrderedMap` are folded into list/dict respectively.  Non-
+    string dict keys are not handled here; the caller validates first.
+    """
+    match data:
+        case datetime.datetime() | datetime.date() | datetime.time():
+            return _kotlin_temporal_to_iso(data=data)
+        case bytes():
+            return data.hex()
+        case OrderedMap() | dict():
+            return {
+                key: _kotlin_to_jsonable(data=value)
+                for key, value in data.items()
+            }
+        case set():
+            items = [_kotlin_to_jsonable(data=item) for item in data]
+            items.sort(key=repr)
+            return items
+        case list():
+            return [_kotlin_to_jsonable(data=item) for item in data]
+        case _:
+            return data
+
+
+@beartype
+def _format_kotlin_json_value(data: Value) -> str:
+    """Serialize *data* as a single-line JSON expression."""
+    return json.dumps(
+        obj=_kotlin_to_jsonable(data=data),
+        ensure_ascii=False,
+    )
+
+
+@beartype
+def _kotlin_parse_to_json_element_expression(data: Value) -> str:
+    """Render ``Json.parseToJsonElement("...")`` for *data*."""
+    json_text = _format_kotlin_json_value(data=data)
+    kotlin_literal = format_string_backslash_dollar(value=json_text)
+    return f"Json.parseToJsonElement({kotlin_literal})"
+
+
+@beartype
+def _format_kotlin_json_declaration(
+    name: str,
+    _value: str,
+    data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a JsonElement declaration backed by
+    ``parseToJsonElement``.
+    """
+    expression = _kotlin_parse_to_json_element_expression(data=data)
+    return f"val {name}: JsonElement = {expression}"
+
+
+@beartype
+def _format_kotlin_json_assignment(
+    name: str,
+    _value: str,
+    data: Value,
+) -> str:
+    """Format a JsonElement assignment backed by
+    ``parseToJsonElement``.
+    """
+    return f"{name} = {_kotlin_parse_to_json_element_expression(data=data)}"
+
+
+@beartype
+def _format_kotlin_json_call_arg(raw_value: Value, _formatted: str) -> str:
+    """Format a direct call argument as a JsonElement literal."""
+    return _kotlin_parse_to_json_element_expression(data=raw_value)
+
+
 @beartype
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Kotlin(metaclass=LanguageCls):
@@ -646,6 +794,11 @@ class Kotlin(metaclass=LanguageCls):
               sequences, ``Triple(…)`` for three-element sequences,
               e.g. ``Pair("a", 1)``.  Other sizes fall back to
               ``listOf<Any?>(…)``.
+
+        json_type: When set to ``json_types.KOTLINX_JSON_ELEMENT``,
+            render values through ``Json.parseToJsonElement(...)`` so
+            the output produces a ``kotlinx.serialization.json.JsonElement``
+            instead of Kotlin's narrow ``List`` / ``Map`` / array types.
     """
 
     format_call_variable_declaration = default_format_call_variable_declaration
@@ -687,13 +840,6 @@ class Kotlin(metaclass=LanguageCls):
     supports_record_struct_name_prefix = True
     supports_record_shape_names = True
     supports_non_string_dict_keys = False
-
-    format_call_arg: ClassVar["staticmethod[[Value, str], str]"] = (
-        staticmethod(
-            identity_call_arg,
-        )
-    )
-    """Callable that rewrites a formatted direct call argument."""
 
     _opener_config = TypedOpenerConfig(
         str_type="String",
@@ -1088,6 +1234,14 @@ class Kotlin(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """JSON value type options for Kotlin."""
+
+        KOTLINX_JSON_ELEMENT = "kotlinx.serialization.json.JsonElement"
+        """Dynamic JSON value type from ``kotlinx.serialization.json``."""
+
+    json_types = JsonTypes
+
     class VersionFormats(enum.Enum):
         """Version options for Kotlin."""
 
@@ -1104,8 +1258,6 @@ class Kotlin(metaclass=LanguageCls):
     supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
         NON_KEBAB_REF_CASES
     )
-
-    validate_spec_for_data = no_validate_spec_for_data
 
     @cached_property
     def validate_call_arg(self) -> Callable[[Value], None]:
@@ -1179,6 +1331,7 @@ class Kotlin(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    json_type: JsonTypes | None = None
     record_struct_name_prefix: str = "Record"
     record_shape_names: Mapping[frozenset[str], str] = dataclasses.field(
         default_factory=lambda: MappingProxyType(mapping={}),
@@ -1199,13 +1352,87 @@ class Kotlin(metaclass=LanguageCls):
     supports_scalar_before_comments: ClassVar[bool] = True
     supports_scalar_inline_comments: ClassVar[bool] = True
     statement_terminator: ClassVar[str] = ""
-    static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
 
     def __post_init__(self) -> None:
         """Validate ``record_shape_names`` after construction."""
         self._validate_record_naming()
+        self._validate_json_type_spec()
+
+    @cached_property
+    def _json_type_active(self) -> bool:
+        """Return whether Kotlin should render via ``JsonElement``."""
+        return self.json_type is not None
+
+    @cached_property
+    def static_preamble(self) -> Sequence[str]:
+        """Static preamble lines emitted once per file.
+
+        When :attr:`json_type` is active the ``Json`` and ``JsonElement``
+        imports are emitted here so every fixture has them in scope
+        regardless of the rendered data.
+        """
+        if self._json_type_active:
+            return _KOTLINX_JSON_ELEMENT_PREAMBLE
+        return ()
+
+    @cached_property
+    def format_call_arg(self) -> Callable[[Value, str], str]:
+        """Callable that rewrites a formatted direct call argument."""
+        if self._json_type_active:
+            return _format_kotlin_json_call_arg
+        return identity_call_arg
+
+    def _validate_json_type_spec(self) -> None:
+        """Reject ``json_type`` combinations the generator cannot emit.
+
+        ``Json.parseToJsonElement(...)`` produces a single
+        ``JsonElement`` value; a ``RECORD`` or ``TUPLE`` heterogeneous
+        strategy would generate ``data class`` declarations and
+        ``Pair``/``Triple`` literals that have no place inside that
+        single JSON value, so both are rejected up front.
+        """
+        if not self._json_type_active:
+            return
+        cls = type(self.heterogeneous_strategy)
+        if self.heterogeneous_strategy is not cls.ERROR:
+            msg = (
+                "Kotlin json_type renders data through "
+                "Json.parseToJsonElement(...) and is incompatible with "
+                f"heterogeneous_strategy={self.heterogeneous_strategy.name}, "
+                "which generates typed declarations. Use "
+                "heterogeneous_strategy=ERROR."
+            )
+            raise IncompatibleFormatsError(msg)
+
+    def _validate_json_value_keys(self, data: Value, /) -> None:
+        """Reject non-string object keys for ``JsonElement``."""
+        match data:
+            case OrderedMap() | dict():
+                for key, value in data.items():
+                    if not isinstance(key, str):
+                        msg = (
+                            "Kotlin json_type can only represent dict "
+                            "keys as JSON object strings, not "
+                            f"{type(key).__name__}"
+                        )
+                        raise UnrepresentableInputError(msg)
+                    self._validate_json_value_keys(value)
+            case list() | set():
+                for item in data:
+                    self._validate_json_value_keys(item)
+            case _:
+                return
+
+    def validate_spec_for_data(self, data: Value) -> None:
+        """Validate the spec against the data.
+
+        When :attr:`json_type` is active, walk *data* to reject non-
+        string dict keys, which JSON objects cannot represent.
+        """
+        if self._json_type_active:
+            self._validate_json_value_keys(data)
 
     def _validate_record_naming(self) -> None:
         """Validate ``record_shape_names`` for PascalCase identifier
@@ -1266,6 +1493,8 @@ class Kotlin(metaclass=LanguageCls):
     @cached_property
     def format_variable_assignment(self) -> Callable[[str, str, Value], str]:
         """Format an assignment to an existing variable."""
+        if self._json_type_active:
+            return _format_kotlin_json_assignment
         return variable_formatter(template="{name} = {value}")
 
     @cached_property
@@ -1432,7 +1661,13 @@ class Kotlin(metaclass=LanguageCls):
         carries an out-of-range integer; under
         ``HeterogeneousStrategies.RECORD`` additionally emits one
         ``data class`` declaration per record shape present in the data.
+        When :attr:`json_type` is active neither applies: integers
+        outside the 64-bit range ride inside the JSON text, and the
+        data flows through a single ``Json.parseToJsonElement`` call
+        instead of typed records.
         """
+        if self._json_type_active:
+            return no_data_preamble
         record_preamble = self._record_strategy.preamble
 
         def _preamble(data: Value, /) -> tuple[str, ...]:
@@ -1444,6 +1679,11 @@ class Kotlin(metaclass=LanguageCls):
     @cached_property
     def heterogeneous_behavior(self) -> HeterogeneousBehavior:
         """Return the behavior for the chosen heterogeneous strategy."""
+        if self._json_type_active:
+            return dataclasses.replace(
+                NO_HETEROGENEOUS_BEHAVIOR,
+                skip_scalar_checks=True,
+            )
         return self._record_strategy.behavior
 
     @cached_property
@@ -1549,6 +1789,8 @@ class Kotlin(metaclass=LanguageCls):
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
         """Configuration for the chosen sequence format."""
+        if self._json_type_active:
+            return _JSON_NODE_SEQUENCE_CONFIG
         return self.sequence_format.value
 
     @cached_property
@@ -1561,6 +1803,8 @@ class Kotlin(metaclass=LanguageCls):
         ``RecordN(...)`` literals, not the ``Map<...>`` the typed
         opener would otherwise infer).
         """
+        if self._json_type_active:
+            return _JSON_NODE_SEQUENCE_CONFIG.sequence_open
         fmt = self.sequence_format.value
         if fmt.typed_opener_fallback is None:
             base = fmt.sequence_open
@@ -1593,6 +1837,8 @@ class Kotlin(metaclass=LanguageCls):
     @cached_property
     def set_format_config(self) -> SetFormatConfig:
         """Configuration for the chosen set format."""
+        if self._json_type_active:
+            return _JSON_NODE_SET_CONFIG
         base = self.set_format(default_type=self.default_set_element_type)
         openers = self._opener_config.build(
             date_type=self._date_type_name,
@@ -1609,6 +1855,8 @@ class Kotlin(metaclass=LanguageCls):
     @cached_property
     def dict_format_config(self) -> DictFormatConfig:
         """Configuration for dict formatting."""
+        if self._json_type_active:
+            return _JSON_NODE_DICT_CONFIG
         resolved_dict_opener = self.dict_format.value.opener_template.replace(
             "{key_type}",
             self.default_dict_key_type,
@@ -1702,6 +1950,8 @@ class Kotlin(metaclass=LanguageCls):
     @cached_property
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
         """Configuration for ordered-map formatting."""
+        if self._json_type_active:
+            return _JSON_NODE_ORDERED_MAP_CONFIG
         return OrderedMapFormatConfig(
             ordered_map_open=fixed_open(
                 open_str=(
@@ -1726,6 +1976,8 @@ class Kotlin(metaclass=LanguageCls):
         self,
     ) -> Callable[[str, str, Value, frozenset[enum.Enum]], str]:
         """Callable that formats a new variable declaration."""
+        if self._json_type_active:
+            return _format_kotlin_json_declaration
         return self.variable_type_hints.formatter(
             auto_formatter=self.declaration_style.value.formatter,
             keyword=self.declaration_style.name.lower(),
@@ -1757,7 +2009,15 @@ class Kotlin(metaclass=LanguageCls):
 
     @cached_property
     def scalar_preamble(self) -> dict[type, tuple[str, ...]]:
-        """Per-instance scalar preamble computed from date/datetime format."""
+        """Per-instance scalar preamble computed from date/datetime format.
+
+        Under :attr:`json_type` every temporal value is folded into the
+        JSON text as an ISO-8601 string, so the temporal Kotlin imports
+        that the configured ``date_format`` / ``datetime_format`` would
+        otherwise add do not apply.
+        """
+        if self._json_type_active:
+            return {}
         return date_scalar_preamble(
             date_format=self.date_format,
             datetime_format=self.datetime_format,

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -741,8 +741,8 @@ def _make_format_kotlin_json_declaration(
     """Build a JsonElement declaration formatter for ``val`` or ``var``.
 
     The keyword tracks ``declaration_style`` so the combined
-    declaration + assignment form stays compilable (``var`` lets the
-    later assignment retarget the binding).
+    declaration + assignment form stays valid Kotlin (``var`` lets the
+    later assignment rebind the variable).
     """
 
     @beartype

--- a/tests/errors/test_kotlin_json_type_errors.py
+++ b/tests/errors/test_kotlin_json_type_errors.py
@@ -1,0 +1,38 @@
+"""Kotlin ``json_type`` rejection paths."""
+
+import pytest
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.exceptions import (
+    IncompatibleFormatsError,
+    UnrepresentableInputError,
+)
+from literalizer.languages import Kotlin
+
+
+def test_kotlin_json_type_rejects_non_string_dict_keys() -> None:
+    """``JsonElement`` object keys must be strings."""
+    with pytest.raises(
+        expected_exception=UnrepresentableInputError,
+        match="dict keys as JSON object strings",
+    ):
+        literalize(
+            source="{1: one}",
+            input_format=InputFormat.YAML,
+            language=Kotlin(
+                json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT,
+            ),
+            variable_form=NewVariable(name="my_data"),
+        )
+
+
+def test_kotlin_json_type_rejects_record_strategy() -> None:
+    """``parseToJsonElement`` rendering cannot coexist with records."""
+    with pytest.raises(
+        expected_exception=IncompatibleFormatsError,
+        match="incompatible with heterogeneous_strategy=RECORD",
+    ):
+        Kotlin(
+            json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT,
+            heterogeneous_strategy=Kotlin.heterogeneous_strategies.RECORD,
+        )

--- a/tests/integration/cases/binary/Kotlin_json_type_kotlinx_json_element_binary@v1_9.kts
+++ b/tests/integration/cases/binary/Kotlin_json_type_kotlinx_json_element_binary@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("[\"48656c6c6f\"]")

--- a/tests/integration/cases/call_scalar_args/Kotlin_json_type_kotlinx_json_element_call@v1_9.kts
+++ b/tests/integration/cases/call_scalar_args/Kotlin_json_type_kotlinx_json_element_call@v1_9.kts
@@ -1,0 +1,6 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+fun process(value: Any? = null): Any? = null
+process(value = Json.parseToJsonElement("\"hello\""))
+process(value = Json.parseToJsonElement("42"))
+process(value = Json.parseToJsonElement("true"))

--- a/tests/integration/cases/date_set/Kotlin_json_type_kotlinx_json_element_date_set@v1_9.kts
+++ b/tests/integration/cases/date_set/Kotlin_json_type_kotlinx_json_element_date_set@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("[\"2024-01-15\", \"2024-06-01\"]")

--- a/tests/integration/cases/dates/Kotlin_json_type_kotlinx_json_element_dates@v1_9.kts
+++ b/tests/integration/cases/dates/Kotlin_json_type_kotlinx_json_element_dates@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("{\"date\": \"2024-01-15\", \"datetime\": \"2024-01-15T12:30:00+00:00\"}")

--- a/tests/integration/cases/dict_with_list_value/Kotlin_json_type_kotlinx_json_element@v1_9.kts
+++ b/tests/integration/cases/dict_with_list_value/Kotlin_json_type_kotlinx_json_element@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}")

--- a/tests/integration/cases/dict_with_list_value/Kotlin_json_type_kotlinx_json_element_combined@v1_9.kts
+++ b/tests/integration/cases/dict_with_list_value/Kotlin_json_type_kotlinx_json_element_combined@v1_9.kts
@@ -1,0 +1,4 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}")
+my_data = Json.parseToJsonElement("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}")

--- a/tests/integration/cases/dict_with_list_value/Kotlin_json_type_kotlinx_json_element_combined@v1_9.kts
+++ b/tests/integration/cases/dict_with_list_value/Kotlin_json_type_kotlinx_json_element_combined@v1_9.kts
@@ -1,4 +1,4 @@
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-val my_data: JsonElement = Json.parseToJsonElement("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}")
+var my_data: JsonElement = Json.parseToJsonElement("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}")
 my_data = Json.parseToJsonElement("{\"name\": \"Alice\", \"scores\": [10, 20, 30]}")

--- a/tests/integration/cases/dict_with_nulls/Kotlin_json_type_kotlinx_json_element_nulls@v1_9.kts
+++ b/tests/integration/cases/dict_with_nulls/Kotlin_json_type_kotlinx_json_element_nulls@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("{\"name\": \"Alice\", \"score\": null, \"age\": 30}")

--- a/tests/integration/cases/nested_mixed_inner/Kotlin_json_type_kotlinx_json_element_nested_mixed@v1_9.kts
+++ b/tests/integration/cases/nested_mixed_inner/Kotlin_json_type_kotlinx_json_element_nested_mixed@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("[[1, \"a\"], [2, \"b\"]]")

--- a/tests/integration/cases/ordered_map/Kotlin_json_type_kotlinx_json_element_ordered_map@v1_9.kts
+++ b/tests/integration/cases/ordered_map/Kotlin_json_type_kotlinx_json_element_ordered_map@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("{\"name\": \"Alice\", \"age\": 30, \"active\": true}")

--- a/tests/integration/cases/scalar_datetime_naive/Kotlin_json_type_kotlinx_json_element_datetime_naive@v1_9.kts
+++ b/tests/integration/cases/scalar_datetime_naive/Kotlin_json_type_kotlinx_json_element_datetime_naive@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("\"2024-01-15T12:30:00\"")

--- a/tests/integration/cases/scalar_float/Kotlin_json_type_kotlinx_json_element_float@v1_9.kts
+++ b/tests/integration/cases/scalar_float/Kotlin_json_type_kotlinx_json_element_float@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("3.14")

--- a/tests/integration/cases/scalar_int_large/Kotlin_json_type_kotlinx_json_element_long@v1_9.kts
+++ b/tests/integration/cases/scalar_int_large/Kotlin_json_type_kotlinx_json_element_long@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("2147483648")

--- a/tests/integration/cases/scalar_int_very_large/Kotlin_json_type_kotlinx_json_element_bigint@v1_9.kts
+++ b/tests/integration/cases/scalar_int_very_large/Kotlin_json_type_kotlinx_json_element_bigint@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("9223372036854775808")

--- a/tests/integration/cases/scalar_time/Kotlin_json_type_kotlinx_json_element_time@v1_9.kts
+++ b/tests/integration/cases/scalar_time/Kotlin_json_type_kotlinx_json_element_time@v1_9.kts
@@ -1,0 +1,3 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+val my_data: JsonElement = Json.parseToJsonElement("{\"starts_at\": \"09:30:00\"}")

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -554,6 +554,15 @@ def build_json_type_variants() -> Iterable[Variant]:
             lang_cls=D,
             collection_layout=literalizer.CollectionLayout.COMPACT,
         ),
+        Variant(
+            name="Kotlin_json_type_kotlinx_json_element",
+            spec=make_spec(
+                lang_cls=Kotlin,
+                json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT,
+            ),
+            lang_cls=Kotlin,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
+        ),
     ]
 
 
@@ -2499,6 +2508,21 @@ def build_variant_cases() -> list[VariantCase]:
                 ),
                 case_dir_name="dict_with_list_value",
                 variable_form=literalizer.ExistingVariable(name="my_data"),
+            ),
+            VariantCase(
+                variant_name="Kotlin_json_type_kotlinx_json_element_combined",
+                variant=Variant(
+                    name="Kotlin_json_type_kotlinx_json_element_combined",
+                    spec=make_spec(
+                        lang_cls=Kotlin,
+                        json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT,
+                        declaration_style=Kotlin.declaration_styles.VAR,
+                    ),
+                    lang_cls=Kotlin,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
+                ),
+                case_dir_name="dict_with_list_value",
+                variable_form=literalizer.BothVariableForms(name="my_data"),
             ),
             VariantCase(
                 variant_name="Nim_json_type_json_node_let",


### PR DESCRIPTION
## Summary

- Add `Kotlin(json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT)` so output renders through `Json.parseToJsonElement("...")` and binds to `kotlinx.serialization.json.JsonElement` instead of Kotlin's narrow `List`/`Map` types.
- Mirrors PR #2610 (Java Jackson) with the same JSON-text shortcut. Validates non-string dict keys and rejects `heterogeneous_strategy=RECORD`/`TUPLE`.
- Wires `LITERALIZER_LINT_CLASSPATH` through `.github/scripts/lint-kotlin.main.kts` so the per-fixture compile picks up `kotlinx-serialization-json` jars downloaded by the workflow.

Closes #2592.

## Test plan

- [x] `uv run --extra dev pytest` (5328 passed)
- [x] `uv run --extra dev pytest tests/errors/test_kotlin_json_type_errors.py`
- [x] pre-commit hooks on changed files pass
- [x] manual `spelling` hook passes
- [ ] CI lint-kotlin step compiles new fixtures with kotlinx-serialization-json on classpath

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Kotlin rendering mode that bypasses existing typed collection/record formatting and changes validation rules, which could affect Kotlin output and fixture compilation paths. CI lint wiring now downloads external jars and forwards a dynamic classpath, introducing some workflow fragility if versions or classpaths drift.
> 
> **Overview**
> Adds a new Kotlin `json_type` option (`Kotlin.json_types.KOTLINX_JSON_ELEMENT`) that renders any value as `Json.parseToJsonElement("...")` and types the binding as `kotlinx.serialization.json.JsonElement`, including updating call-arg/declaration/assignment formatting and relaxing heterogeneity checks.
> 
> Introduces Kotlin-side validation for this mode (rejects non-string dict keys and disallows `heterogeneous_strategy=RECORD`/`TUPLE`), updates docs/news, and adds new integration fixtures plus targeted error tests.
> 
> Updates Kotlin linting in CI to download pinned `kotlinx-serialization-json` jars and forwards them via a new `LITERALIZER_LINT_CLASSPATH` environment variable through the Kotlin lint script’s `-classpath` args so the new fixtures compile during lint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee5231a16637bb96559a5b324f22436053ee987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->