### PR TITLE
Add Rust JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_rust_roundtrip.py
+++ b/.github/scripts/run_rust_roundtrip.py
@@ -1,0 +1,124 @@
+"""Rust JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Rust
+``let my_data: serde_json::Value = ...`` declaration via the
+``json_type=SERDE_JSON_VALUE`` strategy, wrap it in a tiny ``main`` that
+prints ``serde_json::to_string(&my_data)``, compile and run it with
+``rustc`` linked against ``serde_json``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-rust`` job in
+``.github/workflows/lint.yml``, because that job is where the Rust
+toolchain and a prebuilt ``libserde_json-*.rlib`` are already available.
+It shares the same input and comparison logic as the other per-language
+round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value fits in ``i128`` (which the Rust backend emits) but
+``serde_json::Value`` stores numbers as ``i64``/``u64``/``f64``, so the
+``json!`` macro would coerce it to a ``f64`` and lose precision before
+serialization. Same shape as the Go, TypeScript, and Zig exclusions.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Rust
+
+_VAR_NAME = "my_data"
+_LABEL = "Rust"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Rust program literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=Rust(json_type=Rust.json_types.SERDE_JSON_VALUE),
+        pre_indent_level=1,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{preamble}\n"
+        "fn main() {\n"
+        f"{result.code}\n"
+        f"    let out = serde_json::to_string(&{_VAR_NAME}).unwrap();\n"
+        '    print!("{}", out);\n'
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Rust backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    rustc = shutil.which(cmd="rustc") or "rustc"
+    deps_dir = sys.argv[1]
+    serde_json_rlib = sys.argv[2]
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        src = tmpdir / "main.rs"
+        src.write_text(data=program, encoding="utf-8")
+        binary = tmpdir / "main"
+        compile_result = subprocess.run(
+            args=[
+                rustc,
+                "--edition",
+                "2021",
+                "-L",
+                f"dependency={deps_dir}",
+                "--extern",
+                f"serde_json={serde_json_rlib}",
+                str(object=src),
+                "-o",
+                str(object=binary),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+        if compile_result.returncode != 0:
+            sys.stderr.write(
+                f"{_LABEL}: rustc error\n"
+                f"{compile_result.stdout}{compile_result.stderr}",
+            )
+            sys.stderr.write(f"\nProgram:\n{program}\n")
+            sys.exit(1)
+        run_result = subprocess.run(
+            args=[str(object=binary)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: run error\n{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1726,10 +1726,13 @@ jobs:
         shell: bash
         run: find tests/integration/cases -name '*.rs' -print0 > /tmp/files-to-lint
           && test -s /tmp/files-to-lint
-      - name: Check Rust syntax and run binaries
+      # Build chrono + serde_json once and stash the rlib paths in
+      # `$GITHUB_ENV`; both the per-fixture compile step below and the
+      # `Rust roundtrip` step reuse them. The build tmpdir is kept for
+      # the rest of the job (the runner is ephemeral).
+      - name: Build Rust dependencies
         run: |-
           tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
           cargo init "$tmpdir/chrono-check"
           cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" chrono
           cargo add --manifest-path "$tmpdir/chrono-check/Cargo.toml" serde_json
@@ -1739,6 +1742,14 @@ jobs:
           test -n "$chrono_rlib"
           serde_json_rlib=$(find "$deps" -name "libserde_json-*.rlib" -print -quit)
           test -n "$serde_json_rlib"
+          {
+            echo "RUST_TMPDIR=$tmpdir"
+            echo "RUST_DEPS=$deps"
+            echo "RUST_CHRONO_RLIB=$chrono_rlib"
+            echo "RUST_SERDE_JSON_RLIB=$serde_json_rlib"
+          } >> "$GITHUB_ENV"
+      - name: Check Rust syntax and run binaries
+        run: |-
           # ``--edition 2021`` matches ``Rust.language_version`` in
           # ``src/literalizer/languages/rust.py``; keep them in sync.
           # rustc infers a crate name from the source filename and
@@ -1749,12 +1760,26 @@ jobs:
             crate_name=${stem//@/_}
             rustc --edition 2021 \
               --crate-name "$crate_name" \
-              -L "dependency=$deps" \
-              --extern "chrono=$chrono_rlib" \
-              --extern "serde_json=$serde_json_rlib" \
-              "$f" -o "$tmpdir/out" 2>&1 || exit 1
-            "$tmpdir/out" || exit 1
+              -L "dependency=$RUST_DEPS" \
+              --extern "chrono=$RUST_CHRONO_RLIB" \
+              --extern "serde_json=$RUST_SERDE_JSON_RLIB" \
+              "$f" -o "$RUST_TMPDIR/out" 2>&1 || exit 1
+            "$RUST_TMPDIR/out" || exit 1
           done < /tmp/files-to-lint
+      # `uv` is needed by the `Rust roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Rust -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Rust toolchain and a prebuilt
+      # `libserde_json-*.rlib`; `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_rust_roundtrip.py`.
+      - name: Rust roundtrip
+        run: uv run python .github/scripts/run_rust_roundtrip.py "$RUST_DEPS" "$RUST_SERDE_JSON_RLIB"
 
   lint-r:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, and Zig JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, and Rust JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalizes the shared `roundtrip_input.json` to a Rust program via `json_type=SERDE_JSON_VALUE`, serializes back with `serde_json::to_string`, and verifies the result.
- Splits `lint-rust`'s chrono + serde_json build into a dedicated step that exports the rlib paths via `$GITHUB_ENV`, reused by both the per-fixture compile and the new roundtrip step.
- Excludes `biginteger` from the comparison: the 26-digit value collapses to `f64` inside `serde_json::Value` (same shape as the Go/TypeScript/Zig exclusions).

## Test plan
- [ ] `lint-rust` job (per-fixture compile + new `Rust roundtrip` step) green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `lint-rust` GitHub Actions job by restructuring dependency build and adding a new Rust compilation/execution step, which could cause CI failures if env var propagation or rustc linking differs across runners.
> 
> **Overview**
> Adds a new CI gate that round-trips the shared `roundtrip_input.json` through the Rust backend by literalizing it as `serde_json::Value`, compiling a tiny Rust program with `rustc`, re-serializing via `serde_json::to_string`, and verifying the output (excluding `biginteger`).
> 
> Refactors `lint-rust` to build `chrono`/`serde_json` once, export the resulting `.rlib`/deps paths via `$GITHUB_ENV` for reuse, installs `uv`, and runs the new `.github/scripts/run_rust_roundtrip.py` helper as an additional step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab9e426570cb217fb5923e296af0152c8dd5b3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->