### PR TITLE
Add JSON5 JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_json5_roundtrip.py
+++ b/.github/scripts/run_json5_roundtrip.py
@@ -1,0 +1,56 @@
+"""JSON5 JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a JSON5
+value, parse the resulting JSON5 text with ``pyjson5``, then re-serialize
+the parsed value as JSON and hand it to :func:`roundtrip_common.verify`.
+
+Like the TOML round-trip, there is no language runtime to invoke: the
+analogous "back to JSON" step is a JSON5 parser re-emitting the parsed
+value.  ``pyjson5`` is already a core ``literalizer`` dependency, so the
+``Lint Toml`` job's ``uv run`` (project mode) resolves it without extra
+``--with`` layering.  Unlike most other backends, ``Json5`` does not
+support a ``variable_form``: the literalized output is a bare JSON5
+value, so the parsed result is fed directly to ``verify``.
+"""
+
+import json
+import sys
+
+import pyjson5
+import roundtrip_common
+
+from literalizer import InputFormat, literalize
+from literalizer.languages import Json5
+
+_LABEL = "JSON5"
+
+
+def _build_document(json_text: str) -> str:
+    """Return a JSON5 document literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Json5(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n{result.code}\n" if preamble else f"{result.code}\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the JSON5 backend."""
+    document = _build_document(json_text=roundtrip_common.read_input())
+    parsed: dict[str, object] = pyjson5.loads(document)
+    produced_json = json.dumps(obj=parsed)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=produced_json,
+        exclude_keys=(),
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -854,6 +854,13 @@ jobs:
       - name: Toml roundtrip
         run: uv run --with 'tomli>=2.4.0' python .github/scripts/run_toml_roundtrip.py
 
+      # Basic JSON -> JSON5 -> JSON round-trip (issue 1867).  ``pyjson5``
+      # is already a core ``literalizer`` dependency, so plain ``uv run``
+      # (project mode) resolves it without an extra ``--with`` layer.
+      # See ``.github/scripts/run_json5_roundtrip.py``.
+      - name: Json5 roundtrip
+        run: uv run python .github/scripts/run_json5_roundtrip.py
+
       - name: Lint Yaml
         run: |-
           find tests/integration/cases -name '*.yaml' ! -name 'input.yaml' -print0 > /tmp/files-yaml && test -s /tmp/files-yaml

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, and OCaml JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, and JSON5 JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- New `.github/scripts/run_json5_roundtrip.py`: literalizes the shared `roundtrip_input.json` to JSON5, parses it with `pyjson5`, re-serializes via `json.dumps`, and hands the result to `roundtrip_common.verify`.
- Wired into `lint-fast` as a new `Json5 roundtrip` step just after `Toml roundtrip`; plain `uv run` (no `--with`) since `pyjson5` is already a core dependency.
- No `exclude_keys` needed — `pyjson5` round-trips the 26-digit `biginteger`, `-0.0`, large-exponent floats, unicode/escaped strings, and empty/nested collections losslessly.
- Unlike most backends, `Json5` has no `variable_form`, so the script omits it and feeds the parsed dict directly to `verify`.

## Test plan
- [ ] CI `lint-fast` Json5 roundtrip step passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds CI scripting and workflow wiring; no changes to literalizer runtime behavior or application logic.
> 
> **Overview**
> Adds a **JSON5** path to the shared issue **#1867** JSON round-trip CI checks, alongside the existing per-language helpers.
> 
> A new `.github/scripts/run_json5_roundtrip.py` literalizes `roundtrip_input.json` to JSON5 via `literalizer`, parses that text with `pyjson5`, re-serializes with `json.dumps`, and asserts equality through `roundtrip_common.verify` with **no** `exclude_keys` (unlike backends that need `variable_form`, JSON5 output is a bare value fed straight into verify).
> 
> The `lint-uv-scripts` job in `.github/workflows/lint.yml` runs a **Json5 roundtrip** step immediately after **Toml roundtrip**, using plain `uv run` because `pyjson5` is already a core dependency. The `newsfragments/1867.change` entry is updated to list JSON5 among the languages covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c1646335afa4eb3ddf3aba7a15639ec8d9e5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->