### PR TITLE
Add Swift JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_swift_roundtrip.py
+++ b/.github/scripts/run_swift_roundtrip.py
@@ -1,0 +1,97 @@
+"""Swift JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Swift
+``let myData: Any = ...`` declaration, wrap it in a tiny ``main`` that
+serializes ``myData`` back to JSON via ``JSONSerialization`` from
+``Foundation`` and writes the bytes to stdout, run it with ``swift``,
+and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-swift`` job in
+``.github/workflows/lint.yml``, because that job is where the Swift
+toolchain is installed.  It shares the same input and comparison logic
+as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value overflows ``Int64`` (the widest signed integer the
+Swift backend's literal output supports), so the program would not
+compile if the field were kept.  Same shape as the Go, TypeScript and
+Zig exclusions.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Swift
+
+_VAR_NAME = "myData"
+_LABEL = "Swift"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Swift program literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=Swift(),
+        pre_indent_level=1,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "import Foundation\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        "    let data = try JSONSerialization.data(\n"
+        f"        withJSONObject: {_VAR_NAME},\n"
+        "        options: [],\n"
+        "    )\n"
+        "    FileHandle.standardOutput.write(data)\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Swift backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    swift = shutil.which(cmd="swift") or "swift"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        (tmpdir / "main.swift").write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[swift, "-swift-version", "5", "main.swift"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: swift run error\n"
+            f"{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1445,6 +1445,20 @@ jobs:
       - name: Run Swift files
         run: xargs -0 -P "$(nproc)" -n1 swift -swift-version 5 -warnings-as-errors
           < /tmp/files-to-lint
+      # `uv` is needed by the `Swift roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Swift -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Swift toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_swift_roundtrip.py`.
+      - name: Swift roundtrip
+        run: uv run python .github/scripts/run_swift_roundtrip.py
 
   lint-ocaml:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, and Zig JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, and Swift JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalizes the shared `roundtrip_input.json` to a Swift program that re-emits the value as JSON via Foundation's `JSONSerialization` and writes the bytes to stdout
- Wired into `lint-swift` (Swift toolchain already present; `uv` added so `import literalizer` resolves)
- Excludes `biginteger`: its 26-digit value overflows `Int64` (the widest signed integer the Swift backend emits), same shape as the Go, TypeScript and Zig exclusions

Part of #1867.

## Test plan
- [x] `uv run --extra dev python .github/scripts/run_swift_roundtrip.py` passes locally (macOS Swift 6)
- [ ] `lint-swift` green on CI (Linux, Swift 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Swift-driven JSON round-trip gate to CI and installs `uv` in `lint-swift`, which could cause new CI failures due to Swift toolchain/runtime differences or dependency resolution.
> 
> **Overview**
> Adds a Swift JSON round-trip CI check that literalizes the shared `roundtrip_input.json` into a small Swift program, re-serializes it via `Foundation.JSONSerialization`, and verifies the output matches the fixture (excluding the `biginteger` field).
> 
> Wires this into the `lint-swift` job by installing `uv` and running the new `.github/scripts/run_swift_roundtrip.py` helper, and updates the #1867 changelog fragment to include Swift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe4e0d20275d7ca98fc0678d28eab691464d035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->