### PR TITLE
Add Zig JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_zig_roundtrip.py
+++ b/.github/scripts/run_zig_roundtrip.py
@@ -1,0 +1,156 @@
+"""Zig JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Zig
+``const myData: ZVal = ...`` declaration, wrap it in a tiny ``main``
+that serializes ``myData`` back to JSON via a small recursive helper,
+run it with ``zig run``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-zig`` job in
+``.github/workflows/lint.yml``, because that job is where the Zig
+toolchain is installed.  It shares the same input and comparison logic
+as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value overflows ``u64`` (the widest unsigned integer the
+Zig backend's generated ``ZVal`` union carries), so the program would
+not compile if the field were kept.  Same shape as the Go and
+TypeScript exclusions.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Zig
+
+_VAR_NAME = "myData"
+_LABEL = "Zig"
+_EXCLUDED_KEYS = ("biginteger",)
+
+# Recursive ZVal -> JSON writer. ``.arr`` and ``.set`` share the
+# ``[]const ZVal`` payload type, so a single switch prong handles both;
+# ``.nil`` never appears in the shared input (it is ``null``-free) but
+# the union is exhaustive so the prong is required.
+_WRITE_JSON = r"""
+fn writeJsonString(writer: anytype, s: []const u8) !void {
+    try writer.writeByte('"');
+    for (s) |c| {
+        switch (c) {
+            '"' => try writer.writeAll("\\\""),
+            '\\' => try writer.writeAll("\\\\"),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            0x08 => try writer.writeAll("\\b"),
+            0x0c => try writer.writeAll("\\f"),
+            else => {
+                if (c < 0x20) {
+                    try std.fmt.format(writer, "\\u{x:0>4}", .{c});
+                } else {
+                    try writer.writeByte(c);
+                }
+            },
+        }
+    }
+    try writer.writeByte('"');
+}
+
+fn writeJson(writer: anytype, v: ZVal) !void {
+    switch (v) {
+        .nil => try writer.writeAll("null"),
+        .bool => |b| try writer.writeAll(if (b) "true" else "false"),
+        .int => |i| try std.fmt.format(writer, "{d}", .{i}),
+        .uint => |u| try std.fmt.format(writer, "{d}", .{u}),
+        .float => |f| try std.fmt.format(writer, "{e}", .{f}),
+        .str => |s| try writeJsonString(writer, s),
+        .arr, .set => |a| {
+            try writer.writeByte('[');
+            for (a, 0..) |item, i| {
+                if (i > 0) try writer.writeByte(',');
+                try writeJson(writer, item);
+            }
+            try writer.writeByte(']');
+        },
+        .map => |m| {
+            try writer.writeByte('{');
+            for (m, 0..) |kv, i| {
+                if (i > 0) try writer.writeByte(',');
+                try writeJsonString(writer, kv.key);
+                try writer.writeByte(':');
+                try writeJson(writer, kv.val);
+            }
+            try writer.writeByte('}');
+        },
+    }
+}
+"""
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Zig program literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=Zig(),
+        pre_indent_level=1,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        'const std = @import("std");\n'
+        f"{preamble}\n"
+        "\n"
+        f"{_WRITE_JSON}"
+        "\n"
+        "pub fn main() !void {\n"
+        f"{result.code}\n"
+        "    const stdout = std.io.getStdOut().writer();\n"
+        f"    try writeJson(stdout, {_VAR_NAME});\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Zig backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    zig = shutil.which(cmd="zig") or "zig"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        (tmpdir / "main.zig").write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[zig, "run", "main.zig"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: zig run error\n{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/run_zig_roundtrip.py
+++ b/.github/scripts/run_zig_roundtrip.py
@@ -2,9 +2,9 @@
 
 Literalize the shared ``roundtrip_input.json`` document to a Zig
 ``const myData: ZVal = ...`` declaration, wrap it in a tiny ``main``
-that serializes ``myData`` back to JSON via a small recursive helper,
-run it with ``zig run``, and hand the emitted JSON to
-:func:`roundtrip_common.verify`.
+that converts ``myData`` into a ``std.json.Value`` tree and serializes
+it back to JSON via ``std.json.stringify``, run it with ``zig run``,
+and hand the emitted JSON to :func:`roundtrip_common.verify`.
 
 This lives here, driven by a step of the ``lint-zig`` job in
 ``.github/workflows/lint.yml``, because that job is where the Zig
@@ -34,61 +34,34 @@ _VAR_NAME = "myData"
 _LABEL = "Zig"
 _EXCLUDED_KEYS = ("biginteger",)
 
-# Recursive ZVal -> JSON writer. ``.arr`` and ``.set`` share the
-# ``[]const ZVal`` payload type, so a single switch prong handles both;
-# ``.nil`` never appears in the shared input (it is ``null``-free) but
-# the union is exhaustive so the prong is required.
-_WRITE_JSON = r"""
-fn writeJsonString(writer: anytype, s: []const u8) !void {
-    try writer.writeByte('"');
-    for (s) |c| {
-        switch (c) {
-            '"' => try writer.writeAll("\\\""),
-            '\\' => try writer.writeAll("\\\\"),
-            '\n' => try writer.writeAll("\\n"),
-            '\r' => try writer.writeAll("\\r"),
-            '\t' => try writer.writeAll("\\t"),
-            0x08 => try writer.writeAll("\\b"),
-            0x0c => try writer.writeAll("\\f"),
-            else => {
-                if (c < 0x20) {
-                    try std.fmt.format(writer, "\\u{x:0>4}", .{c});
-                } else {
-                    try writer.writeByte(c);
-                }
-            },
-        }
-    }
-    try writer.writeByte('"');
-}
-
-fn writeJson(writer: anytype, v: ZVal) !void {
-    switch (v) {
-        .nil => try writer.writeAll("null"),
-        .bool => |b| try writer.writeAll(if (b) "true" else "false"),
-        .int => |i| try std.fmt.format(writer, "{d}", .{i}),
-        .uint => |u| try std.fmt.format(writer, "{d}", .{u}),
-        .float => |f| try std.fmt.format(writer, "{e}", .{f}),
-        .str => |s| try writeJsonString(writer, s),
-        .arr, .set => |a| {
-            try writer.writeByte('[');
-            for (a, 0..) |item, i| {
-                if (i > 0) try writer.writeByte(',');
-                try writeJson(writer, item);
-            }
-            try writer.writeByte(']');
+# Build a ``std.json.Value`` tree mirroring ``ZVal`` and let
+# ``std.json.stringify`` do the emission. ``.arr`` and ``.set`` share
+# the ``[]const ZVal`` payload type, so one switch prong handles both;
+# ``.nil`` and ``.uint`` never appear in the shared input (it is
+# ``null``-free and ``biginteger`` is excluded) but the union is
+# exhaustive so the prongs are still required.
+_TO_JSON_VALUE = r"""
+fn toJsonValue(allocator: std.mem.Allocator, v: ZVal) !std.json.Value {
+    return switch (v) {
+        .nil => .{ .null = {} },
+        .bool => |b| .{ .bool = b },
+        .int => |i| .{ .integer = i },
+        .uint => |u| .{ .integer = @intCast(u) },
+        .float => |f| .{ .float = f },
+        .str => |s| .{ .string = s },
+        .arr, .set => |a| blk: {
+            var arr = std.json.Array.init(allocator);
+            for (a) |item| try arr.append(try toJsonValue(allocator, item));
+            break :blk .{ .array = arr };
         },
-        .map => |m| {
-            try writer.writeByte('{');
-            for (m, 0..) |kv, i| {
-                if (i > 0) try writer.writeByte(',');
-                try writeJsonString(writer, kv.key);
-                try writer.writeByte(':');
-                try writeJson(writer, kv.val);
+        .map => |m| blk: {
+            var obj = std.json.ObjectMap.init(allocator);
+            for (m) |kv| {
+                try obj.put(kv.key, try toJsonValue(allocator, kv.val));
             }
-            try writer.writeByte('}');
+            break :blk .{ .object = obj };
         },
-    }
+    };
 }
 """
 
@@ -112,13 +85,17 @@ def _build_program(json_text: str) -> str:
     return (
         'const std = @import("std");\n'
         f"{preamble}\n"
-        "\n"
-        f"{_WRITE_JSON}"
+        f"{_TO_JSON_VALUE}"
         "\n"
         "pub fn main() !void {\n"
         f"{result.code}\n"
+        "    var arena = std.heap.ArenaAllocator.init(\n"
+        "        std.heap.page_allocator,\n"
+        "    );\n"
+        "    defer arena.deinit();\n"
+        f"    const value = try toJsonValue(arena.allocator(), {_VAR_NAME});\n"
         "    const stdout = std.io.getStdOut().writer();\n"
-        f"    try writeJson(stdout, {_VAR_NAME});\n"
+        "    try std.json.stringify(value, .{}, stdout);\n"
         "}\n"
     )
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2150,6 +2150,20 @@ jobs:
             printf '}\n'
           } > "$driver"
           zig run "$driver"
+      # `uv` is needed by the `Zig roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Zig -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Zig toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_zig_roundtrip.py`.
+      - name: Zig roundtrip
+        run: uv run python .github/scripts/run_zig_roundtrip.py
 
   lint-systemverilog:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, and Go JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, and Zig JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/run_zig_roundtrip.py` following the Java/Go/Haskell/Perl/PHP/Ruby/TypeScript pattern: literalizes the shared `roundtrip_input.json` to a Zig program that walks the generated `ZVal` union and re-emits the value as JSON to stdout via `std.fmt.format`, then compares parsed values.
- Wires it into the `lint-zig` job (Zig toolchain already present; `uv` added so `import literalizer` resolves).
- Excludes `biginteger`: its 26-digit value overflows `u64`, the widest unsigned integer the Zig backend's generated `ZVal` carries. Same shape as the Go / TypeScript exclusions.

Picks Zig off the TODO list in issue #1867.

## Test plan
- [ ] `lint-zig` job passes the new `Zig roundtrip` step on CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI verification step and helper script without changing runtime/library code; main impact is potential CI flakiness or longer `lint-zig` job time if Zig/uv tooling behaves unexpectedly.
> 
> **Overview**
> Adds a Zig JSON round-trip CI check that literalizes the shared `roundtrip_input.json` into a temporary Zig program, converts the generated `ZVal` into `std.json.Value`, re-serializes via `std.json.stringify`, and verifies the output matches the fixture (excluding `biginteger`).
> 
> Wires this into the `lint-zig` workflow by installing `uv` (to run in project mode so `import literalizer` resolves) and running the new `.github/scripts/run_zig_roundtrip.py` helper; updates the #1867 newsfragment to include Zig.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e1c50ba49751398e0a674759cede6f593040a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->