### PR TITLE
Add Lua JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_lua_roundtrip.py
+++ b/.github/scripts/run_lua_roundtrip.py
@@ -1,0 +1,82 @@
+"""Lua JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Lua
+``local my_data = ...`` assignment, wrap it in a tiny script that prints
+``dkjson.encode(my_data)``, run it under ``lua``, and hand the emitted
+JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Lua roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where the Lua toolchain is installed and the ``dkjson`` rock is
+provisioned (``LUA_PATH``/``LUA_CPATH`` are exported there so
+``require "dkjson"`` resolves).  It shares the same input and comparison
+logic as the other per-language round-trip helpers.
+
+Lua has no standard-library JSON serializer; ``dkjson`` is the pure-Lua
+library option, preferred over hand-rolling one per the issue brief.
+
+Three top-level keys are excluded from the comparison:
+
+* ``biginteger`` — its 26-digit value overflows Lua's 64-bit integer so
+  the literalized program parses the literal as a ``double`` (``1e+26``),
+  same shape as the Go, TypeScript, Zig, Swift, Rust, D, and C++
+  exclusions.
+* ``float_large_exponent`` — Lua 5.4's default float-to-string format
+  is ``%.14g``, which rounds ``1.7976931348623157e+308`` down to
+  ``1.7976931348623e+308`` and loses the trailing significant digits;
+  ``dkjson`` uses ``tostring`` for number encoding so it inherits that
+  precision floor.
+* ``empty_object`` — Lua represents both arrays and objects as bare
+  tables and an empty ``{}`` is genuinely ambiguous, so ``dkjson``
+  serializes the empty-object value as ``[]`` instead of ``{}``.  Same
+  shape as the R exclusion.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Lua
+
+_VAR_NAME = "my_data"
+_LABEL = "Lua"
+_EXCLUDED_KEYS = ("biginteger", "float_large_exponent", "empty_object")
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Lua program literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Lua(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        'local json = require "dkjson"\n'
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"io.write(json.encode({_VAR_NAME}))\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Lua backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    lua = shutil.which(cmd="lua") or "lua"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.lua",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[lua, "main.lua"],
+                failure_label="lua runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,6 +77,19 @@ jobs:
         uses: leafo/gh-actions-lua@v13
         with:
           luaVersion: '5.4'
+      # ``luarocks`` is needed by the ``Lua roundtrip`` step below to
+      # install the ``dkjson`` JSON library; Lua has no standard-library
+      # JSON serializer.  Pinned to a recent ``leafo/gh-actions-luarocks``
+      # release; the action picks the LuaRocks version compatible with
+      # the Lua installed above.  See ``.github/scripts/run_lua_roundtrip.py``.
+      - name: Install LuaRocks
+        uses: leafo/gh-actions-luarocks@v5
+      # ``dkjson`` is the pure-Lua JSON library used by
+      # ``.github/scripts/run_lua_roundtrip.py``; pinned to a ``2.x``
+      # release.  Installed into the per-job tree provisioned above so
+      # ``require "dkjson"`` resolves under the ``Lua roundtrip`` step.
+      - name: Install dkjson
+        run: luarocks install dkjson 2.10-1
       # The pinned Nix ``2.34.7`` is in the Nix 2.x series, which is
       # ``>=`` the ``V2`` default of ``Nix.language_version`` in
       # ``src/literalizer/languages/nix.py``; keep them in sync. ``V2``
@@ -362,6 +375,15 @@ jobs:
           find tests/integration/cases -name '*.lua' -print0 > /tmp/files-lua && test -s /tmp/files-lua
           xargs -0 luac -p < /tmp/files-lua
           xargs -0 -P "$(nproc)" -n1 lua < /tmp/files-lua
+
+      # Basic JSON -> Lua -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Lua toolchain (pinned by the
+      # `Install Lua` step above) and the `dkjson` rock provisioned by
+      # the `Install dkjson` step; `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_lua_roundtrip.py`.
+      - name: Lua roundtrip
+        run: uv run python .github/scripts/run_lua_roundtrip.py
 
       - name: Lint Nix
         run: |-

--- a/newsfragments/2662.change
+++ b/newsfragments/2662.change
@@ -1,0 +1,1 @@
+Add a Lua JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalize the shared `roundtrip_input.json` to a Lua `local my_data = ...` block, run it under `lua`, and re-serialize with `dkjson.encode` for comparison via `roundtrip_common.verify`.
- Wire into the `lint-fast` job: install LuaRocks (`leafo/gh-actions-luarocks@v5`) next to the existing Lua install, install `dkjson 2.10-1`, and add a `Lua roundtrip` step after `Lint Lua`.
- Exclude `biginteger` (overflows Lua's 64-bit int), `float_large_exponent` (Lua 5.4's default `%.14g` tostring drops trailing significant digits), and `empty_object` (Lua/dkjson cannot disambiguate `{}` from an array — same shape as the R exclusion).

Closes #2662.

## Test plan
- [ ] CI `lint-fast` job passes (new `Install LuaRocks`, `Install dkjson`, and `Lua roundtrip` steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change extending an existing round-trip pattern; no runtime product or auth/data paths affected.
> 
> **Overview**
> Adds a **Lua** path to the shared JSON round-trip CI checks: literalize `roundtrip_input.json` with the existing `Lua` literalizer, run under Lua 5.4, re-encode with **dkjson**, and compare via `roundtrip_common` (same pattern as Ruby/JS/etc.).
> 
> The **`lint-fast`** job now installs **LuaRocks** and pins **dkjson 2.10-1**, then runs `uv run python .github/scripts/run_lua_roundtrip.py` after **Lint Lua**. Comparison skips **`biginteger`**, **`float_large_exponent`**, and **`empty_object`** for Lua number/table limits documented in the script.
> 
> A **newsfragment** records the CI addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09cb1d5e799b097a5afbe85369c853536cac2537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->