### PR TITLE
Add Kotlin JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_kotlin_roundtrip.py
+++ b/.github/scripts/run_kotlin_roundtrip.py
@@ -1,0 +1,146 @@
+"""Kotlin JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Kotlin
+``val myData = ...`` declaration, wrap it in a tiny ``.kts`` script
+that walks the generated ``Any?`` value into a
+``kotlinx.serialization.json.JsonElement`` and prints
+``Json.encodeToString(...)`` to stdout, run it with ``kotlin``, and
+hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-kotlin`` job in
+``.github/workflows/lint.yml``, because that job is where the Kotlin
+toolchain and the ``kotlinx-serialization-json`` jars are already
+installed (same ``LITERALIZER_LINT_CLASSPATH`` the per-fixture compile
+host reads).  It shares the same input and comparison logic as the
+other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value is emitted as ``java.math.BigInteger("...")`` which
+``kotlinx.serialization.json`` has no first-class ``JsonPrimitive``
+overload for, same shape as the Go, TypeScript and Zig exclusions.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Kotlin
+
+_VAR_NAME = "myData"
+_LABEL = "Kotlin"
+_EXCLUDED_KEYS = ("biginteger",)
+
+# Recursive ``Any?`` -> ``JsonElement`` walker.  The Kotlin backend
+# emits primitive-typed arrays (``intArrayOf``, ...) for homogeneous
+# numeric lists, so each primitive-array shape needs its own branch
+# before the generic ``List<*>`` arm.  ``Map<*, *>`` covers both
+# ``mapOf<String, Any?>`` and the narrower homogeneous-value maps the
+# backend emits for inner objects.
+_TO_JSON_ELEMENT = r"""
+fun toJsonElement(v: Any?): JsonElement = when (v) {
+    null -> JsonNull
+    is Boolean -> JsonPrimitive(v)
+    is Number -> JsonPrimitive(v)
+    is String -> JsonPrimitive(v)
+    is IntArray -> JsonArray(v.map { JsonPrimitive(it) })
+    is LongArray -> JsonArray(v.map { JsonPrimitive(it) })
+    is DoubleArray -> JsonArray(v.map { JsonPrimitive(it) })
+    is BooleanArray -> JsonArray(v.map { JsonPrimitive(it) })
+    is List<*> -> JsonArray(v.map(::toJsonElement))
+    is Map<*, *> -> JsonObject(
+        v.entries.associate { (k, vv) -> k.toString() to toJsonElement(vv) }
+    )
+    else -> error("unhandled type: " + v::class)
+}
+"""
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Kotlin script literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=Kotlin(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "import kotlinx.serialization.json.Json\n"
+        "import kotlinx.serialization.json.JsonArray\n"
+        "import kotlinx.serialization.json.JsonElement\n"
+        "import kotlinx.serialization.json.JsonNull\n"
+        "import kotlinx.serialization.json.JsonObject\n"
+        "import kotlinx.serialization.json.JsonPrimitive\n"
+        f"{preamble}\n"
+        f"{_TO_JSON_ELEMENT}"
+        "\n"
+        f"{result.code}\n"
+        "\n"
+        "print(Json.encodeToString("
+        "JsonElement.serializer(), "
+        f"toJsonElement({_VAR_NAME})"
+        "))\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Kotlin backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    kotlin = shutil.which(cmd="kotlin") or "kotlin"
+    # ``LITERALIZER_LINT_CLASSPATH`` is set by the ``lint-kotlin`` job
+    # to ``/tmp/kotlinx-jars/*`` for the per-fixture compile host.  The
+    # ``kotlin`` script wrapper does not forward the JVM ``dir/*``
+    # wildcard intact, so expand it here to an explicit jar list.
+    classpath = ":".join(
+        sorted(
+            str(p)
+            for entry in os.environ["LITERALIZER_LINT_CLASSPATH"].split(":")
+            for p in (
+                Path(entry.removesuffix("/*")).glob("*.jar")
+                if entry.endswith("/*")
+                else [Path(entry)]
+            )
+        ),
+    )
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        (tmpdir / "main.kts").write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[kotlin, "-classpath", classpath, "main.kts"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: kotlin run error\n"
+            f"{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1414,6 +1414,23 @@ jobs:
         env:
           LITERALIZER_LINT_CLASSPATH: /tmp/kotlinx-jars/*
         run: kotlin .github/scripts/lint-kotlin.main.kts < /tmp/files-to-lint
+      # `uv` is needed by the `Kotlin roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Kotlin -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Kotlin toolchain and the
+      # kotlinx-serialization-json jars already on disk; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_kotlin_roundtrip.py`.
+      - name: Kotlin roundtrip
+        env:
+          LITERALIZER_LINT_CLASSPATH: /tmp/kotlinx-jars/*
+        run: uv run python .github/scripts/run_kotlin_roundtrip.py
 
   lint-swift:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, and Zig JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, and Kotlin JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalizes the shared `roundtrip_input.json` to a Kotlin `.kts` script that walks the generated `Any?` value into `kotlinx.serialization.json.JsonElement` and prints `Json.encodeToString(...)` to stdout, then compares back via `roundtrip_common.verify`.
- Wires a `Kotlin roundtrip` step into the `lint-kotlin` job (Kotlin toolchain and kotlinx-serialization-json jars already present; `uv` added for `import literalizer`).
- Excludes `biginteger` from the comparison: its 26-digit value is emitted as `java.math.BigInteger("...")` which has no first-class `JsonPrimitive` overload, same shape as the Go, TypeScript and Zig exclusions.

## Test plan
- [ ] `lint-kotlin` job passes, including the new `Kotlin roundtrip` step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI verification script and workflow step without changing runtime/library behavior; primary risk is increased CI time or intermittent failures due to Kotlin/classpath execution.
> 
> **Overview**
> Adds a Kotlin JSON round-trip CI check that literalizes the shared `roundtrip_input.json` into a generated `.kts`, re-serializes it via `kotlinx.serialization.json`, and compares the output with `roundtrip_common.verify` (excluding the `biginteger` field).
> 
> Wires this into the `lint-kotlin` job in `lint.yml` by installing `uv` and running the new helper with the existing `LITERALIZER_LINT_CLASSPATH` setup, and updates the changelog fragment to include Kotlin in the list of round-trip checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd38973e3014612dbe23b54d513d66e6d10c4eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->