### PR TITLE
Factor out shared roundtrip runner into roundtrip_common

### DIFF
--- a/.github/scripts/roundtrip_common.py
+++ b/.github/scripts/roundtrip_common.py
@@ -12,11 +12,31 @@ null map values or cannot infer the type of a bare ``null``.  Per-value
 type coverage (wide ints, large-exponent / negative-zero floats, unicode
 and escaped strings, empty/nested arrays and objects, heterogeneous
 arrays) lives in that one file rather than in many small cases.
+
+The helpers below collapse the boilerplate shared across the per-language
+scripts: :func:`trim_keys` drops the language-specific lossy fields from
+the input JSON before re-serialization, :func:`literalize_new_variable`
+wraps the one ``literalize`` shape every script uses, and
+:func:`execute` writes the assembled program to a tmpdir, runs a chain
+of :class:`Step` subprocesses (compile then run, or just run), and hands
+the final stdout to :func:`verify`.
 """
 
 import json
+import subprocess
 import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
+
+from literalizer import (
+    InputFormat,
+    Language,
+    LiteralizeResult,
+    NewVariable,
+    literalize,
+)
 
 INPUT_PATH = Path(__file__).resolve().parent / "roundtrip_input.json"
 
@@ -71,3 +91,114 @@ def verify(
             f"  got:      {got!r}\n",
         )
         sys.exit(1)
+
+
+def trim_keys(json_text: str, excluded_keys: tuple[str, ...]) -> str:
+    """Return *json_text* with *excluded_keys* removed at the top level.
+
+    Mirrors the round-trip ``verify`` exclusion: scripts whose backend
+    cannot represent a particular field losslessly trim it *before*
+    literalization so the generated program does not need to carry a
+    value the toolchain would reject (e.g. an integer that overflows
+    the target's widest literal type).
+    """
+    parsed: dict[str, object] = json.loads(s=json_text)
+    for key in excluded_keys:
+        parsed.pop(key, None)
+    return json.dumps(obj=parsed)
+
+
+def literalize_new_variable(
+    *,
+    language: Language,
+    json_text: str,
+    var_name: str,
+    pre_indent_level: int,
+) -> LiteralizeResult:
+    """Literalize *json_text* into a ``NewVariable(var_name)`` binding.
+
+    Wraps the single ``literalize(...)`` shape every per-language
+    round-trip script uses: JSON input, ``include_delimiters=True``,
+    ``wrap_in_file=False`` so the caller can splice the declaration
+    into its own ``main``/module template.
+    """
+    return literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=language,
+        pre_indent_level=pre_indent_level,
+        include_delimiters=True,
+        variable_form=NewVariable(name=var_name),
+        wrap_in_file=False,
+    )
+
+
+@dataclass(frozen=True)
+class Step:
+    """A subprocess to run inside the per-script tmpdir.
+
+    *args* is the argv (cwd is always the tmpdir).  *failure_label* is
+    the short phrase :func:`execute` prefixes to stderr when the step's
+    exit code is non-zero (e.g. ``"rustc error"``, ``"go run error"``).
+    """
+
+    args: Sequence[str]
+    failure_label: str
+
+
+def execute(
+    *,
+    label: str,
+    source_filename: str,
+    program: str,
+    steps: Sequence[Step],
+    excluded_keys: tuple[str, ...],
+    extra_files: Mapping[str, str] | None = None,
+) -> None:
+    """Run *program* through *steps* and verify the final stdout.
+
+    Writes *program* to ``<tmpdir>/<source_filename>`` (parent dirs
+    created on demand) and each ``extra_files`` entry under the same
+    tmpdir, then runs each :class:`Step` with cwd set to that tmpdir.
+    The first non-zero exit aborts with a diagnostic that includes the
+    failing step's stdout/stderr and a dump of *program*.
+
+    On success, the *last* step's stdout is passed to :func:`verify`
+    with *label* and *excluded_keys*, and a ``"{label} round-trip OK"``
+    line is written to stdout.  Callers do not need to emit that line
+    themselves.
+    """
+    extras = extra_files or {}
+    last_stdout = ""
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        source_path = tmpdir / source_filename
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(data=program, encoding="utf-8")
+        for rel_path, content in extras.items():
+            extra_path = tmpdir / rel_path
+            extra_path.parent.mkdir(parents=True, exist_ok=True)
+            extra_path.write_text(data=content, encoding="utf-8")
+        for step in steps:
+            result = subprocess.run(
+                args=list(step.args),
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=tmpdir,
+                encoding="utf-8",
+            )
+            if result.returncode != 0:
+                sys.stderr.write(
+                    f"{label}: {step.failure_label}\n"
+                    f"{result.stdout}{result.stderr}",
+                )
+                sys.stderr.write(f"\nProgram:\n{program}\n")
+                sys.exit(1)
+            last_stdout = result.stdout
+    verify(
+        label=label,
+        produced_json=last_stdout,
+        exclude_keys=excluded_keys,
+    )
+    sys.stdout.write(f"{label} round-trip OK\n")

--- a/.github/scripts/run_cpp_roundtrip.py
+++ b/.github/scripts/run_cpp_roundtrip.py
@@ -18,16 +18,10 @@ comparison: its 26-digit value overflows ``nlohmann::json``'s
 Rust and D exclusions.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Cpp
 
 _VAR_NAME = "my_data"
@@ -37,18 +31,15 @@ _EXCLUDED_KEYS = ("biginteger",)
 
 def _build_program(json_text: str) -> str:
     """Return a runnable C++ program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Cpp(json_type=Cpp.json_types.NLOHMANN_JSON),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=1,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -66,50 +57,22 @@ def main() -> None:
     """Round-trip the shared document through the C++ backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     clangxx = shutil.which(cmd="clang++") or "clang++"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        src = tmpdir / "main.cpp"
-        src.write_text(data=program, encoding="utf-8")
-        binary = tmpdir / "main"
-        compile_result = subprocess.run(
-            args=[
-                clangxx,
-                "-std=c++20",
-                str(object=src),
-                "-o",
-                str(object=binary),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: clang++ error\n"
-                f"{compile_result.stdout}{compile_result.stderr}",
-            )
-            sys.stderr.write(f"\nProgram:\n{program}\n")
-            sys.exit(1)
-        run_result = subprocess.run(
-            args=[str(object=binary)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: run error\n{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.cpp",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[clangxx, "-std=c++20", "main.cpp", "-o", "main"],
+                failure_label="clang++ error",
+            ),
+            roundtrip_common.Step(
+                args=["./main"],
+                failure_label="run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_crystal_roundtrip.py
+++ b/.github/scripts/run_crystal_roundtrip.py
@@ -21,16 +21,10 @@ double quotes inside string values: they would be reinterpreted by the
 ``%(...)`` percent literal before the JSON parser sees them.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Crystal
 
 _VAR_NAME = "my_data"
@@ -40,18 +34,15 @@ _EXCLUDED_KEYS = ("biginteger", "string_escapes")
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Crystal program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Crystal(json_type=Crystal.json_types.JSON_ANY),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return f"{preamble}\n{result.code}\nprint {_VAR_NAME}.to_json\n"
@@ -61,30 +52,18 @@ def main() -> None:
     """Round-trip the shared document through the Crystal backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     crystal = shutil.which(cmd="crystal") or "crystal"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        src = tmpdir / "main.cr"
-        src.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[crystal, "run", str(object=src)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: crystal run error\n"
-            f"{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.cr",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[crystal, "run", "main.cr"],
+                failure_label="crystal run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_csharp_roundtrip.py
+++ b/.github/scripts/run_csharp_roundtrip.py
@@ -21,16 +21,10 @@ is where the .NET toolchain is installed; it is deliberately not a
 pytest test under ``tests/``.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import CSharp
 
 _VAR_NAME = "myData"
@@ -56,18 +50,15 @@ _CSPROJ = (
 
 def _build_program(json_text: str) -> str:
     """Return a runnable C# program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=CSharp(sequence_format=CSharp.sequence_formats.ARRAY),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=2,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join(result.preamble)
     body_preamble = "\n".join(result.body_preamble)
@@ -89,31 +80,25 @@ def main() -> None:
     """Round-trip the shared document through the C# backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     dotnet = shutil.which(cmd="dotnet") or "dotnet"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        (tmpdir / "Program.cs").write_text(data=program, encoding="utf-8")
-        (tmpdir / "fixture.csproj").write_text(data=_CSPROJ, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[dotnet, "run", "--project", "fixture.csproj", "--nologo"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: dotnet run error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="Program.cs",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    dotnet,
+                    "run",
+                    "--project",
+                    "fixture.csproj",
+                    "--nologo",
+                ],
+                failure_label="dotnet run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+        extra_files={"fixture.csproj": _CSPROJ},
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_d_roundtrip.py
+++ b/.github/scripts/run_d_roundtrip.py
@@ -19,16 +19,10 @@ if the field were kept.  Same shape as the Go, TypeScript, Zig, Swift
 and Rust exclusions.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import D
 
 _VAR_NAME = "my_data"
@@ -38,18 +32,15 @@ _EXCLUDED_KEYS = ("biginteger",)
 
 def _build_program(json_text: str) -> str:
     """Return a runnable D program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=D(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=1,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -66,49 +57,22 @@ def main() -> None:
     """Round-trip the shared document through the D backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     dmd = shutil.which(cmd="dmd") or "dmd"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        src = tmpdir / "main.d"
-        src.write_text(data=program, encoding="utf-8")
-        binary = tmpdir / "main"
-        compile_result = subprocess.run(
-            args=[
-                dmd,
-                f"-of={binary}",
-                f"-od={tmpdir}",
-                str(object=src),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: dmd error\n"
-                f"{compile_result.stdout}{compile_result.stderr}",
-            )
-            sys.stderr.write(f"\nProgram:\n{program}\n")
-            sys.exit(1)
-        run_result = subprocess.run(
-            args=[str(object=binary)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: run error\n{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.d",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[dmd, "-of=main", "main.d"],
+                failure_label="dmd error",
+            ),
+            roundtrip_common.Step(
+                args=["./main"],
+                failure_label="run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_elm_roundtrip.py
+++ b/.github/scripts/run_elm_roundtrip.py
@@ -29,16 +29,10 @@ been translated.
 """
 
 import json
-import os
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Elm
 
 _VAR_NAME = "myData"
@@ -154,18 +148,15 @@ main =
 
 def _build_main(json_text: str) -> str:
     """Return a runnable Elm port module literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Elm(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     # ``result.code`` for Elm starts with the body_preamble (the
     # ``type Val ...`` declaration restricted to used constructors);
@@ -187,50 +178,26 @@ def main() -> None:
     program = _build_main(json_text=roundtrip_common.read_input())
     elm = shutil.which(cmd="elm") or "elm"
     node = shutil.which(cmd="node") or "node"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        src_dir = tmpdir / "src"
-        src_dir.mkdir()
-        (tmpdir / "elm.json").write_text(data=_ELM_JSON, encoding="utf-8")
-        (src_dir / "Main.elm").write_text(data=program, encoding="utf-8")
-        (tmpdir / "run.js").write_text(data=_RUN_JS, encoding="utf-8")
-        compile_result = subprocess.run(
-            args=[elm, "make", "src/Main.elm", "--output=main.js"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-            env={**os.environ},
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: elm make error\n"
-                f"{compile_result.stdout}{compile_result.stderr}",
-            )
-            sys.stderr.write(f"\nProgram:\n{program}\n")
-            sys.exit(1)
-        run_result = subprocess.run(
-            args=[node, "run.js"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: node run error\n"
-            f"{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="src/Main.elm",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[elm, "make", "src/Main.elm", "--output=main.js"],
+                failure_label="elm make error",
+            ),
+            roundtrip_common.Step(
+                args=[node, "run.js"],
+                failure_label="node run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+        extra_files={
+            "elm.json": _ELM_JSON,
+            "run.js": _RUN_JS,
+        },
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_go_roundtrip.py
+++ b/.github/scripts/run_go_roundtrip.py
@@ -18,16 +18,10 @@ losslessly under the parsed-value comparison in
 :func:`roundtrip_common.verify`.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Go
 
 _VAR_NAME = "myData"
@@ -43,18 +37,15 @@ _GO_MOD = "module fixture\n\ngo 1.18\n"
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Go program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Go(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=1,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -82,30 +73,19 @@ def main() -> None:
     """Round-trip the shared document through the Go backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     go = shutil.which(cmd="go") or "go"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        (tmpdir / "main.go").write_text(data=program, encoding="utf-8")
-        (tmpdir / "go.mod").write_text(data=_GO_MOD, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[go, "run", "."],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: go run error\n{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.go",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[go, "run", "."],
+                failure_label="go run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+        extra_files={"go.mod": _GO_MOD},
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_haskell_roundtrip.py
+++ b/.github/scripts/run_haskell_roundtrip.py
@@ -22,14 +22,8 @@ future expansion of ``roundtrip_input.json`` that adds a new scalar
 kind would fail compilation here until ``valToValue`` is extended.
 """
 
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
-
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Haskell
 
 _VAR_NAME = "myData"
@@ -67,14 +61,11 @@ valToEncoding (HMap kvs) =
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Haskell cabal-script program for *json_text*."""
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=Haskell(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     # ``Haskell.literalize`` already inlines ``result.body_preamble``
     # (the ``data Val`` declaration and its instances) at the top of
@@ -100,32 +91,21 @@ def _build_program(json_text: str) -> str:
 def main() -> None:
     """Round-trip the shared document through the Haskell backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        source_path = tmpdir / f"{_MODULE_NAME}.hs"
-        source_path.write_text(data=program, encoding="utf-8")
-        # ``--verbose=0`` keeps cabal's progress chatter off stdout so
-        # only the program's encoded JSON reaches ``run_result.stdout``.
-        run_result = subprocess.run(
-            args=["cabal", "run", "--verbose=0", str(source_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: cabal run error\n"
-            f"{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    source_filename = f"{_MODULE_NAME}.hs"
+    # ``--verbose=0`` keeps cabal's progress chatter off stdout so only
+    # the program's encoded JSON reaches the verified stdout.
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=(),
+        source_filename=source_filename,
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=["cabal", "run", "--verbose=0", source_filename],
+                failure_label="cabal run error",
+            ),
+        ],
+        excluded_keys=(),
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_java_roundtrip.py
+++ b/.github/scripts/run_java_roundtrip.py
@@ -15,14 +15,10 @@ test under ``tests/``.  It is the template for further per-language
 """
 
 import shutil
-import subprocess
-import sys
-import tempfile
 from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Java
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
@@ -33,14 +29,11 @@ _LABEL = "Java"
 
 def _build_main(json_text: str) -> str:
     """Return a runnable ``Main`` program literalized from *json_text*."""
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=Java(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     imports = "\n".join(result.preamble)
     body_preamble = "\n".join(result.body_preamble)
@@ -66,44 +59,24 @@ def main() -> None:
     program = _build_main(json_text=roundtrip_common.read_input())
     javac = shutil.which(cmd="javac") or "javac"
     java = shutil.which(cmd="java") or "java"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        (tmpdir / "Main.java").write_text(data=program, encoding="utf-8")
-        shutil.copy(src=_SERIALIZER_SRC, dst=tmpdir / _SERIALIZER_SRC.name)
-        compile_result = subprocess.run(
-            args=[javac, "Main.java", _SERIALIZER_SRC.name],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: javac error\n{compile_result.stdout}"
-                f"{compile_result.stderr}",
-            )
-            sys.exit(1)
-        run_result = subprocess.run(
-            args=[java, "Main"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: java runtime error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.exit(1)
-    roundtrip_common.verify(
+    serializer_text = _SERIALIZER_SRC.read_text(encoding="utf-8")
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=(),
+        source_filename="Main.java",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[javac, "Main.java", _SERIALIZER_SRC.name],
+                failure_label="javac error",
+            ),
+            roundtrip_common.Step(
+                args=[java, "Main"],
+                failure_label="java runtime error",
+            ),
+        ],
+        excluded_keys=(),
+        extra_files={_SERIALIZER_SRC.name: serializer_text},
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_javascript_roundtrip.py
+++ b/.github/scripts/run_javascript_roundtrip.py
@@ -19,14 +19,9 @@ the round-trip even with a custom serializer.
 """
 
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import JavaScript
 
 _VAR_NAME = "myData"
@@ -38,14 +33,11 @@ def _build_program(json_text: str) -> str:
     """Return a runnable JavaScript program literalized from
     *json_text*.
     """
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=JavaScript(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -59,28 +51,18 @@ def main() -> None:
     """Round-trip the shared document through the JavaScript backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     node = shutil.which(cmd="node") or "node"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        script_path = Path(tmpdir_name) / "main.js"
-        script_path.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[node, str(script_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: node runtime error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.js",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[node, "main.js"],
+                failure_label="node runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_jsonnet_roundtrip.py
+++ b/.github/scripts/run_jsonnet_roundtrip.py
@@ -26,12 +26,7 @@ The whole file evaluates to that expression, which is exactly what we
 want.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
@@ -44,10 +39,10 @@ _EXCLUDED_KEYS = ("biginteger",)
 
 def _build_program(json_text: str) -> str:
     """Return a Jsonnet program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
     result = literalize(
         source=trimmed_json,
         input_format=InputFormat.JSON,
@@ -63,29 +58,18 @@ def main() -> None:
     """Round-trip the shared document through the Jsonnet backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     jsonnet = shutil.which(cmd="jsonnet") or "jsonnet"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        program_path = tmpdir / "main.jsonnet"
-        program_path.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[jsonnet, str(program_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: jsonnet error\n{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.jsonnet",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[jsonnet, "main.jsonnet"],
+                failure_label="jsonnet error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_julia_roundtrip.py
+++ b/.github/scripts/run_julia_roundtrip.py
@@ -20,16 +20,10 @@ the input.  Same shape as the Go, TypeScript, Zig, Rust, and Elm
 exclusions.
 """
 
-import os
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Julia
 
 _VAR_NAME = "my_data"
@@ -39,14 +33,11 @@ _EXCLUDED_KEYS = ("biginteger",)
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Julia program literalized from *json_text*."""
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=Julia(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -61,30 +52,18 @@ def main() -> None:
     """Round-trip the shared document through the Julia backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     julia = shutil.which(cmd="julia") or "julia"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        script_path = Path(tmpdir_name) / "main.jl"
-        script_path.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[julia, "--startup-file=no", str(script_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-            env={**os.environ},
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: julia runtime error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.jl",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[julia, "--startup-file=no", "main.jl"],
+                failure_label="julia runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_kotlin_roundtrip.py
+++ b/.github/scripts/run_kotlin_roundtrip.py
@@ -20,17 +20,12 @@ its 26-digit value is emitted as ``java.math.BigInteger("...")`` which
 overload for, same shape as the Go, TypeScript and Zig exclusions.
 """
 
-import json
 import os
 import shutil
-import subprocess
-import sys
-import tempfile
 from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Kotlin
 
 _VAR_NAME = "myData"
@@ -64,18 +59,15 @@ fun toJsonElement(v: Any?): JsonElement = when (v) {
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Kotlin script literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Kotlin(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -116,30 +108,18 @@ def main() -> None:
             )
         ),
     )
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        (tmpdir / "main.kts").write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[kotlin, "-classpath", classpath, "main.kts"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: kotlin run error\n"
-            f"{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.kts",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[kotlin, "-classpath", classpath, "main.kts"],
+                failure_label="kotlin run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_ocaml_roundtrip.py
+++ b/.github/scripts/run_ocaml_roundtrip.py
@@ -29,16 +29,10 @@ so the literalizer would raise rather than emit a literal for it.
 Same shape as the Go, TypeScript, Swift, Zig, Rust, and D exclusions.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import OCaml
 
 _VAR_NAME = "my_data"
@@ -62,18 +56,15 @@ let () = print_string (Yojson.Safe.to_string (val_to_yojson my_data))
 
 def _build_program(json_text: str) -> str:
     """Return a runnable OCaml program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=OCaml(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     # ``OCaml.literalize`` already inlines ``result.body_preamble``
     # (the ``type val_t`` declaration) at the top of ``result.code``,
@@ -88,54 +79,31 @@ def main() -> None:
     """Round-trip the shared document through the OCaml backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     ocamlfind = shutil.which(cmd="ocamlfind") or "ocamlfind"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        src = tmpdir / "main.ml"
-        src.write_text(data=program, encoding="utf-8")
-        binary = tmpdir / "main"
-        compile_result = subprocess.run(
-            args=[
-                ocamlfind,
-                "ocamlopt",
-                "-package",
-                "yojson",
-                "-linkpkg",
-                str(object=src),
-                "-o",
-                str(object=binary),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: ocamlfind error\n"
-                f"{compile_result.stdout}{compile_result.stderr}",
-            )
-            sys.stderr.write(f"\nProgram:\n{program}\n")
-            sys.exit(1)
-        run_result = subprocess.run(
-            args=[str(object=binary)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: run error\n{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.ml",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    ocamlfind,
+                    "ocamlopt",
+                    "-package",
+                    "yojson",
+                    "-linkpkg",
+                    "main.ml",
+                    "-o",
+                    "main",
+                ],
+                failure_label="ocamlfind error",
+            ),
+            roundtrip_common.Step(
+                args=["./main"],
+                failure_label="run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_perl_roundtrip.py
+++ b/.github/scripts/run_perl_roundtrip.py
@@ -39,14 +39,9 @@ and comparison logic as the other per-language round-trip helpers.
 """
 
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Perl
 
 _VAR_NAME = "myData"
@@ -60,14 +55,11 @@ def _build_program(json_text: str) -> str:
         bool_format=Perl.bool_formats.JSON_PP_REF,
         integer_width_strategy=Perl.integer_width_strategies.MATH_BIG_INT,
     )
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=language,
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -86,28 +78,18 @@ def main() -> None:
     """Round-trip the shared document through the Perl backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     perl = shutil.which(cmd="perl") or "perl"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        script_path = Path(tmpdir_name) / "main.pl"
-        script_path.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[perl, str(script_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: perl runtime error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.pl",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[perl, "main.pl"],
+                failure_label="perl runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_php_roundtrip.py
+++ b/.github/scripts/run_php_roundtrip.py
@@ -22,30 +22,23 @@ cannot represent them losslessly:
 """
 
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Php
 
 _VAR_NAME = "myData"
 _LABEL = "PHP"
+_EXCLUDED_KEYS = ("biginteger", "empty_object")
 
 
 def _build_program(json_text: str) -> str:
     """Return a runnable PHP program literalized from *json_text*."""
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=Php(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return f"{preamble}\n{result.code}\necho json_encode(${_VAR_NAME});\n"
@@ -55,28 +48,18 @@ def main() -> None:
     """Round-trip the shared document through the PHP backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     php = shutil.which(cmd="php") or "php"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        script_path = Path(tmpdir_name) / "main.php"
-        script_path.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[php, str(script_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: php runtime error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=("biginteger", "empty_object"),
+        source_filename="main.php",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[php, "main.php"],
+                failure_label="php runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_purescript_roundtrip.py
+++ b/.github/scripts/run_purescript_roundtrip.py
@@ -32,17 +32,11 @@ relies on the standard JSON formatter for the tricky bits (escapes,
 negative zero, large exponents) rather than re-implementing them.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 from purescript_common import PRELUDE_JS, PRELUDE_PURS
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import PureScript
 
 _VAR_NAME = "myData"
@@ -140,18 +134,15 @@ _NODE_DRIVER = (
 
 def _build_check(json_text: str) -> str:
     """Return a runnable PureScript ``Check`` module from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=PureScript(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     body_preamble_text = "\n".join(result.body_preamble)
     declaration = result.code
@@ -171,59 +162,34 @@ def main() -> None:
     program = _build_check(json_text=roundtrip_common.read_input())
     purs = shutil.which(cmd="purs") or "purs"
     node = shutil.which(cmd="node") or "node"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        prelude_purs = tmpdir / "Prelude.purs"
-        prelude_js = tmpdir / "Prelude.js"
-        prelude_purs.write_text(data=PRELUDE_PURS, encoding="utf-8")
-        prelude_js.write_text(data=PRELUDE_JS, encoding="utf-8")
-        check_purs = tmpdir / "Check.purs"
-        check_js = tmpdir / "Check.js"
-        check_purs.write_text(data=program, encoding="utf-8")
-        check_js.write_text(data=_CHECK_JS, encoding="utf-8")
-        output_dir = tmpdir / "output"
-        compile_result = subprocess.run(
-            args=[
-                purs,
-                "compile",
-                check_purs.as_posix(),
-                prelude_purs.as_posix(),
-                "-o",
-                output_dir.as_posix(),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: purs compile error\n"
-                f"{compile_result.stdout}{compile_result.stderr}",
-            )
-            sys.stderr.write(f"\nProgram:\n{program}\n")
-            sys.exit(1)
-        run_result = subprocess.run(
-            args=[node, "--input-type=module", "-e", _NODE_DRIVER],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: node run error\n"
-            f"{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="Check.purs",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    purs,
+                    "compile",
+                    "Check.purs",
+                    "Prelude.purs",
+                    "-o",
+                    "output",
+                ],
+                failure_label="purs compile error",
+            ),
+            roundtrip_common.Step(
+                args=[node, "--input-type=module", "-e", _NODE_DRIVER],
+                failure_label="node run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+        extra_files={
+            "Prelude.purs": PRELUDE_PURS,
+            "Prelude.js": PRELUDE_JS,
+            "Check.js": _CHECK_JS,
+        },
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_ruby_roundtrip.py
+++ b/.github/scripts/run_ruby_roundtrip.py
@@ -12,14 +12,9 @@ comparison logic as the other per-language round-trip helpers.
 """
 
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Ruby
 
 _VAR_NAME = "myData"
@@ -28,14 +23,11 @@ _LABEL = "Ruby"
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Ruby program literalized from *json_text*."""
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=Ruby(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -52,28 +44,18 @@ def main() -> None:
     """Round-trip the shared document through the Ruby backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     ruby = shutil.which(cmd="ruby") or "ruby"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        script_path = Path(tmpdir_name) / "main.rb"
-        script_path.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[ruby, str(script_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: ruby runtime error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=(),
+        source_filename="main.rb",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[ruby, "main.rb"],
+                failure_label="ruby runtime error",
+            ),
+        ],
+        excluded_keys=(),
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_rust_roundtrip.py
+++ b/.github/scripts/run_rust_roundtrip.py
@@ -20,16 +20,11 @@ its 26-digit value fits in ``i128`` (which the Rust backend emits) but
 serialization. Same shape as the Go, TypeScript, and Zig exclusions.
 """
 
-import json
 import shutil
-import subprocess
 import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Rust
 
 _VAR_NAME = "my_data"
@@ -39,18 +34,15 @@ _EXCLUDED_KEYS = ("biginteger",)
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Rust program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Rust(json_type=Rust.json_types.SERDE_JSON_VALUE),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=1,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -69,55 +61,33 @@ def main() -> None:
     rustc = shutil.which(cmd="rustc") or "rustc"
     deps_dir = sys.argv[1]
     serde_json_rlib = sys.argv[2]
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        src = tmpdir / "main.rs"
-        src.write_text(data=program, encoding="utf-8")
-        binary = tmpdir / "main"
-        compile_result = subprocess.run(
-            args=[
-                rustc,
-                "--edition",
-                "2021",
-                "-L",
-                f"dependency={deps_dir}",
-                "--extern",
-                f"serde_json={serde_json_rlib}",
-                str(object=src),
-                "-o",
-                str(object=binary),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-        if compile_result.returncode != 0:
-            sys.stderr.write(
-                f"{_LABEL}: rustc error\n"
-                f"{compile_result.stdout}{compile_result.stderr}",
-            )
-            sys.stderr.write(f"\nProgram:\n{program}\n")
-            sys.exit(1)
-        run_result = subprocess.run(
-            args=[str(object=binary)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: run error\n{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.rs",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    rustc,
+                    "--edition",
+                    "2021",
+                    "-L",
+                    f"dependency={deps_dir}",
+                    "--extern",
+                    f"serde_json={serde_json_rlib}",
+                    "main.rs",
+                    "-o",
+                    "main",
+                ],
+                failure_label="rustc error",
+            ),
+            roundtrip_common.Step(
+                args=["./main"],
+                failure_label="run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_scala_roundtrip.py
+++ b/.github/scripts/run_scala_roundtrip.py
@@ -17,14 +17,9 @@ field losslessly via ``noSpaces``, so no top-level keys need excluding.
 """
 
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Scala
 
 _VAR_NAME = "myData"
@@ -34,14 +29,11 @@ _CIRCE_DEP = "io.circe::circe-core:0.14.10"
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Scala program literalized from *json_text*."""
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=Scala(json_type=Scala.JsonTypes.CIRCE),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=1,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -58,40 +50,28 @@ def main() -> None:
     """Round-trip the shared document through the Scala backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     scala_cli = shutil.which(cmd="scala-cli") or "scala-cli"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        (tmpdir / "Main.scala").write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[
-                scala_cli,
-                "run",
-                ".",
-                "-S",
-                "3",
-                "--dep",
-                _CIRCE_DEP,
-                "--main-class",
-                "runRoundtrip",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: scala-cli run error\n"
-            f"{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=(),
+        source_filename="Main.scala",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    scala_cli,
+                    "run",
+                    ".",
+                    "-S",
+                    "3",
+                    "--dep",
+                    _CIRCE_DEP,
+                    "--main-class",
+                    "runRoundtrip",
+                ],
+                failure_label="scala-cli run error",
+            ),
+        ],
+        excluded_keys=(),
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_swift_roundtrip.py
+++ b/.github/scripts/run_swift_roundtrip.py
@@ -18,16 +18,10 @@ compile if the field were kept.  Same shape as the Go, TypeScript and
 Zig exclusions.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Swift
 
 _VAR_NAME = "myData"
@@ -37,18 +31,15 @@ _EXCLUDED_KEYS = ("biginteger",)
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Swift program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Swift(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=1,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -67,30 +58,18 @@ def main() -> None:
     """Round-trip the shared document through the Swift backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     swift = shutil.which(cmd="swift") or "swift"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        (tmpdir / "main.swift").write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[swift, "-swift-version", "5", "main.swift"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: swift run error\n"
-            f"{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.swift",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[swift, "-swift-version", "5", "main.swift"],
+                failure_label="swift run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_typescript_roundtrip.py
+++ b/.github/scripts/run_typescript_roundtrip.py
@@ -19,14 +19,9 @@ the round-trip even with a custom serializer.
 """
 
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import TypeScript
 
 _VAR_NAME = "myData"
@@ -38,14 +33,11 @@ def _build_program(json_text: str) -> str:
     """Return a runnable TypeScript program literalized from
     *json_text*.
     """
-    result = literalize(
-        source=json_text,
-        input_format=InputFormat.JSON,
+    result = roundtrip_common.literalize_new_variable(
         language=TypeScript(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
         pre_indent_level=0,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -59,28 +51,18 @@ def main() -> None:
     """Round-trip the shared document through the TypeScript backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     tsx = shutil.which(cmd="tsx") or "tsx"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        script_path = Path(tmpdir_name) / "main.ts"
-        script_path.write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[tsx, str(script_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: tsx runtime error\n{run_result.stdout}"
-            f"{run_result.stderr}",
-        )
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.ts",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[tsx, "main.ts"],
+                failure_label="tsx runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_zig_roundtrip.py
+++ b/.github/scripts/run_zig_roundtrip.py
@@ -18,16 +18,10 @@ not compile if the field were kept.  Same shape as the Go and
 TypeScript exclusions.
 """
 
-import json
 import shutil
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
 
 import roundtrip_common
 
-from literalizer import InputFormat, NewVariable, literalize
 from literalizer.languages import Zig
 
 _VAR_NAME = "myData"
@@ -68,18 +62,15 @@ fn toJsonValue(allocator: std.mem.Allocator, v: ZVal) !std.json.Value {
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Zig program literalized from *json_text*."""
-    parsed: dict[str, object] = json.loads(s=json_text)
-    for key in _EXCLUDED_KEYS:
-        parsed.pop(key, None)
-    trimmed_json = json.dumps(obj=parsed)
-    result = literalize(
-        source=trimmed_json,
-        input_format=InputFormat.JSON,
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
         language=Zig(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
         pre_indent_level=1,
-        include_delimiters=True,
-        variable_form=NewVariable(name=_VAR_NAME),
-        wrap_in_file=False,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
@@ -104,29 +95,18 @@ def main() -> None:
     """Round-trip the shared document through the Zig backend."""
     program = _build_program(json_text=roundtrip_common.read_input())
     zig = shutil.which(cmd="zig") or "zig"
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = Path(tmpdir_name)
-        (tmpdir / "main.zig").write_text(data=program, encoding="utf-8")
-        run_result = subprocess.run(
-            args=[zig, "run", "main.zig"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=tmpdir,
-            encoding="utf-8",
-        )
-    if run_result.returncode != 0:
-        sys.stderr.write(
-            f"{_LABEL}: zig run error\n{run_result.stdout}{run_result.stderr}",
-        )
-        sys.stderr.write(f"\nProgram:\n{program}\n")
-        sys.exit(1)
-    roundtrip_common.verify(
+    roundtrip_common.execute(
         label=_LABEL,
-        produced_json=run_result.stdout,
-        exclude_keys=_EXCLUDED_KEYS,
+        source_filename="main.zig",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[zig, "run", "main.zig"],
+                failure_label="zig run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
     )
-    sys.stdout.write(f"{_LABEL} round-trip OK\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `trim_keys`, `literalize_new_variable`, and `Step`/`execute` helpers to `.github/scripts/roundtrip_common.py` that collapse the tmpdir + subprocess + verify boilerplate every per-language JSON round-trip script was repeating.
- Rewrites all 22 subprocess-based `run_<lang>_roundtrip.py` scripts to use the shared runner, leaving each one as language-specific program assembly plus a list of `Step`s (net −381 lines).
- Generated programs are byte-identical to before the refactor (diffed for C++, Java, Haskell, Elm, PureScript, Rust, Kotlin); in-process scripts (yaml/toml/json5) are unchanged.

## Test plan

- [ ] CI lint matrix (all `<Lang> roundtrip` steps) still passes
- [ ] Locally verified Ruby, JavaScript, PHP, Perl, Jsonnet round-trips still print `OK`
- [ ] `ruff check`, `pyrefly check`, and the pylint manual stage pass on the modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to GitHub Actions helper scripts; behavior is intended to stay identical, with risk limited to subtle subprocess/cwd or verify wiring regressions in CI.
> 
> **Overview**
> Centralizes duplicated CI JSON round-trip harness code in `roundtrip_common.py` and rewires the per-language `run_*_roundtrip.py` scripts to call it.
> 
> **Shared module:** Adds `trim_keys` (top-level JSON key drops before literalize), `literalize_new_variable` (standard `NewVariable` + JSON literalize shape), frozen `Step` (argv + failure label), and `execute` (write program and optional `extra_files` in a temp dir, run subprocess chain, `verify`, print `"{label} round-trip OK"`).
> 
> **Per-language scripts:** Each subprocess-based round-trip script now mostly builds its program template and passes a `steps` list into `execute`; inline `tempfile`/`subprocess`/`verify`/manual success lines and repeated `json.loads` + key popping + `literalize(...)` calls are removed. Jsonnet still calls `literalize` directly (no named binding) but uses `trim_keys` and `execute` like the rest.
> 
> Net effect is a large line-count reduction with the same workflow: shared `roundtrip_input.json`, language-specific exclusions, compile/run tooling unchanged at the call-site level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e0e9c19a826c0969d97ce1802760473fdb1f82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->