### PR TITLE
Add Erlang JSON round-trip check (#2650)

### DIFF
--- a/.github/scripts/run_erlang_roundtrip.py
+++ b/.github/scripts/run_erlang_roundtrip.py
@@ -1,0 +1,92 @@
+"""Erlang JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to an Erlang
+``MyData = #{...},`` map binding, wrap it in an ``escript`` whose
+``main/1`` normalizes Erlang charlist strings/keys to UTF-8 binaries
+and prints ``json:encode(...)`` on standard output, run it under
+``escript``, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Erlang roundtrip`` step of the
+``lint-erlang`` job in ``.github/workflows/lint.yml``, because that job
+is where the Erlang/OTP toolchain is installed.  It shares the same
+input and comparison logic as the other per-language round-trip helpers.
+
+The serializer is OTP 27's built-in ``json`` module rather than a
+hand-rolled encoder (matching the preference expressed in the issue
+notes).  The default ``json`` encoder rejects Erlang charlists as map
+keys and emits charlist string values as arrays of integers, so the
+program first deep-normalizes the literalized data: charlist map keys
+and printable charlist values become UTF-8 binaries, while non-printable
+lists (e.g. ``[1, 2, 3]``) stay lists.  The non-empty guard on
+``io_lib:printable_unicode_list/1`` keeps ``[]`` (an ``empty_array``)
+from being mistakenly converted to ``<<>>``.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Erlang
+
+_VAR_NAME = "myData"
+_LABEL = "Erlang"
+
+_NORMALIZE_AND_ENCODE = """\
+    ok = io:setopts(standard_io, [{encoding, unicode}]),
+    Json = json:encode(normalize(MyData)),
+    ok = io:put_chars(Json).
+
+normalize(M) when is_map(M) ->
+    maps:from_list(
+      [{to_binary_key(K), normalize(V)} || {K, V} <- maps:to_list(M)]);
+normalize(L) when is_list(L) ->
+    case L =/= [] andalso io_lib:printable_unicode_list(L) of
+        true -> unicode:characters_to_binary(L);
+        false -> [normalize(X) || X <- L]
+    end;
+normalize(X) -> X.
+
+to_binary_key(K) when is_list(K) -> unicode:characters_to_binary(K);
+to_binary_key(K) -> K.
+"""
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Erlang escript literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Erlang(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    indented_decl = result.code.replace("\n", "\n    ")
+    return (
+        "#!/usr/bin/env escript\n"
+        "%% -*- coding: utf-8 -*-\n"
+        "\n"
+        "main(_) ->\n"
+        f"    {indented_decl}\n"
+        f"{_NORMALIZE_AND_ENCODE}"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Erlang backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    escript = shutil.which(cmd="escript") or "escript"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.erl",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[escript, "main.erl"],
+                failure_label="escript error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1084,6 +1084,22 @@ jobs:
             Results = [Run(M) || M <- [$modules]],
             case lists:member(error, Results) of true -> halt(1); false -> halt(0) end."
 
+      # `uv` is needed by the `Erlang roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Erlang -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Erlang/OTP toolchain (`escript`
+      # on PATH, OTP 27's built-in `json` module available); `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_erlang_roundtrip.py`.
+      - name: Erlang roundtrip
+        run: uv run python .github/scripts/run_erlang_roundtrip.py
+
   lint-gleam:
     runs-on: ubuntu-latest
     # Every Gleam fixture on disk carries the tag from

--- a/newsfragments/2650.change
+++ b/newsfragments/2650.change
@@ -1,0 +1,1 @@
+Add an Erlang JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Add `.github/scripts/run_erlang_roundtrip.py` that literalizes the shared `roundtrip_input.json` to an escript and re-encodes via OTP 27's built-in `json` module (no hand-rolled serializer); a small `normalize/1` deep-converts Erlang charlists to UTF-8 binaries so `json:encode` accepts string keys and emits strings (not integer arrays).
- Wire `Install uv` + `Erlang roundtrip` steps into the existing `lint-erlang` job in `.github/workflows/lint.yml`, alongside a `newsfragments/2650.change` entry.
- No `excluded_keys`: Erlang bignums handle the 26-digit `biginteger` natively. `io:setopts(standard_io, [{encoding, unicode}])` is set before write so escript stdout under a pipe doesn't latin1-translate the UTF-8 output.

## Test plan
- [ ] CI `lint-erlang` job passes the new `Erlang roundtrip` step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test harness and workflow steps; no production runtime or auth/data-path changes.
> 
> **Overview**
> Adds **Erlang** to the shared JSON round-trip CI checks: a new helper builds an **escript** from `roundtrip_input.json` via the literalizer, deep-normalizes charlist keys/strings for OTP 27’s **`json:encode`**, and compares output with the other language round-trip scripts.
> 
> The **`lint-erlang`** workflow gains **`Install uv`** and an **`Erlang roundtrip`** step (after existing compile/run fixture steps). A **newsfragment** records the user-facing change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dee998c3145f07691bc93d22c4823194cec56e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->