### PR TITLE
Add D JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_d_roundtrip.py
+++ b/.github/scripts/run_d_roundtrip.py
@@ -1,0 +1,115 @@
+"""D JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a D
+``auto my_data = JSONValue(...);`` declaration via the default
+``std.json.JSONValue`` model, wrap it in a tiny ``void main`` that
+serializes ``my_data`` back to JSON via ``JSONValue.toString`` and writes
+it to stdout, compile and run it with ``dmd``, and hand the emitted JSON
+to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-d`` job in
+``.github/workflows/lint.yml``, because that job is where the D
+toolchain (``dmd``) is already installed.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value overflows D's 64-bit ``long`` (the widest integer the
+``JSONValue`` integer node can carry), so the program would not compile
+if the field were kept.  Same shape as the Go, TypeScript, Zig, Swift
+and Rust exclusions.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import D
+
+_VAR_NAME = "my_data"
+_LABEL = "D"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable D program literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=D(),
+        pre_indent_level=1,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{preamble}\n"
+        "import std.stdio;\n"
+        "void main() {\n"
+        f"{result.code}\n"
+        f"    write({_VAR_NAME}.toString());\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the D backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    dmd = shutil.which(cmd="dmd") or "dmd"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        src = tmpdir / "main.d"
+        src.write_text(data=program, encoding="utf-8")
+        binary = tmpdir / "main"
+        compile_result = subprocess.run(
+            args=[
+                dmd,
+                f"-of={binary}",
+                f"-od={tmpdir}",
+                str(object=src),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+        if compile_result.returncode != 0:
+            sys.stderr.write(
+                f"{_LABEL}: dmd error\n"
+                f"{compile_result.stdout}{compile_result.stderr}",
+            )
+            sys.stderr.write(f"\nProgram:\n{program}\n")
+            sys.exit(1)
+        run_result = subprocess.run(
+            args=[str(object=binary)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: run error\n{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1911,6 +1911,19 @@ jobs:
           "$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-d.sh < /tmp/files-to-lint
+      # `uv` is needed by the `D roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> D -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the D toolchain; `uv run` (project
+      # mode, not `--no-project`) is required so `import literalizer`
+      # resolves. See `.github/scripts/run_d_roundtrip.py`.
+      - name: D roundtrip
+        run: uv run python .github/scripts/run_d_roundtrip.py
 
   lint-crystal:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, and Rust JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, and D JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalize the shared `roundtrip_input.json` to a D program using `std.json.JSONValue` (default), then serialize it back with `JSONValue.toString` and compare via `roundtrip_common.verify`.
- Wire a new `D roundtrip` step into the existing `lint-d` job (with `astral-sh/setup-uv` so `import literalizer` resolves).
- Exclude `biginteger`: its 26-digit value overflows D's 64-bit `long`. Same shape as the Go / TypeScript / Zig / Swift / Rust exclusions.

## Test plan
- [x] Locally compiled the generated program with `ldc2` and confirmed `roundtrip_common.verify` accepts the output.
- [ ] `lint-d` green in CI (D roundtrip step compiles + runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition following the existing per-language round-trip pattern; no production or library runtime changes.
> 
> **Overview**
> Adds **D** to the shared JSON round-trip CI checks (#1867): a new `.github/scripts/run_d_roundtrip.py` helper literalizes `roundtrip_input.json` to `std.json.JSONValue`, compiles with **`dmd`**, serializes via **`JSONValue.toString`**, and verifies with **`roundtrip_common`**.
> 
> The **`lint-d`** job now installs **uv** and runs **`uv run python .github/scripts/run_d_roundtrip.py`** after the existing D fixture compile/run steps. **`biginteger`** is dropped from the fixture and comparison (same as Go/TS/etc.) because it overflows D’s 64-bit integer JSON nodes.
> 
> The newsfragment list of languages now includes **D**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a11c64bc2e2b0ff692a5defcf70e7ee6bb8274e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->