### PR TITLE
Add TOML JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_toml_roundtrip.py
+++ b/.github/scripts/run_toml_roundtrip.py
@@ -1,0 +1,64 @@
+"""TOML JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a TOML
+``myData = { ... }`` assignment, parse the resulting TOML document with
+``tomli``, then re-serialize the inner value as JSON and hand it to
+:func:`roundtrip_common.verify`.
+
+Unlike the executable-language round-trips, there is no language
+runtime to invoke: the analogous "back to JSON" step is a TOML parser
+re-emitting the parsed value.  ``tomli`` is used (rather than the
+stdlib ``tomllib``) because the literalized output uses TOML 1.1
+multiline inline tables, which ``tomli`` >= 2.4 understands but
+stdlib ``tomllib`` does not.
+
+This lives here, driven by the ``Toml roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, alongside the
+existing ``Lint Toml`` syntax check that uses the same ``tomli``
+dependency.  It shares the same input and comparison logic as the
+other per-language round-trip helpers.
+"""
+
+import json
+import sys
+
+import roundtrip_common
+import tomli
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Toml
+
+_VAR_NAME = "myData"
+_LABEL = "TOML"
+
+
+def _build_document(json_text: str) -> str:
+    """Return a TOML document literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Toml(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n{result.code}\n" if preamble else f"{result.code}\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the TOML backend."""
+    document = _build_document(json_text=roundtrip_common.read_input())
+    parsed: dict[str, object] = tomli.loads(document)
+    produced_json = json.dumps(obj=parsed[_VAR_NAME])
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=produced_json,
+        exclude_keys=(),
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -838,6 +838,14 @@ jobs:
           find tests/integration/cases -name '*.toml' -print0 > /tmp/files-toml && test -s /tmp/files-toml
           xargs -0 -P "$(nproc)" -n1 uv run --with 'tomli>=2.4.0' --no-project python .github/scripts/check_toml_syntax.py < /tmp/files-toml
 
+      # Basic JSON -> TOML -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the ``tomli`` TOML parser already
+      # configured; ``uv run`` (project mode, not ``--no-project``) is
+      # required so ``import literalizer`` resolves, and ``--with`` adds
+      # ``tomli`` on top.  See ``.github/scripts/run_toml_roundtrip.py``.
+      - name: Toml roundtrip
+        run: uv run --with 'tomli>=2.4.0' python .github/scripts/run_toml_roundtrip.py
+
       - name: Lint Yaml
         run: |-
           find tests/integration/cases -name '*.yaml' ! -name 'input.yaml' -print0 > /tmp/files-yaml && test -s /tmp/files-yaml

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, and Rust JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, and TOML JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalize the shared `roundtrip_input.json` to a TOML `myData = { ... }` assignment, parse it with `tomli>=2.4.0` (needed for the TOML 1.1 multiline inline tables the literalizer emits; stdlib `tomllib` does not yet support them), and re-serialize the inner value as JSON for `roundtrip_common.verify`.
- No exclusions needed: the 26-digit `biginteger`, `negative_zero`, `float_large_exponent`, unicode/escaped strings, and empty/nested collections all round-trip losslessly through `tomli` + `json.dumps`.
- Wired into `lint-fast` immediately after the existing `Lint Toml` syntax check, reusing the same `tomli` dependency.

## Test plan
- [ ] `lint-fast` job in CI passes the new `Toml roundtrip` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test harness and changelog text; no runtime or library behavior changes.
> 
> **Overview**
> Adds **TOML** to the shared JSON round-trip CI checks for issue #1867.
> 
> A new helper **literalizes** `roundtrip_input.json` to a `myData = …` TOML assignment, **parses** it with **`tomli>=2.4.0`** (for TOML 1.1 multiline inline tables the literalizer emits), **re-serializes** the value with `json.dumps`, and asserts equality via **`roundtrip_common.verify`** with **no key exclusions**. The **`Toml roundtrip`** step runs in **`lint-uv-scripts`** right after **`Lint Toml`**, using `uv run --with 'tomli>=2.4.0'`. The **1867** newsfragment now mentions TOML alongside the other languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c351787e102ba92871cb8058c82ba2b11bd6be0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->