### PR TITLE
Add R JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_r_roundtrip.py
+++ b/.github/scripts/run_r_roundtrip.py
@@ -1,0 +1,99 @@
+"""R JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to an R
+``my_data <- ...`` assignment, wrap it in a tiny script that prints
+``jsonlite::toJSON(my_data, auto_unbox = TRUE)``, run it with
+``Rscript``, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``R roundtrip`` step of the ``lint-r``
+job in ``.github/workflows/lint.yml``, because that job is where the R
+toolchain is installed and the ``jsonlite`` package is provisioned
+(``R_LIBS_USER`` points the script's ``Rscript`` subprocess at that
+package directory so ``library(jsonlite)`` resolves).  It shares the
+same input and comparison logic as the other per-language round-trip
+helpers.
+
+Three top-level keys are excluded from the comparison:
+
+* ``biginteger`` — its 26-digit value overflows R's double-precision
+  numeric, same shape as the Go, TypeScript, Zig, Swift, Rust, D, and
+  C++ exclusions.
+* ``float_large_exponent`` — R's parser rounds the literal
+  ``1.7976931348623157e+308`` up to ``Inf``, which ``jsonlite`` then
+  serializes as the JSON string ``"Inf"`` rather than a number.
+* ``empty_object`` — R represents both arrays and objects as ``list()``
+  and an empty unnamed ``list()`` is genuinely ambiguous, so
+  ``jsonlite`` serializes the empty-object value as ``[]`` instead of
+  ``{}``.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import R
+
+_VAR_NAME = "my_data"
+_LABEL = "R"
+_EXCLUDED_KEYS = ("biginteger", "float_large_exponent", "empty_object")
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable R program literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=R(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "library(jsonlite)\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"cat(jsonlite::toJSON({_VAR_NAME}, auto_unbox = TRUE, "
+        'digits = NA, null = "null"))\n'
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the R backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    rscript = shutil.which(cmd="Rscript") or "Rscript"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        script_path = Path(tmpdir_name) / "main.R"
+        script_path.write_text(data=program, encoding="utf-8")
+        run_result = subprocess.run(
+            args=[rscript, "--no-init-file", str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+            env={**os.environ},
+        )
+    if run_result.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: Rscript runtime error\n{run_result.stdout}"
+            f"{run_result.stderr}",
+        )
+        sys.stderr.write(f"\nProgram:\n{program}\n")
+        sys.exit(1)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=run_result.stdout,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1980,6 +1980,31 @@ jobs:
           < /tmp/files-to-lint
       - name: Run R files
         run: xargs -0 -P "$(nproc)" -n1 Rscript < /tmp/files-to-lint
+      # `jsonlite` is needed by the `R roundtrip` step below (see
+      # `.github/scripts/run_r_roundtrip.py`); install it into a
+      # per-job library directory and point `R_LIBS_USER` at it so the
+      # script's `Rscript` subprocess can `library(jsonlite)`.
+      - name: Install jsonlite
+        run: |
+          mkdir -p /tmp/r-lint-libs
+          Rscript -e 'install.packages("jsonlite", lib="/tmp/r-lint-libs", repos="https://cloud.r-project.org")'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> R -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with `Rscript` on PATH and the
+      # `/tmp/r-lint-libs` library (with the `jsonlite` package) already
+      # provisioned above; `R_LIBS_USER` points the script's `Rscript`
+      # subprocess at that library so `library(jsonlite)` resolves.
+      # `uv run` (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_r_roundtrip.py`.
+      - name: R roundtrip
+        env:
+          R_LIBS_USER: /tmp/r-lint-libs
+        run: uv run python .github/scripts/run_r_roundtrip.py
 
   lint-d:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, YAML, and Julia JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, YAML, Julia, and R JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalize the shared `roundtrip_input.json` to an R `my_data <- list(...)`, run it under `Rscript`, and re-serialize via `jsonlite::toJSON(..., auto_unbox = TRUE)` for the round-trip check (issue #2673, sub-issue of #1867).
- Wire the check into `lint-r` after the existing fixture-run step. The job now installs `jsonlite` into `/tmp/r-lint-libs` and the round-trip step sets `R_LIBS_USER` so the subprocess `Rscript` can `library(jsonlite)`.
- Three keys are excluded from the comparison: `biginteger` (overflows R's double, same shape as the existing Go/TypeScript/Rust/D/C++ exclusions), `float_large_exponent` (R parses `1.7976931348623157e+308` as `Inf`), and `empty_object` (R uses `list()` for both arrays and objects, so an empty `list()` is genuinely ambiguous and `jsonlite` serializes it as `[]`).

## Test plan
- [ ] `lint-r` job passes on CI (syntax check, fixture run, and new `R roundtrip` step).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test harness and workflow steps; no application runtime or auth/data-path changes.
> 
> **Overview**
> Adds an **R** entry to the shared JSON round-trip CI checks (issue #1867): literalize `roundtrip_input.json` to R, run under `Rscript`, re-emit with **`jsonlite::toJSON`**, and compare via `roundtrip_common.verify`.
> 
> A new helper **`.github/scripts/run_r_roundtrip.py`** follows the same pattern as the other language round-trip scripts. The **`lint-r`** job now installs **`jsonlite`** into `/tmp/r-lint-libs`, sets **`R_LIBS_USER`** for the round-trip step, adds **`uv`**, and runs **`uv run python .github/scripts/run_r_roundtrip.py`**.
> 
> Comparison skips **`biginteger`**, **`float_large_exponent`**, and **`empty_object`** because of R double overflow, `Inf` parsing, and empty `list()` vs `{}` ambiguity. The **newsfragment** list of languages now includes R.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6293300a5261e0b0b8898be446c96ed2ce602149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->