### PR TITLE
Add JavaScript JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_javascript_roundtrip.py
+++ b/.github/scripts/run_javascript_roundtrip.py
@@ -1,0 +1,87 @@
+"""JavaScript JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a JavaScript
+``const myData = ...;`` declaration, wrap it in a tiny script that
+writes ``JSON.stringify(myData)`` to stdout, run it with ``node``, and
+hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-fast`` job in
+``.github/workflows/lint.yml``, because that job is where the Node
+toolchain is already installed for the ``Lint JavaScript`` step.  It
+follows the same template as ``run_typescript_roundtrip.py``: a single
+``.py`` file, no separate serializer source, because ``JSON.stringify``
+is in the JavaScript standard library.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+the literalizer emits a plain numeric literal, which JavaScript stores
+as an IEEE-754 double, so the original 26-digit integer cannot survive
+the round-trip even with a custom serializer.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import JavaScript
+
+_VAR_NAME = "myData"
+_LABEL = "JavaScript"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable JavaScript program literalized from
+    *json_text*.
+    """
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=JavaScript(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"process.stdout.write(JSON.stringify({_VAR_NAME}));\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the JavaScript backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    node = shutil.which(cmd="node") or "node"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        script_path = Path(tmpdir_name) / "main.js"
+        script_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[node, str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: node runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -240,6 +240,14 @@ jobs:
           xargs -0 -P "$(nproc)" -n1 node --check < /tmp/files-js
           xargs -0 -P "$(nproc)" -n1 node < /tmp/files-js
 
+      # Basic JSON -> JavaScript -> JSON round-trip (issue 1867). Runs
+      # here because this is the job with the Node toolchain (pinned by
+      # the `Set up Node` step above); `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_javascript_roundtrip.py`.
+      - name: JavaScript roundtrip
+        run: uv run python .github/scripts/run_javascript_roundtrip.py
+
       # The host compiles each fixture into an in-memory assembly, then
       # reflectively constructs `Main` and invokes its `main()` method
       # (or runs field initializers on field-only fixtures), so javac

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, and OCaml JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, and JavaScript JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Port the per-language round-trip helper to JavaScript: literalize the shared `roundtrip_input.json`, run the emitted program under `node`, and feed `JSON.stringify(myData)` back to `roundtrip_common.verify`.
- Skips `biginteger` (same IEEE-754 reason as TypeScript / Go / Zig / Rust / Elm).
- Wired into `lint-fast` next to the existing `Lint JavaScript` step, where Node 22 and `uv` are already on the runner.

## Test plan
- [x] `uv run --extra dev python .github/scripts/run_javascript_roundtrip.py` locally -> `JavaScript round-trip OK`.
- [ ] CI `lint-fast / JavaScript roundtrip` step passes.

Refs #1867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only regression test mirroring other language roundtrips; no production literalizer or runtime behavior changes.
> 
> **Overview**
> Adds a **JavaScript** JSON round-trip CI check for issue **#1867**, matching the existing TypeScript/Ruby pattern.
> 
> A new `.github/scripts/run_javascript_roundtrip.py` literalizes shared `roundtrip_input.json` to `const myData`, runs it under **Node** with `JSON.stringify`, and compares output via `roundtrip_common.verify`. **`biginteger`** is excluded from verification (IEEE-754 double semantics, same as TypeScript).
> 
> **`lint-fast`** gains a **JavaScript roundtrip** step immediately after **Lint JavaScript**, using `uv run python` so `literalizer` resolves on the runner that already has Node 22.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e514b88ac5d97e81e5bf5183f97749f51f79b33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->