### PR TITLE
Add F# JSON round-trip check (#2653)

### DIFF
--- a/.github/scripts/run_fsharp_roundtrip.py
+++ b/.github/scripts/run_fsharp_roundtrip.py
@@ -1,0 +1,128 @@
+r"""F# JSON round-trip check (issue #2653).
+
+Literalize the shared ``roundtrip_input.json`` document to an F#
+``let my_data : Val = ...`` binding (with the generated tagged ``Val``
+discriminated union), append a small ``writeVal`` mapping that walks
+each constructor into the built-in :class:`System.Text.Json.Utf8JsonWriter`,
+evaluate the script under ``dotnet fsi``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-dotnet`` job in
+``.github/workflows/lint.yml``, because that job is where the .NET
+toolchain (which ships ``dotnet fsi`` and ``System.Text.Json``) is
+already provisioned.  It shares the same input and comparison logic as
+the other per-language round-trip helpers.
+
+F#'s standard environment ships ``System.Text.Json`` (no NuGet install
+required), so we route through that rather than hand-rolling a JSON
+encoder, matching the issue brief's preference for built-in libraries.
+``Utf8JsonWriter`` has no automatic mapping for the generated ``Val``
+discriminated union, so a tiny ``writeVal`` ``match`` translates each
+constructor into the writer's ``WriteBooleanValue`` / ``WriteNumberValue``
+/ ``WriteStringValue`` / ``WriteStartArray`` / ``WriteStartObject`` calls.
+``JavaScriptEncoder.UnsafeRelaxedJsonEscaping`` disables the default
+HTML-safe ``\\u00xx`` escapes so non-ASCII strings round-trip as their
+literal UTF-8 bytes.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value exceeds F#'s 64-bit ``int64``, so the literalizer
+would emit a ``bigint`` literal that ``Utf8JsonWriter.WriteNumberValue``
+has no overload for.  Same shape as the Go, OCaml, TypeScript, Swift,
+Zig, Rust, and D exclusions.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import FSharp
+
+_VAR_NAME = "my_data"
+_LABEL = "FSharp"
+_EXCLUDED_KEYS = ("biginteger",)
+
+_WRITE_VAL = """\
+open System.IO
+open System.Text.Json
+
+let rec writeVal (writer: Utf8JsonWriter) (v: Val) =
+    match v with
+    | FBool b -> writer.WriteBooleanValue(b)
+    | FInt i -> writer.WriteNumberValue(i)
+    | FFloat f -> writer.WriteNumberValue(f)
+    | FStr s -> writer.WriteStringValue(s)
+    | FList xs ->
+        writer.WriteStartArray()
+        for x in xs do writeVal writer x
+        writer.WriteEndArray()
+    | FMap kvs ->
+        writer.WriteStartObject()
+        for (k, v) in kvs do
+            writer.WritePropertyName(k)
+            writeVal writer v
+        writer.WriteEndObject()
+
+let _stream = new MemoryStream()
+let _opts =
+    JsonWriterOptions(
+        Encoder =
+            System.Text.Encodings.Web
+                .JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    )
+let _writer = new Utf8JsonWriter(_stream, _opts)
+writeVal _writer my_data
+_writer.Flush()
+let _stdout = System.Console.OpenStandardOutput()
+_stream.WriteTo(_stdout)
+_stdout.Flush()
+"""
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable F# script literalized from *json_text*."""
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=FSharp(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    # ``FSharp.literalize`` already inlines ``result.body_preamble``
+    # (the ``type Val`` declaration) at the top of ``result.code``,
+    # so we only join ``preamble`` (currently empty) with ``code``
+    # here. Prepending ``body_preamble`` separately would duplicate
+    # the ``Val`` type and break compilation.
+    preamble = "\n".join(result.preamble)
+    return f"{preamble}\n{result.code}\n{_WRITE_VAL}"
+
+
+def main() -> None:
+    """Round-trip the shared document through the F# backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    dotnet = shutil.which(cmd="dotnet") or "dotnet"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.fsx",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    dotnet,
+                    "fsi",
+                    "--nologo",
+                    "--langversion:8.0",
+                    "--exec",
+                    "main.fsx",
+                ],
+                failure_label="dotnet fsi error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -990,6 +990,14 @@ jobs:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 \
             dotnet fsi --nologo --langversion:8.0 --exec "$driver"
 
+      # Basic JSON -> F# -> JSON round-trip (issue 2653). Runs here
+      # because this is the job with the .NET toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_fsharp_roundtrip.py`.
+      - name: FSharp roundtrip
+        run: uv run python .github/scripts/run_fsharp_roundtrip.py
+
   lint-sml:
     runs-on: ubuntu-latest
     steps:

--- a/newsfragments/2653.change
+++ b/newsfragments/2653.change
@@ -1,0 +1,1 @@
+Add an F# JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- New `.github/scripts/run_fsharp_roundtrip.py` literalizes the shared `roundtrip_input.json` to an F# script, walks the generated `Val` discriminated union into `System.Text.Json.Utf8JsonWriter` (built-in, no NuGet), and evaluates it under `dotnet fsi`.
- Wired into the existing `lint-dotnet` job in `.github/workflows/lint.yml` (the .NET toolchain is already provisioned there).
- Excludes only `biginteger` from the comparison: its 26-digit value exceeds F#'s `int64` and would force a `bigint` literal that `Utf8JsonWriter.WriteNumberValue` has no overload for.

## Test plan
- [ ] CI `lint-dotnet` job's `FSharp roundtrip` step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition following established round-trip patterns; no production literalizer or runtime behavior changes.
> 
> **Overview**
> Adds **CI coverage for F# JSON round-tripping** (issue #2653), aligned with the existing per-language `run_*_roundtrip.py` helpers.
> 
> A new **`.github/scripts/run_fsharp_roundtrip.py`** literalizes the shared `roundtrip_input.json` into an F# script (`let my_data : Val = ...` plus the generated `Val` DU), appends a hand-written **`writeVal`** that serializes each DU case through **`System.Text.Json.Utf8JsonWriter`** (with relaxed JSON escaping for Unicode), runs it via **`dotnet fsi --langversion:8.0`**, and compares stdout with **`roundtrip_common.verify`**. The script documents that **`body_preamble` must not be duplicated** when assembling the program, since the F# literalizer already inlines the `Val` type in `result.code`.
> 
> The **`lint-dotnet`** job gains an **`FSharp roundtrip`** step (`uv run python .github/scripts/run_fsharp_roundtrip.py`) immediately after **`Lint FSharp`**, reusing the job’s .NET toolchain. Comparison **drops only `biginteger`**, because the fixture value does not fit **`int64`** / `WriteNumberValue` without `bigint`.
> 
> A **newsfragment** records the user-facing change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657ed637bfa8660ed2f26848185829e2e99b5eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->