### PR TITLE
Add Clojure JSON round-trip check (#2642)

### DIFF
--- a/.github/scripts/run_clojure_roundtrip.py
+++ b/.github/scripts/run_clojure_roundtrip.py
@@ -1,0 +1,67 @@
+"""Clojure JSON round-trip check (issue #2642).
+
+Literalize the shared ``roundtrip_input.json`` document to a Clojure
+``(def my-data ...)`` form, wrap it in a tiny script that prints
+``cheshire.core/generate-string`` of that value, run it under
+``bb`` (Babashka), and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Clojure roundtrip`` step of the
+``lint-jvm-mini`` job in ``.github/workflows/lint.yml``, because that is
+the job where Babashka is installed (pinned by the
+``Install clj-kondo and Babashka`` step).  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+``cheshire.core`` ships built in with Babashka and is the de-facto
+Clojure JSON library, so no extra rock/dependency install is needed and
+no hand-rolled serializer is involved (per the issue brief, which
+prefers a built-in/library serializer).
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Clojure
+
+_VAR_NAME = "my-data"
+_LABEL = "Clojure"
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Clojure program literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Clojure(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        "(require '[cheshire.core :as json])\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"(print (json/generate-string {_VAR_NAME}))\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Clojure backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    bb = shutil.which(cmd="bb") or "bb"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.clj",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[bb, "main.clj"],
+                failure_label="bb runtime error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1222,13 +1222,24 @@ jobs:
           find tests/integration/cases -name '*.groovy' -print0 > /tmp/files-groovy && test -s /tmp/files-groovy
           groovy .github/scripts/lint-groovy.groovy < /tmp/files-groovy
 
-      # `uv` is needed by the `Groovy roundtrip` step below; it runs the
-      # helper in project mode so `import literalizer` resolves.
+      # `uv` is needed by the `Clojure roundtrip` and `Groovy roundtrip`
+      # steps below; they run their helpers in project mode so
+      # `import literalizer` resolves.
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Clojure -> JSON round-trip (issue 2642). Runs here
+      # because this is the job with Babashka (pinned by the
+      # `Install clj-kondo and Babashka` step above); `cheshire.core`
+      # ships built in with Babashka so no extra rock is needed.
+      # `uv run` (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves.
+      # See `.github/scripts/run_clojure_roundtrip.py`.
+      - name: Clojure roundtrip
+        run: uv run python .github/scripts/run_clojure_roundtrip.py
+
       # Basic JSON -> Groovy -> JSON round-trip (issue 1867). Runs here
       # because this is the job with the Groovy toolchain (pinned by the
       # `Install Groovy` step above); `uv run` (project mode, not

--- a/newsfragments/2642.change
+++ b/newsfragments/2642.change
@@ -1,0 +1,1 @@
+Add a Clojure JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/run_clojure_roundtrip.py`, literalizing the shared `roundtrip_input.json` to a Clojure `(def my-data ...)` form, running it under `bb`, and serializing back via `cheshire.core/generate-string`.
- Wires a `Clojure roundtrip` step into `lint-jvm-mini` alongside the existing Groovy round-trip; `cheshire.core` ships built in with Babashka so no extra rock install is needed and no keys are excluded.
- Towncrier fragment `newsfragments/2642.change`.

## Test plan
- [ ] CI `lint-jvm-mini` passes (Clojure round-trip step + existing Clojure lint/run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI and changelog; no runtime or library behavior changes.
> 
> **Overview**
> Adds **CI coverage** for Clojure JSON literalization by round-tripping the shared `roundtrip_input.json` fixture: a new helper builds a Babashka script from literalized `(def my-data ...)`, serializes with built-in **cheshire**, and compares output via the same `roundtrip_common` path as other languages.
> 
> The **`lint-jvm-mini`** workflow gains a **Clojure roundtrip** step (after `uv` install, alongside Groovy), chosen because Babashka is already pinned there—no extra JSON dependency. A **towncrier** fragment records the user-facing change for #2642.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241b6685d65ec9bfe5aa948e9082542845b895f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->