### PR TITLE
Add Julia JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_julia_roundtrip.py
+++ b/.github/scripts/run_julia_roundtrip.py
@@ -1,0 +1,91 @@
+"""Julia JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Julia
+``my_data = ...`` assignment, wrap it in a tiny script that prints
+``JSON.json(my_data)``, run it with Julia, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Julia roundtrip`` step of the
+``lint-julia`` job in ``.github/workflows/lint.yml``, because that job
+is where the Julia toolchain is installed and a project with the
+``JSON`` package is provisioned (the ``JULIA_PROJECT`` env var is set
+there so ``using JSON`` resolves).  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value overflows Julia's ``Int64`` so the literal is parsed
+as ``Int128`` / ``BigInt`` and ``JSON.json`` for big integers cannot be
+relied on across versions to emit a JSON-number representation matching
+the input.  Same shape as the Go, TypeScript, Zig, Rust, and Elm
+exclusions.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Julia
+
+_VAR_NAME = "my_data"
+_LABEL = "Julia"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Julia program literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Julia(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "using JSON\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"print(JSON.json({_VAR_NAME}))\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Julia backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    julia = shutil.which(cmd="julia") or "julia"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        script_path = Path(tmpdir_name) / "main.jl"
+        script_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[julia, "--startup-file=no", str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+            env={**os.environ},
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: julia runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1763,14 +1763,34 @@ jobs:
         uses: julia-actions/setup-julia@v3
         with:
           version: '1.9'
+      # `JSON` is needed by the `Julia roundtrip` step below (see
+      # `.github/scripts/run_julia_roundtrip.py`); `DataStructures`
+      # backs the `OrderedDict` literals the fixture goldens use.
       - name: Set up Julia project
         run: |
           mkdir -p /tmp/julia-lint
           julia --startup-file=no --project=/tmp/julia-lint -e \
-            'using Pkg; Pkg.add("DataStructures"); Pkg.precompile()'
+            'using Pkg; Pkg.add(["DataStructures", "JSON"]); Pkg.precompile()'
       - name: Run Julia golden files
         run: xargs -0 -P "$(nproc)" -n1 julia --startup-file=no --project=/tmp/julia-lint
           < /tmp/files-to-lint
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Julia -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with `julia` on PATH and the
+      # `/tmp/julia-lint` project (with the `JSON` package) already
+      # provisioned above; `JULIA_PROJECT` points the script's `julia`
+      # subprocess at that project so `using JSON` resolves. `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_julia_roundtrip.py`.
+      - name: Julia roundtrip
+        env:
+          JULIA_PROJECT: /tmp/julia-lint
+        run: uv run python .github/scripts/run_julia_roundtrip.py
 
   lint-go:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, and OCaml JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, and Julia JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/run_julia_roundtrip.py`, modeled on the other per-language round-trip helpers, using `JSON.json` from the `JSON.jl` package.
- Wires a `Julia roundtrip` step into the existing `lint-julia` job, adding `JSON` to the `/tmp/julia-lint` project and installing `uv` so `import literalizer` resolves; `JULIA_PROJECT` points the subprocess `julia` at that project.
- Excludes `biginteger` from the comparison (same Int64-overflow rationale as Go/Rust/TS/Zig/Elm) and updates the 1867 newsfragment.

## Test plan
- [ ] `lint-julia` job passes on CI (golden files + new `Julia roundtrip` step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test wiring following existing round-trip scripts; no production literalizer or runtime behavior changes.
> 
> **Overview**
> Adds **Julia** to the shared JSON round-trip CI checks for issue **#1867**.
> 
> A new `.github/scripts/run_julia_roundtrip.py` helper literalizes `roundtrip_input.json` to Julia, runs it with `JSON.json`, and compares output via `roundtrip_common.verify`, excluding **`biginteger`** (same Int64 overflow rationale as Go/Rust/TS/Zig/Elm).
> 
> The **`lint-julia`** job now adds the **`JSON`** package to `/tmp/julia-lint`, installs **`uv`**, and runs **`Julia roundtrip`** with `JULIA_PROJECT` set so `using JSON` resolves. The **1867** newsfragment lists Julia instead of Jsonnet among the languages covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95fce6a42a13879997ac0c249a9a603c2383b4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->