### PR TITLE
Add Tcl JSON round-trip check (#2680)

### DIFF
--- a/.github/scripts/run_tcl_roundtrip.py
+++ b/.github/scripts/run_tcl_roundtrip.py
@@ -1,0 +1,138 @@
+"""Tcl JSON round-trip check (issue #2680).
+
+Literalize the shared ``roundtrip_input.json`` document to a Tcl
+``set myData [dict create ...]`` binding, wrap it in a ``tclsh`` script
+that re-emits JSON on standard output via tcllib's ``json::write``, run
+it under ``tclsh``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Tcl roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where the ``tcl`` and ``tcllib`` apt packages are installed.  It shares
+the same input and comparison logic as the other per-language round-trip
+helpers.
+
+Tcl is type-less (every value is a string), so a generic encoder cannot
+tell a dict from a same-shape list, or a literalized boolean (``1``/
+``0``) from an integer.  ``tcllib``'s ``json::write`` is a *constructor*
+library: ``json::write string``, ``json::write array``, ``json::write
+object`` build typed fragments, but the caller still has to know each
+value's JSON type.  This script therefore drives ``json::write`` along
+the *known* JSON shape: Python walks the parsed input and emits a single
+nested ``json::write`` expression whose leaves read scalars out of the
+literalized ``$myData`` via ``dict get`` / ``lindex``.  Tcl preserves
+the textual rep of un-shimmered numeric scalars stored in a ``dict``, so
+wide integers and large exponents round-trip without needing the
+precision-loss exclusions seen in the typed-language scripts.
+"""
+
+import json
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Tcl
+
+# `json.loads` returns this recursive shape; typing the walker against
+# it lets `isinstance` narrow cleanly under pyright, pyrefly, and ty
+# without `cast`.
+type JsonValue = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["JsonValue"]
+    | dict[str, "JsonValue"]
+)
+
+_VAR_NAME = "myData"
+_LABEL = "Tcl"
+
+_HEADER = """\
+package require json::write
+json::write indented 0
+json::write aligned 0
+fconfigure stdout -encoding utf-8 -translation lf
+"""
+
+
+def _emit_array(*, items: list[JsonValue], path_expr: str) -> str:
+    """Return a Tcl expression that yields a JSON array for *items*."""
+    parts = [
+        _emit(value=item, path_expr=f"[lindex {path_expr} {index}]")
+        for index, item in enumerate(iterable=items)
+    ]
+    return f"[json::write array {' '.join(parts)}]"
+
+
+def _emit_object(*, entries: dict[str, JsonValue], path_expr: str) -> str:
+    """Return a Tcl expression that yields a JSON object for *entries*."""
+    # Shared `roundtrip_input.json` only has ASCII-identifier keys, so
+    # each key embeds cleanly as a `{...}` Tcl word; `json::write
+    # object` escapes the key on its own.
+    parts: list[str] = []
+    for key, sub_value in entries.items():
+        sub_path = f"[dict get {path_expr} {{{key}}}]"
+        parts.append(f"{{{key}}}")
+        parts.append(_emit(value=sub_value, path_expr=sub_path))
+    return f"[json::write object {' '.join(parts)}]"
+
+
+def _emit(*, value: JsonValue, path_expr: str) -> str:
+    """Return a Tcl expression yielding the JSON encoding of *value*.
+
+    *path_expr* is a Tcl expression that, when evaluated, yields the
+    sub-value at this position inside the literalized ``$myData``.
+    """
+    if isinstance(value, bool):
+        return f'[expr {{{path_expr} ? "true" : "false"}}]'
+    if isinstance(value, (int, float)):
+        # Raw Tcl token serves as a JSON number literal; `json::write`
+        # passes numeric values through unmodified.
+        return path_expr
+    if isinstance(value, str):
+        return f"[json::write string {path_expr}]"
+    if isinstance(value, list):
+        return _emit_array(items=value, path_expr=path_expr)
+    if isinstance(value, dict):
+        return _emit_object(entries=value, path_expr=path_expr)
+    return '"null"'
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Tcl script literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Tcl(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    parsed: JsonValue = json.loads(s=json_text)
+    emit_expr = _emit(value=parsed, path_expr=f"${_VAR_NAME}")
+    return (
+        f"{_HEADER}\n{preamble}\n{result.code}\nputs -nonewline {emit_expr}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Tcl backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    tclsh = shutil.which(cmd="tclsh") or "tclsh"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.tcl",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[tclsh, "main.tcl"],
+                failure_label="tclsh runtime error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,6 +112,10 @@ jobs:
       # Ubuntu 24.04 build of Tcl 8.6.14), which is ``>=`` the ``V8_6``
       # (Tcl 8.6) default of ``Tcl.language_version`` in
       # ``src/literalizer/languages/tcl.py``; keep them in sync.
+      # ``tcllib`` (pinned to the Ubuntu 24.04 build of ``1.21+dfsg-1``)
+      # provides the ``json::write`` package used by
+      # ``.github/scripts/run_tcl_roundtrip.py`` to re-emit JSON from a
+      # literalized Tcl ``dict``; Tcl itself ships no JSON library.
       # The ``guile-3.0`` apt package pins Guile to the 3.x series,
       # which implements ``R7RS``, matching ``Scheme.language_version``
       # (``R7RS``) in ``src/literalizer/languages/scheme.py``; keep them
@@ -122,7 +126,8 @@ jobs:
       - name: Install apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: tcl=8.6.14build1 gforth=0.7.3+dfsg-9build4.1 guile-3.0
+          packages: tcl=8.6.14build1 tcllib=1.21+dfsg-1 gforth=0.7.3+dfsg-9build4.1
+            guile-3.0
           version: 1.0
       - name: Install Dhall
         # The pinned ``dhall-haskell`` 1.42.2 binary implements Dhall
@@ -394,6 +399,14 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.tcl' -print0 > /tmp/files-tcl && test -s /tmp/files-tcl
           xargs -0 -P "$(nproc)" -n1 tclsh < /tmp/files-tcl
+
+      # Driven from `lint-fast` because that is the job where the `tcl`
+      # apt package (pinned by the `Install apt packages` step above) is
+      # installed; `uv run` (project mode, not `--no-project`) is required
+      # so `import literalizer` resolves.
+      # See `.github/scripts/run_tcl_roundtrip.py`.
+      - name: Tcl roundtrip
+        run: uv run python .github/scripts/run_tcl_roundtrip.py
 
       - name: Lint Forth
         run: |-

--- a/newsfragments/2680.change
+++ b/newsfragments/2680.change
@@ -1,0 +1,1 @@
+Add a Tcl JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/run_tcl_roundtrip.py`, which literalizes the shared `roundtrip_input.json` to a `set myData [dict create ...]` Tcl binding and re-emits JSON via tcllib's `json::write` driven along the known JSON shape.
- Pins `tcllib=1.21+dfsg-1` alongside the existing `tcl` apt package and wires up a `Tcl roundtrip` step in the `lint-fast` job right after `Lint Tcl`.
- Tcl preserves the textual rep of un-shimmered numeric scalars stored in a `dict`, so the full fixture round-trips with **no excluded keys** (bignum, large-exponent float, `-0.0`, unicode, escapes, booleans, empty/nested containers all survive).

## Test plan
- [x] `uv run python .github/scripts/run_tcl_roundtrip.py` locally (tclsh 9.0)
- [ ] CI `lint-fast` → `Tcl roundtrip` step passes on Ubuntu 24.04 (tcllib 1.21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI scripts, apt pins, and a newsfragment; no runtime or library behavior in the main package.
> 
> **Overview**
> Adds **CI coverage** for Tcl JSON literalization: a new helper script round-trips the shared `roundtrip_input.json` through the Tcl literalizer and **tcllib** `json::write`, then compares output via the same `roundtrip_common` path as other languages.
> 
> The workflow installs pinned **`tcllib`** (for `json::write`) and runs a **`Tcl roundtrip`** step in `lint-fast` after existing Tcl lint. Because Tcl keeps numeric text in dicts, the check uses **no excluded keys** unlike many typed-language round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6bc56df19e3666cd71f3b8d0e2adea5b9c2567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->