### PR TITLE
Add YAML JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_yaml_roundtrip.py
+++ b/.github/scripts/run_yaml_roundtrip.py
@@ -1,0 +1,60 @@
+"""YAML JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a YAML
+flow-style value, parse the resulting YAML with ``PyYAML``, then
+re-serialize the parsed value as JSON and hand it to
+:func:`roundtrip_common.verify`.
+
+Like the TOML round-trip, there is no language runtime to invoke:
+the analogous "back to JSON" step is a YAML parser re-emitting the
+parsed value.  The :class:`literalizer.languages.Yaml` backend emits
+flow mappings / sequences, which ``yaml.safe_load`` parses to native
+Python ``dict``/``list``/``int``/``float``/``bool``/``str`` values.
+
+This lives here, driven by the ``Yaml roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, alongside the
+existing ``Lint Yaml`` syntax check.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+"""
+
+import json
+import sys
+
+import roundtrip_common
+import yaml
+
+from literalizer import InputFormat, literalize
+from literalizer.languages import Yaml
+
+_LABEL = "YAML"
+
+
+def _build_document(json_text: str) -> str:
+    """Return a YAML document literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Yaml(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n{result.code}\n" if preamble else f"{result.code}\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the YAML backend."""
+    document = _build_document(json_text=roundtrip_common.read_input())
+    parsed: dict[str, object] = yaml.safe_load(stream=document)
+    produced_json = json.dumps(obj=parsed)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=produced_json,
+        exclude_keys=(),
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -859,6 +859,14 @@ jobs:
           find tests/integration/cases -name '*.yaml' ! -name 'input.yaml' -print0 > /tmp/files-yaml && test -s /tmp/files-yaml
           xargs -0 uvx yamllint --strict -d '{extends: default, rules: {document-start: disable, line-length: disable}}' -- < /tmp/files-yaml
 
+      # Basic JSON -> YAML -> JSON round-trip (issue 1867). Runs here
+      # alongside the existing Yaml syntax check; ``uv run`` (project
+      # mode, not ``--no-project``) is required so ``import literalizer``
+      # resolves, and ``--with`` layers ``pyyaml`` on top.  See
+      # ``.github/scripts/run_yaml_roundtrip.py``.
+      - name: Yaml roundtrip
+        run: uv run --with 'pyyaml' python .github/scripts/run_yaml_roundtrip.py
+
   # .NET-hosted linters. Run host builds in parallel-looking sequential
   # steps so the .NET runtime startup is paid once for the whole job.
   lint-dotnet:

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, and OCaml JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, and YAML JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalize the shared `roundtrip_input.json` to a YAML flow-style document, parse with `PyYAML`'s `safe_load`, re-serialize to JSON, and hand it to `roundtrip_common.verify`.
- Wired into the `lint-fast` job right after the existing `Lint Yaml` syntax check; uses `uv run --with 'pyyaml'` so `import literalizer` resolves while layering PyYAML on top.
- No exclusions needed: `biginteger` (Python arbitrary-precision int), `float_large_exponent`, `negative_zero`, unicode/escaped strings, and empty/nested collections all round-trip losslessly through PyYAML + `json.dumps`.

## Test plan
- [ ] `lint-fast` -> `Yaml roundtrip` step passes in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test harness using existing roundtrip_common and the Yaml literalizer backend; no application or auth changes.
> 
> **Overview**
> Adds a **YAML JSON round-trip** CI check for issue #1867, alongside the existing per-language round-trip helpers.
> 
> A new script **literalizes** the shared `roundtrip_input.json` through the `Yaml` backend (flow-style YAML), **parses** it with `yaml.safe_load`, **re-serializes** with `json.dumps`, and **compares** via `roundtrip_common.verify` with no key exclusions. The **`lint-uv-scripts`** job in `lint.yml` runs it immediately after **Lint Yaml**, using `uv run --with 'pyyaml'` so `literalizer` and PyYAML are both available.
> 
> The **newsfragment** for #1867 is updated to mention YAML in the list of round-trip languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee557eaa7b8c9d7f444cab414be554e52c9598bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->