### PR TITLE
Add HCL JSON round-trip check (#2657)

### DIFF
--- a/.github/scripts/run_hcl_roundtrip.py
+++ b/.github/scripts/run_hcl_roundtrip.py
@@ -1,0 +1,89 @@
+"""HCL JSON round-trip check (issue #2657).
+
+Literalize the shared ``roundtrip_input.json`` document to an HCL
+``myData = { ... }`` attribute, parse the resulting HCL document with
+``hcl2json``, then re-serialize the inner value as JSON and hand it to
+:func:`roundtrip_common.verify`.
+
+Unlike the executable-language round-trips, there is no language
+runtime to invoke: the analogous "back to JSON" step is the
+``hcl2json`` parser re-emitting the parsed value.  ``hcl2json`` is the
+same binary the ``Lint Hcl`` syntax check uses, so the pinned
+toolchain in the ``lint-go-installed`` job already provides it; no
+extra install step is needed.
+
+This lives here, driven by the ``Hcl roundtrip`` step of the
+``lint-go-installed`` job in ``.github/workflows/lint.yml``, alongside
+the existing ``Lint Hcl`` syntax check that uses the same ``hcl2json``
+dependency.  It shares the same input and comparison logic as the
+other per-language round-trip helpers.
+
+``float_large_exponent`` is excluded from the comparison because
+``hcl2json`` emits ``1.7976931348623157e+308`` as a fully-expanded
+309-digit integer literal in its JSON output, and parsing that integer
+back through Python's ``json`` yields a value that does not compare
+equal to the original ``float`` (large ints are not equal to floats of
+the same magnitude when the rounded conversion would lose bits).
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import roundtrip_common
+
+from literalizer.languages import Hcl
+
+_VAR_NAME = "myData"
+_LABEL = "HCL"
+_EXCLUDED_KEYS = ("float_large_exponent",)
+
+
+def _build_document(json_text: str) -> str:
+    """Return an HCL document literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Hcl(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    return f"{result.code}\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the HCL backend."""
+    document = _build_document(json_text=roundtrip_common.read_input())
+    hcl2json = shutil.which(cmd="hcl2json") or "hcl2json"
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        source_path = Path(tmpdir_name) / "main.hcl"
+        source_path.write_text(data=document, encoding="utf-8")
+        completed = subprocess.run(
+            args=[hcl2json, str(object=source_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            encoding="utf-8",
+        )
+    if completed.returncode != 0:
+        sys.stderr.write(
+            f"{_LABEL}: hcl2json error\n"
+            f"{completed.stdout}{completed.stderr}"
+            f"\nProgram:\n{document}\n",
+        )
+        sys.exit(1)
+    parsed: dict[str, object] = json.loads(s=completed.stdout)
+    inner = parsed[_VAR_NAME]
+    produced_json = json.dumps(obj=inner)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=produced_json,
+        exclude_keys=_EXCLUDED_KEYS,
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -649,6 +649,13 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.hcl' -print0 > /tmp/files-hcl && test -s /tmp/files-hcl
           xargs -0 -P "$(nproc)" -n1 hcl2json < /tmp/files-hcl > /dev/null
+      # Basic JSON -> HCL -> JSON round-trip (issue 2657). Runs here
+      # because this is the job with the `hcl2json` binary (from the
+      # `go install` above) already on PATH; `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_hcl_roundtrip.py`.
+      - name: Hcl roundtrip
+        run: uv run python .github/scripts/run_hcl_roundtrip.py
 
   # Json5 + Norg + TypeScript syntax check. The Run-TypeScript and Elm
   # passes are split into sibling jobs (`lint-typescript-run`, `lint-elm`)

--- a/newsfragments/2657.change
+++ b/newsfragments/2657.change
@@ -1,0 +1,1 @@
+Add an HCL JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/run_hcl_roundtrip.py`, which literalizes the shared `roundtrip_input.json` to an HCL `myData = { ... }` attribute, parses the result with `hcl2json`, and verifies the inner value matches the original (excluding `float_large_exponent`, which `hcl2json` expands to a 309-digit integer literal that no longer compares equal to the source float).
- Wires it into the `lint-go-installed` job in `.github/workflows/lint.yml` alongside the existing `Lint Hcl` syntax check, since that job already installs `hcl2json` and exposes `uv`.
- Adds `newsfragments/2657.change`.

## Test plan
- [ ] CI `lint-go-installed` job passes the new `Hcl roundtrip` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no production code or auth/data-path changes; reuses existing tooling and shared round-trip helpers.
> 
> **Overview**
> Adds CI coverage that the HCL literalizer round-trips the shared `roundtrip_input.json` fixture: JSON is emitted as an HCL `myData` attribute, parsed with **`hcl2json`**, and compared via **`roundtrip_common.verify`** (same pattern as Jsonnet and other language round-trip scripts).
> 
> A new **`Hcl roundtrip`** step runs in the **`lint-go-installed`** job right after **`Lint Hcl`**, reusing the existing `hcl2json` install and `uv run` for `literalizer`. Comparison skips **`float_large_exponent`** because `hcl2json` can expand that float to a huge integer literal that no longer matches the source float in Python JSON parsing.
> 
> Changelog: **`newsfragments/2657.change`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a5bdbfaf8980241b797454b496d9810bb30a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->