### PR TITLE
Add Scala JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_scala_roundtrip.py
+++ b/.github/scripts/run_scala_roundtrip.py
@@ -1,0 +1,98 @@
+"""Scala JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Scala
+``val myData: io.circe.Json = ...`` declaration (via
+``json_type=Scala.JsonTypes.CIRCE``), wrap it in a tiny ``@main`` that
+prints ``myData.noSpaces``, run it with ``scala-cli``, and hand the
+emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-scala`` job in
+``.github/workflows/lint.yml``, because that job is where the Scala
+toolchain (``scala-cli``) and the ``circe-core`` dependency are
+configured.  It shares the same input and comparison logic as the other
+per-language round-trip helpers.
+
+Circe's ``Json.fromBigInt`` round-trips the 26-digit ``biginteger``
+field losslessly via ``noSpaces``, so no top-level keys need excluding.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Scala
+
+_VAR_NAME = "myData"
+_LABEL = "Scala"
+_CIRCE_DEP = "io.circe::circe-core:0.14.10"
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Scala program literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Scala(json_type=Scala.JsonTypes.CIRCE),
+        pre_indent_level=1,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{preamble}\n"
+        "\n"
+        "@main def runRoundtrip(): Unit = {\n"
+        f"{result.code}\n"
+        f"    print({_VAR_NAME}.noSpaces)\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Scala backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    scala_cli = shutil.which(cmd="scala-cli") or "scala-cli"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        (tmpdir / "Main.scala").write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[
+                scala_cli,
+                "run",
+                ".",
+                "-S",
+                "3",
+                "--dep",
+                _CIRCE_DEP,
+                "--main-class",
+                "runRoundtrip",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: scala-cli run error\n"
+            f"{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=(),
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1550,6 +1550,20 @@ jobs:
           scala-cli run "$workspace" -S 3 \
             --dep io.circe::circe-core:0.14.10 \
             --main-class __run
+      # `uv` is needed by the `Scala roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Scala -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Scala toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves.  See
+      # `.github/scripts/run_scala_roundtrip.py`.
+      - name: Scala roundtrip
+        run: uv run python .github/scripts/run_scala_roundtrip.py
 
   lint-haxe:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, and Zig JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, and Scala JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalizes the shared `roundtrip_input.json` to a Scala program using `json_type=Scala.JsonTypes.CIRCE`, then re-emits JSON via `io.circe.Json#noSpaces` and compares to the original through the shared `roundtrip_common.verify` helper.
- Wired into the existing `lint-scala` job (Scala toolchain + `circe-core` already configured there; `uv` added so the helper can `import literalizer`).
- No top-level keys excluded: Circe's `Json.fromBigInt` round-trips the 26-digit `biginteger` field losslessly.

## Test plan
- [x] Local: `uv run python .github/scripts/run_scala_roundtrip.py` -> `Scala round-trip OK`
- [ ] CI: `lint-scala` job's new `Scala roundtrip` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI validation step and helper script without changing production code paths; main risk is increased CI time/flakiness due to additional tool execution (`uv`/`scala-cli`).
> 
> **Overview**
> Adds a Scala JSON round-trip CI check that literalizes the shared `roundtrip_input.json` into a tiny Circe program, executes it via `scala-cli`, and verifies the emitted JSON matches the fixture.
> 
> Wires this into the `lint-scala` job by installing `uv` (so the helper can import the project) and running the new `.github/scripts/run_scala_roundtrip.py`; updates the changelog fragment to include Scala in the round-trip checks list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc44f8e49f9570db51581b6aebf89243bd624922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->