### PR TITLE
Add Dart JSON round-trip check (#2647)

### DIFF
--- a/.github/scripts/run_dart_roundtrip.py
+++ b/.github/scripts/run_dart_roundtrip.py
@@ -1,0 +1,75 @@
+"""Dart JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Dart
+``final my_data = <String, dynamic>{...}`` assignment, wrap it in a
+tiny program that prints ``jsonEncode(my_data)`` from ``dart:convert``,
+run it with ``dart run``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-dart`` job in
+``.github/workflows/lint.yml``, because that job is where the Dart
+toolchain is already installed.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the
+comparison: the literalized program represents the 26-digit value as
+a ``BigInt`` instance, which ``dart:convert``'s ``jsonEncode`` does
+not know how to serialize.  Trimming the field before literalization
+keeps the generated program free of values the standard JSON encoder
+would reject.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Dart
+
+_VAR_NAME = "my_data"
+_LABEL = "Dart"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Dart program literalized from *json_text*."""
+    trimmed = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=Dart(),
+        json_text=trimmed,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "import 'dart:convert';\n"
+        f"{preamble}\n"
+        "void main() {\n"
+        f"  {result.code}\n"
+        f"  print(jsonEncode({_VAR_NAME}));\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Dart backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    dart = shutil.which(cmd="dart") or "dart"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.dart",
+        program=program,
+        steps=(
+            roundtrip_common.Step(
+                args=(dart, "run", "main.dart"),
+                failure_label="dart run error",
+            ),
+        ),
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1803,6 +1803,20 @@ jobs:
           } >> "$driver"
           dart analyze --fatal-infos "$tmpdir"
           (cd "$tmpdir" && dart run main.dart)
+      # `uv` is needed by the `Dart roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Dart -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Dart toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so `import
+      # literalizer` resolves. See
+      # `.github/scripts/run_dart_roundtrip.py`.
+      - name: Dart roundtrip
+        run: uv run python .github/scripts/run_dart_roundtrip.py
 
   lint-julia:
     runs-on: ubuntu-latest

--- a/newsfragments/2647.change
+++ b/newsfragments/2647.change
@@ -1,0 +1,1 @@
+Add a Dart JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Drive the shared `roundtrip_input.json` fixture through `Dart()` and `dart:convert`'s `jsonEncode` so the `lint-dart` CI job verifies a basic JSON -> Dart -> JSON loop.
- Excludes the `biginteger` key: the literalized program represents it as a `BigInt`, which `jsonEncode` cannot serialize. Trimming it before literalization keeps the generated program free of values the standard encoder would reject.

Closes #2647.

## Test plan
- [x] `uv run python .github/scripts/run_dart_roundtrip.py` locally (Dart SDK 3.11.5)
- [ ] `lint-dart` job green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change (workflow + helper script); no application runtime or auth/data-path changes.
> 
> **Overview**
> Adds **Dart** to the shared JSON round-trip CI checks: a new helper **literalizes** `roundtrip_input.json` with the `Dart()` backend, runs a small program that **`jsonEncode`s** the result via `dart:convert`, and compares output through **`roundtrip_common`**.
> 
> The **`lint-dart`** workflow gains **`setup-uv`** and a **Dart roundtrip** step (`uv run python .github/scripts/run_dart_roundtrip.py`) so the check runs where the Dart SDK is already installed. **`biginteger`** is omitted before literalization and from verification because literalized values become **`BigInt`**, which standard **`jsonEncode`** cannot serialize.
> 
> A **newsfragment** records the new CI coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d50466773551cb1f1c681d07513d3b8de6c5294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->