### PR TITLE
Add Groovy JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_groovy_roundtrip.py
+++ b/.github/scripts/run_groovy_roundtrip.py
@@ -1,0 +1,65 @@
+"""Groovy JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Groovy
+``def myData = ...`` declaration, wrap it in a tiny script whose final
+statement prints ``groovy.json.JsonOutput.toJson(myData)``, run it, and
+hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Groovy roundtrip`` step of the
+``lint-jvm-mini`` job in ``.github/workflows/lint.yml``, because that
+job is where the pinned Apache Groovy distribution is installed; it is
+deliberately not a pytest test under ``tests/``.  No separate
+serializer is needed because ``groovy.json.JsonOutput`` (Groovy
+stdlib) already serializes ``Map``/``List``/``BigInteger``/``Number``
+/``String``/``Boolean`` directly.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Groovy
+
+_VAR_NAME = "myData"
+_LABEL = "Groovy"
+
+
+def _build_script(json_text: str) -> str:
+    """Return a runnable Groovy script literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Groovy(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    imports = "\n".join(result.preamble)
+    body_preamble = "\n".join(result.body_preamble)
+    return (
+        "import groovy.json.JsonOutput\n"
+        f"{imports}\n"
+        f"{body_preamble}\n"
+        f"{result.code}\n"
+        f"print JsonOutput.toJson({_VAR_NAME})\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Groovy backend."""
+    program = _build_script(json_text=roundtrip_common.read_input())
+    groovy = shutil.which(cmd="groovy") or "groovy"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="Main.groovy",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[groovy, "Main.groovy"],
+                failure_label="groovy error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1184,6 +1184,21 @@ jobs:
           find tests/integration/cases -name '*.groovy' -print0 > /tmp/files-groovy && test -s /tmp/files-groovy
           groovy .github/scripts/lint-groovy.groovy < /tmp/files-groovy
 
+      # `uv` is needed by the `Groovy roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Groovy -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Groovy toolchain (pinned by the
+      # `Install Groovy` step above); `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_groovy_roundtrip.py`.
+      - name: Groovy roundtrip
+        run: uv run python .github/scripts/run_groovy_roundtrip.py
+
   # Haskell + PureScript share the Haskell toolchain.
   lint-haskell-family:
     runs-on: ubuntu-latest

--- a/newsfragments/1867.change
+++ b/newsfragments/1867.change
@@ -1,1 +1,1 @@
-Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, YAML, Julia, and R JSON round-trip checks to CI using the shared round-trip fixture.
+Add Ruby, TypeScript, Haskell, Perl, PHP, Go, Zig, C#, Scala, Swift, Kotlin, Rust, D, TOML, Elm, OCaml, YAML, Julia, R, and Groovy JSON round-trip checks to CI using the shared round-trip fixture.


### PR DESCRIPTION
Sub-issue #2655 of #1867: applies the Java round-trip pattern to Groovy. Adds `.github/scripts/run_groovy_roundtrip.py`, which literalizes the shared `roundtrip_input.json` to a `def myData = ...` script and pipes it through `groovy.json.JsonOutput.toJson` (stdlib, no hand-rolled serializer). Wires a `Groovy roundtrip` step (plus the `Install uv` step) into the `lint-jvm-mini` job in `.github/workflows/lint.yml`, alongside the existing Groovy toolchain install. Updates the `1867.change` newsfragment to mention Groovy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test harness and workflow steps; no production literalizer or runtime behavior changes.
> 
> **Overview**
> Adds **Groovy** to the shared JSON round-trip CI checks for issue #1867, following the same pattern as Java and other JVM languages.
> 
> A new `.github/scripts/run_groovy_roundtrip.py` literalizes `roundtrip_input.json` to `def myData = ...`, runs a short script that prints `groovy.json.JsonOutput.toJson(myData)` (stdlib serialization, no extra serializer), and verifies output via `roundtrip_common`. The **`lint-jvm-mini`** workflow job gains **`Install uv`** and a **`Groovy roundtrip`** step so the check runs next to the pinned Apache Groovy install. The `1867.change` newsfragment now lists Groovy among the languages covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90dbc0e50a2a6c93fa92e67a9c7d274377baac4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->