### PR TITLE
Add Raku JSON round-trip check (#2675)

### DIFF
--- a/.github/scripts/run_raku_roundtrip.py
+++ b/.github/scripts/run_raku_roundtrip.py
@@ -1,0 +1,68 @@
+"""Raku JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Raku
+``my $my_data = ...;`` declaration, wrap it in a tiny script that prints
+``to-json($my_data)``, run it under ``raku``, and hand the emitted JSON
+to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Raku roundtrip`` step of the
+``lint-raku`` job in ``.github/workflows/lint.yml``, because that job is
+where the pinned Rakudo toolchain is installed and the ``JSON::Fast``
+module is provisioned via ``zef``.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+``JSON::Fast`` is the standard Raku JSON library, preferred over
+hand-rolling one per the issue brief.  Rakudo Int is arbitrary
+precision so the 26-digit ``biginteger`` value round-trips without an
+exclusion (same shape as the Erlang case), and Hash and Array are
+distinct types so ``empty_object`` ``{}`` survives the round-trip.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Raku
+
+_VAR_NAME = "my_data"
+_LABEL = "Raku"
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Raku program literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Raku(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "use v6.d;\n"
+        "use JSON::Fast;\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"print to-json(${_VAR_NAME}, :!pretty);\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Raku backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    raku = shutil.which(cmd="raku") or "raku"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.raku",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[raku, "main.raku"],
+                failure_label="raku runtime error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2413,10 +2413,32 @@ jobs:
         uses: Raku/setup-raku@v1
         with:
           raku-version: ${{ env.RAKU_VERSION }}
+      # ``JSON::Fast`` is the standard Raku JSON library used by the
+      # ``Raku roundtrip`` step below; Rakudo has no standard-library
+      # JSON serializer.  ``--/test`` skips the module's own test suite
+      # to keep the install fast.  See
+      # ``.github/scripts/run_raku_roundtrip.py``.
+      - name: Install JSON::Fast
+        run: zef install --/test JSON::Fast
       - name: Check Raku syntax
         run: xargs -0 -P "$(nproc)" -n1 raku -c < /tmp/files-to-lint
       - name: Run Raku files
         run: xargs -0 -P "$(nproc)" -n1 raku < /tmp/files-to-lint
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
+      # Basic JSON -> Raku -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Raku toolchain (pinned by the
+      # `Install Raku` step above) and ``JSON::Fast`` provisioned by the
+      # `Install JSON::Fast` step; `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_raku_roundtrip.py`.
+      - name: Raku roundtrip
+        run: uv run python .github/scripts/run_raku_roundtrip.py
 
   lint-zig:
     runs-on: ubuntu-latest

--- a/newsfragments/2675.change
+++ b/newsfragments/2675.change
@@ -1,0 +1,1 @@
+Add a Raku JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Literalizes the shared `roundtrip_input.json` to a Raku `my $my_data = ...;` declaration via `Raku()`, runs it under `raku` with `JSON::Fast`, and verifies the emitted JSON matches the input.
- Adds a `zef install --/test JSON::Fast` step and a `Raku roundtrip` step to the existing `lint-raku` job (with `astral-sh/setup-uv@v8.1.0` so `import literalizer` resolves under `uv run`).
- No keys are excluded: Rakudo's `Int` is arbitrary precision so `biginteger` round-trips (matching Erlang), and `Hash` and `Array` are distinct types so `empty_object` survives.

## Test plan
- [ ] CI `lint-raku` job passes, including the new `Raku roundtrip` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition following established round-trip scripts; no production runtime or auth/data-path changes.
> 
> **Overview**
> Adds **CI coverage** so the shared `roundtrip_input.json` fixture is literalized to Raku, executed with **`JSON::Fast`** (`to-json`), and compared via the existing `roundtrip_common` helpers—same pattern as other language `run_*_roundtrip.py` scripts.
> 
> In **`lint-raku`**, the workflow now **`zef install --/test JSON::Fast`**, installs **`uv`**, and runs **`uv run python .github/scripts/run_raku_roundtrip.py`**. The helper uses **`excluded_keys=()`** (full fixture compare, including large integers and empty objects). A **newsfragment** records the user-facing change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 183454235e780be8e819bd83807aa63862931392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->