### PR TITLE
Add Nim JSON round-trip check (#2665)

### DIFF
--- a/.github/scripts/run_nim_roundtrip.py
+++ b/.github/scripts/run_nim_roundtrip.py
@@ -1,0 +1,81 @@
+"""Nim JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Nim
+``var myData: JsonNode = %*(...)`` declaration via the
+``json_type=JSON_NODE`` strategy, wrap it in a tiny program that prints
+``$myData`` (Nim's ``$`` for :class:`json.JsonNode` emits JSON), compile
+and run it under ``nim c -r``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Nim roundtrip`` step of the
+``lint-nim`` job in ``.github/workflows/lint.yml``, because that job is
+where the Nim toolchain is installed.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+The serializer is Nim's standard-library ``std/json`` module rather
+than a hand-rolled encoder (matching the preference expressed in the
+issue notes).
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value overflows Nim's widest integer type, so the
+literalizer rejects the value with
+:class:`literalizer.exceptions.UnrepresentableIntegerError` before the
+program is even produced.  Same shape as the Go, TypeScript, Zig,
+Swift, Rust, D, and C++ exclusions.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Nim
+
+_VAR_NAME = "myData"
+_LABEL = "Nim"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Nim program literalized from *json_text*."""
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=Nim(json_type=Nim.json_types.JSON_NODE),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n{result.code}\nstdout.write(${_VAR_NAME})\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the Nim backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    nim = shutil.which(cmd="nim") or "nim"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.nim",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    nim,
+                    "c",
+                    "-r",
+                    "--hints:off",
+                    "--warnings:off",
+                    "--nimcache:.",
+                    "main.nim",
+                ],
+                failure_label="nim c -r error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2330,6 +2330,21 @@ jobs:
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-nim.sh < /tmp/files-to-lint
 
+      # ``uv`` is needed by the ``Nim roundtrip`` step below; it runs
+      # the helper in project mode so ``import literalizer`` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Nim -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Nim toolchain (pinned by the
+      # ``Install Nim`` step above); ``uv run`` (project mode, not
+      # ``--no-project``) is required so ``import literalizer`` resolves.
+      # See ``.github/scripts/run_nim_roundtrip.py``.
+      - name: Nim roundtrip
+        run: uv run python .github/scripts/run_nim_roundtrip.py
+
   lint-python:
     runs-on: ubuntu-latest
     steps:

--- a/newsfragments/2665.change
+++ b/newsfragments/2665.change
@@ -1,0 +1,1 @@
+Add a Nim JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary

- Adds a Nim JSON round-trip check (issue #2665, sub-issue of #1867), modeled on the Erlang/Lua scripts.
- Literalizes the shared `roundtrip_input.json` to a Nim `var myData: JsonNode = %*(...)` binding via `json_type=JSON_NODE`, runs it under `nim c -r`, and serializes back with `$myData` (`std/json`'s built-in `$` emits JSON).
- Wired into the existing `lint-nim` job (already provisions the pinned Nim toolchain).
- Excludes `biginteger` from the comparison: its 26-digit value overflows Nim's widest integer type and the literalizer rejects it before the program is produced (same shape as the Go/Rust/Swift/D/Zig/C++ exclusions). No other exclusions are needed; `float_large_exponent`, `negative_zero`, and `empty_object` all round-trip cleanly.

## Test plan

- [x] `uv run --extra dev python .github/scripts/run_nim_roundtrip.py` locally with Nim 2.2.10 → `Nim round-trip OK`.
- [ ] CI `lint-nim` job's new `Nim roundtrip` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition following existing round-trip script patterns; no production runtime or auth/data-path changes.
> 
> **Overview**
> Adds **Nim** to the shared JSON round-trip CI checks: a new `.github/scripts/run_nim_roundtrip.py` helper literalizes `roundtrip_input.json` to `JsonNode` via `%*`, compiles/runs with `nim c -r`, and compares output using `roundtrip_common` (serialization via `$myData` / `std/json`).
> 
> The **`lint-nim`** workflow job now installs **uv** and runs **`uv run python .github/scripts/run_nim_roundtrip.py`** after the existing Nim fixture lint step. The comparison **drops `biginteger`** from the fixture (same overflow/literalizer limitation as several other language round-trips).
> 
> A **newsfragment** records the CI addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4202ea7d70abae4b283d84ceda6ad06a9267e3ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->