### PR TITLE
Add Racket JSON round-trip check (#1867)

### DIFF
--- a/.github/scripts/run_racket_roundtrip.py
+++ b/.github/scripts/run_racket_roundtrip.py
@@ -1,0 +1,80 @@
+"""Racket JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Racket
+``(define my-data ...)`` binding, wrap it in a tiny ``#lang racket``
+module that normalizes the literalized value into a Racket JSON
+``jsexpr?`` and prints ``write-json`` on standard output, run it under
+``racket``, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Racket roundtrip`` step of the
+``lint-racket`` job in ``.github/workflows/lint.yml``, because that job
+is where the Racket toolchain is installed.  It shares the same input
+and comparison logic as the other per-language round-trip helpers.
+
+The serializer is Racket's built-in ``json`` module rather than a
+hand-rolled encoder (matching the preference expressed in the issue
+notes).  The ``json`` module's ``write-json`` requires JSON objects to
+be hash tables keyed by symbols, but the literalized output uses string
+keys (Racket dicts support arbitrary keys), so the program first walks
+the value: every ``hash?`` is rebuilt as a ``hasheq`` with
+``string->symbol`` keys, and lists/atoms pass through.  No top-level
+keys are excluded: Racket has arbitrary-precision integers (so the
+26-digit ``biginteger`` survives) and ``write-json`` emits inexact reals
+via ``number->string``, which round-trips ``1.7976931348623157e+308``
+and ``-0.0`` exactly.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Racket
+
+_VAR_NAME = "my-data"
+_LABEL = "Racket"
+
+_NORMALIZE_AND_WRITE = """\
+(define (->jsexpr v)
+  (cond
+    [(hash? v)
+     (for/hasheq ([(k val) (in-hash v)])
+       (values (string->symbol k) (->jsexpr val)))]
+    [(list? v) (map ->jsexpr v)]
+    [else v]))
+
+(write-json (->jsexpr my-data))
+"""
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Racket program literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Racket(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n(require json)\n{result.code}\n{_NORMALIZE_AND_WRITE}"
+
+
+def main() -> None:
+    """Round-trip the shared document through the Racket backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    racket = shutil.which(cmd="racket") or "racket"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.rkt",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[racket, "main.rkt"],
+                failure_label="racket runtime error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2391,6 +2391,20 @@ jobs:
         run: xargs -0 raco make < /tmp/files-to-lint
       - name: Run Racket files
         run: xargs -0 -P "$(nproc)" -n1 racket < /tmp/files-to-lint
+      # `uv` is needed by the `Racket roundtrip` step below; it runs
+      # the helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Racket -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Racket toolchain (`racket` on
+      # PATH, the built-in `json` module available); `uv run` (project
+      # mode, not `--no-project`) is required so `import literalizer`
+      # resolves. See `.github/scripts/run_racket_roundtrip.py`.
+      - name: Racket roundtrip
+        run: uv run python .github/scripts/run_racket_roundtrip.py
 
   lint-raku:
     runs-on: ubuntu-latest

--- a/newsfragments/2674.change
+++ b/newsfragments/2674.change
@@ -1,0 +1,1 @@
+Add a Racket JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary

Closes #2674. Literalizes the shared `roundtrip_input.json` to a Racket program via `Racket()`, runs it under `racket`, and serializes back to JSON with the built-in `json` module's `write-json` (preferred over a hand-rolled encoder per the issue brief). The literalized output uses string-keyed `hash`es, so the program walks the value and rebuilds each hash as a `hasheq` with `string->symbol` keys before encoding. No top-level keys are excluded: Racket's bignums handle the 26-digit `biginteger` and `write-json` round-trips `1.7976931348623157e+308` and `-0.0` exactly. Wired into the existing `lint-racket` job (Racket toolchain already installed there) with an added `uv` setup step.

## Test plan

- [ ] `lint-racket` job passes in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and script following existing per-language round-trip helpers; no auth, data paths, or literalizer runtime behavior changes beyond the new check.
> 
> **Overview**
> Adds **Racket** to the shared JSON round-trip CI checks: literalize `roundtrip_input.json` with `Racket()`, run under `racket`, and compare stdout JSON via `roundtrip_common`.
> 
> The new helper `.github/scripts/run_racket_roundtrip.py` rebuilds string-keyed literalized hashes into `hasheq` with symbol keys so the built-in `json` module’s `write-json` can emit JSON (no top-level key exclusions). **`lint-racket`** gains `setup-uv` and a **Racket roundtrip** step (`uv run python .github/scripts/run_racket_roundtrip.py`). Changelog: `newsfragments/2674.change`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5138b43aab4ab77151d00593054ae85f4dc6124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->