### PR TITLE
Add Crystal JSON round-trip check (#2646)

### DIFF
--- a/.github/scripts/run_crystal_roundtrip.py
+++ b/.github/scripts/run_crystal_roundtrip.py
@@ -1,0 +1,91 @@
+"""Crystal JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Crystal
+``my_data = JSON.parse(%(...))`` assignment via
+``Crystal(json_type=JSON_ANY)``, append a ``print my_data.to_json``
+statement, compile and run the resulting program with ``crystal run``,
+and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-crystal`` job in
+``.github/workflows/lint.yml``, because that job is where the Crystal
+toolchain is already installed.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the
+comparison: its 26-digit value overflows the ``Int64`` integer node
+that Crystal's ``JSON.parse`` exposes, same shape as the Go,
+TypeScript, Zig, Swift, Rust, D and C++ exclusions.  The
+``string_escapes`` field is excluded because the
+``Crystal(json_type=JSON_ANY)`` backend rejects literal backslashes and
+double quotes inside string values: they would be reinterpreted by the
+``%(...)`` percent literal before the JSON parser sees them.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Crystal
+
+_VAR_NAME = "my_data"
+_LABEL = "Crystal"
+_EXCLUDED_KEYS = ("biginteger", "string_escapes")
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Crystal program literalized from *json_text*."""
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in _EXCLUDED_KEYS:
+        parsed.pop(key, None)
+    trimmed_json = json.dumps(obj=parsed)
+    result = literalize(
+        source=trimmed_json,
+        input_format=InputFormat.JSON,
+        language=Crystal(json_type=Crystal.json_types.JSON_ANY),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n{result.code}\nprint {_VAR_NAME}.to_json\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the Crystal backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    crystal = shutil.which(cmd="crystal") or "crystal"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        src = tmpdir / "main.cr"
+        src.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[crystal, "run", str(object=src)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: crystal run error\n"
+            f"{run_result.stdout}{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2070,6 +2070,20 @@ jobs:
             printf '%s.cr <- %s\n' "$name" "$f"
           done < /tmp/files-to-lint
           crystal run "$driver"
+      # `uv` is needed by the `Crystal roundtrip` step below; it runs
+      # the helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Crystal -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Crystal toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so `import
+      # literalizer` resolves. See
+      # `.github/scripts/run_crystal_roundtrip.py`.
+      - name: Crystal roundtrip
+        run: uv run python .github/scripts/run_crystal_roundtrip.py
 
   # Mojo reserves ~3.6 GB of virtual address space per invocation
   # (upstream: modular/modular#6433), so ubuntu-latest's 7 GB runner

--- a/newsfragments/2646.change
+++ b/newsfragments/2646.change
@@ -1,0 +1,1 @@
+Add a Crystal JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Drive the shared `roundtrip_input.json` through `Crystal(json_type=JSON_ANY)` and `JSON::Any#to_json` so the `lint-crystal` CI job exercises a basic JSON -> Crystal -> JSON loop (sub-issue of #1867).
- Exclude `biginteger` (overflows the `Int64` JSON::Any integer node, matching Go/TS/Zig/Swift/Rust/D/C++) and `string_escapes` (the `JSON_ANY` backend rejects literal `\` / `"` because Crystal's `%(...)` percent literal would reinterpret them before the JSON parser sees them).

## Test plan
- [x] `uv run --extra dev python .github/scripts/run_crystal_roundtrip.py` locally with Crystal 1.20.0.
- [ ] `lint-crystal` CI job's new `Crystal roundtrip` step.

Closes #2646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI and a small helper script; no runtime product or auth/data paths.
> 
> **Overview**
> Adds **Crystal** to the shared JSON round-trip CI checks (issue #1867): a new `.github/scripts/run_crystal_roundtrip.py` literalizes `roundtrip_input.json` with `Crystal(json_type=JSON_ANY)`, runs `crystal run`, and compares stdout via `roundtrip_common.verify`.
> 
> The **`lint-crystal`** workflow gains **`Install uv`** and a **`Crystal roundtrip`** step (`uv run python .github/scripts/run_crystal_roundtrip.py`) so the check runs where Crystal 1.20.0 is already installed. Comparison skips **`biginteger`** (Int64 overflow in `JSON::Any`) and **`string_escapes`** (Crystal `%(...)` literals vs backslashes/quotes), consistent with other backends’ documented exclusions.
> 
> A **newsfragment** records the CI addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b369ede6bad9737a0b2d06addff347c26d3fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->