### PR TITLE
Add Jsonnet JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_jsonnet_roundtrip.py
+++ b/.github/scripts/run_jsonnet_roundtrip.py
@@ -1,0 +1,92 @@
+"""Jsonnet JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Jsonnet
+expression, write it to a ``.jsonnet`` file, and evaluate it with the
+``jsonnet`` interpreter.  Jsonnet is a JSON superset whose evaluator
+emits JSON on stdout, so there is no separate "back to JSON" step: the
+interpreter is both the language runtime and the serializer.  The
+emitted JSON is then handed to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-go-installed`` job in
+``.github/workflows/lint.yml``, because that job is where the
+``jsonnet`` binary (installed via ``go install
+github.com/google/go-jsonnet/cmd/jsonnet``) is already on the PATH.
+It shares the same input and comparison logic as the other
+per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the comparison
+because Jsonnet numbers are IEEE 754 doubles, so the 26-digit literal
+rounds when the evaluator emits it.  Same shape as the Go, TypeScript,
+Zig, Rust, and Elm exclusions.
+
+Jsonnet has no concept of a top-level named binding
+(``supports_variable_names`` is ``False``), so the literalized output
+is a bare expression rather than a ``local myData = ...;`` declaration.
+The whole file evaluates to that expression, which is exactly what we
+want.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, literalize
+from literalizer.languages import Jsonnet
+
+_LABEL = "Jsonnet"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a Jsonnet program literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=Jsonnet(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        wrap_in_file=False,
+    )
+    return f"{result.code}\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the Jsonnet backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    jsonnet = shutil.which(cmd="jsonnet") or "jsonnet"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        program_path = tmpdir / "main.jsonnet"
+        program_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[jsonnet, str(program_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: jsonnet error\n{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -597,11 +597,23 @@ jobs:
           go install github.com/google/go-jsonnet/cmd/jsonnet@latest
           go install github.com/tmccombs/hcl2json@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
 
       - name: Lint Jsonnet
         run: |-
           find tests/integration/cases -name '*.jsonnet' -print0 > /tmp/files-jsonnet && test -s /tmp/files-jsonnet
           xargs -0 -P "$(nproc)" -n1 jsonnet < /tmp/files-jsonnet > /dev/null
+      # Basic JSON -> Jsonnet -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the `jsonnet` binary (from the
+      # `go install` above) already on PATH; `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_jsonnet_roundtrip.py`.
+      - name: Jsonnet roundtrip
+        run: uv run python .github/scripts/run_jsonnet_roundtrip.py
 
       - name: Lint Hcl
         run: |-

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, and OCaml JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, and Jsonnet JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- New `.github/scripts/run_jsonnet_roundtrip.py` literalizes the shared `roundtrip_input.json` to a bare Jsonnet expression and runs `jsonnet` (the interpreter natively emits JSON, so no separate serializer is needed), then hands the output to `roundtrip_common.verify`.
- Wired into the existing `lint-go-installed` job (which already installs the `jsonnet` binary via `go install`); added `astral-sh/setup-uv` and a `Jsonnet roundtrip` step.
- `biginteger` is excluded from the comparison: Jsonnet numbers are IEEE 754 doubles, same exclusion as Go/TypeScript/Zig/Rust/Elm.

## Test plan
- [ ] CI `lint-go-installed` job passes the new `Jsonnet roundtrip` step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only additions (new scripts and workflow steps); no changes to the literalizer library or application runtime behavior.
> 
> **Overview**
> Adds three more **issue #1867** JSON round-trip CI checks on the shared `roundtrip_input.json`, using the same `roundtrip_common` pattern as existing language helpers.
> 
> **C++** (`run_cpp_roundtrip.py`): literalizes with `Cpp(NLOHMANN_JSON)`, compiles/runs a small program that `dump()`s JSON, wired into **`lint-cpp`** after **`setup-uv`** (project-mode `uv run` for `literalizer`). **`biginteger`** is stripped before literalize and excluded from verification (64-bit integer limits).
> 
> **JavaScript** (`run_javascript_roundtrip.py`): literalizes to `const myData`, runs under **Node** with `JSON.stringify`, wired into **`lint-fast`** next to the existing JS lint steps. **`biginteger`** is excluded (IEEE-754 doubles).
> 
> **JSON5** (`run_json5_roundtrip.py`): literalizes to a bare JSON5 document, round-trips via **`pyjson5`** + `json.dumps` (no runtime), wired into **`lint-uv-scripts`** beside the TOML round-trip. No `biginteger` exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c06f15ab5eed7cdded5cb3acccd4c2a2a8a151f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->