### PR TITLE
Add C# JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_csharp_roundtrip.py
+++ b/.github/scripts/run_csharp_roundtrip.py
@@ -1,0 +1,120 @@
+"""C# JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a C#
+``var myData = ...;`` declaration, wrap it in a tiny ``Program`` whose
+``Main`` prints ``System.Text.Json.JsonSerializer.Serialize(myData)``,
+``dotnet run`` it, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+``System.Text.Json`` is part of the .NET base class library, so no
+NuGet packages are needed; serializing through ``object`` dispatches on
+the runtime type and walks ``IDictionary`` / array values
+polymorphically.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value exceeds every C# integer literal type the literalizer
+emits, so the program would not compile if the field were kept.
+
+This lives here, driven by the ``CSharp roundtrip`` step of the
+``lint-dotnet`` job in ``.github/workflows/lint.yml``, because that job
+is where the .NET toolchain is installed; it is deliberately not a
+pytest test under ``tests/``.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import CSharp
+
+_VAR_NAME = "myData"
+_LABEL = "CSharp"
+_EXCLUDED_KEYS = ("biginteger",)
+
+# ``LangVersion 10`` matches ``CSharp.language_version`` in
+# ``src/literalizer/languages/csharp.py`` and the ``LanguageVersion.CSharp10``
+# pin in ``.github/scripts/lint-csharp/Program.cs``; keep them in sync.
+_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup>\n"
+    "    <OutputType>Exe</OutputType>\n"
+    "    <TargetFramework>net8.0</TargetFramework>\n"
+    "    <RollForward>LatestMajor</RollForward>\n"
+    "    <Nullable>disable</Nullable>\n"
+    "    <ImplicitUsings>disable</ImplicitUsings>\n"
+    "    <LangVersion>10</LangVersion>\n"
+    "  </PropertyGroup>\n"
+    "</Project>\n"
+)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable C# program literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=CSharp(sequence_format=CSharp.sequence_formats.ARRAY),
+        pre_indent_level=2,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join(result.preamble)
+    body_preamble = "\n".join(result.body_preamble)
+    return (
+        f"{preamble}\n"
+        "using System;\n"
+        "using System.Text.Json;\n"
+        f"{body_preamble}\n"
+        "static class Program {\n"
+        "    public static void Main() {\n"
+        f"{result.code}\n"
+        f"        Console.Write(JsonSerializer.Serialize({_VAR_NAME}));\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the C# backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    dotnet = shutil.which(cmd="dotnet") or "dotnet"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        (tmpdir / "Program.cs").write_text(data=program, encoding="utf-8")
+        (tmpdir / "fixture.csproj").write_text(data=_CSPROJ, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[dotnet, "run", "--project", "fixture.csproj", "--nologo"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: dotnet run error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -878,6 +878,22 @@ jobs:
           find tests/integration/cases -name '*.cs' -print0 > /tmp/files-cs && test -s /tmp/files-cs
           dotnet /tmp/lint-csharp/lint-csharp.dll < /tmp/files-cs
 
+      # `uv` is needed by the `CSharp roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
+      # Basic JSON -> C# -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the .NET toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_csharp_roundtrip.py`.
+      - name: CSharp roundtrip
+        run: uv run python .github/scripts/run_csharp_roundtrip.py
+
       - name: Lint VisualBasic
         run: |-
           find tests/integration/cases -name '*.vb' -print0 > /tmp/files-vb && test -s /tmp/files-vb

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, and Go JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, and C# JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds a basic JSON → C# → JSON round-trip CI check using the shared `roundtrip_input.json` fixture, modeled on the Java setup from #1867.
- `.github/scripts/run_csharp_roundtrip.py` literalizes the input as a `Dictionary<string, object>` (sequence_format=ARRAY), wraps it in a `Program.Main` that dumps via `System.Text.Json.JsonSerializer.Serialize` (built-in, no NuGet), and `dotnet run`s a generated `fixture.csproj`. The 26-digit `biginteger` field is excluded (no C# literal type can hold it), matching the Go check.
- Wired into the `lint-dotnet` job in `.github/workflows/lint.yml` (where the .NET toolchain lives) and noted in `newsfragments/1867.change`.

## Test plan
- [ ] `lint-dotnet` CI job passes the new `CSharp roundtrip` step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `lint-dotnet` GitHub Actions job and adds a new `dotnet run`-based verification step, which could introduce CI flakiness or longer runtimes if the generated project/tooling behaves differently across runners.
> 
> **Overview**
> Adds a new CI round-trip gate that verifies the C# literalizer can reproduce the shared `roundtrip_input.json` by generating a small C# program, running it via `dotnet run`, and comparing the emitted JSON against the fixture (skipping the top-level `biginteger` field).
> 
> Wires this check into the `lint-dotnet` workflow by installing `uv` in that job and running `.github/scripts/run_csharp_roundtrip.py`, and updates the `newsfragments/1867.change` note to include C#.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a0241805fd8854950febd3fd7fe3e641f253e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->