### PR TITLE
Add Wren JSON round-trip check (#2683)

### DIFF
--- a/.github/scripts/run_wren_roundtrip.py
+++ b/.github/scripts/run_wren_roundtrip.py
@@ -1,0 +1,129 @@
+"""Wren JSON round-trip check (issue #2683).
+
+Literalize the shared ``roundtrip_input.json`` document to a Wren
+``var myData = ...`` declaration, wrap it in a script that re-emits JSON
+on standard output through a small in-program encoder, run it under
+``wren_cli``, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Wren roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where the ``wren_cli`` binary (pinned by the ``Install Wren CLI`` step)
+is installed.  It shares the same input and comparison logic as the
+other per-language round-trip helpers.
+
+Wren ships no standard-library JSON encoder, so this script hand-rolls
+one in Wren itself.  Wren is dynamically typed (``value is Num`` /
+``is String`` / ``is List`` / ``is Map``), so a generic walker over the
+literalized ``myData`` can produce JSON directly without needing the
+Python side to know the document's shape, unlike the Tcl helper which
+must drive ``tcllib``'s typed constructors along the parsed shape.
+
+Two top-level keys are excluded from the comparison:
+
+* ``biginteger`` -- Wren has a single ``Num`` numeric type backed by a
+  64-bit double, so the 26-digit literal is parsed as the nearest double
+  and ``Num.toString`` re-emits it as ``1e+26``; same shape as the Go,
+  TypeScript, Lua, Zig, Swift, Rust, D, and C++ exclusions.
+* ``float_large_exponent`` -- ``Num.toString`` uses ``%.14g``, which
+  rounds ``1.7976931348623157e+308`` to ``1.7976931348623e+308`` and
+  loses the trailing significant digits; same shape as the Lua
+  exclusion.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Wren
+
+_VAR_NAME = "myData"
+_LABEL = "Wren"
+_EXCLUDED_KEYS = ("biginteger", "float_large_exponent")
+
+# Walks ``myData`` and emits JSON to standard output.  Lives at module
+# scope (rather than inside ``main``) because Wren's ``import`` cannot
+# resolve sibling files inside the per-run tmpdir, so the encoder must
+# be prepended to the same source file as the literalized data.
+_ENCODER = """\
+class JsonEnc {
+    static encode(value) {
+        if (value == null) return "null"
+        if (value is Bool) return value ? "true" : "false"
+        if (value is Num) return value.toString
+        if (value is String) return JsonEnc.encodeString(value)
+        if (value is List) {
+            var parts = []
+            for (item in value) parts.add(JsonEnc.encode(item))
+            return "[" + parts.join(",") + "]"
+        }
+        if (value is Map) {
+            var parts = []
+            for (key in value.keys) {
+                var entry = JsonEnc.encodeString(key) + ":"
+                parts.add(entry + JsonEnc.encode(value[key]))
+            }
+            return "{" + parts.join(",") + "}"
+        }
+        Fiber.abort("unsupported type")
+    }
+
+    static encodeString(s) {
+        var out = "\\""
+        for (c in s) {
+            if (c == "\\"") {
+                out = out + "\\\\\\""
+            } else if (c == "\\\\") {
+                out = out + "\\\\\\\\"
+            } else if (c == "\\n") {
+                out = out + "\\\\n"
+            } else if (c == "\\r") {
+                out = out + "\\\\r"
+            } else if (c == "\\t") {
+                out = out + "\\\\t"
+            } else {
+                out = out + c
+            }
+        }
+        return out + "\\""
+    }
+}
+"""
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Wren program literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Wren(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{_ENCODER}\n"
+        f"{preamble}\n"
+        f"{result.code}\n"
+        f"System.write(JsonEnc.encode({_VAR_NAME}))\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Wren backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    wren = shutil.which(cmd="wren_cli") or "wren_cli"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.wren",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[wren, "main.wren"],
+                failure_label="wren_cli runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -435,6 +435,14 @@ jobs:
           find tests/integration/cases -name '*.wren' -print0 > /tmp/files-wren && test -s /tmp/files-wren
           xargs -0 -P "$(nproc)" -n1 wren_cli < /tmp/files-wren
 
+      # Driven from `lint-fast` because that is the job where the
+      # `wren_cli` binary (pinned by the `Install Wren CLI` step above)
+      # is installed; `uv run` (project mode, not `--no-project`) is
+      # required so `import literalizer` resolves.
+      # See `.github/scripts/run_wren_roundtrip.py`.
+      - name: Wren roundtrip
+        run: uv run python .github/scripts/run_wren_roundtrip.py
+
       # Each fixture defines its own main, so compile and run directly.
       # The build-and-run step also surfaces any syntax errors, so a
       # separate `-fsyntax-only` pass would be redundant.

--- a/newsfragments/2683.change
+++ b/newsfragments/2683.change
@@ -1,0 +1,1 @@
+Add a Wren JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Hand-rolls a small Wren JSON encoder (no stdlib option) using runtime `is Num`/`is String`/`is List`/`is Map` checks, runs it against the shared `roundtrip_input.json` under `wren_cli`, and asserts the round-trip.
- Excludes `biginteger` and `float_large_exponent`: Wren's single `Num` is a 64-bit double and `Num.toString` uses `%.14g`, the same precision floor seen in the Lua exclusions.
- Wires it as a new `Wren roundtrip` step in `lint-fast`, right after `Lint Wren`, where `wren_cli` is already installed.

Closes #2683.

## Test plan
- [x] Ran the new helper locally (`uv run python .github/scripts/run_wren_roundtrip.py`) under the pinned 0.4.0 `wren_cli`.
- [ ] CI `lint-fast` -> `Wren roundtrip` step is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test harness and workflow step; no production literalizer or runtime behavior changes.
> 
> **Overview**
> Adds **Wren** to the shared JSON round-trip CI gate: a new `.github/scripts/run_wren_roundtrip.py` helper literalizes `roundtrip_input.json` to `var myData`, prepends an in-file `JsonEnc` walker (Wren has no stdlib JSON encoder), runs `wren_cli`, and compares output via `roundtrip_common`.
> 
> The **`lint-fast`** workflow gains a **`Wren roundtrip`** step immediately after **`Lint Wren`**, using the already-pinned `wren_cli` and `uv run` so `literalizer` resolves.
> 
> Comparison skips **`biginteger`** and **`float_large_exponent`** because Wren’s `Num` is a 64-bit double and `Num.toString` uses limited precision—aligned with other language round-trip exclusions. A **`newsfragments/2683.change`** entry documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a16003d2b522ac0a77808b43ef47a4dad27cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->